### PR TITLE
PDI-11592 PaloJLib v1.0.73 need to be added to distribution

### DIFF
--- a/plugins/kettle-palo-plugin/ivy.xml
+++ b/plugins/kettle-palo-plugin/ivy.xml
@@ -27,7 +27,9 @@
     <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="3.7" transitive="false"/>
     <dependency org="org.eclipse" name="jface" rev="3.3.0-I20070606-0010" transitive="false"/> 
     
+    <dependency org="palo" name="palojlib" rev="1.0.73" transitive="false" conf="default->default"/> 
+
     <dependency org="junit" name="junit" rev="4.7" conf="test->default"/> 
-    
+
   </dependencies>
 </ivy-module>

--- a/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_en_US.properties
+++ b/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_en_US.properties
@@ -5,21 +5,17 @@ PaloCellInput.TransDescription=Reads data from a defined Palo Cube
 
 #Sat Apr 24 22:06:45 CEST 2010
 PaloCellInputDialog.MeasureName=Measure Name
-PaloCellInputDialog.PaloLibWarningDialog.Option2=Don''t show this warning anymore\!
 PaloCellInputDialog.PaloCellInput=Palo Cell Input
-PaloCellInputDialog.PaloLibWarningDialog.Option1=I understand\!
 PaloCellInputDialog.FailedToSaveDataError=Getting data to save step changes failed
 PaloCellInputDialog.MeasureType=Measure Type
 PaloCellInputDialog.FailedToSaveDataErrorTitle=Getting data to save step changes failed
 PaloCellInputDialog.SelectCubeFirstError=Please select a cube first
 RowGeneratorDialog.Illegal.Dialog.Settings.Title=Settings
-PaloCellInputDialog.PaloLibWarningDialog.DialogTitle=Warning\!
 PaloCellInputDialog.ColumnField=Field
 PaloCellInputDialog.SelectCube=Cube
 RowGeneratorDialog.Illegal.Dialog.Settings.Message=Settings
 PaloCellInputDialog.RetreiveCubesError=Failed to retreive Cubes
 PaloCellInputDialog.ColumnDimension=Dimension
-PaloCellInputDialog.PaloLibWarningDialog.DialogMessage=The license of the palojlib.jar library (GPL) is not compatible with the LGPL license of Pentaho Data Integration.  Because of this you need to place this library into the lib/ folder yourself before any PALO step can work properly.
 PaloCellInputDialog.ColumnType=Type
 PaloCellInputDialog.ClearDimensions=Clear Dimensions
 PaloCellInputDialog.GetDimensions=Get Dimensions

--- a/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_es_AR.properties
+++ b/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_es_AR.properties
@@ -3,21 +3,17 @@
 #
 #Tue Jul 13 14:23:17 ART 2010
 PaloCellInputDialog.MeasureName=Nombre de la medida
-PaloCellInputDialog.PaloLibWarningDialog.Option2=No mostrar esta advertencia en el futuro
 PaloCellInputDialog.PaloCellInput=Palo - Entrada de celdas
-PaloCellInputDialog.PaloLibWarningDialog.Option1=OK
 PaloCellInputDialog.FailedToSaveDataError=Error al obtener de datos para guardar los cambios del paso
 PaloCellInputDialog.MeasureType=Tipo de medida
 PaloCellInputDialog.FailedToSaveDataErrorTitle=Error al guardar cambios
 PaloCellInputDialog.SelectCubeFirstError=Por favor seleccione un cubo primero
 RowGeneratorDialog.Illegal.Dialog.Settings.Title=Ajustes
-PaloCellInputDialog.PaloLibWarningDialog.DialogTitle=Advertencia
 PaloCellInputDialog.ColumnField=Campo
 PaloCellInputDialog.SelectCube=Cubo
 RowGeneratorDialog.Illegal.Dialog.Settings.Message=Ajustes
 PaloCellInputDialog.RetreiveCubesError=Error al obtener cubos
 PaloCellInputDialog.ColumnDimension=Dimensi\u00F3n
-PaloCellInputDialog.PaloLibWarningDialog.DialogMessage=La licencia de la librer\u00EDa palojlib.jar (GPL) no es compatible con la licencia de Pentaho Data Integration (LGPL). Debido a esto usted deber\u00E1 copiar la librer\u00EDa al directorio "lib" de PDI antes de poder utilizar este paso.
 PaloCellInputDialog.ColumnType=Tipo
 PaloCellInputDialog.ClearDimensions=Limpiar dimensiones
 PaloCellInputDialog.GetDimensions=Obtener dimensiones

--- a/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_fr_FR.properties
+++ b/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_fr_FR.properties
@@ -3,22 +3,18 @@
 
 #Sat Apr 24 22:06:45 CEST 2010
 PaloCellInputDialog.MeasureName=Nom mesure
