### PR TITLE
PDI-3064 : identical class names in identical packages mess up my IDE

### DIFF
--- a/engine/test-src/org/pentaho/di/trans/steps/mapping/MappingTestParameters.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/mapping/MappingTestParameters.java
@@ -10,7 +10,7 @@ import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.steps.StepMockUtil;
 
-public class MappingTest {
+public class MappingTestParameters {
 
   private Mapping step;
   private Trans trans;


### PR DESCRIPTION
A simple file rename in other words.
