### PR TITLE
PDI-12017 processing a field name twice with getSafeFieldName() strips u...

### DIFF
--- a/core/src/org/pentaho/di/core/database/BaseDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/BaseDatabaseMeta.java
@@ -2184,8 +2184,8 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterface {
         newName.append( '_' );
       } else {
         // allow protectors
-        for ( char protector : protectors) {
-          if (c == protector) {
+        for ( char protector : protectors ) {
+          if ( c == protector ) {
             newName.append( c );
           }
         }


### PR DESCRIPTION
...nderscores, field protector characters

@mattcasters, please review. This method will append field protectors, but if it finds those characters, will strip them. Added logic to protect field protectors and the hard-referenced underscore.
