### PR TITLE
[PDI-10389] Changed step to cover the changes of the expecting result in...

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -179,7 +179,12 @@ public class TextFileOutput extends BaseStep implements StepInterface {
 
     if ( r == null ) {
       // no more input to be expected...
-      if ( !bEndedLineWrote && data.writer != null ) {
+      if ( !bEndedLineWrote && meta.getEndedLine() != null ) {
+        if ( data.writer == null ) {
+          openNewFile( meta.getFileName() );
+          data.oneFileOpened = true;
+          initBinaryDataFields();
+        }
         // add tag to last line if needed
         writeEndedLine();
         bEndedLineWrote = true;

--- a/engine/test-src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputTest.java
@@ -131,8 +131,8 @@ public class TextFileOutputTest {
     contents.add( END_LINE );
     contents.add( null );
     contents.add( null );
-    contents.add( null );
-    contents.add( null );
+    contents.add( END_LINE );
+    contents.add( END_LINE );
     contents.add( RESULT_ROWS );
     contents.add( RESULT_ROWS );
     contents.add( RESULT_ROWS + END_LINE );
@@ -147,8 +147,8 @@ public class TextFileOutputTest {
     contents.add( TEST_PREVIOUS_DATA + END_LINE );
     contents.add( TEST_PREVIOUS_DATA );
     contents.add( TEST_PREVIOUS_DATA );
-    contents.add( TEST_PREVIOUS_DATA );
-    contents.add( TEST_PREVIOUS_DATA );
+    contents.add( END_LINE  );
+    contents.add( TEST_PREVIOUS_DATA + END_LINE  );
     contents.add( RESULT_ROWS );
     contents.add( TEST_PREVIOUS_DATA + RESULT_ROWS );
     contents.add( RESULT_ROWS + END_LINE );


### PR DESCRIPTION
... 4 unit test cases.

Text File Output Step throws a null pointer error when "Do not create file at start" is checked, "Add Ending line of file" is valued, and transformation does not pass any rows to the file input step.
