### PR TITLE
PDI-10389 Text File Output Step throws a null pointer error when "Do not...

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -177,9 +177,9 @@ public class TextFileOutput extends BaseStep implements StepInterface {
       }
     }
 
-    if ( r == null ) // no more input to be expected...
-    {
-      if ( false == bEndedLineWrote ) {
+    if ( r == null ) {
+      // no more input to be expected...
+      if ( !bEndedLineWrote && !first ) {
         // add tag to last line if needed
         writeEndedLine();
         bEndedLineWrote = true;
@@ -511,8 +511,8 @@ public class TextFileOutput extends BaseStep implements StepInterface {
           }
         }
         data.writer.write( data.binaryNewline );
-      } else if ( r != null ) // Just put all field names in the header/footer
-      {
+      } else if ( r != null ) {
+        // Just put all field names in the header/footer
         for ( int i = 0; i < r.size(); i++ ) {
           if ( i > 0 && data.binarySeparator.length > 0 ) {
             data.writer.write( data.binarySeparator );
@@ -978,12 +978,14 @@ public class TextFileOutput extends BaseStep implements StepInterface {
         }
       } else {
         if ( isDetailed() ) {
-          logDetailed( BaseMessages.getString( PKG, "TextFileOutput.Log.ParentFolderNotExist", parentfolder.getName() ) );
+          logDetailed( BaseMessages.getString( PKG,
+                  "TextFileOutput.Log.ParentFolderNotExist", parentfolder.getName() ) );
         }
         if ( meta.isCreateParentFolder() ) {
           parentfolder.createFolder();
           if ( isDetailed() ) {
-            logDetailed( BaseMessages.getString( PKG, "TextFileOutput.Log.ParentFolderCreated", parentfolder.getName() ) );
+            logDetailed( BaseMessages.getString( PKG,
+                    "TextFileOutput.Log.ParentFolderCreated", parentfolder.getName() ) );
           }
         } else {
           throw new KettleException( BaseMessages.getString( PKG, "TextFileOutput.Log.ParentFolderNotExistCreateIt",


### PR DESCRIPTION
... create file at start" is checked, "Add Ending line of file" is valued, and transformation does not pass any rows to the file input step.

Changed condition for writing ending to a file in case of empty data.
