### PR TITLE
Added Preload-Cache option to combination lookup step

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/combinationlookup/CombinationLookup.java
+++ b/engine/src/org/pentaho/di/trans/steps/combinationlookup/CombinationLookup.java
@@ -35,6 +35,7 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.Database;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleConfigException;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -379,6 +380,7 @@ public class CombinationLookup extends BaseStep implements StepInterface {
       }
 
       setCombiLookup( getInputRowMeta() );
+      preloadCache( data.hashRowMeta );
     }
 
     try {
@@ -724,5 +726,75 @@ public class CombinationLookup extends BaseStep implements StepInterface {
 
     super.dispose( smi, sdi );
   }
+  
+  /** Preload the cache
+   * 
+   * @param hashRowMeta The RowMeta of the hashRow
+   * @author nwyrwa
+   * @throws KettleDatabaseException If something went wrong while selecting the values from the db
+   * @throws KettleValueException If something went wrong while adding the data to the cache
+   * @throws KettleConfigException If the step configuration is incomplete
+   */
+	private void preloadCache( RowMetaInterface hashRowMeta ) throws KettleDatabaseException, KettleValueException, KettleConfigException {
+		// fast exit if no preload cache or no cache
+		if ( meta.getPreloadCache() && meta.getCacheSize() >= 0 )
+		{
+			if ( hashRowMeta == null ) throw new KettleConfigException( BaseMessages.getString( PKG, "CombinationLookup.Log.UnexpectedError" ) );
+			DatabaseMeta databaseMeta = meta.getDatabaseMeta();
+			if ( databaseMeta == null ) throw new KettleConfigException( BaseMessages.getString( PKG, "CombinationLookup.Log.UnexpectedError" ) );
+			String lookupKeys = "";
+			String sql = "";
+			List<Object[]> cacheValues;
+			
+			/* build SQl Statement to preload cache
+			 * 
+	         * SELECT 
+	         * min(<retval>) as <retval>, 
+	         * key1, 
+	         * key2, 
+	         * key3  
+	         * FROM   <table> 
+	         * 
+	         * GROUP BY key1,
+	         * key2,
+	         * key3;
+	         * 
+	         */
+			
+			
+			// Build a string representation of the lookupKeys 
+			for ( int i = 0; i < meta.getKeyLookup().length; i++ )
+	        {
+				lookupKeys += databaseMeta.quoteField( meta.getKeyLookup()[i] );
+				
+				// No comma after last field
+				if ( i < meta.getKeyLookup().length - 1 ) lookupKeys += "," + Const.CR;
+	        }
+			
+			// Use min in case of disambiguation
+			sql += "SELECT " + Const.CR;
+			sql += "MIN(" + databaseMeta.quoteField( meta.getTechnicalKeyField() ) + ") as " + databaseMeta.quoteField( meta.getTechnicalKeyField() ) + "," + Const.CR;			
+			sql += lookupKeys + Const.CR;
+			sql += "FROM "+ data.schemaTable + Const.CR;
+			sql += "GROUP BY" + Const.CR;
+			sql += lookupKeys + Const.CR;
+			
+			
+			
+			if ( log.isDebug() ) logDebug( "Using preload cache statement:" + Const.CR + sql );
+			cacheValues = data.db.getRows( databaseMeta.stripCR(sql), meta.getCacheSize() );
+			for ( Object[] cacheRow: cacheValues ) {
+				// Create a correctly structured array for the cache
+				Object[] hashRow = new Object[data.hashRowMeta.size()];
+				// Assumes the technical key is at position 0 !!
+				System.arraycopy( cacheRow, 1, hashRow, 0, hashRow.length );
+				// Potential Cache Overflow is ahndled inside 
+				addToCache( hashRowMeta, hashRow, (Long) cacheRow[0] );
+				incrementLinesInput();
+			}
+			
+		}
+		
+	}
 
 }

--- a/engine/src/org/pentaho/di/trans/steps/combinationlookup/CombinationLookupMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/combinationlookup/CombinationLookupMeta.java
@@ -98,6 +98,11 @@ public class CombinationLookupMeta extends BaseStepMeta implements StepMetaInter
 
   /** Commit size for insert / update */
   private int commitSize;
