### PR TITLE
[PDI-10270] Fix: do not set result.nrErrors in case of 'normal' fail of ...

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -872,6 +872,13 @@ public class Const {
   public static final String KETTLE_DEFAULT_DATE_FORMAT = "KETTLE_DEFAULT_DATE_FORMAT";
 
   /**
+   * Compatibility settings for setNrErrors
+   */
+  // see PDI-10270 for details.
+  public static final String KETTLE_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_JOB_ENTRIES =
+      "KETTLE_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_JOB_ENTRIES";
+
+  /**
    * The XML file that contains the list of native import rules
    */
   public static final String XML_FILE_KETTLE_IMPORT_RULES = "kettle-import-rules.xml";

--- a/engine/src/org/pentaho/di/job/entries/fileexists/JobEntryFileExists.java
+++ b/engine/src/org/pentaho/di/job/entries/fileexists/JobEntryFileExists.java
@@ -137,6 +137,7 @@ public class JobEntryFileExists extends JobEntryBase implements Cloneable, JobEn
   public Result execute( Result previousResult, int nr ) {
     Result result = previousResult;
     result.setResult( false );
+    result.setNrErrors( 0 );
 
     if ( filename != null ) {
       String realFilename = getRealFilename();

--- a/engine/src/org/pentaho/di/job/entries/folderisempty/JobEntryFolderIsEmpty.java
+++ b/engine/src/org/pentaho/di/job/entries/folderisempty/JobEntryFolderIsEmpty.java
@@ -183,9 +183,13 @@ public class JobEntryFolderIsEmpty extends JobEntryBase implements Cloneable, Jo
   }
 
   public Result execute( Result previousResult, int nr ) {
+    // see PDI-10270 for details
+    boolean oldBehavior =
+        "Y".equalsIgnoreCase( getVariable( Const.KETTLE_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_JOB_ENTRIES, "N" ) );
+
     Result result = previousResult;
     result.setResult( false );
-    result.setNrErrors( 1 );
+    result.setNrErrors( oldBehavior ? 1 : 0 );
 
     filescount = 0;
     folderscount = 0;
@@ -212,17 +216,18 @@ public class JobEntryFolderIsEmpty extends JobEntryBase implements Cloneable, Jo
             if ( filescount == 0 ) {
               result.setResult( true );
               result.setNrLinesInput( folderscount );
-              result.setNrErrors( 0 );
             }
           } else {
             // Not a folder, fail
             log.logError( "[" + realFoldername + "] is not a folder, failing." );
+            result.setNrErrors( 1 );
           }
         } else {
           // No Folder found
           if ( log.isBasic() ) {
             logBasic( "we can not find [" + realFoldername + "] !" );
           }
+          result.setNrErrors( 1 );
         }
       } catch ( Exception e ) {
         logError( "Error checking folder [" + realFoldername + "]", e );
@@ -239,6 +244,7 @@ public class JobEntryFolderIsEmpty extends JobEntryBase implements Cloneable, Jo
       }
     } else {
       logError( "No Foldername is defined." );
+      result.setNrErrors( 1 );
     }
 
     return result;

