### PR TITLE
[PDI-10424] do setOutputDone() for the case of empty input RowSet

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/script/Script.java
+++ b/engine/src/org/pentaho/di/trans/steps/script/Script.java
@@ -625,10 +625,7 @@ public class Script extends BaseStep implements StepInterface {
         stopAll();
       }
 
-      if ( data.cx != null ) {
-        // Context.exit(); TODO AKRETION not sure
-        setOutputDone();
-      }
+      setOutputDone();
       return false;
     }
 

--- a/engine/test-src/org/pentaho/di/trans/steps/script/ScriptTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/script/ScriptTest.java
@@ -1,0 +1,73 @@
+package org.pentaho.di.trans.steps.script;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.BlockingRowSet;
+import org.pentaho.di.core.RowSet;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+public class ScriptTest {
+  private StepMockHelper<ScriptMeta, ScriptData> helper;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    helper = new StepMockHelper<ScriptMeta, ScriptData>( "test-script", ScriptMeta.class, ScriptData.class );
+    when( helper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+        helper.logChannelInterface );
+    when( helper.trans.isRunning() ).thenReturn( true );
+    when( helper.initStepMetaInterface.getJSScripts() ).thenReturn(
+        new ScriptValuesScript[] {
+          new ScriptValuesScript( ScriptValuesScript.NORMAL_SCRIPT, "", "var i = 0;" )
+        }
+    );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public void testOutputDoneIfInputEmpty() throws Exception {
+    Script step = new Script( helper.stepMeta, helper.stepDataInterface, 1, helper.transMeta, helper.trans );
+    step.init( helper.initStepMetaInterface, helper.initStepDataInterface );
+
+    RowSet rs = helper.getMockInputRowSet( new Object[0][0] );
+    List<RowSet> in = new ArrayList<RowSet>( );
+    in.add( rs );
+    step.setInputRowSets( in );
+
+    rs = new BlockingRowSet( 5 );
+    List<RowSet> out = new ArrayList<RowSet>();
+    out.add( rs );
+    step.setOutputRowSets( out );
+
+    step.processRow( helper.processRowsStepMetaInterface, helper.processRowsStepDataInterface );
+
+    out = step.getOutputRowSets();
+    rs = out.get( 0 );
+
+    assertTrue( "Script step is supposed to done with output if there is no input", rs.isDone() );
+
+    rs.getRow();
+  }
+
+}


### PR DESCRIPTION
the setOutputDone() method was not called what caused hang of the next step.

unit test is provided.

Description for the JIRA case PDI-10424 is updated suggesting users using new implementation of Script step.
