### PR TITLE
PDI-3568 - cancel switches tab when closing an edited transformation

### DIFF
--- a/ui/src/org/pentaho/xul/swt/tab/TabSet.java
+++ b/ui/src/org/pentaho/xul/swt/tab/TabSet.java
@@ -143,8 +143,10 @@ public class TabSet implements SelectionListener, CTabFolder2Listener {
     for ( int i = 0; i < listeners.size(); i++ ) {
       doit &= ( listeners.get( i ) ).tabClose( item );
     }
-    removeItemFromHistory( item );
-    selectLastUsedTab();
+    if ( doit ) {
+      removeItemFromHistory( item );
+      selectLastUsedTab();
+    }
     return doit;
   }
 


### PR DESCRIPTION
Switch a tab only if all closing listeners finish successfully.
