### PR TITLE
fix to PDI-9790 improper merge/rebase

### DIFF
--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -1453,12 +1453,6 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
         //FIFO
         throw new KettleException( badGuys.get( 0 ) );
       }
-      // Signal for the the waitUntilFinished blocker...
-      transFinishedBlockingQueue.add( new Object() );
-      if ( !badGuys.isEmpty() ) {
-        //FIFO
-        throw new KettleException( badGuys.get( 0 ) );
-      }
     }
   }
 


### PR DESCRIPTION
Remove duplicated code first introduced in PDI-5229, then - duplicated merge with PDI-9790.
Also this code will cause 
org.pentaho.di.trans.TransTest.testTransFinishListenersConcurrentModification
junit test failure
