### PR TITLE
PDI-10748 - Select Values ignores time zone for the Timestamp datatype.

### DIFF
--- a/core/src/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
@@ -245,7 +245,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
       return null;
     }
 
-    String dateTime = new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss" ).format( timestamp );
+    String dateTime = getDateFormat().format( timestamp );
     dateTime += "." + new DecimalFormat( "000000000" ).format( timestamp.getNanos() );
     // return timestamp.toString();
 


### PR DESCRIPTION
What was done:
1) changed the way we initialize SimpleDateFormat for Timestamp values.
Now it uses the same format that Date does.
