### PR TITLE
[PDI-9404] Due to the ivy transition, after a local build is made, a couple of files changed (ivy.xml) and a commit marks them as modified

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1029,7 +1029,7 @@
 	    
 	  <target name="publish-local-plugin-task" depends="install-ivy">
 	    <ivy:resolve file="${pluginfolder}/ivy.xml" />
-	    <ivy:publish resolver="local" srcivypattern="${pluginfolder}/ivy.xml" pubrevision="${project.revision}" overwrite="true" forcedeliver="true">
+	    <ivy:publish resolver="local" pubrevision="${project.revision}" overwrite="true" forcedeliver="true">
 	      <artifacts pattern="${pluginfolder}/dist/[artifact]-[revision].[ext]" />
 	    </ivy:publish>
 	  </target>


### PR DESCRIPTION
Removed “srcivypattern" parameter for ivy:publish task so it will be defaulted to “artifactspattern” (“dist" folder’s contents) and keep original ivy.xml file untouched.
