### PR TITLE
PDI-10657: Revert upgrade to Drools 5.5.0 due to downstream dependencies breaking build

### DIFF
--- a/engine/ivy.xml
+++ b/engine/ivy.xml
@@ -38,12 +38,11 @@
     <dependency org="com.enterprisedt"                 name="edtftpj"              rev="2.1.0"           transitive="false"/>
     <dependency org="com.googlecode.jsendnsca"         name="jsendnsca"            rev="2.0.1"           transitive="false"/>
     <dependency org="com.healthmarketscience.jackcess" name="jackcess"             rev="1.2.6"           transitive="false"/>
-    <dependency org="org.drools"                       name="drools-core"          rev="5.5.0.Final"     transitive="false"/>
-    <dependency org="org.drools"                       name="drools-compiler"      rev="5.5.0.Final"     transitive="false"/>
-    <dependency org="org.drools"                       name="knowledge-api"        rev="5.5.0.Final"     transitive="false"/>
-    <dependency org="org.drools"                       name="knowledge-internal-api" rev="5.5.0.Final"     transitive="false"/>
-    <dependency org="org.mvel"                         name="mvel2"                rev="2.1.3.Final"     transitive="false"/>
-    <dependency org="org.eclipse.jdt.core.compiler"    name="ecj"                  rev="3.5.1"           transitive="false"/>    
+    <dependency org="org.drools"                       name="drools-api"           rev="5.0.1"           transitive="false"/>
+    <dependency org="org.drools"                       name="drools-core"          rev="5.0.1"           transitive="false"/>
+    <dependency org="org.drools"                       name="drools-compiler"      rev="5.0.1"           transitive="false"/>
+    <dependency org="org.mvel"                         name="mvel2"                rev="2.0.10"          transitive="false"/>
+    <dependency org="org.eclipse.jdt"                  name="core"                 rev="3.4.2.v_883_R34x" transitive="false"/>
     <dependency org="elasticsearch"                    name="elasticsearch"        rev="0.16.3"          transitive="false"/>
     <dependency org="feed4j"                           name="feed4j"               rev="1.0"             transitive="false"/>
     <dependency org="ftp4che"                          name="ftp4che"              rev="0.7.1"           transitive="false"/>
@@ -107,8 +106,6 @@
     <dependency org="rhino"                            name="js"                   rev="1.7R3"           transitive="false"/>
     <dependency org="javax.mail"                       name="mail"                 rev="1.4.7"           transitive="false" />
     <dependency org="org.mnode.mstor"                  name="mstor"                rev="0.9.13"          transitive="false"/>
-    <dependency org="javassist"                        name="javassist"            rev="3.12.1.GA"       transitive="false"/>
-    <dependency org="org.slf4j"                        name="slf4j-api"            rev="1.7.3"           transitive="false"/>
 
     
     <!-- OLAP4J is bringing in an older version of beanutils-core than is needed -->

--- a/engine/src/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderMeta.java
@@ -24,7 +24,7 @@ package org.pentaho.di.trans.steps.orabulkloader;
 
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.drools.util.StringUtils;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;

--- a/engine/src/org/pentaho/di/trans/steps/rules/Rules.java
+++ b/engine/src/org/pentaho/di/trans/steps/rules/Rules.java
@@ -85,20 +85,6 @@ public class Rules {
       this.external = external;
     }
 
-    public Column( String name, String type, Object payload  ) {
-      this();
-      this.name=name;
-      this.type=type;
-      this.payload=payload;
-    }
-
-    public Column( Boolean external, String name, String type, Object payload  ) {
-      this(external);
-      this.name=name;
-      this.type=type;
-      this.payload=payload;
-    }
-
     public String getName() {
       return name;
     }


### PR DESCRIPTION
There was downstream issues w/ extensions and a modeler project.
