### PR TITLE
Launch Java using exec so that it inherits the PID

### DIFF
--- a/assembly/package-res/spoon.sh
+++ b/assembly/package-res/spoon.sh
@@ -197,4 +197,4 @@ OPT="$OPT $PENTAHO_DI_JAVA_OPTIONS -Djava.library.path=$LIBPATH -DKETTLE_HOME=$K
 # ***************
 # ** Run...    **
 # ***************
-"$_PENTAHO_JAVA" $OPT -jar "$STARTUP" -lib $LIBPATH "${1+$@}"
+exec "$_PENTAHO_JAVA" $OPT -jar "$STARTUP" -lib $LIBPATH "${1+$@}"


### PR DESCRIPTION
This makes it much easier to write init scripts for Carte. It also ensures that issuing Ctrl+C actually terminates Java and doesn't leave it running in the background. Jsvc support would be even better but I'll leave that to someone else.