### PR TITLE
[PPP-3272] - Update all current "infocenter" references to "mind touch"

### DIFF
--- a/assembly/package-res/docs/English/InformationMap.html
+++ b/assembly/package-res/docs/English/InformationMap.html
@@ -283,7 +283,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', end
             </tr>
             <tr>
               <td valign="top" class="bannercontent"><a
-                  href="http://infocenter.pentaho.com/help/index.jsp" target="_blank">Pentaho
+                  href="http://help.pentaho.com" target="_blank">Pentaho
                   InfoCenter</a><br />
                 <span class="style2">Continuously updated, searchable information for all Pentaho
                   products. </span></td>

--- a/assembly/package-res/docs/English/welcome/contents/2013/06/07/upgrade-to-ee.html
+++ b/assembly/package-res/docs/English/welcome/contents/2013/06/07/upgrade-to-ee.html
@@ -97,7 +97,7 @@
 <h3 id='content'>Content</h3>
 
 <ul>
-<li>Pentaho <em>Infocenter</em> includes complete product documentation to ensure you have the right information when you need it.</li>
+<li>Pentaho <em>InfoCenter</em> includes complete product documentation to ensure you have the right information when you need it.</li>
 </ul>
 
 <h3 id='people'>People</h3>

--- a/assembly/package-res/docs/English/welcome/contents/2013/06/20/engage.html
+++ b/assembly/package-res/docs/English/welcome/contents/2013/06/20/engage.html
@@ -17,10 +17,10 @@
 
 <h2 id='documentation'>Documentation</h2>
 
-<p>Both the <a href='http://infocenter.pentaho.com/help/index.jsp'>Pentaho InfoCenter</a> and the <a href='http://wiki.pentaho.com/display/EAI/Latest+Pentaho+Data+Integration+%28aka+Kettle%29+Documentation'>Kettle Wiki</a> are extensive repositories of information. To learn more spend time navigating content through these important links.</p>
+<p>Both the <a href='http://help.pentaho.com'>Pentaho InfoCenter</a> and the <a href='http://wiki.pentaho.com/display/EAI/Latest+Pentaho+Data+Integration+%28aka+Kettle%29+Documentation'>Kettle Wiki</a> are extensive repositories of information. To learn more spend time navigating content through these important links.</p>
 
 <ul>
-<li><a href='http://infocenter.pentaho.com/help/nav/0_4'>InfoCenter, Create DI Solutions</a></li>
+<li><a href='http://help.pentaho.com/Documentation/5.1/0L0/0Y0'>InfoCenter, Create DI Solutions</a></li>
 
 <li><a href='http://wiki.pentaho.com/display/EAI/Pentaho+Data+Integration+Steps'>Transformation Steps Documentation</a></li>
 

--- a/assembly/package-res/docs/English/welcome/index.html
+++ b/assembly/package-res/docs/English/welcome/index.html
@@ -115,10 +115,10 @@
 
 <h2 id='documentation'>Documentation</h2>
 
-<p>Both the <a href='http://infocenter.pentaho.com/help/index.jsp'>Pentaho InfoCenter</a> and the <a href='http://wiki.pentaho.com/display/EAI/Latest+Pentaho+Data+Integration+%28aka+Kettle%29+Documentation'>Kettle Wiki</a> are extensive repositories of information. To learn more spend time navigating content through these important links.</p>
+<p>Both the <a href='http://help.pentaho.com'>Pentaho InfoCenter</a> and the <a href='http://wiki.pentaho.com/display/EAI/Latest+Pentaho+Data+Integration+%28aka+Kettle%29+Documentation'>Kettle Wiki</a> are extensive repositories of information. To learn more spend time navigating content through these important links.</p>
 
 <ul>
-<li><a href='http://infocenter.pentaho.com/help/nav/0_4'>InfoCenter, Create DI Solutions</a></li>
+<li><a href='http://help.pentaho.com/Documentation/5.1/0L0/0Y0'>InfoCenter, Create DI Solutions</a></li>
 
 <li><a href='http://wiki.pentaho.com/display/EAI/Pentaho+Data+Integration+Steps'>Transformation Steps Documentation</a></li>
 
@@ -538,7 +538,7 @@ http://wiki.pentaho.com/display/EAI/Pentaho+Data+Integration+Job+Entries'>Job St
 <h3 id='content'>Content</h3>
 
 <ul>
-<li>Pentaho <em>Infocenter</em> includes complete product documentation to ensure you have the right information when you need it.</li>
+<li>Pentaho <em>InfoCenter</em> includes complete product documentation to ensure you have the right information when you need it.</li>
 </ul>
 
 <h3 id='people'>People</h3>


### PR DESCRIPTION
- Updated link references from infocenter.pentaho.com to help.pentaho.com.
  - Tweaked references to InfoCenter to be consistently spelled (casing)
    InfoCenter is how the Doc team wants to refer to the help documentation
    at this point. No reference to MindTouch since it is only the
    implementation vehicle.
