### PR TITLE
[PDI-8084] - Updated kettle to use version 4.3.2 of swt  ...

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -133,7 +133,7 @@
     
      
     <!-- The OS-specific libraries are bundled together, unzip them all for assembly -->
-    <dependency org="org.eclipse"          name="swtlibs"               rev="3.7" conf="swtlibs->default" transitive="false">
+    <dependency org="org.eclipse"          name="swtlibs"               rev="4.3.2" conf="swtlibs->default" transitive="false">
       <artifact name="swtlibs" type="zip"/>
     </dependency>
       

--- a/dbdialog/ivy.xml
+++ b/dbdialog/ivy.xml
@@ -28,7 +28,7 @@
     <!--  Third-party (external) dependencies -->
     
     <!-- SWT it required to compile any version of any architecture will work -->
-    <dependency org="org.eclipse.swt" name="swt-linux-x86_64"  rev="3.7" transitive="false" />
+    <dependency org="org.eclipse.swt" name="swt-linux-x86_64"  rev="4.3.2" transitive="false" />
     
     <dependency org="junit" name="junit" rev="4.7" conf="test->default" transitive="false"/>
   </dependencies>

--- a/plugins/kettle-gpload-plugin/ivy.xml
+++ b/plugins/kettle-gpload-plugin/ivy.xml
@@ -24,7 +24,7 @@
       
     <dependency org="commons-vfs" name="commons-vfs" rev="20100924-pentaho" transitive="false"/>
     <!-- SWT it required to compile any version of any architecture will work -->
-    <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="3.7" transitive="false"/>
+    <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="4.3.2" transitive="false"/>
     <dependency org="org.eclipse" name="jface" rev="3.3.0-I20070606-0010" transitive="false"/>
     
     <dependency org="junit" name="junit" rev="4.7" transitive="false" conf="test->default"/>            

--- a/plugins/kettle-hl7-plugin/ivy.xml
+++ b/plugins/kettle-hl7-plugin/ivy.xml
@@ -35,7 +35,7 @@
     <dependency org="ca.uhn.hapi" name="hapi-structures-v26" rev="1.1" transitive="false"/>
     
     <!-- SWT it required to compile any version of any architecture will work -->
-    <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="3.7" conf="dev->default" transitive="false"/>
+    <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="4.3.2" conf="dev->default" transitive="false"/>
     
     <dependency org="junit" name="junit" rev="4.7" conf="test->default"/>     
   </dependencies>

--- a/plugins/kettle-openerp-plugin/ivy.xml
+++ b/plugins/kettle-openerp-plugin/ivy.xml
@@ -27,7 +27,7 @@
       <exclude org="junit" module="junit"/>
     </dependency>
     <!-- SWT it required to compile any version of any architecture will work -->
-    <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="3.7" transitive="false"/>
+    <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="4.3.2" transitive="false"/>
     <dependency org="org.eclipse" name="jface" rev="3.3.0-I20070606-0010" transitive="false"/>
     <dependency org="com.debortoliwines.openerp" name="openerp-java-api" rev="1.3.0" conf="default->default" transitive="false"/>
     

--- a/plugins/kettle-palo-plugin/ivy.xml
+++ b/plugins/kettle-palo-plugin/ivy.xml
@@ -24,7 +24,7 @@
     <dependency org="pentaho" name="pentaho-palo-core" rev="${dependency.kettle.revision}" conf="default->default" transitive="false"/>
     
     <!-- SWT it required to compile any version of any architecture will work -->
-    <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="3.7" transitive="false"/>
+    <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="4.3.2" transitive="false"/>
     <dependency org="org.eclipse" name="jface" rev="3.3.0-I20070606-0010" transitive="false"/> 
     
     <dependency org="junit" name="junit" rev="4.7" conf="test->default"/> 

--- a/ui/ivy.xml
+++ b/ui/ivy.xml
@@ -29,7 +29,7 @@
     <!-- Third-party (external) dependencies -->
 
     <!-- SWT it required to compile any version of any architecture will work -->
-    <dependency org="org.eclipse.swt"       name="swt-linux-x86_64"    rev="3.7" transitive="false" />
+    <dependency org="org.eclipse.swt"       name="swt-linux-x86_64"    rev="4.3.2" transitive="false" />
 
     <dependency org="org.eclipse.equinox"   name="common"              rev="3.3.0-v20070426"      transitive="false"/>
     <dependency org="org.eclipse"           name="jface"               rev="3.3.0-I20070606-0010" transitive="false" conf="default->default"/>


### PR DESCRIPTION
... and include the 4.3.2 version of the swt libraries in the distribution. This will also assist other JIRA cases including PDI-10966, PDI-11314, PDI-11853, PDI-11050, PDI-11134, PDI-11323 and PDI-11338