-PaloCellInputDialog.PaloLibWarningDialog.Option2=Ne plus afficher ce message
 PaloCellInputDialog.PaloCellInput=Extraction depuis cube Palo 
-PaloCellInputDialog.PaloLibWarningDialog.Option1=J''ai compris
 PaloCellInputDialog.FailedToSaveDataError=Echec lors de la sauvegarde des informations de l''étape
 PaloCellInputDialog.MeasureType=Type mesure
 PaloCellInputDialog.FailedToSaveDataErrorTitle=Echec
 PaloCellInputDialog.SelectCubeFirstError=Veuillez svp sélectionner un cube
 RowGeneratorDialog.Illegal.Dialog.Settings.Title=Paramètres
-PaloCellInputDialog.PaloLibWarningDialog.DialogTitle=Attention
 PaloCellInputDialog.ColumnField=Champ
 PaloCellInput.TransDescription=Extraction de données depuis un cube Palo 
 PaloCellInputDialog.SelectCube=Cube
 RowGeneratorDialog.Illegal.Dialog.Settings.Message=Paramètres
 PaloCellInputDialog.RetreiveCubesError=Echec
 PaloCellInputDialog.ColumnDimension=Dimension
-PaloCellInputDialog.PaloLibWarningDialog.DialogMessage=La license de la librairie palojlib.jar library (GPL) n''est pas compatible avec celle de Pentaho Data Integration (LGPL).  De ce fait, cette librairie doit être installée par vos soins dans le répertoire lib/ avant de commencer à utiliser les étapes Palo.
 PaloCellInputDialog.ColumnType=Type
 PaloCellInputDialog.ClearDimensions=Vider Dimensions
 PaloCellInputDialog.GetDimensions=Récupérer Dimensions

--- a/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_it_IT.properties
+++ b/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_it_IT.properties
@@ -3,21 +3,17 @@
 #
 #Mon Apr 26 09:03:36 CEST 2010
 PaloCellInputDialog.MeasureName=Nome misura
-PaloCellInputDialog.PaloLibWarningDialog.Option2=Non mostrare pi\u00F9 quest''avviso\!
 PaloCellInputDialog.PaloCellInput=Input celle Palo
-PaloCellInputDialog.PaloLibWarningDialog.Option1=Ho capito\!
 PaloCellInputDialog.FailedToSaveDataError=Fallito il prelievo dei dati per il salvataggio delle modifiche del passo
 PaloCellInputDialog.MeasureType=Tipo misura
 PaloCellInputDialog.FailedToSaveDataErrorTitle=Fallito il prelievo dei dati per il salvataggio delle modifiche del passo
 PaloCellInputDialog.SelectCubeFirstError=Prego selezionare prima un cubo
 RowGeneratorDialog.Illegal.Dialog.Settings.Title=Impostazioni
-PaloCellInputDialog.PaloLibWarningDialog.DialogTitle=Attenzione\!
 PaloCellInputDialog.ColumnField=Campo
 PaloCellInputDialog.SelectCube=Cubo
 RowGeneratorDialog.Illegal.Dialog.Settings.Message=Impostazioni
 PaloCellInputDialog.RetreiveCubesError=Fallito il recupero del cubo
 PaloCellInputDialog.ColumnDimension=Dimensione
-PaloCellInputDialog.PaloLibWarningDialog.DialogMessage=La licenza della libreria palojlib.jar (GPL) non \u00E8 compatibile con la licenza LGPL di Pentaho Data Integration.  Di conseguenza occorre posizionare da soli questa libreria nella cartella lib/ prima di usare il passo PALO.
 PaloCellInputDialog.ColumnType=Tipo
 PaloCellInputDialog.ClearDimensions=Pulisci dimensioni
 PaloCellInputDialog.GetDimensions=Preleva dimensioni

--- a/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_ko_KR.properties
+++ b/plugins/kettle-palo-plugin/src/org/pentaho/di/trans/steps/palo/cellinput/messages/messages_ko_KR.properties
@@ -3,7 +3,6 @@
 #
 #Thu May 06 13:17:29 KST 2010
 PaloCellInputDialog.PaloCellInput=Palo Cells Input
-PaloCellInputDialog.PaloLibWarningDialog.DialogTitle=\uACBD\uACE0\!
 PaloCellInputDialog.ColumnType=\uB370\uC774\uD130\uD615
 PaloCellInputDialog.ColumnDimension=\uB514\uBA58\uC804
 PaloCellInputDialog.ColumnField=\uD544\uB4DC

