### PR TITLE
[PDI-11048] PDI - EE: Connection names displayed incorrectly in the repository view

### DIFF
--- a/core/src/org/pentaho/di/core/database/BaseDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/BaseDatabaseMeta.java
@@ -268,6 +268,7 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
   private static final String FIELDNAME_PROTECTOR = "_";
 
   private String name;
+  private String displayName;
   private int accessType; // Database.TYPE_ODBC / NATIVE / OCI
   private String hostname;
   private String databaseName;
@@ -385,6 +386,26 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
   @Override
   public void setName( String name ) {
     this.name = name;
+
+    // Default display name to be the same as connection name if it has not
+    // been initialized before
+    if ( ( getDisplayName() == null ) || ( getDisplayName().length() == 0 ) ) {
+      setDisplayName( name );
+    }
+  }
+
+  /**
+   * @return Returns the un-escaped connection Name.
+   */
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  /**
+   * @param displayName The un-escaped connection Name to set.
+   */
+  public void setDisplayName( String displayName ) {
+    this.displayName = displayName;
   }
 
   /**
@@ -1297,7 +1318,7 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
   }
 
   /**
-   * @param usePool
+   * @param clustered
    *          true if we want to use a database connection pool
    */
   @Override
@@ -1435,7 +1456,7 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
   }
 
   /**
-   * @param useStreaming
+   * @param quoteAllFields
    *          true if we want the database to stream results (normally this is an option just for MySQL).
    */
   @Override
@@ -1471,7 +1492,7 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
   }
 
   /**
-   * @param forceLowerCase
+   * @param forceUpperCase
    *          true if all identifiers should be forced to upper case
    */
   @Override
@@ -1540,7 +1561,7 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
    *          a connected database
    * @param schemaName
    * @param tableName
-   * @param idxFields
+   * @param idx_fields
    * @return true if the index exists, false if it doesn't.
    * @throws KettleDatabaseException
    */
@@ -2000,9 +2021,9 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
    * Returns the tablespace DDL fragment for a "Data" tablespace. In most databases that use tablespaces this is where
    * the tables are to be created.
    *
-   * @param VariableSpace
+   * @param variables
    *          variables used for possible substitution
-   * @param DatabaseMeta
+   * @param databaseMeta
    *          databaseMeta the database meta used for possible string enclosure of the tablespace. This method needs
    *          this as this is done after environmental substitution.
    *
@@ -2017,9 +2038,9 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
   /**
    * Returns the tablespace DDL fragment for a "Index" tablespace.
    *
-   * @param VariableSpace
+   * @param variables
    *          variables used for possible substitution
-   * @param DatabaseMeta
+   * @param databaseMeta
    *          databaseMeta the database meta used for possible string enclosure of the tablespace. This method needs
    *          this as this is done after environmental substitution.
    *
@@ -2035,13 +2056,13 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
    * Returns an empty string as most databases do not support tablespaces. Subclasses can override this method to
    * generate the DDL.
    *
-   * @param VariableSpace
+   * @param variables
    *          variables needed for variable substitution.
-   * @param DatabaseMeta
+   * @param databaseMeta
    *          databaseMeta needed for it's quoteField method. Since we are doing variable substitution we need to meta
    *          so that we can act on the variable substitution first and then the creation of the entire string that will
    *          be retuned.
-   * @param String
+   * @param tablespaceName
    *          tablespaceName name of the tablespace.
    *
    * @return String an empty String as most databases do not use tablespaces.
@@ -2053,11 +2074,11 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
   /**
    * This method allows a database dialect to convert database specific data types to Kettle data types.
    *
-   * @param resultSet
+   * @param rs
    *          The result set to use
-   * @param valueMeta
+   * @param val
    *          The description of the value to retrieve
-   * @param index
+   * @param i
    *          the index on which we need to retrieve the value, 0-based.
    * @return The correctly converted Kettle data type corresponding to the valueMeta description.
    * @throws KettleDatabaseException

--- a/core/src/org/pentaho/di/core/database/DatabaseInterface.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseInterface.java
@@ -97,6 +97,17 @@ public interface DatabaseInterface extends Cloneable {
   public void setName( String name );
 
   /**
+   * @return Returns the un-escaped connection Name.
+   */
+  public String getDisplayName();
+
+  /**
+   * @param displayName
+   *          The un-escaped connection Name to set.
+   */
+  public void setDisplayName( String displayName );
+
+  /**
    * @return Returns the databaseName.
    */
   public String getDatabaseName();
