### PR TITLE
PDI-11985 - Error while trying to select .kjb in job executor step with ...

### DIFF
--- a/ui/src/org/pentaho/di/ui/trans/steps/jobexecutor/JobExecutorDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/jobexecutor/JobExecutorDialog.java
@@ -619,7 +619,9 @@ public class JobExecutorDialog extends BaseStepDialog implements StepDialogInter
       if ( fname != null ) {
 
         loadFileJob( fname );
-        wFilename.setText( executorJobMeta.getFilename() );
+        // PDI-11985 set filename for UI edit field. This will be saved later in xml
+        // as a filename for JobMeta.
+        wFilename.setText( fname );
         wJobname.setText( Const.NVL( executorJobMeta.getName(), "" ) );
         wDirectory.setText( "" );
         specificationMethod = ObjectLocationSpecificationMethod.FILENAME;

--- a/ui/src/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
@@ -614,7 +614,7 @@ public class TransExecutorDialog extends BaseStepDialog implements StepDialogInt
       if ( fname != null ) {
 
         loadFileTrans( fname );
-        wFilename.setText( executorTransMeta.getFilename() );
+        wFilename.setText( fname );
         wTransname.setText( Const.NVL( executorTransMeta.getName(), "" ) );
         wDirectory.setText( "" );
         specificationMethod = ObjectLocationSpecificationMethod.FILENAME;


### PR DESCRIPTION
...Browse button, if connected to repository.

When using JobExecutorDialog or TransExecutor attempts to select item on a filesystem we used to get NPE.
This was caused by  attempt to set this file name string back on UI after file successful picked up.
For this cases we should use file name discovered from FS instead of using getFilename() method from job
meta.
Job meta will get this file name after executor's dialog will be closed.
No junits due to fix simplicity compare to difficult to write junits for UI dialogs with private elements.
