### PR TITLE
PDI-11831 - ETL Injection needs mapping on all map points

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/sort/SortRowsMetaInjection.java
+++ b/engine/src/org/pentaho/di/trans/steps/sort/SortRowsMetaInjection.java
@@ -204,18 +204,22 @@ public class SortRowsMetaInjection implements StepMetaInjectionInterface {
 
     // Pass the grid to the step metadata
     //
-    meta.setFieldName( sortNames.toArray( new String[sortNames.size()] ) );
-    boolean[] ascending = new boolean[sortAscs.size()];
-    boolean[] cases = new boolean[sortCases.size()];
-    boolean[] presorteds = new boolean[sortPresorteds.size()];
-    for ( int i = 0; i < ascending.length; i++ ) {
-      ascending[i] = sortAscs.get( i );
-      cases[i] = sortCases.get( i );
-      presorteds[i] = sortPresorteds.get( i );
+    // if at least one of the arrays was specified to be injected
+    // we inject the entire grid
+    if ( !sortNames.isEmpty() || !sortAscs.isEmpty() || !sortCases.isEmpty() || !sortPresorteds.isEmpty() ) {
+      meta.setFieldName( sortNames.toArray( new String[sortNames.size()] ) );
+      boolean[] ascending = new boolean[sortAscs.size()];
+      boolean[] cases = new boolean[sortCases.size()];
+      boolean[] presorteds = new boolean[sortPresorteds.size()];
+      for ( int i = 0; i < ascending.length; i++ ) {
+        ascending[i] = sortAscs.get( i );
+        cases[i] = sortCases.get( i );
+        presorteds[i] = sortPresorteds.get( i );
+      }
+      meta.setAscending( ascending );
+      meta.setCaseSensitive( cases );
+      meta.setPreSortedField( presorteds );
     }
-    meta.setAscending( ascending );
-    meta.setCaseSensitive( cases );
-    meta.setPreSortedField( presorteds );
   }
 
   public List<StepInjectionMetaEntry> extractStepMetadataEntries() throws KettleException {

--- a/engine/test-src/org/pentaho/di/trans/steps/sort/SortRowsMetaInjectionTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/sort/SortRowsMetaInjectionTest.java
@@ -1,0 +1,87 @@
+package org.pentaho.di.trans.steps.sort;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.trans.step.StepInjectionMetaEntry;
+
+public class SortRowsMetaInjectionTest {
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Before
+  public void setUp() throws Exception {
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public void sortRowsMetaInjectTest() throws Exception {
+    boolean[] origAscending = new boolean[] { false, true };
+    boolean[] origCaseSensitive = new boolean[] { false, true };
+    boolean[] origPresorted = new boolean[] { false, true };
+    String[] origNames = new String[] {"field1", "field2"};
+
+    SortRowsMeta meta = new SortRowsMeta();
+    meta.setAscending( origAscending );
+    meta.setCaseSensitive( origCaseSensitive );
+    meta.setPreSortedField( origPresorted );
+    meta.setFieldName( origNames );
+    meta.setFreeMemoryLimit( "50" );
+
+    SortRowsMetaInjection inj = meta.getStepMetaInjectionInterface();
+
+    List<StepInjectionMetaEntry> injected = new ArrayList<StepInjectionMetaEntry>();
+    inj.injectStepMetadataEntries( injected );
+
+    assertTrue( "Empty Injection - the same values: acscending", Arrays.equals( origAscending, meta.getAscending() ) );
+    assertTrue( "Empty Injection - the same values: case-sensitive", Arrays.equals( origCaseSensitive, meta.getCaseSensitive() ) );
+    assertTrue( "Empty Injection - the same values: presorted", Arrays.equals( origPresorted, meta.getPreSortedField() ) );
+    assertArrayEquals( "Empty Injection - the same values: field-names", origNames, meta.getFieldName() );
+
+    String memStr = "90";
+    injected.add( new StepInjectionMetaEntry( SortRowsMetaInjection.Entry.FREE_MEMORY_TRESHOLD.toString(), memStr, ValueMetaInterface.TYPE_INTEGER, "descrition" ) );
+    inj.injectStepMetadataEntries( injected );
+
+    assertTrue( "Scalar Injection - the same values: acscending", Arrays.equals( origAscending, meta.getAscending() ) );
+    assertTrue( "Scalar Injection - the same values: case-sensitive", Arrays.equals( origCaseSensitive, meta.getCaseSensitive() ) );
+    assertTrue( "Scalar Injection - the same values: presorted", Arrays.equals( origPresorted, meta.getPreSortedField() ) );
+    assertArrayEquals( "Scalar Injection - the same values: field-names", origNames, meta.getFieldName() );
+    assertEquals( "Memory Treshold has been injected", memStr, meta.getFreeMemoryLimit() );
+
+    injected.clear();
+    String name = "injectedFieldName";
+    StepInjectionMetaEntry fieldsEntry = new StepInjectionMetaEntry( SortRowsMetaInjection.Entry.FIELDS.toString(), memStr, ValueMetaInterface.TYPE_NONE, "descrition" );
+    StepInjectionMetaEntry fieldEntry = new StepInjectionMetaEntry( SortRowsMetaInjection.Entry.FIELD.toString(), memStr, ValueMetaInterface.TYPE_NONE, "descrition" );
+    StepInjectionMetaEntry nameEntry = new StepInjectionMetaEntry( SortRowsMetaInjection.Entry.NAME.toString(), name, ValueMetaInterface.TYPE_STRING, "descrition" );
+
+    fieldsEntry.getDetails().add( fieldEntry );
+    fieldEntry.getDetails().add( nameEntry );
+    injected.add( fieldsEntry );
+    inj.injectStepMetadataEntries( injected );
+
+    boolean[] defBooleanArray = new boolean[] { false };
+    assertTrue( "Grid Injection - new values: acscending", Arrays.equals( defBooleanArray, meta.getAscending() ) );
+    assertTrue( "Grid Injection - new values: case-sensitive", Arrays.equals( defBooleanArray, meta.getCaseSensitive() ) );
+    assertTrue( "Grid Injection - new values: presorted", Arrays.equals( defBooleanArray, meta.getPreSortedField() ) );
+    assertArrayEquals( "Grid Injection - new values: field-names", new String[] {name}, meta.getFieldName() );
+  }
+
+}


### PR DESCRIPTION
prevent overriding sort field settings unless they are explicitely injected.
once at least one sort field's attribute is injected - the entire sort field's settings will be overridden.
