### PR TITLE
[PDI-10503] Synchronize stream loggers

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/shell/JobEntryShell.java
+++ b/engine/src/org/pentaho/di/job/entries/shell/JobEntryShell.java
@@ -590,8 +590,10 @@ public class JobEntryShell extends JobEntryBase implements Cloneable, JobEntryIn
       StreamLogger outputLogger = new StreamLogger( log, proc.getInputStream(), "(stdout)" );
 
       // kick them off
-      new Thread( errorLogger ).start();
-      new Thread( outputLogger ).start();
+      Thread errorLoggerThread = new Thread( errorLogger );
+      errorLoggerThread.start();
+      Thread outputLoggerThread = new Thread( outputLogger );
+      outputLoggerThread.start();
 
       proc.waitFor();
       if ( log.isDetailed() ) {
@@ -608,6 +610,10 @@ public class JobEntryShell extends JobEntryBase implements Cloneable, JobEntryIn
 
         result.setNrErrors( 1 );
       }
+
+      //wait until loggers read all data from stdout and stderr
+      errorLoggerThread.join();
+      outputLoggerThread.join();
 
       // close the streams
       // otherwise you get "Too many open files, java.io.IOException" after a lot of iterations


### PR DESCRIPTION
Synchronize stream logging threads with the thread they are called from.

Unit test isn't provided as the fix affects thread synchronization only.
