### PR TITLE
Added unit test and Cobertura targets to build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1245,6 +1245,38 @@
 	 </unzip> 
   	
    </target>
-
-
+	
+	<target name="test"
+            description="Runs unit tests for each Kettle module."
+            depends="install-antcontrib">
+          
+      <for list="${dev-project.list}" param="module" trim="true">
+        <sequential>
+          <ant antfile="build.xml" dir="@{module}" inheritall="false" >
+          	<target name="clean" />
+            <target name="init-tests" />
+            <target name="init-test-reports" />
+          	<target name="resolve" />
+            <target name="test" />
+          </ant>
+        </sequential>
+      </for>
+    </target>
+	
+	<target name="cobertura"
+            description="Runs Cobertura test coverage for each Kettle module."
+            depends="install-antcontrib">
+          
+      <for list="${dev-project.list}" param="module" trim="true">
+        <sequential>
+          <ant antfile="build.xml" dir="@{module}" inheritall="false" >
+          	<target name="clean" />
+          	<target name="init-tests" />
+          	<target name="init-test-reports" />
+            <target name="resolve" />
+            <target name="cobertura" />
+          </ant>
+        </sequential>
+      </for>
+    </target>
 </project>


### PR DESCRIPTION
Currently unit tests (source located within module directories under test-src/) are not being built and run by Jenkins. I overrode subfloor's test and cobertura targets to delegate down to each module's subfloor targets. After this pull request is merged, the CI job should be updated to call the "test" or "cobertura" target.
