### PR TITLE
PDI-5203 - In Kettle's Repository Explorer, version history is not refreshed when an object is renamed

### DIFF
--- a/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/model/UIJob.java
+++ b/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/model/UIJob.java
@@ -23,7 +23,9 @@
 package org.pentaho.di.ui.repository.repositoryexplorer.model;
 
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryElementMetaInterface;
 
 public class UIJob extends UIRepositoryContent {
@@ -40,8 +42,12 @@ public class UIJob extends UIRepositoryContent {
   @Override
   public void setName( String name ) throws Exception {
     super.setName( name );
-    rep.renameJob( this.getObjectId(), getRepositoryDirectory(), name );
+    renameJob( this.getObjectId(), getRepositoryDirectory(), name );
     uiParent.fireCollectionChanged();
+  }
+
+  protected ObjectId renameJob( ObjectId objectId, RepositoryDirectory directory, String name ) throws Exception {
+    return rep.renameJob( this.getObjectId(), getRepositoryDirectory(), name );
   }
 
   public void delete() throws Exception {

--- a/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/model/UITransformation.java
+++ b/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/model/UITransformation.java
@@ -23,7 +23,9 @@
 package org.pentaho.di.ui.repository.repositoryexplorer.model;
 
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryElementMetaInterface;
 
 public class UITransformation extends UIRepositoryContent {
@@ -40,8 +42,13 @@ public class UITransformation extends UIRepositoryContent {
   @Override
   public void setName( String name ) throws Exception {
     super.setName( name );
-    rep.renameTransformation( this.getObjectId(), getRepositoryDirectory(), name );
+    renameTransformation( this.getObjectId(), getRepositoryDirectory(), name );
     uiParent.fireCollectionChanged();
+  }
+
+  protected ObjectId renameTransformation( ObjectId objectId, RepositoryDirectory directory, String name )
+    throws Exception {
+    return rep.renameTransformation( this.getObjectId(), getRepositoryDirectory(), name );
   }
 
   public void delete() throws Exception {


### PR DESCRIPTION
These changes are connected with pull request (https://github.com/pentaho/pdi-ee-plugin/pull/77) to pdi-ee-plugin.
