### PR TITLE
Add shared cache config to ivysettings.xml

### DIFF
--- a/assembly/ivysettings.xml
+++ b/assembly/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/build-res/ivysettings.xml
+++ b/build-res/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/core/ivysettings.xml
+++ b/core/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/dbdialog/ivysettings.xml
+++ b/dbdialog/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/engine/ivysettings.xml
+++ b/engine/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/plugins/kettle-gpload-plugin/ivysettings.xml
+++ b/plugins/kettle-gpload-plugin/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/plugins/kettle-hl7-plugin/ivysettings.xml
+++ b/plugins/kettle-hl7-plugin/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/plugins/kettle-openerp-plugin/ivysettings.xml
+++ b/plugins/kettle-openerp-plugin/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/plugins/kettle-palo-plugin/ivysettings.xml
+++ b/plugins/kettle-palo-plugin/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/plugins/kettle5-log4j-plugin/ivysettings.xml
+++ b/plugins/kettle5-log4j-plugin/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/plugins/market/ivysettings.xml
+++ b/plugins/market/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/plugins/star-modeler/ivysettings.xml
+++ b/plugins/star-modeler/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />

--- a/ui/ivysettings.xml
+++ b/ui/ivysettings.xml
@@ -2,15 +2,18 @@
 <ivysettings>
   <properties environment="env" />
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
-  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
-    override="false" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]" override="false" />
+  <property name="ivy.shared.default.ivy.pattern" value="[organisation]/[module]/ivy-[revision].xml" override="false" />
+  <property name="ivy.shared.default.artifact.pattern" value="[organisation]/[module]/[type]s/[artifact]-[revision].[ext]" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
-  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
   <resolvers>
     <chain name="pentaho-chained-resolver">
       <resolver ref="local" />
+      <resolver ref="shared" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
           <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />


### PR DESCRIPTION
Yesterday's issues with artifactory resulted in decision to try using shared cache, this will reduce load to pentaho's artifactory and can be used by community groups of developers as well.

In order to make ivy use shared cache ivy.shared.default.root property should be set to path of shared cache location. In case of using override.properties-way the file should exist in every module/plugin folder. I found it more handy to define alias for ant command and add -Divy.shared.default.root as a param.
