### PR TITLE
[PDI-10717]: Reverted ValueMeta changes as they cause NPEs

### DIFF
--- a/core/src/org/pentaho/di/core/row/ValueMetaInterface.java
+++ b/core/src/org/pentaho/di/core/row/ValueMetaInterface.java
@@ -134,7 +134,7 @@ import org.w3c.dom.Node;
  * the set of possible values in getIndex()/setIndex().
  * </Table>
  */
-public interface ValueMetaInterface {
+public interface ValueMetaInterface extends Cloneable {
   /** Value type indicating that the value has no type set */
   public static final int TYPE_NONE = 0;
 

--- a/core/src/org/pentaho/di/core/row/value/ValueMetaFactory.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaFactory.java
@@ -66,40 +66,35 @@ public class ValueMetaFactory {
 
   public static ValueMetaInterface cloneValueMeta( ValueMetaInterface source, int targetType )
     throws KettlePluginException {
-    ValueMetaInterface target;
-    if ( source instanceof Cloneable ) {
-      target = source.clone();
-    } else {
-      target = createValueMeta( source.getName(), targetType, source.getLength(), source.getPrecision() );
-      target.setConversionMask( source.getConversionMask() );
-      target.setDecimalSymbol( source.getDecimalSymbol() );
-      target.setGroupingSymbol( source.getGroupingSymbol() );
-      target.setStorageType( source.getStorageType() );
-      if ( source.getStorageMetadata() != null ) {
-        target
-            .setStorageMetadata( cloneValueMeta( source.getStorageMetadata(), source.getStorageMetadata().getType() ) );
-      }
-      target.setStringEncoding( source.getStringEncoding() );
-      target.setTrimType( source.getTrimType() );
-      target.setDateFormatLenient( source.isDateFormatLenient() );
-      target.setDateFormatLocale( source.getDateFormatLocale() );
-      target.setDateFormatTimeZone( source.getDateFormatTimeZone() );
-      target.setLenientStringToNumber( source.isLenientStringToNumber() );
-      target.setLargeTextField( source.isLargeTextField() );
-      target.setComments( source.getComments() );
-      target.setCaseInsensitive( source.isCaseInsensitive() );
-      target.setIndex( source.getIndex() );
-
-      target.setOrigin( source.getOrigin() );
-
-      target.setOriginalAutoIncrement( source.isOriginalAutoIncrement() );
-      target.setOriginalColumnType( source.getOriginalColumnType() );
-      target.setOriginalColumnTypeName( source.getOriginalColumnTypeName() );
-      target.setOriginalNullable( source.isOriginalNullable() );
-      target.setOriginalPrecision( source.getOriginalPrecision() );
-      target.setOriginalScale( source.getOriginalScale() );
-      target.setOriginalSigned( source.isOriginalSigned() );
+    ValueMetaInterface target =
+        createValueMeta( source.getName(), targetType, source.getLength(), source.getPrecision() );
+    target.setConversionMask( source.getConversionMask() );
+    target.setDecimalSymbol( source.getDecimalSymbol() );
+    target.setGroupingSymbol( source.getGroupingSymbol() );
+    target.setStorageType( source.getStorageType() );
+    if ( source.getStorageMetadata() != null ) {
+      target.setStorageMetadata( cloneValueMeta( source.getStorageMetadata(), source.getStorageMetadata().getType() ) );
     }
+    target.setStringEncoding( source.getStringEncoding() );
+    target.setTrimType( source.getTrimType() );
+    target.setDateFormatLenient( source.isDateFormatLenient() );
+    target.setDateFormatLocale( source.getDateFormatLocale() );
+    target.setDateFormatTimeZone( source.getDateFormatTimeZone() );
+    target.setLenientStringToNumber( source.isLenientStringToNumber() );
+    target.setLargeTextField( source.isLargeTextField() );
+    target.setComments( source.getComments() );
+    target.setCaseInsensitive( source.isCaseInsensitive() );
+    target.setIndex( source.getIndex() );
+
+    target.setOrigin( source.getOrigin() );
+
+    target.setOriginalAutoIncrement( source.isOriginalAutoIncrement() );
+    target.setOriginalColumnType( source.getOriginalColumnType() );
+    target.setOriginalColumnTypeName( source.getOriginalColumnTypeName() );
+    target.setOriginalNullable( source.isOriginalNullable() );
+    target.setOriginalPrecision( source.getOriginalPrecision() );
+    target.setOriginalScale( source.getOriginalScale() );
+    target.setOriginalSigned( source.isOriginalSigned() );
 
     return target;
   }


### PR DESCRIPTION
Reverting changes from previous commit as they cause NPEs when calling clone() directly on a ValueMetaInterface object.  We need to revisit this as part of PDI-10717 to fix this the right way.
