### PR TITLE
[PDI-11795] remove Vertica projection creation code

### DIFF
--- a/core/src/org/pentaho/di/core/database/Database.java
+++ b/core/src/org/pentaho/di/core/database/Database.java
@@ -2865,43 +2865,6 @@ public class Database implements VariableSpace, LoggingObjectInterface {
       retval.append( ";" );
     }
 
-    // TODO: All this custom database code shouldn't really be in Database.java.
-    // It should be in the DB implementations.
-    //
-    if ( databaseMeta.getDatabaseInterface() instanceof VerticaDatabaseMeta ) {
-      retval
-        .append( Const.CR ).append( "CREATE PROJECTION " ).append( tableName ).append( "_unseg_super" ).append(
-          Const.CR );
-
-      retval.append( "(" ).append( Const.CR );
-      for ( int i = 0; i < fields.size(); i++ ) {
-        if ( i > 0 ) {
-          retval.append( ", " );
-        } else {
-          retval.append( "  " );
-        }
-
-        retval.append( fields.getValueMeta( i ).getName() ).append( Const.CR );
-      }
-      retval.append( ")" ).append( Const.CR );
-
-      retval.append( "AS SELECT" ).append( Const.CR );
-      for ( int i = 0; i < fields.size(); i++ ) {
-        if ( i > 0 ) {
-          retval.append( ", " );
-        } else {
-          retval.append( "  " );
-        }
-
-        retval.append( fields.getValueMeta( i ).getName() ).append( Const.CR );
-      }
-      retval.append( "FROM " ).append( tableName ).append( Const.CR );
-      retval.append( "-- Replace UNSEGMENTED with a hash segmentation for optimum performance" ).append( Const.CR );
-      retval.append( "--SEGMENTED BY HASH(X,Y,Z)" ).append( Const.CR );
-      retval.append( "UNSEGMENTED ALL NODES" ).append( Const.CR );
-      retval.append( ";" );
-    }
-
     return retval.toString();
   }
 


### PR DESCRIPTION
No longer needed since Vertica 4.
No previous test case coverage, but after this change, it should test identically to any other create table tests.

An example transformation with steps to reproduce is attached to the JIRA case.
