### PR TITLE
PDI-11545 Add mapping of TYPE_TIMESTAMP to JDBC TIMESTAMP

### DIFF
--- a/core/src/org/pentaho/di/core/database/VerticaDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/VerticaDatabaseMeta.java
@@ -144,6 +144,7 @@ public class VerticaDatabaseMeta extends BaseDatabaseMeta implements DatabaseInt
     int type = v.getType();
     switch ( type ) {
       case ValueMetaInterface.TYPE_DATE:
+      case ValueMetaInterface.TYPE_TIMESTAMP:
         retval += "TIMESTAMP";
         break;
       case ValueMetaInterface.TYPE_BOOLEAN:


### PR DESCRIPTION
The Vertica Database Meta class mapped TYPE_DATE to JDBC TIMESTAMP, but it didn't map TYPE_TIMESTAMP.  Don't know if that is because TYPE_TIMESTAMP is newer or what, but regardless, this one-liner will slightly improve the support for Vertica 6 and Vertica 7 when trying to use the SQL button on Table Output or the Vertica Bulk Loader.