@@ -762,7 +773,7 @@ public interface DatabaseInterface extends Cloneable {
   public String getSQLTableExists( String tablename );
 
   /**
-   * @param columnname
+   * @param column
    *          The column to verify the existance for
    * @param tablename
    *          The table to verify the existance for
@@ -815,7 +826,7 @@ public interface DatabaseInterface extends Cloneable {
   public boolean isForcingIdentifiersToUpperCase();
 
   /**
-   * @param forceLowerCase
+   * @param forceUpperCase
    *          true if all identifiers should be forced to upper case
    */
   public void setForcingIdentifiersToUpperCase( boolean forceUpperCase );
@@ -1035,9 +1046,9 @@ public interface DatabaseInterface extends Cloneable {
    * Returns the tablespace DDL fragment for a "Data" tablespace. In most databases that use tablespaces this is where
    * the tables are to be created.
    *
-   * @param VariableSpace
+   * @param variables
    *          variables used for possible substitution
-   * @param DatabaseMeta
+   * @param databaseMeta
    *          databaseMeta the database meta used for possible string enclosure of the tablespace. This method needs
    *          this as this is done after environmental substitution.
    *
@@ -1049,9 +1060,9 @@ public interface DatabaseInterface extends Cloneable {
   /**
    * Returns the tablespace DDL fragment for a "Index" tablespace.
    *
-   * @param VariableSpace
+   * @param variables
    *          variables used for possible substitution
-   * @param DatabaseMeta
+   * @param databaseMeta
    *          databaseMeta the database meta used for possible string enclosure of the tablespace. This method needs
    *          this as this is done after environmental substitution.
    *

--- a/core/src/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseMeta.java
@@ -560,7 +560,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   /**
    * Search for the right type of DatabaseInterface object and return it.
    *
-   * @param databaseType
+   * @param databaseTypeDesc
    *          the type of DatabaseInterface to look for (id or description)
    * @return The requested DatabaseInterface
    *
@@ -650,6 +650,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     }
 
     setName( oldInterface.getName() );
+    setDisplayName( oldInterface.getDisplayName() );
     setAccessType( oldInterface.getAccessType() );
     setHostname( oldInterface.getHostname() );
     setDBName( oldInterface.getDatabaseName() );
@@ -686,6 +687,20 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   @Override
   public String getName() {
     return databaseInterface.getName();
+  }
+
+
+  public void setDisplayName( String displayName ) {
+    databaseInterface.setDisplayName( displayName );
+  }
+
+  /**
+   * Returns the name of the database connection
+   *
+   * @return The name of the database connection
+   */
+  public String getDisplayName() {
+    return databaseInterface.getDisplayName();
   }
 
   /**
@@ -959,6 +974,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
       }
 
       setName( XMLHandler.getTagValue( con, "name" ) );
+      setDisplayName( getName() );
       setHostname( XMLHandler.getTagValue( con, "server" ) );
       String acc = XMLHandler.getTagValue( con, "access" );
       setAccessType( getAccessType( acc ) );
@@ -2489,7 +2505,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   }
 
   /**
-   * @param forceLowerCase
+   * @param forceUpperCase
    *          true if all identifiers should be forced to upper case
    */
   public void setForcingIdentifiersToUpperCase( boolean forceUpperCase ) {
@@ -2647,7 +2663,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   }
 
   /**
-   * @param useStreaming
+   * @param useDoubleDecimalSeparator
    *          true if we want the database to stream results (normally this is an option just for MySQL).
    */
   public void setUsingDoubleDecimalAsSchemaTableSeparator( boolean useDoubleDecimalSeparator ) {

--- a/ui/src/org/pentaho/di/ui/core/database/dialog/XulDatabaseDialog.java
+++ b/ui/src/org/pentaho/di/ui/core/database/dialog/XulDatabaseDialog.java
@@ -225,9 +225,9 @@ public class XulDatabaseDialog {
 
   public void setDatabaseMeta( DatabaseMeta dbMeta ) {
     databaseMeta = dbMeta;
-    databaseMetaObjectId = dbMeta.getObjectId();
     if ( dbMeta != null ) {
-      databaseName = databaseMeta.getName();
+      databaseMetaObjectId = databaseMeta.getObjectId();
+      databaseName = databaseMeta.getDisplayName();
     }
   }
 

--- a/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/model/UIDatabaseConnection.java
+++ b/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/model/UIDatabaseConnection.java
@@ -49,6 +49,13 @@ public class UIDatabaseConnection extends XulEventSourceAdapter {
     return null;
   }
 
+  public String getDisplayName() {
+    if ( dbMeta != null ) {
+      return dbMeta.getDisplayName();
+    }
+    return null;
+  }
+
   public String getType() {
     if ( dbMeta != null ) {
       return dbMeta.getPluginId();

--- a/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/xul/explorer-layout.xul
+++ b/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/xul/explorer-layout.xul
@@ -149,7 +149,7 @@
 									<!-- Connection list -->
 									<tree id="connections-table" flex="1" hidecolumnpicker="true" treeLines="false" sortable="true">
 										<treecols>
-											<treecol id="name-col" flex="1" label="${RepositoryExplorerDialog.Tab.TableColumn.Name}" pen:binding="name" pen:childrenbinding="children" sortActive="true" sortDirection="ASCENDING"/>
+											<treecol id="name-col" flex="1" label="${RepositoryExplorerDialog.Tab.TableColumn.Name}" pen:binding="displayName" pen:childrenbinding="children" sortActive="true" sortDirection="ASCENDING"/>
 											<treecol id="type-col" flex="1" label="${RepositoryExplorerDialog.Tab.TableColumn.Type}" pen:binding="type"/>
 											<treecol id="date-mod-col" flex="1" label="${RepositoryExplorerDialog.Tab.TableColumn.DateModified}" pen:binding="dateModified"/>
 										</treecols>
@@ -161,7 +161,7 @@
 						</vbox>
 					</hbox>
 				</tabpanel>
-				
+				                                                                                                                                                                        n
 				
 				<!--
 					###############################################################################


### PR DESCRIPTION
DatabaseMeta getName() was used to display the connection names when creating a connection in the repo.  We were encoding this name (removing JCR reserved characters and replacing with an underscore).  The encoded connection name was displayed in the UI.  Now we display the un-encoded connection name in the UI.

Note: There is a corresponding fix in the pdi-ee-plugin git repo.  Will issue a pull request after this one.  No build dependency.
