### PR TITLE
[PDI-10744] - Some more updates due to UX changes. 

### DIFF
--- a/engine/src/org/pentaho/di/repository/RepositoryOperation.java
+++ b/engine/src/org/pentaho/di/repository/RepositoryOperation.java
@@ -26,6 +26,7 @@ public enum RepositoryOperation {
 
   READ_TRANSFORMATION( "Read transformation" ), MODIFY_TRANSFORMATION( "Modify transformation" ),
     DELETE_TRANSFORMATION( "Delete transformation" ), EXECUTE_TRANSFORMATION( "Execute transformation" ),
+    CREATE_TRANSFORMATION( "Create Transformation" ), CREATE_JOB( "Create Job" ),
     LOCK_TRANSFORMATION( "Lock transformation" ),
 
     READ_JOB( "Read job" ), MODIFY_JOB( "Modify job" ), DELETE_JOB( "Delete job" ), EXECUTE_JOB( "Execute job" ),

--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -1028,8 +1028,8 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     }
 
     boolean createPerms = !RepositorySecurityUI
-        .verifyOperations( shell, rep, false, RepositoryOperation.MODIFY_TRANSFORMATION,
-            RepositoryOperation.MODIFY_JOB );
+        .verifyOperations( shell, rep, false, RepositoryOperation.CREATE_TRANSFORMATION,
+            RepositoryOperation.CREATE_JOB );
     boolean executePerms = !RepositorySecurityUI
         .verifyOperations( shell, rep, false, RepositoryOperation.EXECUTE_TRANSFORMATION,
             RepositoryOperation.EXECUTE_JOB );
@@ -1040,7 +1040,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     String warningTitle = BaseMessages.getString( PKG, "Spoon.Dialog.WarnToCloseAllForce.Disconnect.Title" );
     String warningText = BaseMessages.getString( PKG, "Spoon.Dialog.WarnToCloseAllForce.Disconnect.Message" );
     int buttons = SWT.OK;
-    if ( ( readPerms && createPerms && executePerms ) || ( readPerms && executePerms ) ) {
+    if ( readPerms && createPerms && executePerms ) {
       warningTitle = BaseMessages.getString( PKG, "Spoon.Dialog.WarnToCloseAllOption.Disconnect.Title" );
       warningText = BaseMessages.getString( PKG, "Spoon.Dialog.WarnToCloseAllOption.Disconnect.Message" );
       buttons = SWT.YES | SWT.NO;
@@ -3655,6 +3655,17 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   }
 
   public void openRepository() {
+    // Check to tabs are dirty and warn user that they must save tabs prior to connecting.  Don't connect!
+    if ( Spoon.getInstance().isTabsChanged() ) {
+      MessageBox mb = new MessageBox( Spoon.getInstance().getShell(), SWT.OK );
+      mb.setMessage(  BaseMessages.getString( PKG, "Spoon.Dialog.WarnToSaveAllPriorToConnect.Message" ) );
+      mb.setText( BaseMessages.getString( PKG, "Spoon.Dialog.WarnToCloseAllForce.Disconnect.Title" ) );
+      mb.open();
+
+      // Don't connect, user will need to save all their dirty tabs.
+      return;
+    }
+
     loginDialog = new RepositoriesDialog( shell, null, new ILoginCallback() {
 
       public void onSuccess( Repository repository ) {
@@ -6700,8 +6711,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         disableMenuItem( doc, "trans-last-impact", disableTransMenu );
 
         // Tools
-        // Enable Connect to repository only when all tabs are not dirty
-        disableMenuItem( doc, "repository-connect", isTabsChanged() );
+        disableMenuItem( doc, "repository-connect", isRepositoryRunning );
         disableMenuItem( doc, "repository-disconnect", !isRepositoryRunning );
         disableMenuItem( doc, "repository-explore", !isRepositoryRunning );
         disableMenuItem( doc, "repository-clear-shared-object-cache", !isRepositoryRunning );
@@ -6801,9 +6811,6 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       anyTabsChanged |= changed;
       entry.getTabItem().setChanged( changed );
     }
-
-    // If there are tabs that are dirty, then disable connect menu-item
-    disableMenuItem( mainSpoonContainer.getDocumentRoot(), "repository-connect", anyTabsChanged );
   }
 
   /**

--- a/ui/src/org/pentaho/di/ui/spoon/messages/messages_en_US.properties
+++ b/ui/src/org/pentaho/di/ui/spoon/messages/messages_en_US.properties
@@ -963,3 +963,4 @@ Spoon.Dialog.WarnToCloseAllOption.Disconnect.Title=Close Files
 Spoon.Dialog.WarnToCloseAllForce.Disconnect.Title=Warning
 Spoon.Dialog.WarnToCloseAllForce.Disconnect.Message=All open files will be closed.
 Spoon.Dialog.WarnToCloseAllOption.Disconnect.Message=Would you like to close all open files?
+Spoon.Dialog.WarnToSaveAllPriorToConnect.Message=You must save files before connecting.


### PR DESCRIPTION
1) Revert disabling of connect menu-item due to updated UX flow.  UX flow to be updated.
2) Add warning user that tabs are dirty prior to connecting to repo per UX flow
3) When disconnecting from repo, don't give option for tabs to remain open if user has read & execute.  UX modified flow to reflect this.
4) Wiring up of create content permissions.
