### PR TITLE
PDI-10828 -  Variables in Commit Size for Update, Insert/Update and Delete Steps are not accepted

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/delete/DeleteMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/delete/DeleteMeta.java
@@ -112,6 +112,8 @@ public class DeleteMeta extends BaseStepMeta implements StepMetaInterface {
    * @return Returns the commitSize.
    */
   public int getCommitSize( VariableSpace vs ) {
+    // this happens when the step is created via API and no setDefaults was called
+    commitSize = ( commitSize == null ) ? "0" : commitSize;
     return Integer.parseInt( vs.environmentSubstitute( commitSize ) );
   }
 
@@ -331,13 +333,13 @@ public class DeleteMeta extends BaseStepMeta implements StepMetaInterface {
 
       commitSize = rep.getStepAttributeString( id_step, "commit" );
       if ( commitSize == null ) {
-        long comSz = 0;
+        long comSz = -1;
         try {
           comSz = rep.getStepAttributeInteger( id_step, "commit" );
         } catch ( Exception ex ) {
           commitSize = "100";
         }
-        if ( comSz > 0 ) {
+        if ( comSz >= 0 ) {
           commitSize = Long.toString( comSz );
         }
       }

--- a/engine/src/org/pentaho/di/trans/steps/insertupdate/InsertUpdateMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/insertupdate/InsertUpdateMeta.java
@@ -123,6 +123,8 @@ public class InsertUpdateMeta extends BaseStepMeta implements StepMetaInterface 
    * @return Returns the commitSize.
    */
   public int getCommitSize( VariableSpace vs ) {
+    //this happens when the step is created via API and no setDefaults was called
+    commitSize = ( commitSize == null ) ? "0" : commitSize;
     return Integer.parseInt( vs.environmentSubstitute( commitSize ) );
   }
 
@@ -435,13 +437,13 @@ public class InsertUpdateMeta extends BaseStepMeta implements StepMetaInterface 
 
       commitSize = rep.getStepAttributeString( id_step, "commit" );
       if ( commitSize == null ) {
-        long comSz = 0;
+        long comSz = -1;
         try {
           comSz = rep.getStepAttributeInteger( id_step, "commit" );
         } catch ( Exception ex ) {
           commitSize = "100";
         }
-        if ( comSz > 0 ) {
+        if ( comSz >= 0 ) {
           commitSize = Long.toString( comSz );
         }
       }

--- a/engine/src/org/pentaho/di/trans/steps/update/UpdateMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/update/UpdateMeta.java
@@ -130,6 +130,8 @@ public class UpdateMeta extends BaseStepMeta implements StepMetaInterface {
    * @return Returns the commitSize.
    */
   public int getCommitSize( VariableSpace vs ) {
+    // this happens when the step is created via API and no setDefaults was called
+    commitSize = ( commitSize == null ) ? "0" : commitSize;
     return Integer.parseInt( vs.environmentSubstitute( commitSize ) );
   }
 
@@ -470,13 +472,13 @@ public class UpdateMeta extends BaseStepMeta implements StepMetaInterface {
       skipLookup = rep.getStepAttributeBoolean( id_step, "skip_lookup" );
       commitSize = rep.getStepAttributeString( id_step, "commit" );
       if ( commitSize == null ) {
-        long comSz = 0;
+        long comSz = -1;
         try {
           comSz = rep.getStepAttributeInteger( id_step, "commit" );
         } catch ( Exception ex ) {
           commitSize = "100";
         }
-        if ( comSz > 0 ) {
+        if ( comSz >= 0 ) {
           commitSize = Long.toString( comSz );
         }
       }


### PR DESCRIPTION
What was done:
1) changed the way we handle non-default 0 value
2) Added handling of special creation in case of using JUnit (setDefaults method is not called in this case which will lead to NPE in unit tests)
