### PR TITLE
PDI-2753 validation failing in "Get sequence value from database" step

### DIFF
--- a/core/src/org/pentaho/di/core/database/OracleDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/OracleDatabaseMeta.java
@@ -196,7 +196,17 @@ public class OracleDatabaseMeta extends BaseDatabaseMeta implements DatabaseInte
     @Override
     public String getSQLSequenceExists(String sequenceName)
     {
-        return "SELECT * FROM USER_SEQUENCES WHERE SEQUENCE_NAME = '"+sequenceName.toUpperCase()+"'";
+        int dotPos = sequenceName.indexOf('.');
+        String sql = "";
+        if (dotPos == -1) {
+            // if schema is not specified try to get sequence which belongs to current user
+            sql = "SELECT * FROM USER_SEQUENCES WHERE SEQUENCE_NAME = '"+sequenceName.toUpperCase()+"'";
+        } else {
+            String schemaName = sequenceName.substring(0, dotPos);
+            String seqName = sequenceName.substring(dotPos+1);
+            sql = "SELECT * FROM ALL_SEQUENCES WHERE SEQUENCE_NAME = '" + seqName.toUpperCase() + "' AND SEQUENCE_OWNER = '" + schemaName.toUpperCase() + "'";
+        }
+        return sql;
     }
     
     /**


### PR DESCRIPTION
Oracle dictionaries "all_sequences" and "user_sequences" keep the relative name of the sequence (w/o schema prefix). Hence, clean up the sequence name.
