### PR TITLE
[PDI-12292] Update database display Name on edit

### DIFF
--- a/dbdialog/src/org/pentaho/ui/database/event/DataHandler.java
+++ b/dbdialog/src/org/pentaho/ui/database/event/DataHandler.java
@@ -565,6 +565,8 @@ public class DataHandler extends AbstractXulEventHandler {
 
     // Name:
     meta.setName( connectionNameBox.getValue() );
+    // Display Name: (PDI-12292)
+    meta.setDisplayName( connectionNameBox.getValue() );
 
     // Connection type:
     Object connection = connectionBox.getSelectedItem();


### PR DESCRIPTION
Only database 'name' was updated, leaving old name in connection dialogs and the Repository Explorer.

http://jira.pentaho.com/browse/PDI-12292
