### PR TITLE
[PDI-7955] - Changing the feedback row number in transformation settings (misc tab) does not mark the transformation as changed

### DIFF
--- a/ui/src/org/pentaho/di/ui/trans/dialog/TransDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/dialog/TransDialog.java
@@ -513,6 +513,7 @@ public class TransDialog extends Dialog {
     wTransstatus.add( BaseMessages.getString( PKG, "TransDialog.Production_Transstatus.Label" ) );
     wTransstatus.add( "" );
     wTransstatus.select( -1 ); // +1: starts at -1
+    wTransstatus.addSelectionListener( lsModSel );
 
     props.setLook( wTransstatus );
     fdTransstatus = new FormData();


### PR DESCRIPTION
Straightforward

Pure UI changes - no Unit tests provided.
Originally reported issue with Feedback row number is not reproducible.
A check has been performed for the rest of control for transformation properties dialog.
Similar issue has been discovered with Transformation status drop-down.
The corresponding selection listener has been added to 'wTransstatus' combo-box.
