### PR TITLE
PDI-10716 - Mail job doesn't work with encrypted passwords passed as variables (kettle.properties)

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/mail/JobEntryMail.java
+++ b/engine/src/org/pentaho/di/job/entries/mail/JobEntryMail.java
@@ -1148,9 +1148,9 @@ public class JobEntryMail extends JobEntryBase implements Cloneable, JobEntryInt
 
       Transport transport = null;
       try {
-        String authPass = Encr.decryptPasswordOptionallyEncrypted(
-            environmentSubstitute( Const.NVL( authenticationPassword, "" ) ) );
         transport = session.getTransport( protocol );
+        String authPass = getPassword( authenticationPassword );
+
         if ( usingAuthentication ) {
           if ( !Const.isEmpty( port ) ) {
             transport.connect(
@@ -1339,6 +1339,11 @@ public class JobEntryMail extends JobEntryBase implements Cloneable, JobEntryInt
 
     andValidator().validate( this, "port", remarks, putValidators( integerValidator() ) );
 
+  }
+
+  public String getPassword( String authPassword ) {
+    return Encr.decryptPasswordOptionallyEncrypted(
+        environmentSubstitute( Const.NVL( authPassword, "" ) ) );
   }
 
 }

--- a/engine/test-src/org/pentaho/di/job/entries/mail/JobEntryTest.java
+++ b/engine/test-src/org/pentaho/di/job/entries/mail/JobEntryTest.java
@@ -1,0 +1,37 @@
+package org.pentaho.di.job.entries.mail;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+public class JobEntryTest {
+
+  @Test
+  public void testJobEntrymailPasswordFixed() {
+    JobEntryMail jem = new JobEntryMail();
+    Assert.assertEquals( jem.getPassword( "asdf" ), "asdf" );
+  }
+
+  @Test
+  public void testJobEntrymailPasswordEcr() {
+    JobEntryMail jem = new JobEntryMail();
+    Assert.assertEquals( jem.getPassword( "Encrypted 2be98afc86aa7f2e4cb79ce10df81abdc" ), "asdf" );
+  }
+
+  @Test
+  public void testJobEntrymailPasswordVar() {
+    JobEntryMail jem = new JobEntryMail();
+    jem.setVariable( "my_pass", "asdf" );
+    Assert.assertEquals( jem.getPassword( "${my_pass}" ), "asdf" );
+  }
+
+  @Test
+  public void testJobEntrymailPasswordEncrVar() {
+    JobEntryMail jem = new JobEntryMail();
+    jem.setVariable( "my_pass", "Encrypted 2be98afc86aa7f2e4cb79ce10df81abdc" );
+    Assert.assertEquals( jem.getPassword( "${my_pass}" ), "asdf" );
+  }
+}


### PR DESCRIPTION
What was done:
1) Added a call to decrypt method at runtime
