### PR TITLE
PDI-11394 - Empty database browser dialog appears after unsuccessful connect to DB

### DIFF
--- a/test/org/pentaho/di/ui/core/database/dialog/XulDatabaseExplorerControllerTest.java
+++ b/test/org/pentaho/di/ui/core/database/dialog/XulDatabaseExplorerControllerTest.java
@@ -1,0 +1,47 @@
+package org.pentaho.di.ui.core.database.dialog;
+
+import java.util.Collections;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.eclipse.swt.widgets.Shell;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.database.DatabaseMeta;
+
+public class XulDatabaseExplorerControllerTest {
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  /**
+   * PDI-11394 - Empty database browser dialog appears after unsuccessful connect to DB
+   */
+  @Test
+  public void testPostActionStatusForReflectCalls() {
+    Shell shell = new Shell();
+    DatabaseMeta meta = new DatabaseMeta();
+    List<DatabaseMeta> list = Collections.emptyList();
+
+    XulDatabaseExplorerController dialog = new XulDatabaseExplorerController( shell, meta, list, false );
+
+    UiPostActionStatus actual = dialog.getActionStatus();
+    Assert.assertEquals( "By default action status is none", UiPostActionStatus.NONE, actual );
+
+    try {
+      dialog.createDatabaseNodes();
+    } catch ( Exception e ) {
+      // do nothing as it usually used for ui functionality     
+    }
+    actual = dialog.getActionStatus();
+
+    // this error is caused runtime exception on error dialog show
+    Assert.assertEquals( "For reflective calls we have ability to ask for status directly", UiPostActionStatus.ERROR,
+        actual );
+  }
+
+}

--- a/ui/src/org/pentaho/di/ui/core/database/dialog/IUiActionStatus.java
+++ b/ui/src/org/pentaho/di/ui/core/database/dialog/IUiActionStatus.java
@@ -1,0 +1,27 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.core.database.dialog;
+
+public interface IUiActionStatus {
+  public UiPostActionStatus getActionStatus();
+}

--- a/ui/src/org/pentaho/di/ui/core/database/dialog/UiPostActionStatus.java
+++ b/ui/src/org/pentaho/di/ui/core/database/dialog/UiPostActionStatus.java
@@ -1,0 +1,27 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.core.database.dialog;
+
+public enum UiPostActionStatus {
+  OK, ERROR_DIALOG_SHOWN, ERROR, NONE;
+}

--- a/ui/src/org/pentaho/di/ui/core/database/dialog/XulDatabaseExplorerDialog.java
+++ b/ui/src/org/pentaho/di/ui/core/database/dialog/XulDatabaseExplorerDialog.java
@@ -88,11 +88,15 @@ public class XulDatabaseExplorerDialog {
 
       this.runner = new SwtXulRunner();
       this.runner.addContainer( this.container );
+
       this.runner.initialize();
 
       this.controller.setSelectedSchemaAndTable( schemaName, selectedTable );
 
-      theExplorerDialog.show();
+      // show dialog if connection is success only.
+      if ( controller.getActionStatus() == UiPostActionStatus.OK ) {
+        theExplorerDialog.show();
+      }
 
     } catch ( Exception e ) {
       LogChannel.GENERAL.logError( "Error exploring database", e );


### PR DESCRIPTION
Fix behaviour with empty database explorer shown for not success
connections.
Introduced new interface IUiActionStatus and enum UiPostActionStatus to
have ability to read status for reflective calls with exceptions
suppression.

Since Xul is not widely implemented and behavior described in bug is a
private case, this fix only applied for XulDatabaseExplorerController
and
XulDatabaseExplorerDialog classes for 'discover table' ui calls.

junits added into /test folder.
