### PR TITLE
PDI-10553 - log output add/delete filenames to/from result steps shows CheckDb connections

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/addresultfilenames/JobEntryAddResultFilenames.java
+++ b/engine/src/org/pentaho/di/job/entries/addresultfilenames/JobEntryAddResultFilenames.java
@@ -87,7 +87,6 @@ public class JobEntryAddResultFilenames extends JobEntryBase implements Cloneabl
     arguments = null;
 
     includeSubfolders = false;
-    setID( -1L );
   }
 
   public JobEntryAddResultFilenames() {

--- a/engine/src/org/pentaho/di/job/entries/checkdbconnection/JobEntryCheckDbConnections.java
+++ b/engine/src/org/pentaho/di/job/entries/checkdbconnection/JobEntryCheckDbConnections.java
@@ -84,7 +84,6 @@ public class JobEntryCheckDbConnections extends JobEntryBase implements Cloneabl
     connections = null;
     waitfors = null;
     waittimes = null;
-    setID( -1L );
   }
 
   public JobEntryCheckDbConnections() {

--- a/engine/src/org/pentaho/di/job/entries/checkfilelocked/JobEntryCheckFilesLocked.java
+++ b/engine/src/org/pentaho/di/job/entries/checkfilelocked/JobEntryCheckFilesLocked.java
@@ -85,8 +85,6 @@ public class JobEntryCheckFilesLocked extends JobEntryBase implements Cloneable,
     arguments = null;
 
     includeSubfolders = false;
-    setID( -1L );
-
   }
 
   public JobEntryCheckFilesLocked() {

--- a/engine/src/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExist.java
+++ b/engine/src/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExist.java
@@ -71,7 +71,6 @@ public class JobEntryColumnsExist extends JobEntryBase implements Cloneable, Job
     schemaname = null;
     tablename = null;
     connection = null;
-    setID( -1L );
   }
 
   public JobEntryColumnsExist() {

--- a/engine/src/org/pentaho/di/job/entries/copyfiles/JobEntryCopyFiles.java
+++ b/engine/src/org/pentaho/di/job/entries/copyfiles/JobEntryCopyFiles.java
@@ -101,7 +101,6 @@ public class JobEntryCopyFiles extends JobEntryBase implements Cloneable, JobEnt
     add_result_filesname = false;
     destination_is_a_file = false;
     create_destination_folder = false;
-    setID( -1L );
   }
 
   public JobEntryCopyFiles() {

--- a/engine/src/org/pentaho/di/job/entries/copymoveresultfilenames/JobEntryCopyMoveResultFilenames.java
+++ b/engine/src/org/pentaho/di/job/entries/copymoveresultfilenames/JobEntryCopyMoveResultFilenames.java
@@ -124,7 +124,6 @@ public class JobEntryCopyMoveResultFilenames extends JobEntryBase implements Clo
 
     action = "copy";
     success_condition = SUCCESS_IF_NO_ERRORS;
-    setID( -1L );
   }
 
   public JobEntryCopyMoveResultFilenames() {

--- a/engine/src/org/pentaho/di/job/entries/createfile/JobEntryCreateFile.java
+++ b/engine/src/org/pentaho/di/job/entries/createfile/JobEntryCreateFile.java
@@ -76,7 +76,6 @@ public class JobEntryCreateFile extends JobEntryBase implements Cloneable, JobEn
     filename = null;
     failIfFileExists = true;
     addfilenameresult = false;
-    setID( -1L );
   }
 
   public JobEntryCreateFile() {

--- a/engine/src/org/pentaho/di/job/entries/createfolder/JobEntryCreateFolder.java
+++ b/engine/src/org/pentaho/di/job/entries/createfolder/JobEntryCreateFolder.java
@@ -71,7 +71,6 @@ public class JobEntryCreateFolder extends JobEntryBase implements Cloneable, Job
     super( n, "" );
     foldername = null;
     failOfFolderExists = true;
-    setID( -1L );
   }
 
   public JobEntryCreateFolder() {

--- a/engine/src/org/pentaho/di/job/entries/delay/JobEntryDelay.java
+++ b/engine/src/org/pentaho/di/job/entries/delay/JobEntryDelay.java
@@ -65,7 +65,6 @@ public class JobEntryDelay extends JobEntryBase implements Cloneable, JobEntryIn
 
   public JobEntryDelay( String n ) {
     super( n, "" );
-    setID( -1L );
   }
 
   public JobEntryDelay() {

--- a/engine/src/org/pentaho/di/job/entries/deletefile/JobEntryDeleteFile.java
+++ b/engine/src/org/pentaho/di/job/entries/deletefile/JobEntryDeleteFile.java
@@ -76,7 +76,6 @@ public class JobEntryDeleteFile extends JobEntryBase implements Cloneable, JobEn
     super( n, "" );
     filename = null;
     failIfFileNotExists = false;
-    setID( -1L );
   }
 
   public JobEntryDeleteFile() {

--- a/engine/src/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFiles.java
+++ b/engine/src/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFiles.java
@@ -87,7 +87,6 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
     arguments = null;
 
     includeSubfolders = false;
-    setID( -1L );
   }
 
   public JobEntryDeleteFiles() {

--- a/engine/src/org/pentaho/di/job/entries/deletefolders/JobEntryDeleteFolders.java
+++ b/engine/src/org/pentaho/di/job/entries/deletefolders/JobEntryDeleteFolders.java
@@ -93,7 +93,6 @@ public class JobEntryDeleteFolders extends JobEntryBase implements Cloneable, Jo
 
     success_condition = SUCCESS_IF_NO_ERRORS;
     limit_folders = "10";
-    setID( -1L );
   }
 
   public JobEntryDeleteFolders() {

--- a/engine/src/org/pentaho/di/job/entries/deleteresultfilenames/JobEntryDeleteResultFilenames.java
+++ b/engine/src/org/pentaho/di/job/entries/deleteresultfilenames/JobEntryDeleteResultFilenames.java
@@ -77,7 +77,6 @@ public class JobEntryDeleteResultFilenames extends JobEntryBase implements Clone
     wildcardexclude = null;
     wildcard = null;
     specifywildcard = false;
-    setID( -1L );
   }
 
   public JobEntryDeleteResultFilenames() {

--- a/engine/src/org/pentaho/di/job/entries/dostounix/JobEntryDosToUnix.java
+++ b/engine/src/org/pentaho/di/job/entries/dostounix/JobEntryDosToUnix.java
@@ -122,8 +122,6 @@ public class JobEntryDosToUnix extends JobEntryBase implements Cloneable, JobEnt
     include_subfolders = false;
     nr_errors_less_than = "10";
     success_condition = SUCCESS_IF_NO_ERRORS;
-
-    setID( -1L );
   }
 
   public JobEntryDosToUnix() {

--- a/engine/src/org/pentaho/di/job/entries/dtdvalidator/JobEntryDTDValidator.java
+++ b/engine/src/org/pentaho/di/job/entries/dtdvalidator/JobEntryDTDValidator.java
@@ -70,8 +70,6 @@ public class JobEntryDTDValidator extends JobEntryBase implements Cloneable, Job
     xmlfilename = null;
     dtdfilename = null;
     dtdintern = false;
-
-    setID( -1L );
   }
 
   public JobEntryDTDValidator() {

--- a/engine/src/org/pentaho/di/job/entries/eval/JobEntryEval.java
+++ b/engine/src/org/pentaho/di/job/entries/eval/JobEntryEval.java
@@ -65,7 +65,6 @@ public class JobEntryEval extends JobEntryBase implements Cloneable, JobEntryInt
   public JobEntryEval( String n, String scr ) {
     super( n, "" );
     script = scr;
-    setID( -1L );
   }
 
   public JobEntryEval() {

--- a/engine/src/org/pentaho/di/job/entries/evalfilesmetrics/JobEntryEvalFilesMetrics.java
+++ b/engine/src/org/pentaho/di/job/entries/evalfilesmetrics/JobEntryEvalFilesMetrics.java
@@ -153,7 +153,6 @@ public class JobEntryEvalFilesMetrics extends JobEntryBase implements Cloneable,
     ResultFieldFile = null;
     ResultFieldWildcard = null;
     ResultFieldIncludesubFolders = null;
-    setID( -1L );
   }
 
   public JobEntryEvalFilesMetrics() {

--- a/engine/src/org/pentaho/di/job/entries/evaluatetablecontent/JobEntryEvalTableContent.java
+++ b/engine/src/org/pentaho/di/job/entries/evaluatetablecontent/JobEntryEvalTableContent.java
@@ -117,7 +117,6 @@ public class JobEntryEvalTableContent extends JobEntryBase implements Cloneable,
     schemaname = null;
     tablename = null;
     connection = null;
-    setID( -1L );
   }
 
   public JobEntryEvalTableContent() {

--- a/engine/src/org/pentaho/di/job/entries/exportrepository/JobEntryExportRepository.java
+++ b/engine/src/org/pentaho/di/job/entries/exportrepository/JobEntryExportRepository.java
@@ -140,7 +140,6 @@ public class JobEntryExportRepository extends JobEntryBase implements Cloneable,
     add_result_filesname = false;
     nr_errors_less_than = "10";
     success_condition = SUCCESS_IF_NO_ERRORS;
-    setID( -1L );
   }
 
   public JobEntryExportRepository() {

--- a/engine/src/org/pentaho/di/job/entries/filecompare/JobEntryFileCompare.java
+++ b/engine/src/org/pentaho/di/job/entries/filecompare/JobEntryFileCompare.java
@@ -81,7 +81,6 @@ public class JobEntryFileCompare extends JobEntryBase implements Cloneable, JobE
     filename1 = null;
     filename2 = null;
     addFilenameToResult = false;
-    setID( -1L );
   }
 
   public JobEntryFileCompare() {

--- a/engine/src/org/pentaho/di/job/entries/fileexists/JobEntryFileExists.java
+++ b/engine/src/org/pentaho/di/job/entries/fileexists/JobEntryFileExists.java
@@ -71,7 +71,6 @@ public class JobEntryFileExists extends JobEntryBase implements Cloneable, JobEn
   public JobEntryFileExists( String n ) {
     super( n, "" );
     filename = null;
-    setID( -1L );
   }
 
   public JobEntryFileExists() {

--- a/engine/src/org/pentaho/di/job/entries/filesexist/JobEntryFilesExist.java
+++ b/engine/src/org/pentaho/di/job/entries/filesexist/JobEntryFilesExist.java
@@ -64,7 +64,6 @@ public class JobEntryFilesExist extends JobEntryBase implements Cloneable, JobEn
   public JobEntryFilesExist( String n ) {
     super( n, "" );
     filename = null;
-    setID( -1L );
   }
 
   public JobEntryFilesExist() {

--- a/engine/src/org/pentaho/di/job/entries/folderisempty/JobEntryFolderIsEmpty.java
+++ b/engine/src/org/pentaho/di/job/entries/folderisempty/JobEntryFolderIsEmpty.java
@@ -80,7 +80,6 @@ public class JobEntryFolderIsEmpty extends JobEntryBase implements Cloneable, Jo
     wildcard = null;
     includeSubfolders = false;
     specifywildcard = false;
-    setID( -1L );
   }
 
   public JobEntryFolderIsEmpty() {

--- a/engine/src/org/pentaho/di/job/entries/folderscompare/JobEntryFoldersCompare.java
+++ b/engine/src/org/pentaho/di/job/entries/folderscompare/JobEntryFoldersCompare.java
@@ -94,7 +94,6 @@ public class JobEntryFoldersCompare extends JobEntryBase implements Cloneable, J
     wildcard = null;
     filename1 = null;
     filename2 = null;
-    setID( -1L );
   }
 
   public void setCompareOnly( String comparevalue ) {

--- a/engine/src/org/pentaho/di/job/entries/ftp/JobEntryFTP.java
+++ b/engine/src/org/pentaho/di/job/entries/ftp/JobEntryFTP.java
@@ -212,7 +212,6 @@ public class JobEntryFTP extends JobEntryBase implements Cloneable, JobEntryInte
     isaddresult = true;
     createmovefolder = false;
 
-    setID( -1L );
     setControlEncoding( DEFAULT_CONTROL_ENCODING );
   }
 

--- a/engine/src/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
+++ b/engine/src/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
@@ -176,7 +176,6 @@ public class JobEntryFTPDelete extends JobEntryBase implements Cloneable, JobEnt
     keyFilePass = null;
     serverName = null;
     FTPSConnectionType = FTPSConnection.CONNECTION_TYPE_FTP;
-    setID( -1L );
   }
 
   public JobEntryFTPDelete() {

--- a/engine/src/org/pentaho/di/job/entries/ftpput/JobEntryFTPPUT.java
+++ b/engine/src/org/pentaho/di/job/entries/ftpput/JobEntryFTPPUT.java
@@ -122,7 +122,6 @@ public class JobEntryFTPPUT extends JobEntryBase implements Cloneable, JobEntryI
     socksProxyPort = "1080";
     remoteDirectory = null;
     localDirectory = null;
-    setID( -1L );
     setControlEncoding( DEFAULT_CONTROL_ENCODING );
   }
 

--- a/engine/src/org/pentaho/di/job/entries/ftpsget/JobEntryFTPSGet.java
+++ b/engine/src/org/pentaho/di/job/entries/ftpsget/JobEntryFTPSGet.java
@@ -155,8 +155,6 @@ public class JobEntryFTPSGet extends JobEntryBase implements Cloneable, JobEntry
     isaddresult = true;
     createmovefolder = false;
     connectionType = FTPSConnection.CONNECTION_TYPE_FTP;
-
-    setID( -1L );
   }
 
   public JobEntryFTPSGet() {

--- a/engine/src/org/pentaho/di/job/entries/ftpsput/JobEntryFTPSPUT.java
+++ b/engine/src/org/pentaho/di/job/entries/ftpsput/JobEntryFTPSPUT.java
@@ -99,7 +99,6 @@ public class JobEntryFTPSPUT extends JobEntryBase implements Cloneable, JobEntry
     remoteDirectory = null;
     localDirectory = null;
     connectionType = FTPSConnection.CONNECTION_TYPE_FTP;
-    setID( -1L );
   }
 
   public JobEntryFTPSPUT() {

--- a/engine/src/org/pentaho/di/job/entries/getpop/JobEntryGetPOP.java
+++ b/engine/src/org/pentaho/di/job/entries/getpop/JobEntryGetPOP.java
@@ -172,7 +172,6 @@ public class JobEntryGetPOP extends JobEntryBase implements Cloneable, JobEntryI
     createlocalfolder = false;
     aftergetimap = MailConnectionMeta.AFTER_GET_IMAP_NOTHING;
     includesubfolders = false;
-    setID( -1L );
   }
 
   public JobEntryGetPOP() {

--- a/engine/src/org/pentaho/di/job/entries/http/JobEntryHTTP.java
+++ b/engine/src/org/pentaho/di/job/entries/http/JobEntryHTTP.java
@@ -124,7 +124,6 @@ public class JobEntryHTTP extends JobEntryBase implements Cloneable, JobEntryInt
     super( n, "" );
     url = null;
     addfilenameresult = true;
-    setID( -1L );
   }
 
   public JobEntryHTTP() {

--- a/engine/src/org/pentaho/di/job/entries/movefiles/JobEntryMoveFiles.java
+++ b/engine/src/org/pentaho/di/job/entries/movefiles/JobEntryMoveFiles.java
@@ -140,7 +140,6 @@ public class JobEntryMoveFiles extends JobEntryBase implements Cloneable, JobEnt
     date_time_format = null;
     AddDateBeforeExtension = false;
     iffileexists = "do_nothing";
-    setID( -1L );
   }
 
   public JobEntryMoveFiles() {

--- a/engine/src/org/pentaho/di/job/entries/msaccessbulkload/JobEntryMSAccessBulkLoad.java
+++ b/engine/src/org/pentaho/di/job/entries/msaccessbulkload/JobEntryMSAccessBulkLoad.java
@@ -102,8 +102,6 @@ public class JobEntryMSAccessBulkLoad extends JobEntryBase implements Cloneable,
     delimiter = null;
     target_Db = null;
     target_table = null;
-
-    setID( -1L );
   }
 
   public JobEntryMSAccessBulkLoad() {

--- a/engine/src/org/pentaho/di/job/entries/mssqlbulkload/JobEntryMssqlBulkLoad.java
+++ b/engine/src/org/pentaho/di/job/entries/mssqlbulkload/JobEntryMssqlBulkLoad.java
@@ -130,7 +130,6 @@ public class JobEntryMssqlBulkLoad extends JobEntryBase implements Cloneable, Jo
     firetriggers = false;
     keepidentity = false;
     truncate = false;
-    setID( -1L );
   }
 
   public JobEntryMssqlBulkLoad() {

--- a/engine/src/org/pentaho/di/job/entries/mysqlbulkfile/JobEntryMysqlBulkFile.java
+++ b/engine/src/org/pentaho/di/job/entries/mysqlbulkfile/JobEntryMysqlBulkFile.java
@@ -99,7 +99,6 @@ public class JobEntryMysqlBulkFile extends JobEntryBase implements Cloneable, Jo
     iffileexists = 2;
     connection = null;
     addfiletoresult = false;
-    setID( -1L );
   }
 
   public JobEntryMysqlBulkFile() {

--- a/engine/src/org/pentaho/di/job/entries/mysqlbulkload/JobEntryMysqlBulkLoad.java
+++ b/engine/src/org/pentaho/di/job/entries/mysqlbulkload/JobEntryMysqlBulkLoad.java
@@ -102,7 +102,6 @@ public class JobEntryMysqlBulkLoad extends JobEntryBase implements Cloneable, Jo
     localinfile = true;
     connection = null;
     addfiletoresult = false;
-    setID( -1L );
   }
 
   public JobEntryMysqlBulkLoad() {

--- a/engine/src/org/pentaho/di/job/entries/pgpdecryptfiles/JobEntryPGPDecryptFiles.java
+++ b/engine/src/org/pentaho/di/job/entries/pgpdecryptfiles/JobEntryPGPDecryptFiles.java
@@ -145,7 +145,6 @@ public class JobEntryPGPDecryptFiles extends JobEntryBase implements Cloneable, 
     date_time_format = null;
     AddDateBeforeExtension = false;
     iffileexists = "do_nothing";
-    setID( -1L );
   }
 
   public JobEntryPGPDecryptFiles() {

--- a/engine/src/org/pentaho/di/job/entries/pgpencryptfiles/JobEntryPGPEncryptFiles.java
+++ b/engine/src/org/pentaho/di/job/entries/pgpencryptfiles/JobEntryPGPEncryptFiles.java
@@ -157,7 +157,6 @@ public class JobEntryPGPEncryptFiles extends JobEntryBase implements Cloneable, 
     AddDateBeforeExtension = false;
     iffileexists = "do_nothing";
     asciiMode = false;
-    setID( -1L );
   }
 
   public JobEntryPGPEncryptFiles() {

--- a/engine/src/org/pentaho/di/job/entries/pgpverify/JobEntryPGPVerify.java
+++ b/engine/src/org/pentaho/di/job/entries/pgpverify/JobEntryPGPVerify.java
@@ -78,7 +78,6 @@ public class JobEntryPGPVerify extends JobEntryBase implements Cloneable, JobEnt
     filename = null;
     detachedfilename = null;
     useDetachedSignature = false;
-    setID( -1L );
   }
 
   public JobEntryPGPVerify() {

--- a/engine/src/org/pentaho/di/job/entries/ping/JobEntryPing.java
+++ b/engine/src/org/pentaho/di/job/entries/ping/JobEntryPing.java
@@ -87,7 +87,6 @@ public class JobEntryPing extends JobEntryBase implements Cloneable, JobEntryInt
     hostname = null;
     nbrPackets = "2";
     timeout = defaultTimeOut;
-    setID( -1L );
   }
 
   public JobEntryPing() {

--- a/engine/src/org/pentaho/di/job/entries/sendnagiospassivecheck/JobEntrySendNagiosPassiveCheck.java
+++ b/engine/src/org/pentaho/di/job/entries/sendnagiospassivecheck/JobEntrySendNagiosPassiveCheck.java
@@ -131,8 +131,6 @@ public class JobEntrySendNagiosPassiveCheck extends JobEntryBase implements Clon
     encryptionMode = ENCRYPTION_MODE_NONE;
     level = LEVEL_TYPE_UNKNOWN;
     password = null;
-
-    setID( -1L );
   }
 
   public JobEntrySendNagiosPassiveCheck() {

--- a/engine/src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
+++ b/engine/src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
@@ -95,8 +95,6 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
     replaceVars = true;
     variableName = null;
     variableValue = null;
-
-    setID( -1L );
   }
 
   public JobEntrySetVariables() {

--- a/engine/src/org/pentaho/di/job/entries/sftp/JobEntrySFTP.java
+++ b/engine/src/org/pentaho/di/job/entries/sftp/JobEntrySFTP.java
@@ -115,7 +115,6 @@ public class JobEntrySFTP extends JobEntryBase implements Cloneable, JobEntryInt
     proxyPort = null;
     proxyUsername = null;
     proxyPassword = null;
-    setID( -1L );
   }
 
   public JobEntrySFTP() {

--- a/engine/src/org/pentaho/di/job/entries/sftpput/JobEntrySFTPPUT.java
+++ b/engine/src/org/pentaho/di/job/entries/sftpput/JobEntrySFTPPUT.java
@@ -135,7 +135,6 @@ public class JobEntrySFTPPUT extends JobEntryBase implements Cloneable, JobEntry
     destinationfolder = null;
     createDestinationFolder = false;
     successWhenNoFile = false;
-    setID( -1L );
   }
 
   public JobEntrySFTPPUT() {

--- a/engine/src/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEval.java
+++ b/engine/src/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEval.java
@@ -169,8 +169,6 @@ public class JobEntrySimpleEval extends JobEntryBase implements Cloneable, JobEn
     fieldtype = FIELD_TYPE_STRING;
     mask = null;
     successwhenvarset = false;
-
-    setID( -1L );
   }
 
   public JobEntrySimpleEval() {

--- a/engine/src/org/pentaho/di/job/entries/snmptrap/JobEntrySNMPTrap.java
+++ b/engine/src/org/pentaho/di/job/entries/snmptrap/JobEntrySNMPTrap.java
@@ -118,8 +118,6 @@ public class JobEntrySNMPTrap extends JobEntryBase implements Cloneable, JobEntr
     user = null;
     passphrase = null;
     engineid = null;
-
-    setID( -1L );
   }
 
   public JobEntrySNMPTrap() {

--- a/engine/src/org/pentaho/di/job/entries/sql/JobEntrySQL.java
+++ b/engine/src/org/pentaho/di/job/entries/sql/JobEntrySQL.java
@@ -78,7 +78,6 @@ public class JobEntrySQL extends JobEntryBase implements Cloneable, JobEntryInte
     super( n, "" );
     sql = null;
     connection = null;
-    setID( -1L );
   }
 
   public JobEntrySQL() {

--- a/engine/src/org/pentaho/di/job/entries/ssh2get/JobEntrySSH2GET.java
+++ b/engine/src/org/pentaho/di/job/entries/ssh2get/JobEntrySSH2GET.java
@@ -133,7 +133,6 @@ public class JobEntrySSH2GET extends JobEntryBase implements Cloneable, JobEntry
     createtargetfolder = false;
     cachehostkey = false;
     timeout = 0;
-    setID( -1L );
   }
 
   public JobEntrySSH2GET() {

--- a/engine/src/org/pentaho/di/job/entries/ssh2put/JobEntrySSH2PUT.java
+++ b/engine/src/org/pentaho/di/job/entries/ssh2put/JobEntrySSH2PUT.java
@@ -128,7 +128,6 @@ public class JobEntrySSH2PUT extends JobEntryBase implements Cloneable, JobEntry
     createDestinationFolder = false;
     cachehostkey = false;
     timeout = 0;
-    setID( -1L );
   }
 
   public JobEntrySSH2PUT() {

--- a/engine/src/org/pentaho/di/job/entries/syslog/JobEntrySyslog.java
+++ b/engine/src/org/pentaho/di/job/entries/syslog/JobEntrySyslog.java
@@ -74,8 +74,6 @@ public class JobEntrySyslog extends JobEntryBase implements Cloneable, JobEntryI
     datePattern = SyslogDefs.DEFAULT_DATE_FORMAT;
     addTimestamp = true;
     addHostname = true;
-
-    setID( -1L );
   }
 
   public JobEntrySyslog() {

--- a/engine/src/org/pentaho/di/job/entries/tableexists/JobEntryTableExists.java
+++ b/engine/src/org/pentaho/di/job/entries/tableexists/JobEntryTableExists.java
@@ -70,7 +70,6 @@ public class JobEntryTableExists extends JobEntryBase implements Cloneable, JobE
     schemaname = null;
     tablename = null;
     connection = null;
-    setID( -1L );
   }
 
   public JobEntryTableExists() {

--- a/engine/src/org/pentaho/di/job/entries/talendjobexec/JobEntryTalendJobExec.java
+++ b/engine/src/org/pentaho/di/job/entries/talendjobexec/JobEntryTalendJobExec.java
@@ -80,8 +80,6 @@ public class JobEntryTalendJobExec extends JobEntryBase implements Cloneable, Jo
 
   public JobEntryTalendJobExec( String n ) {
     super( n, "" );
-    setID( -1L );
-
     filename = null;
   }
 

--- a/engine/src/org/pentaho/di/job/entries/telnet/JobEntryTelnet.java
+++ b/engine/src/org/pentaho/di/job/entries/telnet/JobEntryTelnet.java
@@ -74,7 +74,6 @@ public class JobEntryTelnet extends JobEntryBase implements Cloneable, JobEntryI
     hostname = null;
     port = String.valueOf( DEFAULT_PORT );
     timeout = String.valueOf( DEFAULT_TIME_OUT );
-    setID( -1L );
   }
 
   public JobEntryTelnet() {

--- a/engine/src/org/pentaho/di/job/entries/truncatetables/JobEntryTruncateTables.java
+++ b/engine/src/org/pentaho/di/job/entries/truncatetables/JobEntryTruncateTables.java
@@ -83,7 +83,6 @@ public class JobEntryTruncateTables extends JobEntryBase implements Cloneable, J
     this.arguments = null;
     this.schemaname = null;
     this.connection = null;
-    setID( -1L );
   }
 
   public JobEntryTruncateTables() {

--- a/engine/src/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
+++ b/engine/src/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
@@ -166,8 +166,6 @@ public class JobEntryUnZip extends JobEntryBase implements Cloneable, JobEntryIn
 
     addOriginalTimestamp = false;
     setOriginalModificationDate = false;
-
-    setID( -1L );
   }
 
   public JobEntryUnZip() {

--- a/engine/src/org/pentaho/di/job/entries/waitforfile/JobEntryWaitForFile.java
+++ b/engine/src/org/pentaho/di/job/entries/waitforfile/JobEntryWaitForFile.java
@@ -83,7 +83,6 @@ public class JobEntryWaitForFile extends JobEntryBase implements Cloneable, JobE
     successOnTimeout = false;
     fileSizeCheck = false;
     addFilenameToResult = false;
-    setID( -1L );
   }
 
   public JobEntryWaitForFile() {

--- a/engine/src/org/pentaho/di/job/entries/waitforsql/JobEntryWaitForSQL.java
+++ b/engine/src/org/pentaho/di/job/entries/waitforsql/JobEntryWaitForSQL.java
@@ -126,7 +126,6 @@ public class JobEntryWaitForSQL extends JobEntryBase implements Cloneable, JobEn
     maximumTimeout = DEFAULT_MAXIMUM_TIMEOUT;
     checkCycleTime = DEFAULT_CHECK_CYCLE_TIME;
     successOnTimeout = false;
-    setID( -1L );
   }
 
   public JobEntryWaitForSQL() {

--- a/engine/src/org/pentaho/di/job/entries/webserviceavailable/JobEntryWebServiceAvailable.java
+++ b/engine/src/org/pentaho/di/job/entries/webserviceavailable/JobEntryWebServiceAvailable.java
@@ -63,7 +63,6 @@ public class JobEntryWebServiceAvailable extends JobEntryBase implements Cloneab
     url = null;
     connectTimeOut = "0";
     readTimeOut = "0";
-    setID( -1L );
   }
 
   public JobEntryWebServiceAvailable() {

--- a/engine/src/org/pentaho/di/job/entries/writetofile/JobEntryWriteToFile.java
+++ b/engine/src/org/pentaho/di/job/entries/writetofile/JobEntryWriteToFile.java
@@ -78,7 +78,6 @@ public class JobEntryWriteToFile extends JobEntryBase implements Cloneable, JobE
     appendFile = false;
     content = null;
     encoding = null;
-    setID( -1L );
   }
 
   public JobEntryWriteToFile() {

--- a/engine/src/org/pentaho/di/job/entries/xmlwellformed/JobEntryXMLWellFormed.java
+++ b/engine/src/org/pentaho/di/job/entries/xmlwellformed/JobEntryXMLWellFormed.java
@@ -108,8 +108,6 @@ public class JobEntryXMLWellFormed extends JobEntryBase implements Cloneable, Jo
     include_subfolders = false;
     nr_errors_less_than = "10";
     success_condition = SUCCESS_IF_NO_ERRORS;
-
-    setID( -1L );
   }
 
   public JobEntryXMLWellFormed() {

--- a/engine/src/org/pentaho/di/job/entries/xsdvalidator/JobEntryXSDValidator.java
+++ b/engine/src/org/pentaho/di/job/entries/xsdvalidator/JobEntryXSDValidator.java
@@ -81,8 +81,6 @@ public class JobEntryXSDValidator extends JobEntryBase implements Cloneable, Job
     super( n, "" );
     xmlfilename = null;
     xsdfilename = null;
-
-    setID( -1L );
   }
 
   public JobEntryXSDValidator() {

--- a/engine/src/org/pentaho/di/job/entries/xslt/JobEntryXSLT.java
+++ b/engine/src/org/pentaho/di/job/entries/xslt/JobEntryXSLT.java
@@ -133,7 +133,6 @@ public class JobEntryXSLT extends JobEntryBase implements Cloneable, JobEntryInt
       outputPropertyName[i] = "outputprop" + i;
       outputPropertyValue[i] = "outputprop";
     }
-    setID( -1L );
   }
 
   public void allocate( int nrParameters, int outputProps ) {

--- a/engine/src/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
+++ b/engine/src/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
@@ -132,7 +132,6 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     createMoveToDirectory = false;
     includingSubFolders = true;
     storedSourcePathDepth = "1";
-    setID( -1L );
   }
 
   public JobEntryZipFile() {

--- a/engine/src/org/pentaho/di/job/entry/JobEntryBase.java
+++ b/engine/src/org/pentaho/di/job/entry/JobEntryBase.java
@@ -94,7 +94,8 @@ public class JobEntryBase implements Cloneable, VariableSpace, CheckResultSource
   /** Whether the job entry has changed. */
   private boolean changed;
 
-  /** The object id for the job entry */
+  /** The object id for the job entry. Should be unique in most cases. Used to distinguish 
+   * Logging channels for objects. */
   private ObjectId id;
 
   /** The variable bindings for the job entry */

--- a/engine/test-src/org/pentaho/di/job/entry/JobEntryBaseTest.java
+++ b/engine/test-src/org/pentaho/di/job/entry/JobEntryBaseTest.java
@@ -1,0 +1,17 @@
+package org.pentaho.di.job.entry;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JobEntryBaseTest {
+
+  /**
+   * PDI-10553 - log output add/delete filenames to/from result steps shows CheckDb connections
+   */
+  @Test
+  public void testIdIsNullByDefault() {
+    JobEntryBase base = new JobEntryBase();
+    Assert.assertNull("Object ID is null by default", base.getObjectId() );
+  }
+
+}


### PR DESCRIPTION
Fix added. Removed setObjectId( -1L ) from most of job entries. If ObjectId is not set explicitly - by default should be null. Otherwise - this ID value is used for LoggingRegistry - cause job entries obtain wrong LogChannels.
See LoggingRegistry.registerLoggingSource(...) / LoggingObject .equals(...) implementations.
