### PR TITLE
publication entries of both sources jar and zip in ivy broke the 5.1 nightly release

### DIFF
--- a/plugins/kettle5-log4j-plugin/ivy.xml
+++ b/plugins/kettle5-log4j-plugin/ivy.xml
@@ -13,7 +13,6 @@
   <publications>
     <artifact name="${ivy.artifact.id}" type="jar" conf="default"/>
     <artifact name="${ivy.artifact.id}" type="zip" conf="zip" />
-    <artifact name="${ivy.artifact.id}" m:classifier="sources" type="source" ext="jar" conf="source"/>
   </publications>
  
   <dependencies defaultconf="dev->default">

--- a/plugins/kettle5-log4j-plugin/package-ivy.xml
+++ b/plugins/kettle5-log4j-plugin/package-ivy.xml
@@ -8,7 +8,6 @@
   <publications>
     <artifact name="${ivy.artifact.id}" type="zip" />
     <artifact name="${ivy.artifact.id}" type="jar" />
-    <artifact name="${ivy.artifact.id}" m:classifier="sources" type="source" ext="jar"/>
   </publications>
 
   <dependencies defaultconf="default->default">


### PR DESCRIPTION
these commits show iterative attempts to try removing these entries and rerun the nightly
