### PR TITLE
[PDI-11590]: Transformation Executor Step Result Rows Table has 2 Length Columns.

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/jobexecutor/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/trans/steps/jobexecutor/messages/messages_en_US.properties
@@ -17,6 +17,7 @@ JobExecutorDialog.RadioRep.Label=Repository by name
 JobExecutorDialog.Exception.UnableToReferenceObjectId.Title=Error
 JobExecutorDialog.Exception.NoValidJobExecutorDetailsFound=No valid job details could be found
 JobExecutorDialog.ColumnInfo.Length=Length
+JobExecutorDialog.ColumnInfo.Precision=Precision
 JobExecutorDialog.GroupSize.Label=The number of rows to send to the job
 JobExecutorDialog.RadioRep.Tooltip=Specify an object in the repository using its name
 JobExecutor.IncorrectDataTypePassed=The ''{0}'' data type passed from the jobs result rows does not correspond to the specified ''{1}'' data type.  Make sure you are passing rows with the expected layout.

--- a/engine/src/org/pentaho/di/trans/steps/transexecutor/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/trans/steps/transexecutor/messages/messages_en_US.properties
@@ -13,6 +13,7 @@ TransExecutorDialog.RadioRep.Label=Repository by name
 TransExecutorDialog.Exception.UnableToReferenceObjectId.Title=Error
 TransExecutorDialog.Exception.NoValidTransExecutorDetailsFound=No valid transformation details could be found
 TransExecutorDialog.ColumnInfo.Length=Length
+TransExecutorDialog.ColumnInfo.Precision=Precision
 TransExecutorDialog.GroupSize.Label=The number of rows to send to the transformation
 TransExecutorDialog.RadioRep.Tooltip=Specify an object in the repository using its name
 TransExecutor.IncorrectDataTypePassed=The ''{0}'' data type passed from the transformation result rows does not correspond to the specified ''{1}'' data type.  Make sure you are passing rows with the expected layout.

--- a/ui/src/org/pentaho/di/ui/trans/steps/jobexecutor/JobExecutorDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/jobexecutor/JobExecutorDialog.java
@@ -1506,7 +1506,7 @@ public class JobExecutorDialog extends BaseStepDialog implements StepDialogInter
           BaseMessages.getString( PKG, "JobExecutorDialog.ColumnInfo.Length" ), ColumnInfo.COLUMN_TYPE_TEXT,
           false ),
         new ColumnInfo(
-          BaseMessages.getString( PKG, "JobExecutorDialog.ColumnInfo.Length" ), ColumnInfo.COLUMN_TYPE_TEXT,
+          BaseMessages.getString( PKG, "JobExecutorDialog.ColumnInfo.Precision" ), ColumnInfo.COLUMN_TYPE_TEXT,
           false ), };
 
     wResultRowsFields =

--- a/ui/src/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
@@ -1472,7 +1472,7 @@ public class TransExecutorDialog extends BaseStepDialog implements StepDialogInt
           ColumnInfo.COLUMN_TYPE_CCOMBO, ValueMeta.getTypes() ),
         new ColumnInfo( BaseMessages.getString( PKG, "TransExecutorDialog.ColumnInfo.Length" ),
           ColumnInfo.COLUMN_TYPE_TEXT, false ),
-        new ColumnInfo( BaseMessages.getString( PKG, "TransExecutorDialog.ColumnInfo.Length" ),
+        new ColumnInfo( BaseMessages.getString( PKG, "TransExecutorDialog.ColumnInfo.Precision" ),
           ColumnInfo.COLUMN_TYPE_TEXT, false ), };
 
     wOutputFields =


### PR DESCRIPTION
There is a fix. The change is just to rename the name of the field in dialog window so there is no need in unit test.
