### PR TITLE
 Regression of PDI-11048 Pt2 - PDI - EE: Connection names displayed incorrectly in the repository view (5.0)

### DIFF
--- a/engine/src/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/org/pentaho/di/trans/TransMeta.java
@@ -1266,13 +1266,13 @@ public class TransMeta extends ChangedFlag implements XMLInterface, Comparator<T
    *
    * @param name the name of the desired database
    * @return the desired database's meta-data, or null if no database is found
-   * @see org.pentaho.di.trans.HasDatabaseInterface#findDatabase(java.lang.String)
    */
   public DatabaseMeta findDatabase(String name) {
     int i;
     for (i = 0; i < nrDatabases(); i++) {
       DatabaseMeta ci = getDatabase(i);
-      if (ci.getName().equalsIgnoreCase(name)) {
+      if ((ci != null) && (ci.getName().equalsIgnoreCase(name)) ||
+              (ci.getDisplayName().equalsIgnoreCase( name ))) {
         return ci;
       }
     }

--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -1277,7 +1277,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     cursor_hand.dispose();
     cursor_hourglass.dispose();
 
-    if (destroy && !display.isDisposed()) {
+    if (destroy && ( display != null ) && !display.isDisposed()) {
       try {
         display.dispose();
       } catch (SWTException e) {
@@ -5748,7 +5748,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
                 continue;
 
               TreeItem tiDb = new TreeItem(tiDbTitle, SWT.NONE);
-              tiDb.setText(databaseMeta.getName());
+              tiDb.setText(databaseMeta.getDisplayName());
               if (databaseMeta.isShared())
                 tiDb.setFont(guiResource.getFontBold());
               tiDb.setImage(guiResource.getImageConnection());
@@ -5941,7 +5941,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
               if (!filterMatch(databaseMeta.getName()))
                 continue;
               TreeItem tiDb = new TreeItem(tiDbTitle, SWT.NONE);
-              tiDb.setText(databaseMeta.getName());
+              tiDb.setText(databaseMeta.getDisplayName());
               if (databaseMeta.isShared())
                 tiDb.setFont(guiResource.getFontBold());
               tiDb.setImage(guiResource.getImageConnection());

--- a/ui/src/org/pentaho/di/ui/spoon/delegates/SpoonTreeDelegate.java
+++ b/ui/src/org/pentaho/di/ui/spoon/delegates/SpoonTreeDelegate.java
@@ -145,8 +145,15 @@ public class SpoonTreeDelegate extends SpoonDelegate
 					{
 						TransMeta transMeta = spoon.delegates.trans.getTransformation(path[1]);
 						if (transMeta!=null) {
-							if (path[2].equals(Spoon.STRING_CONNECTIONS))
-								object = new TreeSelection(path[3], transMeta.findDatabase(path[3]), transMeta);
+							if (path[2].equals(Spoon.STRING_CONNECTIONS)) {
+                String dbName = path[3];
+                DatabaseMeta databaseMeta = transMeta.findDatabase( dbName );
+                if (databaseMeta != null) {
+                  dbName = databaseMeta.getName();
+                }
+
+								object = new TreeSelection(path[3], transMeta.findDatabase(dbName), transMeta);
+              }
 							if (path[2].equals(Spoon.STRING_STEPS))
 								object = new TreeSelection(path[3], transMeta.findStep(path[3]), transMeta);
 							if (path[2].equals(Spoon.STRING_HOPS))


### PR DESCRIPTION
[SP-1203]: In view tree, display title instead of connection name in tree item.  Added some guards.  Fixed issue with double-click events when tree item has an invalid JCR character
