### PR TITLE
[SP-899] - Backport of PDI-8979 - Vertica - Using the "update" step with a datetime field truncates the time (4.8)

### DIFF
--- a/src-db/org/pentaho/di/core/database/Vertica5DatabaseMeta.java
+++ b/src-db/org/pentaho/di/core/database/Vertica5DatabaseMeta.java
@@ -22,87 +22,77 @@
 
 package org.pentaho.di.core.database;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.row.ValueMetaInterface;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
 /**
- * Vertica Analytic Database version 5 and later (changed driver class name) 
+ * Vertica Analytic Database version 5 and later (changed driver class name)
  * 
  * @author DEinspanjer
- * @since  2009-03-16
  * @author Matt
- * @since  May-2008
  * @author Jens
- * @since  Aug-2012
+ * @since Aug-2012
  */
 
-public class Vertica5DatabaseMeta extends VerticaDatabaseMeta
-{
-	@Override
-	public String getDriverClass()
-	{
-        if (getAccessType()==DatabaseMeta.TYPE_ACCESS_NATIVE)
-        {
-            return "com.vertica.jdbc.Driver";            
-        }
-        else
-        {
-            return "sun.jdbc.odbc.JdbcOdbcDriver"; // always ODBC!
-        }
+public class Vertica5DatabaseMeta extends VerticaDatabaseMeta {
+  @Override
+  public String getDriverClass() {
+    if ( getAccessType() == DatabaseMeta.TYPE_ACCESS_NATIVE ) {
+      return "com.vertica.jdbc.Driver";
+    } else {
+      return "sun.jdbc.odbc.JdbcOdbcDriver"; // always ODBC!
+    }
 
-	}
-	
-	/**
-	 * @return false as the database does not support timestamp to date conversion.
-	 */
-	@Override
-	public boolean supportsTimeStampToDateConversion() {
-	   return false;
-	}
-	
-	/**
-	 * This method allows a database dialect to convert database specific data
-	 * types to Kettle data types.
-	 * 
-	 * @param resultSet
-	 *            The result set to use
-	 * @param valueMeta
-	 *            The description of the value to retrieve
-	 * @param index
-	 *            the index on which we need to retrieve the value, 0-based.
-	 * @return The correctly converted Kettle data type corresponding to the
-	 *         valueMeta description.
-	 * @throws KettleDatabaseException
-	 */
-	public Object getValueFromResultSet(ResultSet rs, ValueMetaInterface val,
-			int i) throws KettleDatabaseException {
-		Object data = null;
+  }
 
-		try {
-			switch (val.getType()) {
-			case ValueMetaInterface.TYPE_DATE:
-				if (val.getOriginalColumnType() == java.sql.Types.TIMESTAMP) {
-					data = rs.getTimestamp(i + 1);
-					break; // Timestamp extends java.util.Date
-				} else {
-					data = rs.getDate(i + 1);
-					break;
-				}
-			default:
-				return super.getValueFromResultSet(rs, val, i);
-			}
-			if (rs.wasNull()) {
-				data = null;
-			}
-		} catch (SQLException e) {
-			throw new KettleDatabaseException("Unable to get value '"
-					+ val.toStringMeta() + "' from database resultset, index "
-					+ i, e);
-		}
+  /**
+   * @return false as the database does not support timestamp to date conversion.
+   */
+  @Override
+  public boolean supportsTimeStampToDateConversion() {
+    return true;
+  }
 
-		return data;
-	}
+  /**
+   * This method allows a database dialect to convert database specific data types to Kettle data types.
+   * 
+   * @param resultSet
+   *          The result set to use
+   * @param valueMeta
+   *          The description of the value to retrieve
+   * @param index
+   *          the index on which we need to retrieve the value, 0-based.
+   * @return The correctly converted Kettle data type corresponding to the valueMeta description.
+   * @throws KettleDatabaseException
+   */
+  public Object getValueFromResultSet( ResultSet resultSet, ValueMetaInterface valueMeta, int index )
+    throws KettleDatabaseException {
+    Object data;
+
+    try {
+      switch ( valueMeta.getType() ) {
+        case ValueMetaInterface.TYPE_DATE:
+          if ( valueMeta.getOriginalColumnType() == java.sql.Types.TIMESTAMP ) {
+            data = resultSet.getTimestamp( index + 1 );
+            break; // Timestamp extends java.util.Date
+          } else {
+            data = resultSet.getDate( index + 1 );
+            break;
+          }
+        default:
+          return super.getValueFromResultSet( resultSet, valueMeta, index );
+      }
+      if ( resultSet.wasNull() ) {
+        data = null;
+      }
+    } catch ( SQLException e ) {
+      throw new KettleDatabaseException( "Unable to get value '" + valueMeta.toStringMeta()
+          + "' from database resultset, index " + index, e );
+    }
+
+    return data;
+  }
 }


### PR DESCRIPTION
- Reformat
- Changed: supportsTimeStampToDateConversion() return true;
