### PR TITLE
[PDI-10591]: NPE and exposed exception on the DI-Server/Carte status pag...

### DIFF
--- a/engine/src/org/pentaho/di/www/GetStatusServlet.java
+++ b/engine/src/org/pentaho/di/www/GetStatusServlet.java
@@ -255,7 +255,10 @@ public class GetStatusServlet extends BaseHttpServlet implements CartePluginInte
         try {
           repositoryName = serverConfig.getRepository() != null ? serverConfig.getRepository().getName() : "";
         } catch ( Exception e ) {
-          repositoryName = Const.getStackTracker( e );
+          logError( BaseMessages.getString( PKG, "GetStatusServlet.Parameter.RepositoryName.UnableToConnect",
+              serverConfig.getRepositoryId() ), e );
+          repositoryName = BaseMessages.getString( PKG, "GetStatusServlet.Parameter.RepositoryName.UnableToConnect",
+              serverConfig.getRepositoryId() );
         }
         out.print( "<tr> <td>"
           + BaseMessages.getString( PKG, "GetStatusServlet.Parameter.RepositoryName" ) + "</td> <td>"

--- a/engine/src/org/pentaho/di/www/SlaveServerConfig.java
+++ b/engine/src/org/pentaho/di/www/SlaveServerConfig.java
@@ -259,6 +259,9 @@ public class SlaveServerConfig {
       RepositoriesMeta repositoriesMeta = new RepositoriesMeta();
       repositoriesMeta.readData();
       repositoryMeta = repositoriesMeta.findRepository( repositoryId );
+      if ( repositoryMeta == null ) {
+        throw new KettleException( "Unable to find repository: " + repositoryId );
+      }
       PluginRegistry registry = PluginRegistry.getInstance();
       repository = registry.loadClass( RepositoryPluginType.class, repositoryMeta, Repository.class );
       repository.init( repositoryMeta );

--- a/engine/src/org/pentaho/di/www/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/www/messages/messages_en_US.properties
@@ -127,3 +127,4 @@ TransStatusServlet.GetTransImage=Show an image of the transformation
 GetJobImageServlet.Log.JobImageRequested=Image of job requested
 GetJobImageServlet.GetJobImage=Show an image of the job
 GetStatusServlet.Parameter.RepositoryName=Repository name
+GetStatusServlet.Parameter.RepositoryName.UnableToConnect=Unable to connect to repository: {0}


### PR DESCRIPTION
...e when the repository is not correctly defined (or repositories.xml is not accessible) - exception is not logged in the pentaho.log nor any tomcat\logs

The fix consists of two minor changes:
1)In the case when the repository is not correctly defined (or repositories.xml is not accessible) the page will display the short message: Unable to connect to repository:<Repository_Id>;
2)Added logging for the exception (with full stacktrace ) into pentaho.log

There is no any changes in logic of processing data in GetStatusServlet just minor tune so there is no need in unit tests.
