### PR TITLE
DIRECT-MASTER: PDI-6976 - The Load Content into Memory Step reports an error on check, even though it is setup correctly

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/loadfileinput/LoadFileInputMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/loadfileinput/LoadFileInputMeta.java
@@ -935,20 +935,20 @@ public class LoadFileInputMeta extends BaseStepMeta implements StepMetaInterface
       IMetaStore metaStore ) {
     CheckResult cr;
 
-    // See if we get input...
-    if ( input.length <= 0 ) {
-      cr =
-          new CheckResult( CheckResult.TYPE_RESULT_ERROR, BaseMessages.getString( PKG,
-              "LoadFileInputMeta.CheckResult.NoInputExpected" ), stepMeta );
-      remarks.add( cr );
-    } else {
-      cr =
-          new CheckResult( CheckResult.TYPE_RESULT_OK, BaseMessages.getString( PKG,
-              "LoadFileInputMeta.CheckResult.NoInput" ), stepMeta );
-      remarks.add( cr );
-    }
-
     if ( getIsInFields() ) {
+      // See if we get input...
+      if ( input.length == 0 ) {
+        cr =
+          new CheckResult( CheckResult.TYPE_RESULT_ERROR, BaseMessages.getString(
+            PKG, "LoadFileInputMeta.CheckResult.NoInputExpected" ), stepMeta );
+        remarks.add( cr );
+      } else {
+        cr =
+          new CheckResult( CheckResult.TYPE_RESULT_OK, BaseMessages.getString(
+            PKG, "LoadFileInputMeta.CheckResult.NoInput" ), stepMeta );
+        remarks.add( cr );
+      }
+
       if ( Const.isEmpty( getDynamicFilenameField() ) ) {
         cr =
             new CheckResult( CheckResult.TYPE_RESULT_ERROR, BaseMessages.getString( PKG,
@@ -975,7 +975,6 @@ public class LoadFileInputMeta extends BaseStepMeta implements StepMetaInterface
         remarks.add( cr );
       }
     }
-
   }
 
   /**
@@ -987,7 +986,7 @@ public class LoadFileInputMeta extends BaseStepMeta implements StepMetaInterface
    *          The repository to optionally load other resources from (to be converted to XML)
    * @param metaStore
    *          the metaStore in which non-kettle metadata could reside.
-   * 
+   *
    * @return the filename of the exported resource
    */
   public String exportResources( VariableSpace space, Map<String, ResourceDefinition> definitions,

--- a/engine/test-src/org/pentaho/di/trans/steps/loadfileinput/PDI_6976_Test.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/loadfileinput/PDI_6976_Test.java
@@ -1,0 +1,80 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.loadfileinput;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import javax.tools.FileObject;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.pentaho.di.core.CheckResultInterface;
+import org.pentaho.di.core.fileinput.FileInputList;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.metastore.api.IMetaStore;
+
+/**
+ * Tests for LoadFileInputMeta class
+ *
+ * @author Pavel Sakun
+ * @see LoadFileInputMeta
+ */
+public class PDI_6976_Test {
+  @Test
+  public void testVerifyNoPreviousStep() {
+    LoadFileInputMeta spy = spy( new LoadFileInputMeta() );
+
+    FileInputList fileInputList = mock( FileInputList.class );
+    List<FileObject> files = when( mock( List.class ).size() ).thenReturn( 1 ).getMock();
+    doReturn( files ).when( fileInputList ).getFiles();
+    doReturn( fileInputList ).when( spy ).getFiles( any( VariableSpace.class ) );
+
+    @SuppressWarnings( "unchecked" )
+    List<CheckResultInterface> validationResults = mock( List.class );
+
+    // Check we do not get validation errors
+    doAnswer( new Answer() {
+      @Override
+      public Object answer( InvocationOnMock invocation ) throws Throwable {
+        if ( ( (CheckResultInterface) invocation.getArguments()[0] ).getType() != CheckResultInterface.TYPE_RESULT_OK ) {
+          TestCase.fail( "We've got validation error" );
+        }
+
+        return null;
+      }
+    } ).when( validationResults ).add( any( CheckResultInterface.class ) );
+
+    spy.check( validationResults, mock( TransMeta.class ), mock( StepMeta.class ), mock( RowMetaInterface.class ),
+        new String[] {}, new String[] { "File content", "File size" }, mock( RowMetaInterface.class ),
+        mock( VariableSpace.class ), mock( Repository.class ), mock( IMetaStore.class ) );
+  }
+}


### PR DESCRIPTION
Changed validation logic to report error:
- either when fields are used as input and no input fields
- or when files are used as input and no input files specified