+  
+  /** Preload the cache, defaults to false 
+	 * @author nicow2
+	 * */
+  private boolean preloadCache = false;
 
   /** Limit the cache size to this! */
   private int cacheSize;
@@ -241,6 +246,21 @@ public class CombinationLookupMeta extends BaseStepMeta implements StepMetaInter
   public void setReplaceFields( boolean replaceFields ) {
     this.replaceFields = replaceFields;
   }
+  
+  /**
+   * @param preloadCache 
+   * 		  true to preload the cache
+   */
+  public void setPreloadCache(boolean preloadCache) {
+	this.preloadCache = preloadCache;
+  }
+  
+  /**
+   * @return Returns true if preload the cache.
+   */
+  public boolean getPreloadCache() {
+	return preloadCache;
+  }
 
   /**
    * @return Returns the sequenceFrom.
@@ -358,6 +378,7 @@ public class CombinationLookupMeta extends BaseStepMeta implements StepMetaInter
       cacheSize = Const.toInt( csize, 0 );
 
       replaceFields = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, "replace" ) );
+      preloadCache ="Y".equalsIgnoreCase( XMLHandler.getTagValue(stepnode, "preloadCache" ));
       useHash = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, "crc" ) );
 
       hashField = XMLHandler.getTagValue( stepnode, "crcfield" );
@@ -397,6 +418,7 @@ public class CombinationLookupMeta extends BaseStepMeta implements StepMetaInter
     commitSize = 100;
     cacheSize = DEFAULT_CACHE_SIZE;
     replaceFields = false;
+    preloadCache = false;
     useHash = false;
     hashField = "hashcode";
     int nrkeys = 0;
@@ -441,6 +463,7 @@ public class CombinationLookupMeta extends BaseStepMeta implements StepMetaInter
     retval.append( "      " ).append( XMLHandler.addTagValue( "commit", commitSize ) );
     retval.append( "      " ).append( XMLHandler.addTagValue( "cache_size", cacheSize ) );
     retval.append( "      " ).append( XMLHandler.addTagValue( "replace", replaceFields ) );
+    retval.append( "      " ).append( XMLHandler.addTagValue( "preloadCache", preloadCache));
     retval.append( "      " ).append( XMLHandler.addTagValue( "crc", useHash ) );
     retval.append( "      " ).append( XMLHandler.addTagValue( "crcfield", hashField ) );
 
@@ -477,6 +500,7 @@ public class CombinationLookupMeta extends BaseStepMeta implements StepMetaInter
       commitSize = (int) rep.getStepAttributeInteger( id_step, "commit" );
       cacheSize = (int) rep.getStepAttributeInteger( id_step, "cache_size" );
       replaceFields = rep.getStepAttributeBoolean( id_step, "replace" );
+      preloadCache = rep.getStepAttributeBoolean( id_step, "preloadCache" );
       useHash = rep.getStepAttributeBoolean( id_step, "crc" );
       hashField = rep.getStepAttributeString( id_step, "crcfield" );
 
@@ -509,6 +533,7 @@ public class CombinationLookupMeta extends BaseStepMeta implements StepMetaInter
       rep.saveStepAttribute( id_transformation, id_step, "commit", commitSize );
       rep.saveStepAttribute( id_transformation, id_step, "cache_size", cacheSize );
       rep.saveStepAttribute( id_transformation, id_step, "replace", replaceFields );
+      rep.saveStepAttribute( id_transformation, id_step, "preloadCache", preloadCache);
 
       rep.saveStepAttribute( id_transformation, id_step, "crc", useHash );
       rep.saveStepAttribute( id_transformation, id_step, "crcfield", hashField );
@@ -994,8 +1019,8 @@ public class CombinationLookupMeta extends BaseStepMeta implements StepMetaInter
     if ( useHash() != o.useHash() ) {
       return false;
     }
-    if ( replaceFields() != o.replaceFields() ) {
-      return false;
+    if ( getPreloadCache() != o.getPreloadCache() ) {
+    	return false;
     }
     if ( ( getSequenceFrom() == null && o.getSequenceFrom() != null )
       || ( getSequenceFrom() != null && o.getSequenceFrom() == null )

--- a/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_en_US.properties
@@ -84,4 +84,5 @@ CombinationLookupMeta.CheckResult.NoInputReceived=No input received from other s
 CombinationLookupMeta.ReturnValue.ErrorOccurred=An error occurred\: 
 CombinationLookupDialog.GetSchemas.Error=ERROR
 CombinationLookupDialog.TableMaximum.Tooltip=New technical key will be calculated as the maximum from the table + 1
-CombinationLookupMeta.ReturnValue.NameCollision=Duplicate use of field ''{0}''. 
+CombinationLookupMeta.ReturnValue.NameCollision=Duplicate use of field ''{0}''.
+CombinationLookupDialog.PreloadCache.Label=Pre-load the cache? 

--- a/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_es_AR.properties
+++ b/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_es_AR.properties
@@ -84,3 +84,4 @@ CombinationLookupMeta.ReturnValue.ErrorOccurred=Se ha producido un error\:
 CombinationLookupDialog.GetSchemas.Error=ERROR
 CombinationLookupDialog.TableMaximum.Tooltip=La nueva clave t\u00E9cnica se calcular\u00E1 como el valor m\u00E1ximo de la tabla + 1
 CombinationLookupMeta.ReturnValue.NameCollision=Uso duplicado del campo ''{0}''. 
+CombinationLookupDialog.PreloadCache.Label=\u00BFPrecargar la cache?

--- a/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_fr_FR.properties
+++ b/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_fr_FR.properties
@@ -84,4 +84,5 @@ CombinationLookupMeta.CheckResult.NoInputReceived=Aucune information n''est re\u
 CombinationLookupMeta.ReturnValue.ErrorOccurred=PDI a rencontr\u00E9 une erreur\: 
 CombinationLookupDialog.GetSchemas.Error=ERREUR
 CombinationLookupDialog.TableMaximum.Tooltip=La nouvelle cl\u00E9 technique sera obtenue en incr\u00E9mentant d''une unit\u00E9 la valeur maximale
-CombinationLookupMeta.ReturnValue.NameCollision=Utilisation en double du champ ''{0}''. 
+CombinationLookupMeta.ReturnValue.NameCollision=Utilisation en double du champ ''{0}''.
+CombinationLookupDialog.PreloadCache.Label=Pr\u00E9charger cache

--- a/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_it_IT.properties
+++ b/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_it_IT.properties
@@ -85,3 +85,4 @@ CombinationLookupMeta.ReturnValue.ErrorOccurred=Errore\:
 CombinationLookupDialog.GetSchemas.Error=ERRORE
 CombinationLookupDialog.TableMaximum.Tooltip=La nuova chiave tecnica verr\u00E0 calcolata come il massimo dalla tabella + 1
 CombinationLookupMeta.ReturnValue.NameCollision=Duplica uso del campo ''{0}''. 
+CombinationLookupDialog.PreloadCache.Label=Pre-caricare la cache?

--- a/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_ja_JP.properties
+++ b/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_ja_JP.properties
@@ -84,3 +84,4 @@ CombinationLookupMeta.ReturnValue.ErrorOccurred=An error occurred\:
 CombinationLookupDialog.GetSchemas.Error=\u30a8\u30e9\u30fc
 CombinationLookupDialog.TableMaximum.Tooltip=\u6700\u5927\u5024\u304b\u3089+1\u3057\u305f\u3044\u5834\u5408\u306f\u3059\u308b\u5834\u5408\u306f\u30c1\u30a7\u30c3\u30af\u30dc\u30c3\u30af\u30b9\u3092\u6709\u52b9\u306b\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 CombinationLookupMeta.ReturnValue.NameCollision=Duplicate use of field ''{0}''. 
+CombinationLookupDialog.PreloadCache.Label=\u30ad\u30e3\u30c3\u30b7\u30e5\u3092\u30d7\u30ea\u30ed\u30fc\u30c9\u3059\u308b

--- a/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_ko_KR.properties
+++ b/engine/src/org/pentaho/di/trans/steps/combinationlookup/messages/messages_ko_KR.properties
@@ -78,3 +78,4 @@ CombinationLookupMeta.ReturnValue.ErrorOccurred=\uC624\uB958 \uBC1C\uC0DD\:
 CombinationLookupDialog.GetSchemas.Error=\uC624\uB958
 CombinationLookupDialog.TableMaximum.Tooltip=\uC0C8 technical key\uB294 \uD14C\uC774\uBE14\uC758 \uCD5C\uB300\uAC12 + 1\uB85C \uACC4\uC0B0\uD569\uB2C8\uB2E4.
 CombinationLookupMeta.ReturnValue.NameCollision=\uD544\uB4DC \uC911\uBCF5 \uC0AC\uC6A9 ''{0}''
+CombinationLookupDialog.PreloadCache.Label=\uCE90\uC2DC \uD504\uB9AC\uB85C\uB4DC?

--- a/ui/src/org/pentaho/di/ui/trans/steps/combinationlookup/CombinationLookupDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/combinationlookup/CombinationLookupDialog.java
@@ -96,6 +96,9 @@ public class CombinationLookupDialog extends BaseStepDialog implements StepDialo
 
   private Label wlCachesize;
   private Text wCachesize;
+  
+  private Label wlPreloadCache;
+  private Button wPreloadCache;
 
   private Label wlTk;
   private Text wTk;
@@ -315,6 +318,23 @@ public class CombinationLookupDialog extends BaseStepDialog implements StepDialo
     fdCachesize.right = new FormAttachment( 100, 0 );
     wCachesize.setLayoutData( fdCachesize );
     wCachesize.setToolTipText( BaseMessages.getString( PKG, "CombinationLookupDialog.Cachesize.ToolTip" ) );
+    
+ // Preload Cache
+	wlPreloadCache=new Label( shell, SWT.RIGHT );
+	wlPreloadCache.setText( BaseMessages.getString( PKG, "CombinationLookupDialog.PreloadCache.Label") );
+	props.setLook( wlPreloadCache );
+	FormData fdlPreloadCache = new FormData();
+	fdlPreloadCache.top  = new FormAttachment( wCachesize, margin );
+	fdlPreloadCache.left  = new FormAttachment( wCommit, margin );
+	fdlPreloadCache.right = new FormAttachment( middle+2*(100-middle)/3, -margin );
+	wlPreloadCache.setLayoutData( fdlPreloadCache );
+	wPreloadCache=new Button( shell, SWT.CHECK );
+	props.setLook( wPreloadCache );
+	FormData fdPreloadCache = new FormData();
+	fdPreloadCache.top  = new FormAttachment( wCachesize, margin );
+	fdPreloadCache.left  = new FormAttachment( wlPreloadCache, margin );
+	fdPreloadCache.right = new FormAttachment( 100, 0 );
+	wPreloadCache.setLayoutData( fdPreloadCache );
 
     //
     // The Lookup fields: usually the (business) key
@@ -324,7 +344,7 @@ public class CombinationLookupDialog extends BaseStepDialog implements StepDialo
     props.setLook( wlKey );
     FormData fdlKey = new FormData();
     fdlKey.left = new FormAttachment( 0, 0 );
-    fdlKey.top = new FormAttachment( wCommit, margin );
+    fdlKey.top = new FormAttachment( wlPreloadCache, margin );
     fdlKey.right = new FormAttachment( 100, 0 );
     wlKey.setLayoutData( fdlKey );
 
@@ -753,7 +773,8 @@ public class CombinationLookupDialog extends BaseStepDialog implements StepDialo
         }
       }
     }
-
+    
+    wPreloadCache.setSelection( input.getPreloadCache() );
     wReplace.setSelection( input.replaceFields() );
     wHashcode.setSelection( input.useHash() );
     wHashfield.setEnabled( input.useHash() );
@@ -872,6 +893,7 @@ public class CombinationLookupDialog extends BaseStepDialog implements StepDialo
       in.getKeyField()[i] = item.getText( 2 );
     }
 
+    in.setPreloadCache( wPreloadCache.getSelection() );
     in.setUseAutoinc( wAutoinc.getSelection() && wAutoinc.isEnabled() );
     in.setReplaceFields( wReplace.getSelection() );
     in.setUseHash( wHashcode.getSelection() );


### PR DESCRIPTION
Hi all,

I'm using the combinationlookup step quite often and have always wondered why the preload cache option is missing here, although it is present in the database- and dimension-lookup. So I decided to add it.

Regards
nicow2
