### PR TITLE
PDI-5436 - Database lookup: "Load all data from table" does not work with postgresql db and csv file as input (lazy conversion turned on)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/databaselookup/DatabaseLookupMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/databaselookup/DatabaseLookupMeta.java
@@ -477,10 +477,10 @@ public class DatabaseLookupMeta extends BaseStepMeta implements StepMetaInterfac
     VariableSpace space, Repository repository, IMetaStore metaStore ) throws KettleStepException {
     if ( Const.isEmpty( info ) || info[0] == null ) // null or length 0 : no info from database
     {
-      for ( int i = 0; i < returnValueNewName.length; i++ ) {
+      for ( int i = 0; i < getReturnValueNewName().length; i++ ) {
         try {
           ValueMetaInterface v =
-            ValueMetaFactory.createValueMeta( returnValueNewName[i], returnValueDefaultType[i] );
+            ValueMetaFactory.createValueMeta( getReturnValueNewName()[i], getReturnValueDefaultType()[i] );
           v.setOrigin( name );
           row.addValueMeta( v );
         } catch ( Exception e ) {

--- a/engine/test-src/org/pentaho/di/trans/steps/databaselookup/PDI5436Test.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/databaselookup/PDI5436Test.java
@@ -1,0 +1,149 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.databaselookup;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.QueueRowSet;
+import org.pentaho.di.core.RowSet;
+import org.pentaho.di.core.database.Database;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleStepException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+import org.pentaho.metastore.api.IMetaStore;
+
+/**
+ * Tests for DatabaseLookup step
+ *
+ * @author Pavel Sakun
+ * @see DatabaseLookup
+ */
+public class PDI5436Test {
+  private StepMockHelper<DatabaseLookupMeta, DatabaseLookupData> smh;
+
+  @Before
+  public void setUp() {
+    smh =
+        new StepMockHelper<DatabaseLookupMeta, DatabaseLookupData>( "Database Lookup", DatabaseLookupMeta.class,
+            DatabaseLookupData.class );
+    when( smh.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+        smh.logChannelInterface );
+    when( smh.trans.isRunning() ).thenReturn( true );
+  }
+
+  private RowMeta mockInputRowMeta() {
+    RowMeta inputRowMeta = new RowMeta();
+    ValueMetaString nameMeta = new ValueMetaString( "name" );
+    nameMeta.setStorageType( ValueMetaInterface.STORAGE_TYPE_BINARY_STRING );
+    nameMeta.setStorageMetadata( new ValueMetaString( "name" ) );
+    inputRowMeta.addValueMeta( nameMeta );
+    ValueMetaString idMeta = new ValueMetaString( "id" );
+    idMeta.setStorageType( ValueMetaInterface.STORAGE_TYPE_BINARY_STRING );
+    idMeta.setStorageMetadata( new ValueMetaString( "id" ) );
+    inputRowMeta.addValueMeta( idMeta );
+
+    return inputRowMeta;
+  }
+
+  private RowSet mockInputRowSet() {
+    RowSet inputRowSet = smh.getMockInputRowSet( new Object[][] { { "name".getBytes(), "1".getBytes() } } );
+    inputRowSet.setRowMeta( mockInputRowMeta() );
+    return inputRowSet;
+  }
+
+  private DatabaseLookupMeta mockStepMeta() throws KettleStepException {
+    DatabaseLookupMeta stepMeta = smh.initStepMetaInterface;
+    doReturn( mock( DatabaseMeta.class ) ).when( stepMeta ).getDatabaseMeta();
+    doReturn( new String[] { "=" } ).when( stepMeta ).getKeyCondition();
+
+    doCallRealMethod().when( stepMeta ).getFields( any( RowMetaInterface.class ), anyString(),
+        any( RowMetaInterface[].class ), any( StepMeta.class ), any( VariableSpace.class ), any( Repository.class ),
+        any( IMetaStore.class ) );
+    doReturn( new String[] { "value" } ).when( stepMeta ).getReturnValueNewName();
+    doReturn( new int[] { ValueMetaInterface.TYPE_STRING } ).when( stepMeta ).getReturnValueDefaultType();
+    doReturn( true ).when( stepMeta ).isCached();
+    doReturn( true ).when( stepMeta ).isLoadingAllDataInCache();
+    doReturn( new String[] { "id" } ).when( stepMeta ).getStreamKeyField1();
+    doReturn( new String[] { null } ).when( stepMeta ).getStreamKeyField2();
+    doReturn( new String[] { "id" } ).when( stepMeta ).getTableKeyField();
+    doReturn( new String[] { "value" } ).when( stepMeta ).getReturnValueField();
+    doReturn( new String[] { "" } ).when( stepMeta ).getReturnValueDefault();
+    doReturn( new int[] { ValueMetaInterface.TYPE_STRING } ).when( stepMeta ).getReturnValueDefaultType();
+
+    return stepMeta;
+  }
+
+  private Database mockDatabase() throws KettleDatabaseException {
+    Database databaseMock = mock( Database.class );
+
+    RowMeta databaseRowMeta = new RowMeta();
+    databaseRowMeta.addValueMeta( new ValueMetaString( "id" ) );
+    databaseRowMeta.addValueMeta( new ValueMetaString( "value" ) );
+    doReturn( databaseRowMeta ).when( databaseMock ).getTableFields( anyString() );
+    doReturn( Arrays.asList( new Object[][] { { "1", "value" } } ) ).when( databaseMock ).getRows( anyString(),
+        anyInt() );
+    doReturn( databaseRowMeta ).when( databaseMock ).getReturnRowMeta();
+
+    return databaseMock;
+  }
+
+  @Test
+  public void testCacheAllTable() throws KettleException {
+    KettleEnvironment.init();
+    DatabaseLookup stepSpy =
+        spy( new DatabaseLookup( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans ) );
+
+    doReturn( mockDatabase() ).when( stepSpy ).getDatabase( any( DatabaseMeta.class ) );
+
+    stepSpy.getInputRowSets().add( mockInputRowSet() );
+    stepSpy.setInputRowMeta( mockInputRowMeta() );
+    RowSet outputRowSet = new QueueRowSet();
+    stepSpy.getOutputRowSets().add( outputRowSet );
+
+    StepMetaInterface meta = mockStepMeta();
+    StepDataInterface data = smh.initStepDataInterface;
+
+    Assert.assertTrue( "Step init failed", stepSpy.init( meta, data ) );
+    Assert.assertTrue( "Error processing row", stepSpy.processRow( meta, data ) );
+    Assert.assertEquals( "Cache lookup failed", "value", outputRowSet.getRow()[2] );
+  }
+}


### PR DESCRIPTION
Cache contains data stored with normal storage type, convert binary data and reflect it change in lookup meta.
