### PR TITLE
PDI-9555 - Webservice via /kettle/executeTrans - Pass output to servlet option: getServletPrintWriter does not respect UTF-8 encoding

### DIFF
--- a/engine/src/kettle-variables.xml
+++ b/engine/src/kettle-variables.xml
@@ -283,6 +283,12 @@
 		<variable>KETTLE_DEFAULT_DATE_FORMAT</variable>
 		<default-value></default-value>
 	</kettle-variable>
+
+	<kettle-variable>
+		<description>Defines the default encoding for servlets, leave it empty to use Java default encoding</description>
+		<variable>KETTLE_DEFAULT_SERVLET_ENCODING</variable>
+		<default-value></default-value>
+	</kettle-variable>
 	
 	<kettle-variable>
 		<description>Set this variable to Y when you want the job/transformation fail with an error when the related logging process (e.g. to a database) fails.</description>

--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -25,6 +25,7 @@ package org.pentaho.di.trans;
 
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -670,7 +671,18 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     // folks want to test it locally...
     //
     if ( servletPrintWriter == null ) {
-      servletPrintWriter = new PrintWriter( new OutputStreamWriter( System.out ) );
+      String encoding = System.getProperty( "KETTLE_DEFAULT_SERVLET_ENCODING", null );
+      if ( encoding == null ){
+        servletPrintWriter = new PrintWriter( new OutputStreamWriter( System.out ) );
+      }
+      else{
+        try{
+          servletPrintWriter = new PrintWriter( new OutputStreamWriter( System.out, encoding ) );
+        }
+        catch( UnsupportedEncodingException ex ){
+          servletPrintWriter = new PrintWriter( new OutputStreamWriter( System.out ) );
+        }
+      }
     }
 
     // Keep track of all the row sets and allocated steps
@@ -5321,6 +5333,14 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
   }
 
   public void setServletReponse( HttpServletResponse response ) {
+    try{
+      String encoding = System.getProperty( "KETTLE_DEFAULT_SERVLET_ENCODING", null );
+      if( encoding != null  && !Const.isEmpty( encoding.trim() ) ){
+        response.setCharacterEncoding( encoding );
+        response.setContentType( "text/html; charset=" + encoding );
+      }
+    } catch( Exception ex ){      
+    }
     this.servletresponse = response;
   }
 

--- a/engine/src/org/pentaho/di/www/ExecuteTransServlet.java
+++ b/engine/src/org/pentaho/di/www/ExecuteTransServlet.java
@@ -90,6 +90,12 @@ public class ExecuteTransServlet extends BaseHttpServlet implements CartePluginI
 
     response.setStatus( HttpServletResponse.SC_OK );
 
+    String encoding = System.getProperty( "KETTLE_DEFAULT_SERVLET_ENCODING", null );
+    if ( encoding != null && ! Const.isEmpty( encoding.trim() )) {
+      response.setCharacterEncoding( encoding );
+      response.setContentType( "text/html; charset=" + encoding );
+    }
+
     PrintWriter out = response.getWriter();
 
     try {

--- a/engine/src/org/pentaho/di/www/RunTransServlet.java
+++ b/engine/src/org/pentaho/di/www/RunTransServlet.java
@@ -81,6 +81,11 @@ public class RunTransServlet extends BaseHttpServlet implements CartePluginInter
 
     response.setStatus( HttpServletResponse.SC_OK );
 
+    String encoding = System.getProperty( "KETTLE_DEFAULT_SERVLET_ENCODING", null );
+    if ( encoding != null && !Const.isEmpty( encoding.trim() )) {
+      response.setCharacterEncoding( encoding );
+      response.setContentType( "text/html; charset=" + encoding );
+    }
     PrintWriter out = response.getWriter();
 
     try {


### PR DESCRIPTION
What was done:
1) added new variable KETTLE_DEFAULT_SERVLET_ENCODING
2) changed the way PrintWriter for servlet output is instantionated.
3) changed the way Trans creates servletPrintWriter