--- a/engine/test-src/org/pentaho/di/job/entries/filesexist/JobEntryFilesExistTest.java
+++ b/engine/test-src/org/pentaho/di/job/entries/filesexist/JobEntryFilesExistTest.java
@@ -1,0 +1,134 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.filesexist;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entry.JobEntryCopy;
+
+public class JobEntryFilesExistTest {
+  private Job job;
+  private JobEntryFilesExist entry;
+
+  private String existingFile1;
+  private String existingFile2;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+
+    KettleLogStore.init();
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    job = new Job( null, new JobMeta() );
+    entry = new JobEntryFilesExist();
+
+    job.getJobMeta().addJobEntry( new JobEntryCopy( entry ) );
+    entry.setParentJob( job );
+
+    job.setStopped( false );
+
+    File f = File.createTempFile( "existingFile", "ext" );
+    f.deleteOnExit();
+    existingFile1 = f.getPath();
+
+    f = File.createTempFile( "existingFile", "ext" );
+    f.deleteOnExit();
+    existingFile2 = f.getPath();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public void testSetNrErrorsNewBehaviorFalseResult() throws Exception {
+    // this tests fix for PDI-10270
+    entry.arguments = new String[] { "nonExistingFile.ext" };
+
+    Result res = entry.execute( new Result(), 0 );
+
+    assertFalse( "Entry should fail", res.getResult() );
+    assertEquals( "Files not found. Result is false. But... No of errors should be zero", 0, res.getNrErrors() );
+  }
+
+  @Test
+  public void testSetNrErrorsOldBehaviorFalseResult() throws Exception {
+    // this tests backward compatibility settings for PDI-10270
+    entry.arguments = new String[] { "nonExistingFile1.ext", "nonExistingFile2.ext" };
+
+    entry.setVariable( Const.KETTLE_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_JOB_ENTRIES, "Y" );
+
+    Result res = entry.execute( new Result(), 0 );
+
+    assertFalse( "Entry should fail", res.getResult() );
+    assertEquals(
+        "Files not found. Result is false. And... Number of errors should be the same as number of not found files",
+        entry.arguments.length, res.getNrErrors() );
+  }
+
+  @Test
+  public void testExecuteWithException() throws Exception {
+    entry.arguments = new String[] { null };
+
+    Result res = entry.execute( new Result(), 0 );
+
+    assertFalse( "Entry should fail", res.getResult() );
+    assertEquals( "File with wrong name was specified. One error should be reported", 1, res.getNrErrors() );
+  }
+
+  @Test
+  public void testExecuteSuccess() throws Exception {
+    entry.arguments = new String[] { existingFile1, existingFile2 };
+
+    Result res = entry.execute( new Result(), 0 );
+
+    assertTrue( "Entry failed", res.getResult() );
+  }
+
+  @Test
+  public void testExecuteFail() throws Exception {
+    entry.arguments = new String[] { existingFile1, existingFile2, "nonExistingFile1.ext", "nonExistingFile2.ext" };
+
+    Result res = entry.execute( new Result(), 0 );
+
+    assertFalse( "Entry should fail", res.getResult() );
+  }
+}

--- a/engine/test-src/org/pentaho/di/job/entries/folderisempty/JobEntryFolderIsEmptyTest.java
+++ b/engine/test-src/org/pentaho/di/job/entries/folderisempty/JobEntryFolderIsEmptyTest.java
@@ -1,0 +1,116 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.folderisempty;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileAttribute;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entry.JobEntryCopy;
+
+public class JobEntryFolderIsEmptyTest {
+  private Job job;
+  private JobEntryFolderIsEmpty entry;
+
+  private String emptyDir;
+  private String nonEmptyDir;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    KettleLogStore.init();
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    job = new Job( null, new JobMeta() );
+    entry = new JobEntryFolderIsEmpty();
+
+    job.getJobMeta().addJobEntry( new JobEntryCopy( entry ) );
+    entry.setParentJob( job );
+
+    job.setStopped( false );
+
+    File dir = Files.createTempDirectory( "dir", new FileAttribute<?>[0] ).toFile();
+    dir.deleteOnExit();
+    emptyDir = dir.getPath();
+
+    dir = Files.createTempDirectory( "dir", new FileAttribute<?>[0] ).toFile();
+    dir.deleteOnExit();
+    nonEmptyDir = dir.getPath();
+
+    File file = File.createTempFile( "existingFile", "ext", dir );
+    file.deleteOnExit();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public void testSetNrErrorsSuccess() throws Exception {
+    entry.setFoldername( emptyDir );
+
+    Result result = entry.execute( new Result(), 0 );
+
+    assertTrue( "For empty folder result should be true", result.getResult() );
+    assertEquals( "There should be no errors", 0, result.getNrErrors() );
+  }
+
+  @Test
+  public void testSetNrErrorsNewBehaviorFail() throws Exception {
+    entry.setFoldername( nonEmptyDir );
+
+    Result result = entry.execute( new Result(), 0 );
+
+    assertFalse( "For non-empty folder result should be false", result.getResult() );
+    assertEquals( "There should be still no errors", 0, result.getNrErrors() );
+  }
+
+  @Test
+  public void testSetNrErrorsOldBehaviorFail() throws Exception {
+    entry.setFoldername( nonEmptyDir );
+
+    entry.setVariable( Const.KETTLE_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_JOB_ENTRIES, "Y" );
+
+    Result result = entry.execute( new Result(), 0 );
+
+    assertFalse( "For non-empty folder result should be false", result.getResult() );
+    assertEquals( "According to old behaviour there should be an error", 1, result.getNrErrors() );
+  }
+}


### PR DESCRIPTION
[PDI-10270] Fix: do not set result.nrErrors in case of 'normal' fail of a particular Job Entry
- for the sake of backward compatibility special Kettle variable is introduced:
  KETTLE_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_JOB_ENTRIES
  if this variable is set to "Y" old behavior takes place.
- result.nrErrors is set only in case of exceptional flow:
  e.g. bad arguments (null), non existing directory to be checked by the Job Entry etc.
- unit tests implemented for both FilesExist and FolderIsEmpty job entries.
