### PR TITLE
[PDI-9953] - fix various AutoDoc layout issues

### DIFF
--- a/engine/src/org/pentaho/di/core/gui/SwingGC.java
+++ b/engine/src/org/pentaho/di/core/gui/SwingGC.java
@@ -33,7 +33,9 @@ import java.awt.Stroke;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
 import java.awt.image.ImageObserver;
+import java.awt.image.Raster;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,6 +51,7 @@ import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.laf.BasePropertyHandler;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.reporting.libraries.base.util.WaitingImageObserver;
+
 
 public class SwingGC implements GCInterface {
 
@@ -139,10 +142,15 @@ public class SwingGC implements GCInterface {
 
   private boolean drawingPixelatedImages;
 
-  public SwingGC( ImageObserver observer, Point area, int iconsize, int xOffset, int yOffset )
-    throws KettleException {
-    this.image = new BufferedImage( area.x, area.y, BufferedImage.TYPE_INT_RGB );
-    this.gc = image.createGraphics();
+  private AffineTransform originalTransform;
+
+  private SwingGC( BufferedImage image, Graphics2D gc, ImageObserver observer,
+      Point area, int iconsize, int xOffset, int yOffset ) throws KettleException {
+    this.image = image;
+    this.gc = gc;
+    if ( gc == null && image != null ) {
+      this.gc = image.createGraphics();
+    }
     this.observer = observer;
     this.stepImages = SwingGUIResource.getInstance().getStepImages();
     this.entryImages = SwingGUIResource.getInstance().getEntryImages();
@@ -150,22 +158,19 @@ public class SwingGC implements GCInterface {
     this.area = area;
     this.xOffset = xOffset;
     this.yOffset = yOffset;
+    this.originalTransform = this.gc.getTransform();
 
     init();
   }
 
-  public SwingGC( Graphics2D gc, Rectangle2D rect, int iconsize, int xOffset, int yOffset ) throws KettleException {
-    this.image = null;
-    this.gc = gc;
-    this.observer = null;
-    this.stepImages = SwingGUIResource.getInstance().getStepImages();
-    this.entryImages = SwingGUIResource.getInstance().getEntryImages();
-    this.iconsize = iconsize;
-    this.area = new Point( (int) rect.getWidth(), (int) rect.getHeight() );
-    this.xOffset = xOffset;
-    this.yOffset = yOffset;
+  public SwingGC( ImageObserver observer, Point area, int iconsize, int xOffset, int yOffset ) throws KettleException {
+    this( new BufferedImage( area.x, area.y, BufferedImage.TYPE_INT_RGB ), null, observer,
+        area, iconsize, xOffset, yOffset );
+  }
 
-    init();
+  public SwingGC( Graphics2D gc, Rectangle2D rect, int iconsize, int xOffset, int yOffset ) throws KettleException {
+    this( null, gc, null,
+        new Point( (int) rect.getWidth(), (int) rect.getHeight() ), iconsize, xOffset, yOffset );
   }
 
   private void init() throws KettleException {
@@ -286,32 +291,25 @@ public class SwingGC implements GCInterface {
   public void drawPixelatedImage( BufferedImage img, int locationX, int locationY ) {
 
     if ( isDrawingPixelatedImages() ) {
-      BufferedImage bi = new BufferedImage( img.getWidth(), img.getHeight(), BufferedImage.TYPE_INT_RGB );
-      Graphics2D g2 = (Graphics2D) bi.getGraphics();
-      g2.setColor( Color.WHITE );
-      g2.fillRect( 0, 0, img.getWidth(), img.getHeight() );
-      g2.drawImage( img, 0, 0, observer );
-      g2.dispose();
+      gc.setBackground( Color.white );
+      ColorModel cm = img.getColorModel();
+      Raster raster = img.getRaster();
 
-      for ( int x = 0; x < bi.getWidth( observer ); x++ ) {
-        for ( int y = 0; y < bi.getHeight( observer ); y++ ) {
-          int rgb = bi.getRGB( x, y );
-          gc.setColor( new Color( rgb ) );
+      for ( int x = 0; x < img.getWidth( observer ); x++ ) {
+        for ( int y = 0; y < img.getHeight( observer ); y++ ) {
+          Object pix = raster.getDataElements( x, y, null );
+          gc.setColor( new Color( cm.getRed( pix ), cm.getGreen( pix ), cm.getBlue( pix ) ) ); //, cm.getAlpha( pixel )
           gc.setStroke( new BasicStroke( 1.0f ) );
-          gc.drawLine( locationX + xOffset + x, locationY + yOffset + y, locationX + xOffset + x, locationY
-            + yOffset + y );
-          // gc.drawLine(locationX+xOffset+x, locationY+yOffset+y,
-          // locationX+xOffset+x+1, locationY+yOffset+y);
-          // gc.drawLine(locationX+xOffset+x, locationY+yOffset+y+1,
-          // locationX+xOffset+x+1, locationY+yOffset+y+1);
-          // gc.fillRect(locationX+xOffset+x, locationY+yOffset+y, 1, 1);
+          gc.drawLine(
+              locationX + xOffset + x,
+              locationY + yOffset + y,
+              locationX + xOffset + x + 1,
+              locationY + yOffset + y + 1 );
         }
       }
     } else {
-      boolean changed = false;
-      // Wait
-      while ( changed ) {
-        changed = !gc.drawImage( img, locationX, locationY, observer );
+      while ( !gc.drawImage( img, locationX, locationY, observer ) ) {
+        continue;
       }
     }
 
@@ -552,10 +550,15 @@ public class SwingGC implements GCInterface {
   }
 
   public void setTransform( float translationX, float translationY, int shadowsize, float magnification ) {
-    AffineTransform transform = new AffineTransform();
+    // PDI-9953 - always use original GC's transform.
+    AffineTransform transform = (AffineTransform) originalTransform.clone();
     transform.translate( translationX + shadowsize * magnification, translationY + shadowsize * magnification );
     transform.scale( magnification, magnification );
     gc.setTransform( transform );
+  }
+
+  public AffineTransform getTransform() {
+    return gc.getTransform();
   }
 
   public Point textExtent( String text ) {

--- a/engine/src/org/pentaho/di/trans/steps/autodoc/JobInformation.java
+++ b/engine/src/org/pentaho/di/trans/steps/autodoc/JobInformation.java
@@ -159,6 +159,10 @@ public class JobInformation {
 
     Point min = jobMeta.getMinimum();
     Point area = jobMeta.getMaximum();
+
+    area.x -= min.x;
+    area.y -= min.y;
+
     int iconsize = 32;
 
     ScrollBarInterface bar = new ScrollBarInterface() {
@@ -175,20 +179,20 @@ public class JobInformation {
     Rectangle rect = new java.awt.Rectangle( 0, 0, area.x, area.y );
     double magnificationX = rectangle2d.getWidth() / rect.getWidth();
     double magnificationY = rectangle2d.getHeight() / rect.getHeight();
-    double magnification = Math.min( magnificationX, magnificationY );
+    float magnification = (float) Math.min( 1, Math.min( magnificationX, magnificationY ) );
 
     SwingGC gc = new SwingGC( g2d, rect, iconsize, 0, 0 );
     gc.setDrawingPixelatedImages( pixelateImages );
     List<AreaOwner> areaOwners = new ArrayList<AreaOwner>();
     JobPainter painter =
-      new JobPainter(
-        gc, jobMeta, area, bar, bar, null, null, null, areaOwners, new ArrayList<JobEntryCopy>(), iconsize, 1,
-        0, 0, true, "FreeSans", 10 );
-    painter.setMagnification( (float) Math.min( magnification, 1 ) );
-    if ( pixelateImages ) {
-      painter.setTranslationX( 100 + min.x );
-      painter.setTranslationY( 100 + min.y );
-    }
+        new JobPainter( gc, jobMeta, area, bar, bar, null, null, null, areaOwners, new ArrayList<JobEntryCopy>(),
+            iconsize, 1, 0, 0, true, "FreeSans", 10 );
+
+    painter.setMagnification( magnification );
+
+    painter.setTranslationX( ( -min.x ) * magnification );
+    painter.setTranslationY( ( -min.y ) * magnification );
+
     painter.drawJob();
   }
 

--- a/engine/src/org/pentaho/di/trans/steps/autodoc/TransformationInformation.java
+++ b/engine/src/org/pentaho/di/trans/steps/autodoc/TransformationInformation.java
@@ -139,7 +139,7 @@ public class TransformationInformation {
         0, 0, true, "FreeSans", 10 );
     painter.setMagnification( 0.5f );
     painter.setTranslationX( min.x );
-    painter.setTranslationX( min.y );
+    painter.setTranslationY( min.y );
     painter.buildTransformationImage();
     BufferedImage bufferedImage = (BufferedImage) gc.getImage();
     int newWidth = bufferedImage.getWidth() - min.x;
@@ -165,6 +165,10 @@ public class TransformationInformation {
 
     Point min = transMeta.getMinimum();
     Point area = transMeta.getMaximum();
+
+    area.x -= min.x;
+    area.y -= min.y;
+
     int iconsize = 32;
 
     ScrollBarInterface bar = new ScrollBarInterface() {
@@ -181,20 +185,20 @@ public class TransformationInformation {
     Rectangle rect = new java.awt.Rectangle( 0, 0, area.x, area.y );
     double magnificationX = rectangle2d.getWidth() / rect.getWidth();
     double magnificationY = rectangle2d.getHeight() / rect.getHeight();
-    double magnification = Math.min( magnificationX, magnificationY );
+    float magnification = (float) Math.min( 1, Math.min( magnificationX, magnificationY ) );
 
     SwingGC gc = new SwingGC( g2d, rect, iconsize, 0, 0 );
     gc.setDrawingPixelatedImages( pixelateImages );
 
     TransPainter painter =
-      new TransPainter(
-        gc, transMeta, area, bar, bar, null, null, null, new ArrayList<AreaOwner>(),
-        new ArrayList<StepMeta>(), iconsize, 1, 0, 0, true, "FreeSans", 10 );
-    painter.setMagnification( (float) Math.min( magnification, 1 ) );
-    if ( pixelateImages ) {
-      painter.setTranslationX( 100 + min.x );
-      painter.setTranslationY( 100 + min.y );
-    }
+        new TransPainter( gc, transMeta, area, bar, bar, null, null, null, new ArrayList<AreaOwner>(),
+            new ArrayList<StepMeta>(), iconsize, 1, 0, 0, true, "FreeSans", 10 );
+
+    painter.setMagnification( magnification );
+
+    painter.setTranslationX( ( -min.x ) * magnification );
+    painter.setTranslationY( ( -min.y ) * magnification );
+
     painter.buildTransformationImage();
   }
 


### PR DESCRIPTION
! NO Unit Tests ! - look and feel issues

the following issues are covered:
[PDI-8554] - Autodoc has bad layout in PDF output (missing parts of the image on the top when detailed information is shown)
[PDI-6752] - Autodoc generates bad icons in PDF output
[PDI-9948] - Automatic Documentation Output step excludes image written to output file when carriage return used in "extended description" of transformation settings
[PDI-6751] - Automatic Documentation Output does not support multi-line text for description

the following issues are not yet covered:
[PDI-6757] - Automated Documentation Step DOC export duplicates newlines in extended description ouput - PRD issue - the duplicate Jira case to be filed.

Cause 1: the main cause of layout issue was improper use of
setTransform() method of PdfGraphics2D instance:
it was not accounted that some coordinates shift
has already been defined by external caller (reporting engine)
Solution 1: apply AffineTransform above an existing one instead of
ovverriding the original.

Cause 2: black PDF images were caused by zero-length lines drawn
on "pixelate" procedure.
Solution 2: draw the lines of 1 pixel length.

Cause 3: broken layout in resulting table for all output formats
was caused by improper setup of report band (single band for entire report)
Solution 3: use separate band with ROW layout for each report's row.
