### PR TITLE
[SP-998]: Backport of PDI-9848 - Mappings destroy metadata (when the Mapping input specification does not include all fields) (5.0)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/mappinginput/MappingInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/mappinginput/MappingInput.java
@@ -109,16 +109,6 @@ public class MappingInput extends BaseStep implements StepInterface {
       //
       data.outputRowMeta = getInputRowMeta().clone();
 
-      if (meta.isSelectingAndSortingUnspecifiedFields()) {
-        //
-        // Create a list of the indexes to select to get the right order or fields on the output.
-        //
-        data.fieldNrs = new int[data.outputRowMeta.size()];
-        for (int i = 0; i < data.outputRowMeta.size(); i++) {
-          data.fieldNrs[i] = getInputRowMeta().indexOfValue(data.outputRowMeta.getValueMeta(i).getName());
-        }
-      }
-
       // Now change the field names according to the mapping specification...
       // That means that all fields go through unchanged, unless specified.
       // 
@@ -148,6 +138,16 @@ public class MappingInput extends BaseStep implements StepInterface {
 
       // Fill the output row meta with the processed fields
       meta.getFields(data.outputRowMeta, getStepname(), null, null, this, repository, metaStore);
+      
+      if (meta.isSelectingAndSortingUnspecifiedFields()) {
+          //
+          // Create a list of the indexes to select to get the right order or fields on the output.
+          //
+          data.fieldNrs = new int[data.outputRowMeta.size()];
+          for (int i = 0; i < data.outputRowMeta.size(); i++) {
+            data.fieldNrs[i] = getInputRowMeta().indexOfValue(data.outputRowMeta.getValueMeta(i).getName());
+          }
+        }
     }
 
     // Fill and send the output row

--- a/engine/test-src/org/pentaho/di/trans/steps/mappinginput/MappingInputFieldsTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/mappinginput/MappingInputFieldsTest.java
@@ -1,0 +1,347 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.mappinginput;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.BlockingRowSet;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.logging.LoggingObjectType;
+import org.pentaho.di.core.logging.SimpleLoggingObject;
+import org.pentaho.di.core.plugins.Plugin;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaPluginType;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.mapping.MappingValueRename;
+
+public class MappingInputFieldsTest {
+
+  MappingInput step;
+  MappingInputMeta meta;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    // PluginRegistry.addPluginType(ValueMetaPluginType.getInstance());
+    PluginRegistry.getInstance().registerPluginType( ValueMetaPluginType.class );
+
+    Map<Class<?>, String> classes = new HashMap<Class<?>, String>();
+    classes.put( ValueMetaInterface.class, "org.pentaho.di.core.row.value.ValueMetaString" );
+    Plugin p1 =
+        new Plugin( new String[] { "2" }, ValueMetaPluginType.class, ValueMetaInterface.class, "", "", "", "", false,
+            true, classes, null, null, null );
+
+    classes = new HashMap<Class<?>, String>();
+    classes.put( ValueMetaInterface.class, "org.pentaho.di.core.row.value.ValueMetaInteger" );
+    Plugin p2 =
+        new Plugin( new String[] { "5" }, ValueMetaPluginType.class, ValueMetaInterface.class, "", "", "", "", false,
+            true, classes, null, null, null );
+
+    PluginRegistry.getInstance().registerPlugin( ValueMetaPluginType.class, p1 );
+    PluginRegistry.getInstance().registerPlugin( ValueMetaPluginType.class, p2 );
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    meta = new MappingInputMeta();
+    meta.setFieldName( new String[] { "n2", "n4" } );
+    meta.setFieldType( new int[] { ValueMetaInterface.TYPE_INTEGER, ValueMetaInterface.TYPE_INTEGER } );
+    meta.setFieldLength( new int[] { 0, 0 } );
+    meta.setFieldPrecision( new int[] { 0, 0 } );
+
+    StepMeta sm = new StepMeta( "MappingInput", "SubTrans", meta );
+    TransMeta tm = new TransMeta();
+    tm.addStep( sm );
+    LoggingObjectInterface loi = new SimpleLoggingObject( "lo", LoggingObjectType.STEP, null );
+    Trans tr = new Trans( tm, loi );
+
+    step = new MappingInput( sm, null, 0, tm, tr );
+    step.getTrans().setRunning( true );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  /*
+   * verifies: If SelectingAndSortingUnspecifiedFields checkbox is checked, then 1)all fields throw to the next step;
+   * 2)fields are resorted: mapped fields, then alphabetical sorted not mapped fields.
+   */
+  @Test
+  public void testSelectingAndSortingUnspecifiedFields() throws Exception {
+    meta.setSelectingAndSortingUnspecifiedFields( true );
+
+    MappingInputData sdi = new MappingInputData();
+
+    sdi.linked = true;
+    sdi.valueRenames = new ArrayList<MappingValueRename>();
+    sdi.valueRenames.add( new MappingValueRename( "number2", "n2" ) );
+    sdi.valueRenames.add( new MappingValueRename( "number4", "n4" ) );
+
+    BlockingRowSet in = new BlockingRowSet( 10 );
+    BlockingRowSet out = new BlockingRowSet( 10 );
+
+    RowMeta rm = new RowMeta();
+
+    rm.addValueMeta( new ValueMeta( "string", ValueMetaInterface.TYPE_STRING ) );
+    rm.addValueMeta( new ValueMeta( "number1", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number2", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number3", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number4", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number5", ValueMetaInterface.TYPE_INTEGER ) );
+
+    in.putRow( rm, new Object[] { "str", new Integer( 100501 ), new Integer( 100502 ), new Integer( 100503 ),
+      new Integer( 100500 ), new Integer( 100504 ), new Integer( 100505 ) } );
+    in.putRow( rm, new Object[] { "str_1", new Integer( 200501 ), new Integer( 200502 ), new Integer( 200503 ),
+      new Integer( 200500 ), new Integer( 200504 ), new Integer( 200505 ) } );
+
+    step.getInputRowSets().add( in );
+    step.getOutputRowSets().add( out );
+
+    assertTrue( step.init( meta, sdi ) );
+
+    assertTrue( step.processRow( meta, sdi ) );
+
+    Object[] outRowData = out.getRow();
+
+    RowMetaInterface outMeta = out.getRowMeta();
+
+    assertEquals( "All fields are expected.", 7, outMeta.size() );
+
+    int i = 0;
+
+    // Check if row-meta is formed according to the step specification
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "n2", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "n4", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number1", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number3", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number5", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_STRING, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "string", outMeta.getValueMeta( i++ ).getName() );
+
+    // Check if row-data corresponds to the row-meta
+    assertEquals( "the field value mismatch.", new Integer( 100502 ), outRowData[0] );
+    assertEquals( "the field value mismatch.", new Integer( 100504 ), outRowData[1] );
+    assertEquals( "the field value mismatch.", new Integer( 100500 ), outRowData[2] );
+    assertEquals( "the field value mismatch.", new Integer( 100501 ), outRowData[3] );
+    assertEquals( "the field value mismatch.", new Integer( 100503 ), outRowData[4] );
+    assertEquals( "the field value mismatch.", new Integer( 100505 ), outRowData[5] );
+    assertEquals( "the field value mismatch.", "str", outRowData[6] );
+
+    assertTrue( step.processRow( meta, sdi ) );
+
+    outRowData = out.getRow();
+
+    outMeta = out.getRowMeta();
+
+    assertEquals( "All fields are expected.", 7, outMeta.size() );
+
+    i = 0;
+
+    // Check if row-meta is formed according to the step specification
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "n2", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "n4", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number1", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number3", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number5", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_STRING, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "string", outMeta.getValueMeta( i++ ).getName() );
+
+    // Check if row-data corresponds to the row-meta
+    assertEquals( "the field value mismatch.", new Integer( 200502 ), outRowData[0] );
+    assertEquals( "the field value mismatch.", new Integer( 200504 ), outRowData[1] );
+    assertEquals( "the field value mismatch.", new Integer( 200500 ), outRowData[2] );
+    assertEquals( "the field value mismatch.", new Integer( 200501 ), outRowData[3] );
+    assertEquals( "the field value mismatch.", new Integer( 200503 ), outRowData[4] );
+    assertEquals( "the field value mismatch.", new Integer( 200505 ), outRowData[5] );
+    assertEquals( "the field value mismatch.", "str_1", outRowData[6] );
+
+  }
+
+  /*
+   * verifies: If SelectingAndSortingUnspecifiedFields checkbox is not checked, then 1)all fields throw to the next step;
+   * 2)fields are not resorted;
+   */
+  @Test
+  public void testOnlySpecifiedFields() throws Exception {
+    meta.setSelectingAndSortingUnspecifiedFields( false );
+
+    MappingInputData sdi = new MappingInputData();
+
+    sdi.linked = true;
+    sdi.valueRenames = new ArrayList<MappingValueRename>();
+    sdi.valueRenames.add( new MappingValueRename( "number2", "n2" ) );
+    sdi.valueRenames.add( new MappingValueRename( "number4", "n4" ) );
+
+    BlockingRowSet in = new BlockingRowSet( 10 );
+    BlockingRowSet out = new BlockingRowSet( 10 );
+
+    RowMeta rm = new RowMeta();
+
+    rm.addValueMeta( new ValueMeta( "string", ValueMetaInterface.TYPE_STRING ) );
+    rm.addValueMeta( new ValueMeta( "number1", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number2", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number3", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number4", ValueMetaInterface.TYPE_INTEGER ) );
+    rm.addValueMeta( new ValueMeta( "number5", ValueMetaInterface.TYPE_INTEGER ) );
+
+    in.putRow( rm, new Object[] { "str", new Integer( 100501 ), new Integer( 100502 ), new Integer( 100503 ),
+      new Integer( 100500 ), new Integer( 100504 ), new Integer( 100505 ) } );
+    in.putRow( rm, new Object[] { "str_1", new Integer( 200501 ), new Integer( 200502 ), new Integer( 200503 ),
+      new Integer( 200500 ), new Integer( 200504 ), new Integer( 200505 ) } );
+
+    step.getInputRowSets().add( in );
+    step.getOutputRowSets().add( out );
+
+    assertTrue( step.init( meta, sdi ) );
+
+    assertTrue( step.processRow( meta, sdi ) );
+
+    Object[] outRowData = out.getRow();
+
+    RowMetaInterface outMeta = out.getRowMeta();
+
+    assertEquals( "All fields are expected.", 7, outMeta.size() );
+
+    int i = 0;
+
+    // Check if row-meta is formed according to the step specification
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_STRING, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "string", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number1", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "n2", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number3", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "n4", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number5", outMeta.getValueMeta( i++ ).getName() );
+
+    // Check if row-data corresponds to the row-meta
+    assertEquals( "the field value mismatch.", "str", outRowData[0] );
+    assertEquals( "the field value mismatch.", new Integer( 100501 ), outRowData[1] );
+    assertEquals( "the field value mismatch.", new Integer( 100502 ), outRowData[2] );
+    assertEquals( "the field value mismatch.", new Integer( 100503 ), outRowData[3] );
+    assertEquals( "the field value mismatch.", new Integer( 100500 ), outRowData[4] );
+    assertEquals( "the field value mismatch.", new Integer( 100504 ), outRowData[5] );
+    assertEquals( "the field value mismatch.", new Integer( 100505 ), outRowData[6] );
+
+    assertTrue( step.processRow( meta, sdi ) );
+
+    outRowData = out.getRow();
+
+    outMeta = out.getRowMeta();
+
+    assertEquals( "All fields are expected.", 7, outMeta.size() );
+
+    i = 0;
+
+    // Check if row-meta is formed according to the step specification
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_STRING, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "string", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number1", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "n2", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number3", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "n4", outMeta.getValueMeta( i++ ).getName() );
+
+    assertEquals( "the field type-meta mismatch.", ValueMetaInterface.TYPE_INTEGER, outMeta.getValueMeta( i ).getType() );
+    assertEquals( "the field name-meta mismatch.", "number5", outMeta.getValueMeta( i++ ).getName() );
+
+    // Check if row-data corresponds to the row-meta
+    assertEquals( "the field value mismatch.", "str_1", outRowData[0] );
+    assertEquals( "the field value mismatch.", new Integer( 200501 ), outRowData[1] );
+    assertEquals( "the field value mismatch.", new Integer( 200502 ), outRowData[2] );
+    assertEquals( "the field value mismatch.", new Integer( 200503 ), outRowData[3] );
+    assertEquals( "the field value mismatch.", new Integer( 200500 ), outRowData[4] );
+    assertEquals( "the field value mismatch.", new Integer( 200504 ), outRowData[5] );
+    assertEquals( "the field value mismatch.", new Integer( 200505 ), outRowData[6] );
+
+  }
+}


### PR DESCRIPTION
There are fix and unit tests.
