### PR TITLE
PDI-11899 Stream field dropdowns do not populate on Dimension Lookup

### DIFF
--- a/ui/src/org/pentaho/di/ui/trans/steps/dimensionlookup/DimensionLookupDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/dimensionlookup/DimensionLookupDialog.java
@@ -1219,7 +1219,7 @@ public class DimensionLookupDialog extends BaseStepDialog implements StepDialogI
     String[] fieldNames = entries.toArray( new String[entries.size()] );
     Const.sortStrings( fieldNames );
     ciKey[1].setComboValues( fieldNames );
-    ciKey[1].setComboValues( fieldNames );
+    ciUpIns[1].setComboValues( fieldNames );
   }
 
   public void setAutoincUse() {


### PR DESCRIPTION
Small fix for annoying bug. This has affected PDI since at least 4.4. Code was setting the stream dropdowns on the Key tab twice.
