### PR TITLE
PDI-12648 Line breaks removed from xml tag values in job/transformation files

### DIFF
--- a/core/src/org/pentaho/di/core/xml/XMLHandler.java
+++ b/core/src/org/pentaho/di/core/xml/XMLHandler.java
@@ -768,7 +768,7 @@ public class XMLHandler {
 
     if ( val != null && val.length() > 0 ) {
       value.append( '>' );
-      value.append( encoder.encodeForXML( val ) );
+      value.append( encoder.encodeForXML( val ).replaceAll("&#xd;&#xa;",Const.CR).replaceAll("&#xd;",Const.CR).replaceAll("&#xa;",Const.CR) );
 
       value.append( "</" );
       value.append( tag );


### PR DESCRIPTION
This goes forward with normal XML encoding but then translates CRLF, CR, and/or LF back to an actual line break.

Probably not the most elegant solution, but it works.