### PR TITLE
Regression of PDI-11048 - PDI - EE: Connection names displayed incorrectly in the repository view (5.0)

### DIFF
--- a/core/src/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseMeta.java
@@ -838,7 +838,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
 
   @Override
   public String toString() {
-    return getName();
+    return getDisplayName();
   }
 
   /**

--- a/dbdialog/src/org/pentaho/ui/database/event/DataHandler.java
+++ b/dbdialog/src/org/pentaho/ui/database/event/DataHandler.java
@@ -732,7 +732,7 @@ public class DataHandler extends AbstractXulEventHandler {
     getControls();
 
     // Name:
-    connectionNameBox.setValue(meta.getName());
+    connectionNameBox.setValue(meta.getDisplayName());
 
     PluginRegistry registry = PluginRegistry.getInstance();
     PluginInterface dInterface = registry.getPlugin(DatabasePluginType.class, meta.getPluginId());


### PR DESCRIPTION
[SP-996] - don't display encoded connection name when editing a connection name with an escaped character
