### PR TITLE
PDI-10762 - Trans and TransMeta leak

### DIFF
--- a/core/src/org/pentaho/di/core/logging/LoggingRegistry.java
+++ b/core/src/org/pentaho/di/core/logging/LoggingRegistry.java
@@ -36,7 +36,7 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.EnvUtil;
 
 public class LoggingRegistry {
-  private static LoggingRegistry registry;
+  private static LoggingRegistry registry = new LoggingRegistry();
   private Map<String, LoggingObjectInterface> map;
   private Map<String, List<String>> childrenMap;
   private Date lastModificationTime;
@@ -54,10 +54,6 @@ public class LoggingRegistry {
   }
 
   public static LoggingRegistry getInstance() {
-    if ( registry != null ) {
-      return registry;
-    }
-    registry = new LoggingRegistry();
     return registry;
   }
 
@@ -206,6 +202,22 @@ public class LoggingRegistry {
       }
     }
     return out.toString();
+  }
+
+  /**
+   * For junit testing purposes
+   * @return ro items map
+   */
+  Map<String, LoggingObjectInterface> dumpItems() {
+    return Collections.unmodifiableMap( this.map );
+  }
+
+  /**
+   * For junit testing purposes
+   * @return ro parent-child relations map
+   */
+  Map<String, List<String>> dumpChildren() {
+    return Collections.unmodifiableMap( this.childrenMap );
   }
 
   public void removeIncludingChildren( String logChannelId ) {

--- a/core/test-src/org/pentaho/di/core/logging/LoggingRegistrySingltonTest.java
+++ b/core/test-src/org/pentaho/di/core/logging/LoggingRegistrySingltonTest.java
@@ -1,0 +1,83 @@
+package org.pentaho.di.core.logging;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * Note, this test must be run on separate JAVA instance, to be sure 
+ * LoggingRegistry was not already initialized when using differed initialization
+ * or do initialize immediate in static way.
+ *
+ */
+public class LoggingRegistrySingltonTest {
+
+  /**
+   * Test that LoggingRegistry is concurrent-sage initialized over multiple calls. Creating more than 1000 threads can
+   * cause significant performance impact.
+   * 
+   * @throws InterruptedException
+   * @throws ExecutionException
+   * 
+   */
+  @Test( timeout = 30000 )
+  public void testLoggingRegistryConcurrentInitialization() throws InterruptedException, ExecutionException {
+    CountDownLatch start = new CountDownLatch( 1 );
+
+    int count = 1000;
+    CompletionService<LoggingRegistry> drover = registerHounds( count, start );
+    // fire!
+    start.countDown();
+
+    Set<LoggingRegistry> distinct = new HashSet<LoggingRegistry>();
+
+    int i = 0;
+    while ( i < count ) {
+      Future<LoggingRegistry> complete = drover.poll( 15, TimeUnit.SECONDS );
+      LoggingRegistry instance = complete.get();
+      distinct.add( instance );
+      i++;
+    }
+    Assert.assertEquals( "Only one singlton instance ;)", 1, distinct.size() );
+  }
+
+  CompletionService<LoggingRegistry> registerHounds( int count, CountDownLatch start ) {
+    ExecutorService executor = Executors.newFixedThreadPool( count );
+    CompletionService<LoggingRegistry> completionService = new ExecutorCompletionService<LoggingRegistry>( executor );
+    for ( int i = 0; i < count; i++ ) {
+      LogRegistryKicker hound = new LogRegistryKicker( start );
+      completionService.submit( hound );
+    }
+    return completionService;
+  }
+
+  class LogRegistryKicker implements Callable<LoggingRegistry> {
+    CountDownLatch start;
+
+    LogRegistryKicker( CountDownLatch start ) {
+      this.start = start;
+    }
+
+    @Override
+    public LoggingRegistry call() throws Exception {
+      try {
+        start.await();
+      } catch ( InterruptedException e ) {
+        throw new RuntimeException();
+      }
+      return LoggingRegistry.getInstance();
+    }
+  }
+}

--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -569,7 +569,7 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
         transMeta = new TransMeta( filename, false );
       }
 
-      this.log = new LogChannel( this );
+      this.log = LogChannel.GENERAL;
 
       transMeta.initializeVariablesFrom( parentVariableSpace );
       initializeVariablesFrom( parentVariableSpace );

--- a/engine/src/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/org/pentaho/di/trans/TransMeta.java
@@ -728,7 +728,7 @@ public class TransMeta extends AbstractMeta implements XMLInterface, Comparator<
     loopCache = new HashMap<String, Boolean>();
     transformationType = TransformationType.Normal;
 
-    log = new LogChannel( STRING_TRANSMETA );
+    log = LogChannel.GENERAL;
   }
 
   /**


### PR DESCRIPTION
1) For empty constructors for Trans and TransMeta classes assign LogChannel.GENERAL channel by default.
2) junits to check LogChanel.GENERAL added
3) LoggingRegistry now thread-safe singleton class
4) added junit test to test that LoggingRegistry is statically initialized
