### PR TITLE
PDI-10396 - spoon splash screen overlay text has white background - used  to be transparent

### DIFF
--- a/ui/src/org/pentaho/di/ui/core/dialog/Splash.java
+++ b/ui/src/org/pentaho/di/ui/core/dialog/Splash.java
@@ -154,7 +154,7 @@ public class Splash {
           e.gc.setFont( licFont );
         }
 
-        e.gc.drawText( licenseText, 290, 290, false );
+        e.gc.drawText( licenseText, 290, 290, true );
       }
     } );
 
@@ -230,7 +230,7 @@ public class Splash {
     gc.drawImage( exclamation_image, 304, 243 );
 
     gc.setFont( devWarningFont );
-    gc.drawText( BaseMessages.getString( PKG, "SplashDialog.DevelopmentWarning" ), 335, 241 );
+    gc.drawText( BaseMessages.getString( PKG, "SplashDialog.DevelopmentWarning" ), 335, 241, true );
   }
 
   public void dispose() {


### PR DESCRIPTION
changed Boolean flag to have transparent background.
As of simple fix not junits required.
