### PR TITLE
[SP-1229] Carte falls back to default repo

### DIFF
--- a/engine/src/org/pentaho/di/trans/TransExecutionConfiguration.java
+++ b/engine/src/org/pentaho/di/trans/TransExecutionConfiguration.java
@@ -38,6 +38,8 @@ import org.pentaho.di.core.Props;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.RepositoryPluginType;
@@ -52,6 +54,8 @@ import org.w3c.dom.Node;
 
 public class TransExecutionConfiguration implements Cloneable {
   public static final String XML_TAG = "transformation_execution_configuration";
+
+  private final LogChannelInterface log = LogChannel.GENERAL;
 
   private boolean executingLocally;
 
@@ -636,7 +640,8 @@ public class TransExecutionConfiguration implements Cloneable {
       }
       RepositoryMeta repositoryMeta = repositoriesMeta.findRepository( repositoryName );
       if ( repositoryMeta == null ) {
-        throw new KettleException( "I couldn't find the repository with name '" + repositoryName + "'" );
+        log.logBasic( "I couldn't find the repository with name '" + repositoryName + "'" );
+        return;
       }
       Repository rep =
         PluginRegistry.getInstance().loadClass( RepositoryPluginType.class, repositoryMeta, Repository.class );
@@ -646,7 +651,8 @@ public class TransExecutionConfiguration implements Cloneable {
         rep.connect( username, password );
         setRepository( rep );
       } catch ( Exception e ) {
-        throw new KettleException( "Unable to connect to the repository with name '" + repositoryName + "'", e );
+        log.logBasic( "Unable to connect to the repository with name '" + repositoryName + "'" );
+        return;
       }
     }
   }


### PR DESCRIPTION
When executing a tranformation, carte may not be passed accurate paramters to connect to a repository.
Allow execution to continue with a default preconfigured repository.

http://jira.pentaho.com/browse/SP-1229

Backport of http://jira.pentaho.com/browse/PDI-11946
