### PR TITLE
PDI-8904 - String operations "trim" will erase fields with lazy conversion (Binary)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/stringoperations/StringOperations.java
+++ b/engine/src/org/pentaho/di/trans/steps/stringoperations/StringOperations.java
@@ -26,6 +26,7 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
@@ -48,13 +49,13 @@ public class StringOperations extends BaseStep implements StepInterface {
 
   private StringOperationsData data;
 
-  public StringOperations( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr,
-    TransMeta transMeta, Trans trans ) {
+  public StringOperations( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
+      Trans trans ) {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
 
-  private String processString( String string, int trimType, int lowerUpper, int padType, String padChar,
-    int padLen, int iniCap, int maskHTML, int digits, int removeSpecialCharacters ) {
+  private String processString( String string, int trimType, int lowerUpper, int padType, String padChar, int padLen,
+      int iniCap, int maskHTML, int digits, int removeSpecialCharacters ) {
     String rcode = string;
 
     // Trim ?
@@ -195,12 +196,13 @@ public class StringOperations extends BaseStep implements StepInterface {
         String value = getInputRowMeta().getString( row, data.inStreamNrs[i] );
         // Apply String operations and return result value
         value =
-          processString(
-            value, data.trimOperators[i], data.lowerUpperOperators[i], data.padType[i], data.padChar[i],
-            data.padLen[i], data.initCap[i], data.maskHTML[i], data.digits[i], data.removeSpecialCharacters[i] );
+            processString( value, data.trimOperators[i], data.lowerUpperOperators[i], data.padType[i], data.padChar[i],
+                data.padLen[i], data.initCap[i], data.maskHTML[i], data.digits[i], data.removeSpecialCharacters[i] );
         if ( Const.isEmpty( data.outStreamNrs[i] ) ) {
           // Update field
           RowData[data.inStreamNrs[i]] = value;
+          data.outputRowMeta.getValueMeta( data.inStreamNrs[i] )
+              .setStorageType( ValueMetaInterface.STORAGE_TYPE_NORMAL );
         } else {
           // create a new Field
           RowData[data.inputFieldsNr + j] = value;
@@ -235,13 +237,13 @@ public class StringOperations extends BaseStep implements StepInterface {
         data.inStreamNrs[i] = getInputRowMeta().indexOfValue( meta.getFieldInStream()[i] );
         if ( data.inStreamNrs[i] < 0 ) { // couldn't find field!
 
-          throw new KettleStepException( BaseMessages.getString(
-            PKG, "StringOperations.Exception.FieldRequired", meta.getFieldInStream()[i] ) );
+          throw new KettleStepException( BaseMessages.getString( PKG, "StringOperations.Exception.FieldRequired", meta
+              .getFieldInStream()[i] ) );
         }
         // check field type
         if ( !getInputRowMeta().getValueMeta( data.inStreamNrs[i] ).isString() ) {
-          throw new KettleStepException( BaseMessages.getString(
-            PKG, "StringOperations.Exception.FieldTypeNotString", meta.getFieldInStream()[i] ) );
+          throw new KettleStepException( BaseMessages.getString( PKG, "StringOperations.Exception.FieldTypeNotString",
+              meta.getFieldInStream()[i] ) );
         }
       }
 


### PR DESCRIPTION
Trivial fix: processString returns value in normal storage type while meta doesn't reflect this fact.
