### PR TITLE
PDI-10749 - Table Output step ignores Time zone for DATE datatype

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -665,6 +665,7 @@ public class Const {
    */
   public static final String KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL";
 
+
   /**
    * System wide flag to allow non-strict string to number conversion for backward compatibility. If this setting is set
    * to "Y", an string starting with digits will be converted successfully into a number. (example: 192.168.1.1 will be
@@ -673,6 +674,11 @@ public class Const {
    */
   public static final String KETTLE_LENIENT_STRING_TO_NUMBER_CONVERSION =
     "KETTLE_LENIENT_STRING_TO_NUMBER_CONVERSION";
+
+  /**
+   * System wide flag to ignore timezone while writing date/timestamp value to the database. See PDI-10749 for details.
+   */
+  public static final String KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE = "KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE";
 
   /**
    * System wide flag to set the maximum number of log lines that are kept internally by Kettle. Set to 0 to keep all

--- a/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseSetPreparedStmntValueTest.java
+++ b/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseSetPreparedStmntValueTest.java
@@ -1,0 +1,123 @@
+/*
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ * **************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.core.row.value;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Date;
+
+public class ValueMetaBaseSetPreparedStmntValueTest {
+
+  private DatabaseMeta dbMeta;
+  private PreparedStatement ps;
+  private Date date;
+  private Timestamp ts;
+
+  @Before
+  public void setUp() {
+    dbMeta = mock( DatabaseMeta.class );
+    when( dbMeta.supportsTimeStampToDateConversion() ).thenReturn( true );
+    ps = mock( PreparedStatement.class );
+    date = new Date( System.currentTimeMillis() );
+    ts = new Timestamp( System.currentTimeMillis() );
+  }
+
+
+  @Test
+  public void testDateRegular() throws Exception {
+
+    System.setProperty( Const.KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE, "N" );
+
+    ValueMetaBase valueMeta = new ValueMetaBase( "", ValueMetaInterface.TYPE_DATE, -1, -1 );
+    valueMeta.setPrecision( 1 );
+    valueMeta.setPreparedStatementValue( dbMeta, ps, 1, date );
+
+    verify( ps ).setDate( eq( 1 ), any( java.sql.Date.class ), any( Calendar.class ) );
+  }
+
+  @Test
+  public void testDateIgnoreTZ() throws Exception {
+
+    System.setProperty( Const.KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE, "Y" );
+
+    ValueMetaBase valueMeta = new ValueMetaBase( "", ValueMetaInterface.TYPE_DATE, -1, -1 );
+    valueMeta.setPrecision( 1 );
+    valueMeta.setPreparedStatementValue( dbMeta, ps, 1, date );
+
+    verify( ps ).setDate( eq( 1 ), any( java.sql.Date.class ) );
+  }
+
+  @Test
+  public void testTimestampRegular() throws Exception {
+
+    System.setProperty( Const.KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE, "N" );
+
+    ValueMetaBase valueMeta = new ValueMetaBase( "", ValueMetaInterface.TYPE_DATE, -1, -1 );
+    valueMeta.setPreparedStatementValue( dbMeta, ps, 1, ts );
+
+    verify( ps ).setTimestamp( eq( 1 ), any( Timestamp.class ), any( Calendar.class ) );
+  }
+
+  @Test
+  public void testTimestampIgnoreTZ() throws Exception {
+
+    System.setProperty( Const.KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE, "Y" );
+
+    ValueMetaBase valueMeta = new ValueMetaBase( "", ValueMetaInterface.TYPE_DATE, -1, -1 );
+    valueMeta.setPreparedStatementValue( dbMeta, ps, 1, ts );
+
+    verify( ps ).setTimestamp( eq( 1 ), any( Timestamp.class ) );
+  }
+
+  @Test
+  public void testConvertedTimestampRegular() throws Exception {
+
+    System.setProperty( Const.KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE, "N" );
+
+    ValueMetaBase valueMeta = new ValueMetaBase( "", ValueMetaInterface.TYPE_DATE, -1, -1 );
+    valueMeta.setPreparedStatementValue( dbMeta, ps, 1, date );
+    valueMeta.setStorageType( ValueMetaInterface.STORAGE_TYPE_NORMAL );
+
+    verify( ps ).setTimestamp( eq( 1 ), any( Timestamp.class ), any( Calendar.class ) );
+  }
+
+  @Test
+  public void testConvertedTimestampIgnoreTZ() throws Exception {
+
+    System.setProperty( Const.KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE, "Y" );
+
+    ValueMetaBase valueMeta = new ValueMetaBase( "", ValueMetaInterface.TYPE_DATE, -1, -1 );
+    valueMeta.setPreparedStatementValue( dbMeta, ps, 1, date );
+    valueMeta.setStorageType( ValueMetaInterface.STORAGE_TYPE_NORMAL );
+
+    verify( ps ).setTimestamp( eq( 1 ), any( Timestamp.class ) );
+  }
+
+}

--- a/engine/src/kettle-variables.xml
+++ b/engine/src/kettle-variables.xml
@@ -12,6 +12,12 @@
 		<default-value>N</default-value>
 	</kettle-variable>
 
+  <kettle-variable>
+    <description>System wide flag to ignore timezone while writing date/timestamp value to the database.</description>
+    <variable>KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE</variable>
+    <default-value>N</default-value>
+  </kettle-variable>
+
     <kettle-variable>
     	<description>The log size limit for all transformations and jobs that don't have the "log size limit" property set in their respective properties.</description>
 		<variable>KETTLE_LOG_SIZE_LIMIT</variable>


### PR DESCRIPTION
New system variable KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE has been added
for backward compatibility.