--- a/plugins/kettle-palo-plugin/src/org/pentaho/di/ui/trans/steps/palo/cellinput/PaloCellInputDialog.java
+++ b/plugins/kettle-palo-plugin/src/org/pentaho/di/ui/trans/steps/palo/cellinput/PaloCellInputDialog.java
@@ -70,8 +70,6 @@ import org.pentaho.di.ui.trans.dialog.TransPreviewProgressDialog;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 
 public class PaloCellInputDialog extends BaseStepDialog implements StepDialogInterface {
-  public static final String      STRING_PALO_LIB_WARNING_PARAMETER = "PaloLibWarning";
-
   private static Class<?>         PKG                               = PaloCellInputMeta.class; // for
                                                                                                // i18n
                                                                                                // purposes,
@@ -290,8 +288,6 @@ public class PaloCellInputDialog extends BaseStepDialog implements StepDialogInt
 
     shell.open();
 
-    showPaloLibWarningDialog(shell);
-
     while (!shell.isDisposed()) {
       if (!display.readAndDispatch())
         display.sleep();
@@ -436,28 +432,6 @@ public class PaloCellInputDialog extends BaseStepDialog implements StepDialogInt
       dispose();
     } catch (KettleException e) {
       new ErrorDialog(shell, BaseMessages.getString(PKG, "PaloCellInputDialog.FailedToSaveDataErrorTitle"), BaseMessages.getString(PKG, "PaloCellInputDialog.FailedToSaveDataError"), e);
-    }
-  }
-
-  public static void showPaloLibWarningDialog(Shell shell) {
-    PropsUI props = PropsUI.getInstance();
-
-    if ("Y".equalsIgnoreCase(props.getCustomParameter(STRING_PALO_LIB_WARNING_PARAMETER, "Y")))
-    {
-      MessageDialogWithToggle md = new MessageDialogWithToggle(shell,
-          BaseMessages.getString(PKG, "PaloCellInputDialog.PaloLibWarningDialog.DialogTitle"),
-          null,
-          BaseMessages.getString(PKG, "PaloCellInputDialog.PaloLibWarningDialog.DialogMessage", Const.CR) + Const.CR,
-          MessageDialog.WARNING, new String[] {
-            BaseMessages.getString(PKG, "PaloCellInputDialog.PaloLibWarningDialog.Option1") },
-            0,
-            BaseMessages.getString(PKG, "PaloCellInputDialog.PaloLibWarningDialog.Option2"),
-          "N".equalsIgnoreCase(props.getCustomParameter(STRING_PALO_LIB_WARNING_PARAMETER, "Y"))
-      );
-      MessageDialogWithToggle.setDefaultImage(GUIResource.getInstance().getImageSpoon());
-      md.open();
-      props.setCustomParameter(STRING_PALO_LIB_WARNING_PARAMETER, md.getToggleState() ? "N" : "Y");
-      props.saveProps();
     }
   }
 

--- a/plugins/kettle-palo-plugin/src/org/pentaho/di/ui/trans/steps/palo/celloutput/PaloCellOutputDialog.java
+++ b/plugins/kettle-palo-plugin/src/org/pentaho/di/ui/trans/steps/palo/celloutput/PaloCellOutputDialog.java
@@ -377,8 +377,6 @@ public class PaloCellOutputDialog extends BaseStepDialog implements StepDialogIn
     setSize();
     shell.open();
 
-    PaloCellInputDialog.showPaloLibWarningDialog(shell);
-
     while (!shell.isDisposed()) {
       if (!display.readAndDispatch())
         display.sleep();

--- a/plugins/kettle-palo-plugin/src/org/pentaho/di/ui/trans/steps/palo/diminput/PaloDimInputDialog.java
+++ b/plugins/kettle-palo-plugin/src/org/pentaho/di/ui/trans/steps/palo/diminput/PaloDimInputDialog.java
@@ -259,8 +259,6 @@ public class PaloDimInputDialog extends BaseStepDialog implements StepDialogInte
     setSize();
     shell.open();
 
-    PaloCellInputDialog.showPaloLibWarningDialog(shell);
-
     while (!shell.isDisposed()) {
       if (!display.readAndDispatch())
         display.sleep();

--- a/plugins/kettle-palo-plugin/src/org/pentaho/di/ui/trans/steps/palo/dimoutput/PaloDimOutputDialog.java
+++ b/plugins/kettle-palo-plugin/src/org/pentaho/di/ui/trans/steps/palo/dimoutput/PaloDimOutputDialog.java
@@ -396,8 +396,6 @@ public class PaloDimOutputDialog extends BaseStepDialog implements StepDialogInt
     setSize();
     shell.open();
 
-    PaloCellInputDialog.showPaloLibWarningDialog(shell);
-
     while (!shell.isDisposed()) {
       if (!display.readAndDispatch())
         display.sleep();


### PR DESCRIPTION
1) include the jar
(http://repository.pentaho.org/artifactory/repo/palo/palojlib/1.0.73/palojlib-1.0.73.jar
) within our distribution (it is now LGPL).
2) Disable the warning message about the jar in all Palo dialogs
