### PR TITLE
[BACKLOG-248] Write extension point plugin producing guava bus events

### DIFF
--- a/plugins/kettle-monitoring-plugin/README.md
+++ b/plugins/kettle-monitoring-plugin/README.md
@@ -1,0 +1,55 @@
+KETTLE MONITORING EXTENSION POINT PLUGIN
+========================================
+
+Objective
+---------
+
+The goal of this project is to add support for monitoring all relevant events.
+
+Underlying structure is [PDI Extension Point Plugins](http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins). 
+
+
+Getting started
+---------------
+
+The first thing you should do is to confirm you have ant installed ( http://ant.apache.org/ ).
+
+To prep the project, you first need to resolve/include the necessary dependencies.
+Ivy.xml file contains a list of the dependencies needed to successfully compile this project.
+
+### To fetch dependencies and populate /lib folder 
+
+From the project root and using command-line simply type *ant resolve*
+
+
+How to use
+----------
+
+Following this steps should get you going:
+
+### Compile the project
+
+Just run *ant* and you should be all set
+
+
+### Deploying the plugin in your kettle environment
+
+### A ) Kettle client (standalone application)
+
+Copy the zip folder in ./dist folder and unzip it at 
+
+data-integration/plugins/ 
+
+
+### B ) Kettle server (a.k.a DI Server)
+
+Copy the zip folder in ./dist folder and unzip it at 
+
+data-integration-server/pentaho-solutions/system/kettle/plugins
+
+
+Additional information
+----------------------
+
+In kettle's monitoring plugin root directory you'll find a properties file 
+called 'monitoring.properties'  that will allow you to to some basic log configuration.

--- a/plugins/kettle-monitoring-plugin/build-res/subfloor-pkg.xml
+++ b/plugins/kettle-monitoring-plugin/build-res/subfloor-pkg.xml
@@ -1,0 +1,367 @@
+<!--===========================================================================
+Copyright (c) 2009, Pentaho Engineering Team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Pentaho Corporation nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY Pentaho Engineering Team ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+============================================================================-->
+<!--===========================================================================
+    == SUBFLOOR-PKG ==
+    $Rev: 100 $
+    $Date: 2009-12-09 11:43:26 -0500 (Wed, 09 Dec 2009) $
+    Project Home: http://code.google.com/p/subfloor/
+    Provides default targets for creating application archives such as zip and tar.gzip
+    files.
+    ============================================================================-->
+
+<project name="subfloor-pkg" basedir="." default="default" xmlns:ivy="antlib:org.apache.ivy.ant">
+
+  <!-- Define the default location of the common build file -->
+  <property name="subfloor.file"
+            value="./subfloor.xml"
+            description="This is the location of the standardized subfloor.xml file" />
+
+  <!-- Import the common_build.xml file which contains all the default tasks -->
+  <import file="${subfloor.file}" />
+
+  <property name="stage.dir" value="${bin.dir}/stage" description="Package staging" />
+  <property name="package.root.dir"
+            value="${ivy.artifact.id}"
+            description="Root directory of final zip or tar package" />
+  <property name="approot.stage.dir"
+            value="${stage.dir}/${package.root.dir}"
+            description="Stage application root dir" />
+  <property name="package.id" value="${ivy.artifact.id}" />
+  <property name="package.basename" value="${package.id}-${project.revision}" />
+  <property name="package.resdir" value="${basedir}/package-res" />
+  <property name="package.artifact.ivyfile"
+            value="package-ivy.xml"
+            description="The ivy file defining dependencies of the package" />
+  <property name="package.artifact.pomfile"
+            value="package-pom.xml"
+            description="The Maven pom file defining dependencies of the package" />
+
+  <target name="dist" depends="jar,package" description="Builds and packages the application" />
+
+  <target name="clean-dist">
+    <delete dir="${dist.dir}" />
+    <delete dir="${stage.dir}" />
+  </target>
+
+  <!-- override of jar target.. this definitely should be moved into common build -->
+  <target name="jar"
+          depends="compile,set-build.id,create-version-file"
+          description="Jars up the bin directory after a compile">
+    <jar destfile="${dist.dir}/${ivy.artifact.id}-${project.revision}.jar">
+      <manifest>
+        <attribute name="Implementation-Title" value="${impl.title}" />
+        <attribute name="Implementation-Version" value="${project.revision}.${build.id}" />
+        <attribute name="Implementation-Vendor" value="${impl.vendor}" />
+        <attribute name="Implementation-ProductID" value="${impl.productID}" />
+      </manifest>
+      <fileset dir="${classes.dir}" />
+    </jar>
+  </target>
+
+  <target name="create-version-file">
+    <propertyfile file="${classes.dir}/version.properties" comment="${impl.title} build information">
+      <entry key="version" value="${project.revision}.${build.id}" />
+      <entry key="builddate" type="date" value="now" />
+    </propertyfile>
+  </target>
+
+  <target name="assemble.init">
+    <mkdir dir="${approot.stage.dir}" />
+  </target>
+
+  <target name="assemble" depends="assemble.init,assemble.copy-libs">
+    <copy todir="${approot.stage.dir}" overwrite="true">
+      <fileset dir="${package.resdir}" />
+    </copy>
+    <chmod perm="a+x" dir="${stage.dir}" includes="**/*.sh" />
+  </target>
+
+  <target name="assemble.copy-libs">
+    <copy todir="${approot.stage.dir}/lib">
+      <fileset dir="${lib.dir}" />
+      <fileset file="${dist.dir}/${ivy.artifact.id}-${project.revision}.jar" />
+    </copy>
+  </target>
+
+  <target name="package"
+          depends="assemble,package-zip"
+          description="Creates packaged distributable artifacts" />
+
+  <target name="package-zip">
+    <zip destfile="${dist.dir}/${package.basename}.zip">
+      <zipfileset dir="${stage.dir}" filemode="755">
+        <include name="**/*.sh" />
+        <include name="**/JavaApplicationStub" />
+        <include name="**/*.command" />
+      </zipfileset>
+      <zipfileset dir="${stage.dir}">
+        <exclude name="**/*.sh" />
+        <exclude name="**/JavaApplicationStub" />
+        <exclude name="**/*.command" />
+      </zipfileset>
+    </zip>
+  </target>
+  
+
+  
+  <!-- ============================================linuxPackage===================================================== -->
+
+  <property name="linuxPackage.name" value="pentaho-${package.id}" />
+
+  <property name="linuxPackage.longName" value="${impl.title}" />
+  <property name="linuxPackage.description" value="${impl.title}" />
+  <property name="linuxPackage.release" value="1" />
+  <property name="linuxPackage.initd.startCommandDelegatee" value="start.pentaho.sh" 
+    description="init.d script will delegate to this script located in /opt/pentaho/${linuxPackage.name}" />
+
+  <property name="linuxPackage.initd.stopCommandDelegatee" value="stop.pentaho.sh" 
+    description="init.d script will delegate to this script located in /opt/pentaho/${linuxPackage.name}" />
+
+  <property name="linuxPackage.initd.processName" value="catalina" 
+    description="string that must be present to prove pid is not stale; see init.d script" />
+  <property name="linuxPackage.res.dir" value="linux-res" description="Directory with Linux package resources." />
+  <filterset begintoken="[[[" endtoken="]]]" id="linuxPackage.filterset">
+    <filter token="linuxPackage.initd.startCommandDelegatee" value="${linuxPackage.initd.startCommandDelegatee}" />
+    <filter token="linuxPackage.initd.stopCommandDelegatee" value="${linuxPackage.initd.stopCommandDelegatee}" />
+    <filter token="linuxPackage.initd.processName" value="${linuxPackage.initd.processName}" />
+    <filter token="linuxPackage.name" value="${linuxPackage.name}" />
+    <filter token="linuxPackage.longName" value="${linuxPackage.longName}" />
+  </filterset>
+  <!-- prepares Debian control file and scripts shared by DEB and RPM -->
+  <target name="linuxPackage-prepare-control">
+    <copy todir="${linuxPackage.stage.dir}/control" overwrite="true">
+      <fileset dir="${linuxPackage.res.dir}/control" />
+      <filterset refid="linuxPackage.filterset" />
+      <filterset refid="${linuxPackage.extraFilterset}" />
+    </copy>
+  </target>
+  <!-- prepares actual files to be installed shared by DEB and RPM -->
+  <target name="linuxPackage-prepare-data">
+    <mkdir dir="${linuxPackage.stage.dir}/data/opt/pentaho/${linuxPackage.name}" />
+
+    <antcall target="linuxPackage-copy-files">
+      <param name="linuxPackage.dataDir" value="${linuxPackage.stage.dir}/data" />
+      <param name="linuxPackage.packageFormat" value="${linuxPackage.packageFormat}" />
+    </antcall>
+    <copy todir="${linuxPackage.stage.dir}/data" overwrite="true">
+      <fileset dir="${linuxPackage.res.dir}/data" />
+      <filterset refid="linuxPackage.filterset" />
+      <filterset refid="${linuxPackage.extraFilterset}" />
+    </copy>
+    <!-- if any files named __package.name__, rename them-->
+
+    <if>
+      <available file="${linuxPackage.stage.dir}/data/etc/init.d/__package.name__" type="file" />
+      <then>
+        <move file="${linuxPackage.stage.dir}/data/etc/init.d/__package.name__" tofile="${linuxPackage.stage.dir}/data/etc/init.d/${linuxPackage.name}" />
+      </then>
+    </if>
+    <if>
+      <available file="${linuxPackage.stage.dir}/data/opt/pentaho/__package.name__" type="dir" />
+      <then>
+        <move file="${linuxPackage.stage.dir}/data/opt/pentaho/__package.name__" tofile="${linuxPackage.stage.dir}/data/opt/pentaho/${linuxPackage.name}" />
+      </then>
+    </if>
+  </target>
+
+  <!-- override if necessary -->
+  <target name="linuxPackage-copy-files">
+    <echo>Copying files for Linux package format: ${linuxPackage.packageFormat}</echo>
+    <copy todir="${linuxPackage.dataDir}/opt/pentaho/${linuxPackage.name}">
+      <fileset dir="${stage.dir}/${package.id}" />
+    </copy>
+  </target>
+  <!-- ============================================deb============================================================== -->
+
+  <property name="deb.longName" value="${linuxPackage.longName}" />
+
+  <property name="deb.name" value="${linuxPackage.name}" />
+  <property name="deb.arch"
+            value="all"
+            description="One of i386, amd64, or all." />
+
+ <property name="deb.maintainer" value="buildguy &lt;buildguy@pentaho.com&gt;" />
+  <property name="deb.desc" value="${linuxPackage.description}" />
+  <property name="deb.release" value="${linuxPackage.release}" />
+  <property name="deb.stage.dir"
+            value="${bin.dir}/deb-stage"
+            description="Staging directory for Debian package creation." />
+
+  <property name="deb.res.dir"
+            value="${linuxPackage.res.dir}"
+            description="Debian package resources." />
+  <filterset begintoken="[[[" endtoken="]]]" id="deb.filterset">
+    <filter token="deb.name" value="${deb.name}" />
+    <filter token="deb.version" value="${project.revision}-${deb.release}" />
+    <filter token="deb.longName" value="${deb.longName}" />
+    <filter token="deb.arch" value="${deb.arch}" />
+    <filter token="deb.desc" value="${deb.desc}" />
+    <filter token="deb.maintainer" value="${deb.maintainer}" />
+  </filterset>
+  <!-- jdeb is cross-platform Debian package tool -->
+  <target name="install-jdeb" depends="install-ivy">
+    <taskdef-with-ivy task-name="jdeb" classname="org.vafer.jdeb.ant.DebAntTask" organisation="org.vafer" module="jdeb" 
+      revision="0.8" />
+  </target>
+
+  <target name="package-deb" depends="install-jdeb" description="Creates Debian package.">
+
+    <antcall target="linuxPackage-prepare-control">
+      <param name="linuxPackage.stage.dir" value="${deb.stage.dir}" />
+      <param name="linuxPackage.res.dir" value="${deb.res.dir}" />
+      <param name="linuxPackage.extraFilterset" value="deb.filterset" />
+    </antcall>
+    <antcall target="linuxPackage-prepare-data">
+      <param name="linuxPackage.stage.dir" value="${deb.stage.dir}" />
+      <param name="linuxPackage.res.dir" value="${deb.res.dir}" />
+      <param name="linuxPackage.extraFilterset" value="deb.filterset" />
+      <param name="linuxPackage.packageFormat" value="deb" />
+    </antcall>
+    <!-- tar for the sole purpose of creating execute bit -->
+    <tar destfile="${deb.stage.dir}/data.tar.gz" longfile="gnu" compression="gzip">
+      <tarfileset dir="${deb.stage.dir}/data" mode="755">
+        <include name="**/*.sh" />
+      </tarfileset>
+      <tarfileset dir="${deb.stage.dir}/data">
+        <exclude name="**/*.sh" />
+      </tarfileset>
+    </tar>
+    <!-- do not change this package name; it is consistent with Debian package naming conventions -->
+    <!-- the 1 below is the Debian revision number, which may change if only the control files are changed -->
+    <!-- http://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.html -->
+    <jdeb destfile="${dist.dir}/${deb.name}_${project.revision}-${deb.release}_${deb.arch}.deb"
+        control="${deb.stage.dir}/control">
+      <data src="${deb.stage.dir}/data.tar.gz" type="archive" />
+    </jdeb>
+  </target>
+  <!-- ================================================rpm========================================================== -->
+
+  <property name="rpm.name" value="${linuxPackage.name}" />
+  <property name="rpm.arch"
+            value="NOARCH"
+            description="One of I386, X86_64, or NOARCH. Case matters." />
+  <property name="rpm.group" value="System Environment/Daemons" description="Group for RPM spec file." />
+  <property name="rpm.summary" value="${linuxPackage.description}" description="Summary for RPM spec file." />
+
+  <property name="rpm.stage.dir"
+            value="${bin.dir}/rpm-stage"
+            description="Staging directory for RPM package creation." />
+
+  <property name="rpm.res.dir"
+            value="${linuxPackage.res.dir}"
+            description="RPM package resources." />
+  <filterset begintoken="[[[" endtoken="]]]" id="rpm.filterset">
+  </filterset>
+  <!-- redline is cross-platform RPM package tool -->
+  <target name="install-redline" depends="install-ivy">
+    <taskdef-with-ivy task-name="redline" classname="org.freecompany.redline.ant.RedlineTask" organisation="org.redline-rpm" module="redline" 
+      revision="1.1.9" />
+  </target>
+  <target name="package-rpm" depends="install-redline">
+    <antcall target="linuxPackage-prepare-control">
+      <param name="linuxPackage.stage.dir" value="${rpm.stage.dir}" />
+      <param name="linuxPackage.res.dir" value="${rpm.res.dir}" />
+      <param name="linuxPackage.extraFilterset" value="rpm.filterset" />
+    </antcall>
+    <antcall target="linuxPackage-prepare-data">
+      <param name="linuxPackage.stage.dir" value="${rpm.stage.dir}" />
+      <param name="linuxPackage.res.dir" value="${rpm.res.dir}" />
+      <param name="linuxPackage.extraFilterset" value="rpm.filterset" />
+      <param name="linuxPackage.packageFormat" value="rpm" />
+    </antcall>
+    <!-- to adhere to naming conventions, version number cannot contain dash -->
+    <!-- http://www.rpm.org/max-rpm/ch-rpm-file-format.html -->
+    <propertyregex property="rpm.version" input="${project.revision}" regexp="-" replace="_" />
+    <property name="rpm.release" value="${linuxPackage.release}" />
+    <antcall target="create-rpm"></antcall>
+  </target>
+
+  <target name="create-rpm">
+    <!-- these tarfilesets can be overridden -->
+    <!-- you can't just include everything in ${rpm.stage.dir}/data without a prefix; rpm will complain that the path 
+         already exists; the prefixes here are paths that are expected to already exist and thus should not be created
+         by this package -->
+    <tarfileset erroronmissingdir="false" prefix="/etc/init.d" dir="${rpm.stage.dir}/data/etc/init.d" id="rpm.tarfileset1" />
+    <tarfileset erroronmissingdir="false" prefix="/opt" dir="${rpm.stage.dir}/data/opt" id="rpm.tarfileset2" />
+    <tarfileset erroronmissingdir="false" prefix="/var/run" dir="${rpm.stage.dir}/data/var/run" id="rpm.tarfileset3" />
+    <tarfileset erroronmissingdir="false" dir="${rpm.stage.dir}/data" includes="doesnotexist" id="rpm.tarfileset4" />
+    <tarfileset erroronmissingdir="false" dir="${rpm.stage.dir}/data" includes="doesnotexist" id="rpm.tarfileset5" />
+    <redline architecture="${rpm.arch}" group="${rpm.group}" name="${rpm.name}" version="${rpm.version}" 
+      postInstallScript="${rpm.stage.dir}/control/postinst" preUninstallScript="${rpm.stage.dir}/control/prerm" 
+      destination="${dist.dir}" summary="${rpm.summary}" release="${rpm.release}">
+      <tarfileset refid="rpm.tarfileset1" />
+      <tarfileset refid="rpm.tarfileset2" />
+      <tarfileset refid="rpm.tarfileset3" />
+      <tarfileset refid="rpm.tarfileset4" />
+      <tarfileset refid="rpm.tarfileset5" />
+    </redline>
+  </target>
+  <!-- =========================================================================================================== -->
+
+  <!--=======================================================================
+      create-pom (override)
+      Creates the POM files for publishing the jar and gwt zip package to the Maven repository
+      ====================================================================-->
+  <target name="create-pom"
+          depends="install-ivy,subfloor.create-pom,create-package-pom"
+          description="Creates a POM file based on the ivy dependencies" />
+
+  <!--=======================================================================
+      create-package-pom 
+      Creates a POM file for the package
+      ====================================================================-->
+  <target name="create-package-pom"
+          depends="install-ivy"
+          description="Creates a POM file based on the ivy dependencies for a separate package">
+    <ivy:makepom ivyfile="${package.artifact.ivyfile}" pomfile="${package.artifact.pomfile}" />
+    <replace file="${package.artifact.pomfile}" token="jar" value="zip" />
+  </target>
+
+  <!--=======================================================================
+      publish-nojar (override)
+      Publishes the jar and zip package to the Maven repository
+      ====================================================================-->
+  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,subfloor.publish-nojar">
+
+    <antcall target="maven-publish-artifact">
+      <param name="publish.pomFile" value="${package.artifact.pomfile}" />
+      <param name="publish.file" value="${dist.dir}/${package.basename}.zip" />
+    </antcall>
+  </target>
+
+  <!--=======================================================================
+      publish-local-nojar (override)
+      Publishes jar and zip package locally
+      ====================================================================-->
+  <target name="publish-local-nojar" depends="install-ivy,subfloor.publish-local-nojar">
+    <ivy:resolve file="${package.artifact.ivyfile}" />
+    <ivy:publish resolver="local" pubrevision="${project.revision}" overwrite="true" forcedeliver="true">
+      <artifacts pattern="${dist.dir}/[artifact]-[revision].[ext]" />
+    </ivy:publish>
+  </target>
+
+</project>

--- a/plugins/kettle-monitoring-plugin/build-res/subfloor.xml
+++ b/plugins/kettle-monitoring-plugin/build-res/subfloor.xml
@@ -1,0 +1,2123 @@
+<!--===========================================================================
+Copyright (c) 2008-2009, Pentaho Engineering Team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Pentaho Corporation nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY Pentaho Engineering Team ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+============================================================================-->
+<!--===========================================================================
+    == SUBFLOOR ==
+    
+    $Date: Wed Nov  6 16:13:57 UTC 2013 $
+    Project Home: https://github.com/pentaho/subfloor/
+    
+    This file contains the default implementation of the ant tasks to 
+    perform a build. This file should be included by the build.xml file 
+    for your particular project. That build file should redefine any task 
+    that is defined in subfloor.xml IF AND ONLY IF the function of the 
+    task needs to be customized.
+    
+    FORMATTING: 
+      ALIGNMENT: indent=2 spaces and wrap lines longer than 120 chars
+      NAMING: targets intended for execution by a user are named single-word
+              or hyphenated.  Internal targets use '.' notation.
+    
+    TO GET STARTED with your project, you will need this file in 
+          your project's root directory along with three additional files:
+          1. build.xml 
+          2. build.properties
+          3. ivy_settings.xml
+          4. ivy.xml
+          
+          Below are some templates:
+          
+      === build.xml
+    <project name="MyProject" basedir="." default="jar" xmlns:ivy="antlib:org.apache.ivy.ant" >
+      <description>
+        This build file is used to create the MyProject project and works with the subfloor.xml file.
+      </description>
+
+      <import file="subfloor.xml"/>
+    </project>
+  
+    === build.properties
+    project.revision=1.0-SNAPSHOT  #the version of your project.  This will appear in jar META-INF, dist artifact filenames and IVY revision metadata. 
+    ivy.artifact.id=my-project   #IVY metadata describing the name of the artifact
+    impl.title=My Project #English language version of your project name
+    
+============================================================================-->
+
+
+<project name="subfloor" basedir="." default="default" xmlns:ivy="antlib:org.apache.ivy.ant">
+  <description>
+-------------------------------------------------------------------------------
+     subfloor.xml provides tasks needed to perform a project build. 
+     It is typically not used directly but imported by each project's build.xml
+     file.  The build.xml file can override tasks when customization is required. 
+      
+MAIN TARGETS
+============
+  * clean / clean-all : 
+    remove all artifacts of the build, clean-all adds the removal
+    of any library or jar dependencies downloaded as part of the build
+    
+  * resolve :
+    download/refresh library or jar dependencies needed for the build (uses Apache IVY)
+    
+  * compile :
+    run javac on the project's source
+    
+  * jar :
+    creates a jar file
+    
+  * dist :
+    creates all project distributables
+    
+  * test :
+    runs JUnit tests from your project's test source
+    
+SPECIAL TARGETS
+============
+  * publish-local :
+    builds a jar for your project and registers it with the local artifact repository isolated 
+    to your machine at $HOME/.ivy2/local.  Further executions of the the resolve target by this
+    or other projects will find your published jar.
+    
+  * ivy-clean* :
+    this family of targets helps reset your IVY environment in the event that you are having
+    difficulty resolving dependencies
+    
+TYPICAL TARGET SEQUENCE
+============    
+  * clean-all resolve dist :
+    a good start to build all project distributables from scratch.  Note that jar dependencies
+    will not be downloaded unless you explicitly run the resolve target.  We made the resolution
+    and retrieval completely discretionary since there are many situations in which
+    you will not want to get or refresh dependencies, e.g. if you are offline with no Internet
+    access.  In such case, you could just run "dist" if the set of jars you already have are 
+    sufficient.
+    
+  </description>
+
+  <!-- Load the properties files in the proper order -->
+  <property file="override.properties"
+            description="Properties customized for your development environment belong in this file.  This file will never be checked into the SCM." />
+  <property file="build.properties"
+            description="Properties customized for your particular project belong in this file." />
+
+  <!-- =================================================================================
+       Property Defaults
+       Any of these properties can be overridden in either build.properties or override.properties
+       =================================================================================-->
+
+  <!-- Project meta properties -->
+  <property name="impl.vendor" value="Pentaho Corporation" description="Jar file metadata describing the jar's vendor" />
+  <property name="impl.productID"
+            value=""
+            description="Jar file metadata indicating the product ID (this is not the revision)" />
+
+  <!-- Compile properties -->
+  <property name="src.dir" value="${basedir}/src" description="Project source code directory" />
+  <property name="bin.dir" value="${basedir}/bin" description="Base directory for all non-dist build output" />
+  <property name="classes.dir"
+            value="${bin.dir}/classes"
+            description="Classes compiled from project source code are placed here" />
+  <property name="lib.dir"
+            value="${basedir}/lib"
+            description="Directory that hosts Jar files required to compile project source.  (IVY will populate this directory with required jars)" />
+  <property name="devlib.dir"
+            value="${basedir}/dev-lib"
+            description="Directory for developer to place development Jar files (not affected by clean targets)" />
+
+  <!-- Compiler properties (passed directly to javac ant target) -->
+  <property name="javac.debug"
+            value="true"
+            description="Indicates whether source should be compiled with debug information (passed to javac ant task)." />
+  <property name="javac.deprecation"
+            value="true"
+            description="Indicates whether source should be compiled with deprecation information" />
+  <property name="javac.source" value="6" description="Provide source compatibility with specified release" />
+  <property name="javac.target" value="6" description="Generate class files for specific VM version" />
+  <property name="javac.maxmemory" value="256M" description="Max memory alloted to java compile" />
+  <property name="javac.xlint" value="-Xlint:all" />
+
+  <!-- Third party Ant tasks and tools properties -->
+  <property name="subfloor.resources.dir"
+            value="${user.home}/.subfloor"
+            description="Base dir for runtime jars that are required exclusively by the build process" />
+  <property name="subfloor.tmp.dir"
+            value="${subfloor.resources.dir}/tmp"
+            description="Temporary space where files are prepared for installation" />
+  <property name="antcontrib.build.cache.dir"
+            value="${subfloor.resources.dir}/ant-contrib"
+            description="Directory where the Ant-Contrib jar (and dependencies) is placed after it is auto-downloaded by the build" />
+  <property name="svnant.use-javahl"
+            value="false"
+            description="Prefer JNI JavaHL binding over the command line client for native svn support" />
+  <property name="svnant.use-svnkit"
+            value="true"
+            description="Prefer SVNKit binding over the command line client for native svn support (defaults to true)" />
+  <property name="ivy.url"
+            value="http://repo.pentaho.org/artifactory/repo/org/apache/ivy/ivy/2.3.0/ivy-2.3.0.jar"
+            description="The URL to the current release of Apache IVY" />
+	
+  <!-- Enunciate properties -->
+  <property name="enunciate.home" value="${basedir}/enunciate" />
+  <property name="enunciate.bin.dir" value="${bin.dir}/enunciate" />
+
+
+  <!-- Test properties -->
+  <property name="junit.base.dir" value="${basedir}" description="Directory in which the junit test VM will be invoked" />
+  <property name="testsrc.dir" value="${basedir}/test-src" description="Directory that hosts the test source files" />
+  <property name="testlib.dir"
+            value="${basedir}/test-lib"
+            description="Directory for jar files needed during unit testing" />
+  <property name="testbin.dir"
+            value="${bin.dir}/test"
+            description="Base directory for all compiler generated test output" />
+  <property name="testclasses.dir"
+            value="${testbin.dir}/classes"
+            description="Classes compiled from project test code are placed here" />
+  <property name="testreports.dir"
+            value="${bin.dir}/reports/test"
+            description="Base directory that holds all unit test report files" />
+  <property name="testreports.xml.dir"
+            value="${testreports.dir}/xml"
+            description="Unit test xml reports are placed here" />
+  <property name="testreports.html.dir"
+            value="${testreports.dir}/html"
+            description="Unit test html reports are placed here" />
+  <property name="junit.haltonfailure" value="no" description="Fail the build if a test fails" />
+  <property name="junit.haltonerror" value="no" description="Fail the build if a error occurs" />
+  <property name="junit.maxmemory" value="256M" description="Heap size when Junit is run in fork mode" />
+  <property name="junit.forkmode" 
+            value="perTest" 
+            description="Defines whether JUnit forks a new JVM for each test. Use 'once' for faster test runs, and 'perTest' for complete tests."/>
+  <property name="headless.unittest" value="true" description="Runs the unit tests in headless mode" />
+
+  <!-- Code Coverage properties -->
+  <property name="instrumented.classes.dir"
+            value="${testbin.dir}/instrumented-classes"
+            description="Directory where instrumented project classes are placed for use by code coverage utility" />
+  <property name="cobertura.version"
+            value="1.9.4.1"
+            description="The version of cobertura to use for code coverage" />
+  <property name="cobertura.data.dir"
+            value="${testbin.dir}/cobertura-bin"
+            description="Temporary data directory used by Cobertura" />
+  <property name="coberturareports.dir"
+            value="${bin.dir}/reports/cobertura"
+            description="Base directory for all generated Cobertura code coverage reports" />
+  <property name="coberturareports.xml.dir"
+            value="${coberturareports.dir}/xml"
+            description="Cobertura xml reports are placed here" />
+  <property name="coberturareports.html.dir"
+            value="${coberturareports.dir}/html"
+            description="Cobertura html reports are placed here" />
+
+  <!-- Javadoc properties -->
+  <property name="javadoc.dir"
+            value="${bin.dir}/javadoc"
+            description="Directory where generated javadoc will be placed" />
+  <property name="javadoc.packagenames"
+            value="org.mypackagename.*"
+            description="This property is passed to the packagenames property of the javadoc ant task.  You should customize this for your project." />
+  <property name="javadoc.zip.filename" value="${ivy.artifact.id}-${project.revision}-javadoc.zip" />
+  <property name="javadoc.tar.filename" value="${ivy.artifact.id}-${project.revision}-javadoc.tar.gz" />
+
+  <!-- Distribution and Assembly properties -->
+  <property name="dist.dir"
+            value="${basedir}/dist"
+            description="Base directory for all project artifacts (jar, zip, tar.gz, etc...)" />
+  <property name="license.dir"
+            value="${basedir}"
+            description="Base directory where this project's license files reside" />
+  <property name="res.dir"
+            value="${basedir}/res"
+            description="Directory that holds resources not included in the source tree" />
+  <property name="source.zip.filename" value="${ivy.artifact.id}-${project.revision}-sources.zip" />
+  <property name="source.tar.filename" value="${ivy.artifact.id}-${project.revision}-sources.tar.gz" />
+  <property name="source.publish" value="true" />
+  
+  <!-- Ivy properties -->
+  <property name="ivy.settingsurl"
+            value="file:${basedir}/ivysettings.xml"
+            description="URL to the (common) ivysettings.xml.  This file is required by the build to configure IVY.  Note you must escape the ':' if this property exists in a .properties file" />
+  <property name="ivyfile"
+            value="ivy.xml"
+            description="The name of the IVY xml file defining your project's dependencies" />
+  <property name="ivy.artifact.group"
+            value="mycompanyname"
+            description="IVY metadata describing the originating company or organization" />
+  <property name="ivy.artifact.pomfile"
+            value="${dist.dir}/pom.xml"
+            description="The path to the Maven pom file to deploy with the artifact" />
+  <property name="ivy.artifact.ivyfilename"
+            value="ivy.xml"
+            description="The name of the IVY xml file to deploy with the artifact" />
+  <property name="ivy.artifact.ivypathname"
+            value="${dist.dir}/ivy.xml"
+            description="The full path to the IVY xml file to deploy with the artifact" />
+  <property name="ivy.reports.dir"
+            value="${bin.dir}/reports/ivy"
+            description="Base directory that holds all IVY dependency report files" />
+  <property name="ivy.configs" value="*" description="Set of configs used for IVY reporting and checking operations" />
+  <property name="ivy.use.symlinks" value="true" description="Flag indicating if Ivy should create symlinks when retrieving artifacts."/>
+
+  <!-- Tattletale properties -->
+  <property name="tattletale.url"
+            value="http://repo.pentaho.org/artifactory/repo/jboss/tattletale/1.1.2.Final/tattletale-1.1.2.Final.zip"
+            description="The URL from which to download tattletale" />
+  <property name="tattletale.classname"
+            value="org.jboss.tattletale.ant.ReportTask"
+            description="The name of the class which will run the tattletale reports" />
+  <property name="tattletale.reports.dir"
+            value="${bin.dir}/reports/tattletale"
+            description="Base directory that holds the output of the tattletale reports" />
+  <property name="tattletale.configfile"
+            value=""
+            description="The configuration file for the tattletale report" />
+
+  <!-- Sonar properties -->
+  <property name="sonar.url"
+            value="http://repo1.maven.org/maven2/org/codehaus/sonar-plugins/sonar-ant-task/1.2/sonar-ant-task-1.2.jar"/>
+  <property name="sonar.classname"
+          value="org.sonar.ant.SonarTask"/>
+
+  <!-- Load the manifest file (if any) as a properties file -->
+  <property name="dist.manifest.file"
+            value="${dist.dir}/MANIFEST.MF"
+            description="The manifest file that will be generated as part of the build" />
+  <property name="manifest.file"
+            value="${res.dir}/META-INF/MANIFEST.MF"
+            description="The location of the MANIFEST.MF file for this application." />
+  <property file="${manifest.file}"
+            description="Loads the manifest information from the manifest file as a properties file." />
+
+  <!-- Checkstyle Properties -->
+  <property name="checkstyle.version"
+            value="5.7"
+            description="The version of CheckStyle to use for coding standards" />
+  <property name="checkstyle.dir"
+            value="${basedir}/checkstyle" />
+  <property name="checkstyle.lib.dir"
+            value="${checkstyle.dir}/lib" />
+  <property name="checkstyle.reports.dir"
+            value="${checkstyle.dir}/reports" />
+  <property name="checkstyle.config.url"
+            value="http://ci.pentaho.com/job/pentaho-coding-standards/lastSuccessfulBuild/artifact/pentaho_checkStyle.xml" />
+  <property name="checkstyle.suppressions.url"
+            value="http://ci.pentaho.com/job/pentaho-coding-standards/lastSuccessfulBuild/artifact/suppressions.xml" />
+  <property name="checkstyle.stylesheet.url"
+            value="http://ci.pentaho.com/job/pentaho-coding-standards/lastSuccessfulBuild/artifact/checkstyle-noframes-sorted.xsl" />
+  <property name="checkstyle.config.file"
+            value="${checkstyle.dir}/pentaho_checkStyle.xml" />
+  <property name="checkstyle.suppressions.file"
+            value="${checkstyle.dir}/suppressions.xml" />
+  <property name="checkstyle.stylesheet.file"
+            value="${checkstyle.dir}/checkstyle-noframes-sorted.xsl" />
+
+  <!-- Set the project revision number to the value in the manifest file (if it has not
+       been specified in the properties file -->
+  <property name="project.revision"
+            value="${Implementation-Version}"
+            description="Sets the version number of the project based on the Implementation-Version found in the manifest file (if one is supplied and nothing is specified in the build.properties)" />
+  <fail message="A project revision number has not been determined!">
+    <condition>
+      <matches string="${project.revision}" pattern="\$\{.*\}" />
+    </condition>
+  </fail>
+
+  <!-- Set the project title to the value in the manifest file (if it has not
+       been specified in the properties file -->
+  <property name="impl.title"
+            value="${Implementation-Title}"
+            description="Sets the title of the project based on the Implementation-Title found in the manifest file (if one is supplied and nothing is specified in the build.properties)" />
+  <fail message="A project title has not been determined!">
+    <condition>
+      <matches string="${impl.title}" pattern="\$\{.*\}" />
+    </condition>
+  </fail>
+
+  <!-- Build Mode properties -->
+  <property name="release" value="false" description="Set this to true if you want to generate a release artifact" />
+
+  <!-- Ivy should only use symlinks if we're not in release mode -->
+  <condition property="ivy.use.symlinks.internal">
+    <and>
+      <isfalse value="${release}"/>
+      <istrue value="${ivy.use.symlinks}"/>
+    </and>
+  </condition>
+
+  <!-- Set the os property -->
+  <condition property="isLinux">
+    <os family="unix" />
+  </condition>
+  <condition property="isWindows">
+    <os family="windows" />
+  </condition>
+  <condition property="isMac">
+    <os family="mac" />
+  </condition>
+
+  <condition property="os.classifier" value="win">
+    <os family="windows" />
+  </condition>
+  <condition property="os.classifier" value="mac">
+    <os family="mac" />
+  </condition>
+  <condition property="os.classifier" value="linux">
+    <os family="unix" />
+  </condition>
+  <property name="os.classifier" value="unsupported" />
+
+  <!-- Setup the compile classpath -->
+  <path id="classpath">
+    <fileset dir="${devlib.dir}">
+      <include name="**/*.jar" />
+    </fileset>
+    <fileset dir="${lib.dir}">
+      <include name="**/*.jar" />
+    </fileset>
+  </path>
+
+  <!-- Setup the classpath used for testing -->
+  <path id="test.classpath">
+    <pathelement path="${testclasses.dir}" />
+    <pathelement path="${classes.dir}" />
+    <fileset dir="${devlib.dir}">
+      <include name="**/*.jar" />
+    </fileset>
+    <fileset dir="${testlib.dir}">
+      <include name="**/*.jar" />
+    </fileset>
+    <fileset dir="${lib.dir}">
+      <include name="**/*.jar" />
+    </fileset>
+  </path>
+
+
+  <!--=======================================================================
+      default
+      
+      The target that is run if no target is given
+      ====================================================================-->
+  <target name="default" depends="build" />
+
+
+  <!--=======================================================================
+      build
+      
+      Runs a typical build process to create the project locally
+      ====================================================================-->
+  <target name="build" depends="clean-all,resolve,cobertura,dist-source,dist" />
+
+
+  <!--=======================================================================
+      build-testless
+      
+      Runs a typical build process to create the project locally (no testing)
+      ====================================================================-->
+  <target name="build-testless" depends="clean-all,resolve,dist-source,dist" />
+
+
+  <!--=======================================================================
+      continuous
+      
+      Runs a typical continuous integration build including project dist,
+      test, and coverage artifacts
+      ====================================================================-->
+  <target name="continuous" depends="build,publish" />
+
+
+  <!--=======================================================================
+      continuous-testless
+      
+      Runs a typical continuous integration build including project dist,
+      and coverage artifacts
+      ====================================================================-->
+  <target name="continuous-testless" depends="build-testless,publish" />
+
+
+  <!--=======================================================================
+      install-antcontrib
+      
+      (Fetches and) installs ant-contrib tasks.
+      ====================================================================-->
+  <target name="install-antcontrib" depends="antcontrib.download-check">
+    <taskdef resource="net/sf/antcontrib/antlib.xml">
+      <classpath>
+        <fileset dir="${antcontrib.build.cache.dir}">
+          <include name="*.jar" />
+        </fileset>
+      </classpath>
+    </taskdef>
+  </target>
+
+
+  <!--=======================================================================
+      antcontrib.download-check
+      
+      Fetches ant-contrib from sourceforge if it is not already present
+      ====================================================================-->
+  <target name="antcontrib.download-check">
+    <condition property="antcontrib.available">
+      <and>
+        <available file="${antcontrib.build.cache.dir}" />
+        <available classname="net.sf.antcontrib.logic.IfTask">
+          <classpath>
+            <fileset dir="${antcontrib.build.cache.dir}">
+              <include name="*.jar" />
+            </fileset>
+          </classpath>
+        </available>
+      </and>
+    </condition>
+    <antcall target="antcontrib.download" />
+  </target>
+
+
+  <!--=======================================================================
+      antcontrib.download
+      
+      Fetches ant-contrib from sourceforge
+      ====================================================================-->
+  <target name="antcontrib.download" unless="antcontrib.available">
+    <mkdir dir="${subfloor.tmp.dir}" />
+    <get src="http://downloads.sourceforge.net/ant-contrib/ant-contrib-1.0b3-bin.zip"
+         dest="${subfloor.tmp.dir}/antcontrib.zip"
+         usetimestamp="true" />
+    <unzip src="${subfloor.tmp.dir}/antcontrib.zip" dest="${subfloor.tmp.dir}">
+      <patternset>
+        <include name="**/*.jar" />
+      </patternset>
+    </unzip>
+    <copy todir="${antcontrib.build.cache.dir}">
+      <fileset dir="${subfloor.tmp.dir}/ant-contrib">
+        <include name="**/*.jar" />
+      </fileset>
+    </copy>
+  </target>
+
+
+  <!--=======================================================================
+      init
+      
+      Ensures that all the required directories exist before processing
+      a build.
+      ====================================================================-->
+  <target name="init">
+    <mkdir dir="${classes.dir}" />
+    <mkdir dir="${dist.dir}" />
+    <mkdir dir="${lib.dir}" />
+    <mkdir dir="${devlib.dir}" />
+    <mkdir dir="${testlib.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+    install-svnant
+    
+    (Fetches and) installs the SVN ANT for use by this ant script
+    ====================================================================-->
+  <target name="install-svnant" depends="install-ivy">
+    <if>
+      <istrue value="${svnant.isinstalled}" />
+      <then>
+        <echo message="Skipping SVN ANT install.  SVN ANT has already been configured by the build" />
+      </then>
+      <else>
+        <taskdef-with-ivy organisation="tigris"
+                          module="svnant"
+                          revision="1.3.0"
+                          resource="org/tigris/subversion/svnant/svnantlib.xml"
+                          classname="org.tigris.subversion.svnant.SvnTask" />
+        <property name="svnant.isinstalled" value="true" />
+      </else>
+    </if>
+  </target>
+
+
+  <!--=======================================================================
+        test-svnant
+    
+        Tests SVN by printing out the repository
+        ====================================================================-->
+  <target name="test-svnant" depends="install-svnant">
+    <svn javahl="${svnant.use-javahl}" svnkit="${svnant.use-svnkit}">
+      <wcVersion path="." />
+    </svn>
+    <echo message="Subversion repository url: ${repository.url}" />
+  </target>
+
+
+  <!--=======================================================================
+        svn-revision
+    
+        Prints and sets the SVN revision for the repository at the current dir (if svn.revision is not set)
+        ====================================================================-->
+  <target name="svn-revision" depends="install-svnant">
+
+    <svn javahl="${svnant.use-javahl}" svnkit="${svnant.use-svnkit}">
+      <status path="." revisionProperty="svn.revision" />
+    </svn>
+    <echo message="Subversion repository revision: ${svn.revision}" />
+  </target>
+
+
+  <!--=======================================================================
+        set-build.id
+    
+        Sets a property build.id to the either "development" or the svn revision
+        if in release mode
+        ====================================================================-->
+  <target name="set-build.id" unless="build.id" depends="install-antcontrib">
+    <if>
+      <istrue value="${release}" />
+      <then>
+        <antcallback target="svn-revision" return="svn.revision" />
+        <property name="build.id" value="${svn.revision}" />
+      </then>
+      <else>
+        <property name="build.id" value="development" />
+      </else>
+    </if>
+  </target>
+
+  <!--=================================================================================
+       version-properties: common Ant driven version file generation.  Projects that produce
+       a package or packages should run this target.  Projects that produce
+       jars only should NOT.
+   ===================================================================================-->
+  <target name="version-properties" depends="set-build.id">
+    <tstamp>
+      <format property="build.time" pattern="yyyy/MM/dd hh:mm aa" />
+    </tstamp>
+    <propertyfile file="version.properties" comment="Release Build version info">
+      <entry key="release.major.number" value="${release.major.number}" />
+      <entry key="release.minor.number" value="${release.minor.number}" />
+      <entry key="release.milestone.number" value="${release.milestone.number}" />
+      <entry key="release.candidate.token" value="${release.candidate.token}" />
+      <entry key="impl.vendor" value="${impl.vendor}" />
+      <entry key="impl.version"
+             value="${release.major.number}.${release.minor.number}.${release.milestone.number}.${build.id}" />
+      <entry key="impl.title" value="${impl.title}" />
+      <entry key="buildDate" value="${build.time}" />
+      <entry key="svn.revision" value="${build.id}" />
+      <entry key="release.build.number" default="0" type="int" operation="+" value="1" pattern="0000" />
+    </propertyfile>
+    <property file="${basedir}/version.properties" />
+  </target>
+
+
+  <!--=======================================================================
+      install-ivy 
+      
+      Fetches and installs IVY ant tasks if not already installed 
+      ====================================================================-->
+  <target name="install-ivy" depends="install-antcontrib">
+    <if>
+      <istrue value="${ivy.isinstalled}" />
+      <then>
+        <echo message="Skipping IVY install.  IVY has already been configured by the build" />
+      </then>
+      <else>
+        <download-antlib name="ivy" url="${ivy.url}" classname="org.apache.ivy.ant.IvyTask" extension="jar" />
+        <taskdef resource="org/apache/ivy/ant/antlib.xml" uri="antlib:org.apache.ivy.ant">
+          <classpath>
+            <fileset dir="${subfloor.resources.dir}/ivy">
+              <include name="*.jar" />
+            </fileset>
+          </classpath>
+        </taskdef>
+        <ivy:settings url="${ivy.settingsurl}" />
+        <property name="ivy.isinstalled" value="true" />
+      </else>
+    </if>
+  </target>
+
+
+  <!--=======================================================================
+      ivy.check-releasable
+      
+      Verifies that there are no SNAPSHOT dependencies defined in the ivy xml.
+      If there are SNAPSHOTS, fail the release build.
+      ====================================================================-->
+  <target name="ivy.check-releasable" depends="install-ivy, install-antcontrib">
+    <if>
+      <istrue value="${release}" />
+      <then>
+        <sequential>
+          <ivy:artifactproperty conf="${ivy.configs}" name="dep.[module]/[artifact]-[revision]" value="[revision]" />
+
+          <propertyselector property="violators" match="dep\..*SNAPSHOT.*" select="\0" casesensitive="false" />
+
+          <fail if="violators"
+                message="Release not possible, you have dependencies on non-released artifacts: ${violators}" />
+        </sequential>
+      </then>
+    </if>
+  </target>
+
+
+<!--=======================================================================
+      install-checkstyle
+
+      Fetches and installs CheckStyle resources for use by checkstyle targets
+      ====================================================================-->
+  <target name="install-checkstyle" depends="install-ivy">
+    <ivy:resolve inline="true"
+                 keep="true"
+                 organisation="com.puppycrawl.tools"
+                 module="checkstyle"
+                 revision="${checkstyle.version}"
+                 conf="default"
+                 transitive="true" />
+
+    <ivy:retrieve conf="default" pattern="${checkstyle.lib.dir}/[module]-[revision](-[classifier]).[ext]" />
+    <ivy:cachepath pathid="checkstyle.classpath" />
+  </target>
+
+
+  <!--=======================================================================
+      resolve
+      
+      Using ivy and the dependencies for the project (defined in the ivy.xml
+      file), this task will retrieve the needed files and place them into 
+      the defined directories.
+      ====================================================================-->
+  <target name="resolve"
+          depends="resolve-default, resolve-test, ivy.check-releasable"
+          description="Retrieves all the dependent libraries" />
+
+  <target name="resolve-init" unless="resolve-init.skip" depends="install-ivy">
+    <!-- If this is the 1st time through resolve-init, then we need to clean up the jars
+-->
+    <antcall target="clean-jars" />
+    <property name="resolve-init.skip" value="" />
+  </target>
+
+  <target name="resolve-default" depends="resolve-default.default,resolve-default.composite"/>
+
+  <!-- 
+  This target resolves the default IVY configuration as a composite of child configurations.
+  You should set ivy.default.sub-configs in your build.properties only if you want your default
+  configuration to be treated as a composite of two or more child configurations.
+  To turn this on, set ivy.default.sub-configs property in your build.properties, e.g.
+  ivy.default.sub-configs=external,internal
+  Note: the parent config "default" proper will not be resolved
+  -->
+  <target name="resolve-default.composite" depends="install-antcontrib,resolve-init" if="ivy.default.sub-configs">
+    <for list="${ivy.default.sub-configs}" param="conf">
+      <sequential>
+        <ivy:resolve file="${ivyfile}" conf="default_@{conf}" />
+        <ivy:retrieve conf="default_@{conf}" pattern="${lib.dir}/@{conf}/[module]-[revision](-[classifier]).[ext]" symlink="${ivy.use.symlinks.internal}" />
+      </sequential>
+    </for>
+  </target>
+
+  <target name="resolve-default.default" depends="resolve-init" unless="ivy.default.sub-configs">
+    <ivy:resolve file="${ivyfile}" conf="default" />
+    <ivy:retrieve conf="default" pattern="${lib.dir}/[module]-[revision](-[classifier]).[ext]" symlink="${ivy.use.symlinks.internal}" />
+  </target>
+
+  <target name="resolve-test" depends="resolve-init">
+    <ivy:resolve file="${ivyfile}" conf="test" />
+    <ivy:retrieve conf="test" pattern="${testlib.dir}/[module]-[revision](-[classifier]).[ext]" symlink="${ivy.use.symlinks.internal}" />
+  </target>
+
+  <target name="resolve-enunciate" depends="resolve-init">
+    <ivy:resolve file="${ivyfile}" conf="enunciate" />
+    <ivy:retrieve conf="enunciate" pattern="${basedir}/enunciate/lib/[module]-[revision](-[classifier]).[ext]" />
+  </target>
+
+  <target name="resolve-codegen" depends="resolve-init">
+    <ivy:resolve file="${ivyfile}" conf="codegen" />
+    <ivy:retrieve conf="codegen" pattern="${lib.dir}/[module]-[revision](-[classifier]).[ext]" symlink="${ivy.use.symlinks.internal}" />
+  </target>
+
+  <target name="resolve-runtime" depends="resolve-init">
+    <ivy:resolve file="${ivyfile}" conf="runtime" />
+    <ivy:retrieve conf="runtime" pattern="${lib.dir}/[module]-[revision](-[classifier]).[ext]" symlink="${ivy.use.symlinks.internal}" />
+  </target>
+
+
+  <!--=======================================================================
+      ivy-clean-cache
+      
+      Cleans the IVY cache.  You are erasing IVY's memory.  Run this if you 
+      want to force IVY to go fetch all your project dependencies from scratch.
+      WARNING: this will affect all IVY projects, not just the current workspace
+      ====================================================================-->
+  <target name="ivy-clean-cache" depends="install-ivy">
+    <ivy:cleancache />
+  </target>
+
+
+  <!--=======================================================================
+      ivy-clean-local
+      
+      Completely cleans your local repository of any files published locally
+      by way of publish-local.
+      WARNING: this is a global action and will affect other IVY projects
+      currently referencing a locally published dependency
+      ====================================================================-->
+  <target name="ivy-clean-local" depends="install-ivy">
+    <delete dir="${ivy.local.default.root}/" />
+  </target>
+
+
+  <!--=======================================================================
+      ivy-clean-by-name
+      
+      Cleans your IVY cache and local repository of specific files.
+      WARNING: this is a global action and will affect other IVY projects
+      currently referencing a locally published dependency
+      ====================================================================-->
+  <target name="ivy-clean-pentaho" depends="install-ivy">
+    <mkdir dir="${ivy.local.default.root}" />
+    <!-- just in case it doesn't exist -->
+    <for param="dir">
+      <path>
+        <dirset dir="${ivy.local.default.root}" includes="*${ivy.clean.pattern}*" />
+        <dirset dir="${ivy.default.ivy.user.dir}/cache" includes="*${ivy.clean.pattern}*" />
+      </path>
+      <sequential>
+        <delete dir="@{dir}" includeemptydirs="true" />
+      </sequential>
+    </for>
+    <for param="file">
+      <path>
+        <fileset dir="${ivy.local.default.root}" includes="*${ivy.clean.pattern}*" />
+        <fileset dir="${ivy.default.ivy.user.dir}/cache" includes="*${ivy.clean.pattern}*" />
+      </path>
+      <sequential>
+        <delete file="@{file}" />
+      </sequential>
+    </for>
+  </target>
+
+
+  <!--=======================================================================
+      ivy-report
+      
+      Generates an IVY dependency report for this project. 
+      ====================================================================-->
+  <target name="ivy-report" depends="install-ivy">
+    <ivy:resolve file="${ivyfile}" conf="${ivy.configs}" />
+    <ivy:report xml="true" todir="${ivy.reports.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+      publish-local-nojar
+      
+      Publishes the jar file for this project to the user's local repository
+      for download by other projects currently being executed on the user's
+      system.
+      ====================================================================-->
+  <target name="publish-local-nojar" depends="install-ivy,publish-local-nojar.internal">
+    <if>
+      <equals arg1="${tests.publish}" arg2="true" />
+      <then>
+        <antcall target="publish-local-nojar.internal">
+          <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
+        </antcall>
+      </then>
+    </if>
+    <antcall target="publish-local-nojar.post"/>
+  </target>
+
+  <!--=======================================================================
+      publish-local-nojar.post this target is invoked after the normal set of publish-local-nojar
+      is completed, override this to perform additional publishing in extensions of subfloor, etc
+      ====================================================================-->
+  <target name="publish-local-nojar.post">
+  </target>
+  
+  <target name="publish-local-nojar.internal" depends="install-ivy">
+    <ivy:resolve file="${ivy.artifact.ivyfilename}" />
+    <ivy:publish resolver="local" pubrevision="${project.revision}" overwrite="true" forcedeliver="true" warnonmissing="yes" haltonmissing="no">
+      <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]" />
+    </ivy:publish>
+  </target>
+
+  <!--=======================================================================
+      publish-local
+      
+      Builds and publishes the jar file for this project to the user's 
+      local repository for download by other projects currently being 
+      executed on the user's system.
+      ====================================================================-->
+  <target name="publish-local"
+          depends="dist, dist-source, publish-local-nojar"
+          description="Builds and publishes the jar file to the local repository" />
+
+
+  <!--=======================================================================
+        publish
+    
+        Creates and publishes the jar file for this project to a Maven2 
+        repository. 
+        ====================================================================-->
+  <target name="publish" depends="dist, dist-source, publish-nojar">
+  </target>
+
+
+  <!--=======================================================================
+      publish-nojar
+      
+      Publishes the jar file for this project to a Maven2 repository.
+      ====================================================================-->
+  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+    <if>
+      <equals arg1="${tests.publish}" arg2="true" />
+      <then>
+        <antcall target="publish-nojar.internal">
+          <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
+        </antcall>
+      </then>
+    </if>
+  </target>
+
+  <target name="publish-nojar.internal" depends="install-antcontrib,create-pom,ivy.deliver">
+    <antcall target="maven-publish-dependencies">
+      <param name="publish.groupId" value="${ivy.artifact.group}" />
+      <param name="publish.artifactId" value="${ivy.artifact.id}" />
+      <param name="publish.version" value="${project.revision}" />
+      <param name="publish.file" value="${ivy.artifact.ivypathname}" />
+    </antcall>
+
+    <if>
+      <equals arg1="${source.publish}" arg2="true" />
+        <then>
+          <antcall target="maven-publish-sources">
+            <param name="publish.groupId" value="${ivy.artifact.group}" />
+            <param name="publish.artifactId" value="${ivy.artifact.id}" />
+            <param name="publish.version" value="${project.revision}" />
+            <param name="publish.file" value="${dist.dir}/${ivy.artifact.id}-${project.revision}-sources.jar" />
+          </antcall>
+        </then>
+    </if>
+
+    <antcall target="maven-publish-artifact">
+      <param name="publish.pomFile" value="${ivy.artifact.pomfile}" />
+      <param name="publish.file" value="${dist.dir}/${ivy.artifact.id}-${project.revision}.jar" />
+    </antcall>
+
+    <antcall target="maven-publish.post"/>
+    
+  </target>
+
+  <!-- Override this if anything is needed to be done after the standard parts of publish are completed -->
+  <!-- Such as:  publishing non-standard/extended artifacts, etc -->
+  <target name="maven-publish.post"/>
+  
+  <!--=======================================================================
+        ivy.deliver
+    
+        Creates a publishable version of the ivy dependencies file, ivy.xml
+        ====================================================================-->
+  <target name="ivy.deliver" depends="resolve">
+    <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml" />
+  </target>
+
+
+  <!--=======================================================================
+      maven-publish-dependencies
+      
+      A function that deploys an ivy.xml file to a maven repository
+      ====================================================================-->
+  <target name="maven-publish-dependencies" depends="install-antcontrib">
+    <sequential>
+      <fail message="No file found at: ${publish.file}">
+        <condition>
+          <not>
+            <available file="${publish.file}" />
+          </not>
+        </condition>
+      </fail>
+      <echo message="Publishing ${publish.file} to ${ivy.repository.publish}..." />
+      <if>
+        <isset property="isWindows" />
+        <then>
+          <exec executable="cmd" failonerror="true">
+            <arg value="/c" />
+            <arg value="mvn.bat" />
+            <arg value="deploy:deploy-file" />
+            <arg value="-DrepositoryId=${ivy.repository.id}" />
+            <arg value="-Durl=${ivy.repository.publish}" />
+            <arg value="-DgroupId=${publish.groupId}" />
+            <arg value="-DartifactId=${publish.artifactId}" />
+            <arg value="-Dversion=${publish.version}" />
+            <arg value="-Dpackaging=ivy.xml" />
+            <arg value="-Dfile=${publish.file}" />
+          </exec>
+        </then>
+        <else>
+          <exec executable="mvn" failonerror="true">
+            <arg value="deploy:deploy-file" />
+            <arg value="-DrepositoryId=${ivy.repository.id}" />
+            <arg value="-Durl=${ivy.repository.publish}" />
+            <arg value="-DgroupId=${publish.groupId}" />
+            <arg value="-DartifactId=${publish.artifactId}" />
+            <arg value="-Dversion=${publish.version}" />
+            <arg value="-Dpackaging=ivy.xml" />
+            <arg value="-Dfile=${publish.file}" />
+            <arg value="-e" />
+          </exec>
+        </else>
+      </if>
+    </sequential>
+  </target>
+
+
+  <!--=======================================================================
+      maven-publish-artifact
+      
+      A function that deploys an artifact to a maven repository
+      ====================================================================-->
+  <target name="maven-publish-artifact" depends="install-antcontrib">
+    <sequential>
+      <fail message="No file found at: ${publish.file}">
+        <condition>
+          <not>
+            <available file="${publish.file}" />
+          </not>
+        </condition>
+      </fail>
+      <echo message="Publishing ${publish.file} to ${ivy.repository.publish}..." />
+      <if>
+        <isset property="isWindows" />
+        <then>
+          <exec executable="cmd" failonerror="true">
+            <arg value="/c" />
+            <arg value="mvn.bat" />
+            <arg value="deploy:deploy-file" />
+            <arg value="-DrepositoryId=${ivy.repository.id}" />
+            <arg value="-Durl=${ivy.repository.publish}" />
+            <arg value="-DpomFile=${publish.pomFile}" />
+            <arg value="-Dfile=${publish.file}" />
+          </exec>
+        </then>
+        <else>
+          <exec executable="mvn" failonerror="true">
+            <arg value="deploy:deploy-file" />
+            <arg value="-DrepositoryId=${ivy.repository.id}" />
+            <arg value="-Durl=${ivy.repository.publish}" />
+            <arg value="-DpomFile=${publish.pomFile}" />
+            <arg value="-Dfile=${publish.file}" />
+          </exec>
+        </else>
+      </if>
+    </sequential>
+  </target>
+
+
+  <!--=======================================================================
+      maven-publish-sources
+      
+      A function that deploys a java-sources artifact to a maven repository
+      ====================================================================-->
+  <target name="maven-publish-sources" depends="install-antcontrib">
+    <sequential>
+      <fail message="No file found at: ${publish.file}">
+        <condition>
+          <not>
+            <available file="${publish.file}" />
+          </not>
+        </condition>
+      </fail>
+      <echo message="Publishing ${publish.file} to ${ivy.repository.publish}..." />
+      <if>
+        <isset property="isWindows" />
+        <then>
+          <exec executable="cmd" failonerror="true">
+            <arg value="/c" />
+            <arg value="mvn.bat" />
+            <arg value="deploy:deploy-file" />
+            <arg value="-DrepositoryId=${ivy.repository.id}" />
+            <arg value="-Durl=${ivy.repository.publish}" />
+            <arg value="-DgroupId=${publish.groupId}" />
+            <arg value="-DartifactId=${publish.artifactId}" />
+            <arg value="-Dversion=${publish.version}" />
+            <arg value="-DgeneratePom=true" />
+            <arg value="-Dpackaging=java-source" />
+            <arg value="-Dfile=${publish.file}" />
+          </exec>
+        </then>
+        <else>
+          <exec executable="mvn" failonerror="true">
+            <arg value="deploy:deploy-file" />
+            <arg value="-DrepositoryId=${ivy.repository.id}" />
+            <arg value="-Durl=${ivy.repository.publish}" />
+            <arg value="-DgroupId=${publish.groupId}" />
+            <arg value="-DartifactId=${publish.artifactId}" />
+            <arg value="-Dversion=${publish.version}" />
+            <arg value="-DgeneratePom=true" />
+            <arg value="-Dpackaging=java-source" />
+            <arg value="-Dfile=${publish.file}" />
+          </exec>
+        </else>
+      </if>
+    </sequential>
+  </target>
+
+
+  <!--=======================================================================
+      create-pom
+      
+      Creates the POM file for publishing the jar file to a Maven2 repository.
+      ====================================================================-->
+  <target name="create-pom" depends="install-ivy">
+    <ivy:makepom ivyfile="${ivyfile}" pomfile="${dist.dir}/pom.xml">
+      <mapping conf="default" scope="compile" />
+      <mapping conf="runtime" scope="runtime" />
+    </ivy:makepom>
+  </target>
+
+
+  <!--=======================================================================
+      clean-jars
+      
+      Removes all the libraries that have been downloaded for this project
+      using the ivy dependencies.
+      ====================================================================-->
+  <target name="clean-jars">
+    <delete dir="${lib.dir}" />
+    <delete dir="${testlib.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+      clean
+      
+      Removes all the files generated from the build process.
+      ====================================================================-->
+  <target name="clean"
+          description="Cleans all the files generated from a build with the exception of IVY-downloaded jars (see clean-all)"
+          depends="clean-tests, clean-cobertura, clean-sonar, clean-javadoc, clean-dist">
+    <delete dir="${classes.dir}" />
+    <delete dir="${bin.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+      clean-dist
+      
+      Removes all dist artifacts
+      ====================================================================-->
+  <target name="clean-dist">
+    <delete dir="${dist.dir}" />
+  </target>
+  
+  <!--=======================================================================
+      clean-checkstyle
+      
+      Removes all checkstyle artifacts
+      ====================================================================-->
+  <target name="clean-checkstyle">
+    <delete dir="${checkstyle.dir}" />
+  </target>  
+
+
+  <!--=======================================================================
+      clean-all
+      
+      Removes all the libraries that have been downloaded for this project
+      in the workspace's lib dirs as well as all the files 
+      generated from the build process.
+      ====================================================================-->
+  <target name="clean-all" depends="clean,clean-jars,clean-checkstyle" description="Cleans all the generated and dependency files" />
+
+
+  <!--=======================================================================
+      copy-license-lgpl
+      
+      Copies the LGPL license file into the binary directory.
+      ====================================================================-->
+  <target name="copy-license-lgpl" if="lgpl-license-avail">
+    <copy todir="${classes.dir}/META-INF">
+      <fileset dir="${license.dir}" includes="lgpl-2.1.txt" />
+    </copy>
+  </target>
+
+
+  <!--=======================================================================
+      copy-license-gpl-parent
+      
+      Copies the GPL license file from the parent directory into the 
+      binary directory.
+      ====================================================================-->
+  <target name="copy-license-gpl" if="gpl-license-avail">
+    <copy todir="${classes.dir}/META-INF">
+      <fileset dir="${license.dir}" includes="gpl-2.0.txt" />
+    </copy>
+  </target>
+
+
+  <!--=======================================================================
+      compile
+      
+      Compiles the source code (using the specified options) into the 
+      binary directory.
+      
+      NOTE: This contains multiple sub-tasks which will occur in the 
+            following order (this is provided for easier overriding by
+            the build.xml which will include this file)...
+        - compile.pre      : anything needed to prep for compile
+        - compile.compile  : the actual compilation step
+        - compile.src_copy : copying the source into the bin directory
+        - compile.res_copy : copying the resources into the bin directory
+        - compile.lic_copy : copying the license information into the bin directory
+        - compile.post     : anything needed after the compile is done 
+      ====================================================================-->
+  <target name="compile"
+          depends="init, compile.pre, compile.compile, compile.src_copy, compile.res_copy, compile.lic_copy, compile.post"
+          description="Performs all the steps to prepare the bin directory with a complete compilation" />
+
+
+  <!--=======================================================================
+      compile.pre
+      
+      Prepares to perform the compile.
+      ====================================================================-->
+  <target name="compile.pre" />
+
+
+  <!--=======================================================================
+      compile.compile
+      
+      Performs the actual compile
+      ====================================================================-->
+  <target name="compile.compile" depends="init">
+    <javac destdir="${classes.dir}"
+           debug="${javac.debug}"
+           deprecation="${javac.deprecation}"
+           fork="true"
+           memorymaximumsize="${javac.maxmemory}"
+           source="${javac.source}"
+           target="${javac.target}"
+           encoding="UTF-8">
+      <classpath>
+        <path refid="classpath" />
+      </classpath>
+      <src path="${src.dir}" />
+      <compilerarg value="${javac.xlint}" />
+    </javac>
+  </target>
+
+
+  <!--=======================================================================
+      compile.res_copy
+      
+      Copies any needed resources into the classes directory.  Will not
+      duplicate copying of resources from src tree (handled by compile.src_copy
+      if jar.include.source is set.
+      ====================================================================-->
+  <target name="compile.res_copy" depends="install-antcontrib">
+    <if>
+      <available file="${res.dir}" />
+      <then>
+        <copy todir="${classes.dir}">
+          <fileset dir="${res.dir}" />
+        </copy>
+      </then>
+    </if>
+
+    <if>
+      <not>
+        <isset property="jar.include.source" />
+      </not>
+      <then>
+        <copy todir="${classes.dir}" flatten="false">
+          <fileset dir="${src.dir}" excludes="**/*.java" />
+        </copy>
+      </then>
+    </if>
+  </target>
+
+
+  <!--=======================================================================
+      compile.src_copy
+      
+      Copies the source files to the bin directory
+      NOTE: if the dont.copy.source variable exists, this step will be
+            skipped!
+      ====================================================================-->
+  <target name="compile.src_copy" depends="init" if="jar.include.source">
+    <copy todir="${classes.dir}" flatten="false">
+      <fileset dir="${src.dir}" />
+    </copy>
+  </target>
+
+
+  <!--=======================================================================
+      compile.lic_copy
+      
+      Copies the license file(s) into the bin directory
+      ====================================================================-->
+  <target name="compile.lic_copy" depends="init">
+    <condition property="lgpl-license-avail">
+      <available file="${license.dir}/lgpl-2.1.txt" />
+    </condition>
+    <antcall target="copy-license-lgpl" />
+    <condition property="gpl-license-avail">
+      <available file="${license.dir}/gpl-2.0.txt" />
+    </condition>
+    <antcall target="copy-license-gpl" />
+  </target>
+
+
+  <!--=======================================================================
+      compile.post
+      
+      Performs any needed post-compile tasks
+      ====================================================================-->
+  <target name="compile.post" />
+
+
+  <!--=======================================================================
+      jar
+      
+      Creates a jar file from the bin directory
+      ====================================================================-->
+  <target name="jar"
+          depends="jar.main,jar.test"
+          description="Jars up the bin directory after a compile">
+  </target>
+
+  <!-- jar the tests ONLY IF tests.publish it true -->
+  <!-- if the compile-tests target is in the dependency list for this target, -->
+  <!-- it will get executed no matter what the value of tests.publish is      -->
+  <target name="jar.test"
+          if="tests.publish">
+    <antcall target="compile-tests" />
+    <jar destfile="${dist.dir}/${ivy.artifact.id}-test-${project.revision}.jar" manifest="${dist.manifest.file}">
+      <fileset dir="${testclasses.dir}"/>
+    </jar>
+  </target>
+
+  <target name="jar.main"
+          depends="compile,set-build.id,generate.manifest">
+    <jar destfile="${dist.dir}/${ivy.artifact.id}-${project.revision}.jar" manifest="${dist.manifest.file}">
+      <fileset dir="${classes.dir}" />
+    </jar>
+  </target>
+
+  <!--=======================================================================
+      generate.manifest
+      
+      Creates a new manifest file if one is not specified, or updates
+      an existing manifest file if one is specified.
+      ====================================================================-->
+  <target name="generate.manifest" depends="init,set-build.id">
+    <delete file="${dist.manifest.file}" />
+    <touch file="${dist.manifest.file}" />
+    <copy file="${manifest.file}" tofile="${dist.manifest.file}" overwrite="true" failonerror="false" />
+
+    <manifest file="${dist.manifest.file}" mode="update">
+      <attribute name="Implementation-Title" value="${impl.title}" />
+      <attribute name="Implementation-Version" value="${project.revision}.${build.id}" />
+      <attribute name="Implementation-Vendor" value="${impl.vendor}" />
+      <attribute name="Implementation-ProductID" value="${impl.productID}" />
+    </manifest>
+  </target>
+
+
+  <!--=======================================================================
+      dist-source
+      
+      Generates zip and targz distributions of the javadoc
+      ====================================================================-->
+  <target name="dist-source" depends="source.jar, source.zip, source.targz" />
+
+
+  <!--=======================================================================
+      source.jar
+      
+      Creates a jar of the project source for distribution
+      ====================================================================-->
+  <target name="source.jar" depends="init,install-antcontrib">
+    <jar jarfile="${dist.dir}/${ivy.artifact.id}-${project.revision}-sources.jar" basedir="${src.dir}" />
+    <if>
+      <equals arg1="${tests.publish}" arg2="true" />
+      <then>
+        <jar jarfile="${dist.dir}/${ivy.artifact.id}-test-${project.revision}-sources.jar" basedir="${src.dir}" />
+      </then>
+    </if>
+  </target>
+
+  <!--=======================================================================
+      source.zip
+      
+      Creates a zip of the project source for distribution
+      ====================================================================-->
+  <target name="source.zip" depends="init">
+    <jar jarfile="${dist.dir}/${source.zip.filename}" basedir="${src.dir}" />
+  </target>
+
+  <!--=======================================================================
+      source.targz
+      
+      Creates a gzipped tar of the project source for distribution
+      ====================================================================-->
+  <target name="source.targz" depends="init">
+    <tar compression="gzip" destfile="${dist.dir}/${source.tar.filename}" basedir="${src.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+      clean-tests
+      
+      Removes all files related to tests
+      ====================================================================-->
+  <target name="clean-tests">
+    <delete dir="${testbin.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+      init-tests
+      
+      Compiles project test source
+      ====================================================================-->
+  <target name="init-tests" depends="clean-tests">
+    <mkdir dir="${testclasses.dir}" />
+    <mkdir dir="${testsrc.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+      compile-tests
+      
+      Compiles project test source
+      ====================================================================-->
+  <target name="compile-tests" depends="init-tests">
+    <javac destdir="${testclasses.dir}"
+           debug="true"
+           optimize="false"
+           source="${javac.source}"
+           target="${javac.target}"
+           fork="true"
+            encoding="UTF-8">
+      <src path="${testsrc.dir}" />
+      <classpath refid="test.classpath" />
+    </javac>
+
+    <!-- Copy the non-java files from the source directory to the test classes directory
+-->
+    <copy todir="${testclasses.dir}">
+      <fileset dir="${testsrc.dir}">
+        <exclude name="**/*.java" />
+      </fileset>
+    </copy>
+  </target>
+
+
+  <!--=======================================================================
+      test
+      
+      Compiles and runs all the tests for the project
+      ====================================================================-->
+  <target name="test" depends="compile,compile-tests, init-test-reports" description="Compiles and runs unit tests">
+    <junit maxmemory="${junit.maxmemory}"
+           dir="${junit.base.dir}"
+           fork="yes"
+           forkmode="${junit.forkmode}"
+           failureProperty="test.failed"
+           haltonfailure="${junit.haltonfailure}"
+           haltonerror="${junit.haltonerror}"
+           printsummary="yes">
+      <sysproperty key="java.awt.headless" value="${headless.unittest}" />
+      
+      <syspropertyset>
+        <propertyref prefix="junit.sysprop." />
+        <mapper type="glob" from="junit.sysprop.*" to="*"/>
+      </syspropertyset>
+      
+      <classpath refid="test.classpath" />
+      <formatter type="xml" />
+      <test name="${testcase}" todir="${testreports.xml.dir}" if="testcase" />
+      <batchtest fork="yes" todir="${testreports.xml.dir}" unless="testcase">
+        <fileset dir="${testsrc.dir}" casesensitive="yes">
+          <include name="**/*Test.java" />
+        </fileset>
+      </batchtest>
+    </junit>
+
+    <junitreport todir="${testreports.html.dir}">
+      <fileset dir="${testreports.xml.dir}">
+        <include name="TEST-*.xml" />
+      </fileset>
+      <report format="frames" todir="${testreports.html.dir}" />
+    </junitreport>
+  </target>
+
+
+  <!--=======================================================================
+    clean-test-reports
+
+    Remove all xml and html JUnit test reports
+    ====================================================================-->
+  <target name="clean-test-reports">
+    <delete dir="${testreports.xml.dir}" />
+    <delete dir="${testreports.html.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+    init-test-reports
+
+    Prepare directories for JUnit test reports
+    ====================================================================-->
+  <target name="init-test-reports" depends="clean-test-reports">
+    <mkdir dir="${testreports.xml.dir}" />
+    <mkdir dir="${testreports.html.dir}" />
+  </target>
+
+  <!--=======================================================================
+      dist
+      
+      Creates a distribution of this project
+      ====================================================================-->
+  <target name="dist" depends="jar" description="Creates a distribution" />
+
+
+  <!--=======================================================================
+      dist-full
+      
+      Creates a distribution of this project including all sources needed
+      to build as well as the resultant jar
+      ====================================================================-->
+  <target name="dist-full" depends="jar"
+          description="Creates all the distributable items for this project">
+    <!-- Create the required zip distribution which contains the entire project -->
+    <zip destfile="${dist.dir}/${ivy.artifact.id}-${project.revision}.zip">
+      <fileset dir="${basedir}">
+        <exclude name="bin/"/>
+        <exclude name="dist/"/>
+        <exclude name="eclipse-bin/"/>
+      </fileset>
+      <zipfileset dir="${dist.dir}" includes="**/*.jar"/>
+    </zip>
+  </target>
+
+
+  <!--=======================================================================
+      javadoc
+      
+      Generates javadoc source documentation for this project
+      ====================================================================-->
+  <target name="javadoc" depends="javadoc.init, compile">
+    <javadoc destdir="${javadoc.dir}/docs/api"
+             access="public"
+             source="6"
+             use="true"
+             notree="false"
+             nonavbar="false"
+             noindex="false"
+             splitindex="true"
+             author="true"
+             version="true"
+             maxmemory="256M"
+             nodeprecatedlist="false"
+             nodeprecated="false"
+             packagenames="${javadoc.packagenames}"
+             sourcepath="${src.dir}"
+             doctitle="${impl.title} documentation">
+      <link href="http://docs.oracle.com/javase/6/docs/api/" />
+      <classpath refid="classpath" />
+    </javadoc>
+  </target>
+
+  	
+  <!--=======================================================================
+	enunciate
+        
+	Generates enunciate documentation for the resoruce 
+	classes comprising the BIServer REST api
+  ====================================================================-->
+  <target name="enunciate" depends="resolve-enunciate">
+    <path id="enunciate.classpath">
+      <fileset dir="${lib.dir}">
+        <include name="*.jar" />
+      	<exclude name="saxon*.jar" />
+      </fileset>
+      <dirset dir="${classes.dir}" />
+      <fileset dir="${dist.dir}">
+        <include name="*.jar" />
+      </fileset>
+      <fileset dir="${enunciate.home}/lib">
+        <include name="*.jar" />
+      </fileset>
+    </path>
+
+    <taskdef name="enunciate" classname="org.codehaus.enunciate.main.EnunciateTask">
+      <classpath refid="enunciate.classpath" />
+    </taskdef>
+
+    <enunciate dir="${basedir}/src" 
+               configFile="${basedir}/enunciate.xml" 
+               generateDir="${enunciate.bin.dir}/generate" 
+               compileDir="${enunciate.bin.dir}/compile" 
+               buildDir="${enunciate.bin.dir}/build" 
+               packageDir="${enunciate.bin.dir}/package" 
+               verbose="true">
+      <include name="**/*.java" />
+      <!-- have to exclude class that contains jersey multipart endpoint until http://jira.codehaus.org/browse/ENUNCIATE-537 is fixed -->
+      
+      <classpath refid="enunciate.classpath" />
+      <export artifactId="docs" destination="${dist.dir}/${enunciate.packagename}.zip" />
+    </enunciate>
+  </target>
+
+  <!--=======================================================================
+      dist-javadoc
+      
+      Generates zip and targz distributions of the javadoc
+      ====================================================================-->
+  <target name="dist-javadoc" depends="javadoc.zip, javadoc.targz" />
+
+
+  <!--=======================================================================
+      clean-javadoc
+      
+      Removes generated javadoc files (note, this does not remove javadoc distributions.
+      Use clean-dist to remove artifacts from the dist.dir.
+      ====================================================================-->
+  <target name="clean-javadoc">
+    <delete dir="${javadoc.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+      javadoc.init
+      
+      Creates directories for javadoc process
+      ====================================================================-->
+  <target name="javadoc.init" depends="clean-javadoc">
+    <mkdir dir="${javadoc.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+      javadoc.zip
+      
+      Creates a zip of the javadoc for distribution
+      ====================================================================-->
+  <target name="javadoc.zip" depends="javadoc">
+    <jar jarfile="${dist.dir}/${javadoc.zip.filename}"
+         basedir="${javadoc.dir}"
+         includes="**/*"
+         excludes="**/Thumbs.db" />
+  </target>
+
+
+  <!--=======================================================================
+      javadoc.targz
+      
+      Creates a gzipped tar of the javadoc for distribution
+      ====================================================================-->
+  <target name="javadoc.targz" depends="javadoc">
+    <tar compression="gzip"
+         destfile="${dist.dir}/${javadoc.tar.filename}"
+         basedir="${javadoc.dir}"
+         includes="**/*"
+         excludes="**/Thumbs.db" />
+  </target>
+
+
+  <!--=======================================================================
+      cobertura
+      
+      Runs tests in an instrumented environment and produces Cobertura test coverage reports
+      ====================================================================-->
+  <target name="cobertura"
+          description="Runs tests in an instrumented environment and produces Cobertura test coverage reports"
+          depends="clean-cobertura,install-cobertura,compile,compile-tests,cobertura.instrument-classes,cobertura.test-instrumented,cobertura.xml-report,cobertura.html-report" />
+
+
+  <!--=======================================================================
+      cobertura.instrument-classes
+      
+      Instruments the application classes used by Cobertura during cobertura.test-instrumented
+      ====================================================================-->
+  <target name="cobertura.instrument-classes" depends="cobertura.clean-instrumented-classes,install-cobertura,compile">
+    <cobertura-instrument todir="${instrumented.classes.dir}" datafile="${cobertura.data.dir}/cobertura.ser">
+      <ignore regex="org.apache.log4j.*" />
+      <fileset dir="${classes.dir}">
+        <!--
+          Instrument all the application classes, but
+          don't instrument the test classes.
+        -->
+        <include name="**/*.class" />
+        <exclude name="**/*Test.class" />
+      </fileset>
+
+    </cobertura-instrument>
+  </target>
+
+
+
+  <!--=======================================================================
+      install-cobertura
+      
+      Downloads and installs Cobertura ant tasks
+      ====================================================================-->
+  <target name="install-cobertura" depends="install-ivy">
+    <taskdef-with-ivy organisation="net.sourceforge.cobertura" module="cobertura" revision="${cobertura.version}" resource="tasks.properties" classname="net.sourceforge.cobertura.ant.InstrumentTask"/>
+  </target>
+
+
+  <!--=======================================================================
+      clean-cobertura
+      
+      Removes all files created by Cobertura code coverage utility
+      ====================================================================-->
+  <target name="clean-cobertura" depends="cobertura.clean-instrumented-classes,cobertura.clean-coverage-reports">
+    <delete dir="${cobertura.data.dir}" />
+  </target>
+
+  <!--=======================================================================
+      clean-sonar
+      
+      Removes the temporary file location for sonar files
+      ====================================================================-->
+  <target name="clean-sonar">
+    <delete dir="${basedir}/.sonar" />
+  </target>
+
+
+  <!--=======================================================================
+    cobertura.clean-instrumented-classes
+
+    Remove the instrumented classes used by Cobertura
+    ====================================================================-->
+  <target name="cobertura.clean-instrumented-classes">
+    <delete dir="${instrumented.classes.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+    cobertura.clean-coverage-reports
+
+    Remove all xml and html Cobertura coverage reports
+    ====================================================================-->
+  <target name="cobertura.clean-coverage-reports">
+    <delete dir="${coberturareports.xml.dir}" />
+    <delete dir="${coberturareports.html.dir}" />
+    <delete dir="${coberturareports.dir}" />
+  </target>
+
+
+  <!--=======================================================================
+      cobertura.test-instrumented
+      
+      Runs tests against instrumented classes and generates xml and html JUnit test reports
+      ====================================================================-->
+  <target name="cobertura.test-instrumented"
+          depends="init-test-reports,install-cobertura,compile,compile-tests,cobertura.instrument-classes">
+    <mkdir dir="${instrumented.classes.dir}" />
+    <path id="cobertura.classpath">
+      <fileset dir="${subfloor.resources.dir}/cobertura-${cobertura.version}">
+        <include name="*.jar" />
+      </fileset>
+    </path>
+    <junit fork="yes"
+           forkmode="${junit.forkmode}"
+           dir="${junit.base.dir}"
+           maxmemory="${junit.maxmemory}"
+           failureProperty="test.failed"
+           haltonerror="${junit.haltonerror}"
+           haltonfailure="${junit.haltonfailure}">
+      <sysproperty key="java.awt.headless" value="${headless.unittest}" />
+
+      <!-- Specify the name of the coverage data file to use. -->
+      <sysproperty key="net.sourceforge.cobertura.datafile" file="${cobertura.data.dir}/cobertura.ser" />
+
+      <syspropertyset>
+        <propertyref prefix="junit.sysprop." />
+        <mapper type="glob" from="junit.sysprop.*" to="*"/>
+      </syspropertyset>
+      
+      <!--
+        Note the classpath order: instrumented classes are before the
+        original (uninstrumented) classes.  This is important.
+      -->
+      <classpath location="${instrumented.classes.dir}" />
+      <classpath refid="test.classpath" />
+      <classpath refid="cobertura.classpath" />
+
+      <formatter type="xml" />
+      <test name="${testcase}" todir="${testreports.xml.dir}" if="testcase" />
+      <batchtest todir="${testreports.xml.dir}" unless="testcase">
+        <fileset dir="${testsrc.dir}" casesensitive="yes">
+          <include name="**/*Test.java" />
+        </fileset>
+      </batchtest>
+    </junit>
+
+    <junitreport todir="${testreports.html.dir}">
+      <fileset dir="${testreports.xml.dir}">
+        <include name="TEST-*.xml" />
+      </fileset>
+      <report format="frames" todir="${testreports.html.dir}" />
+    </junitreport>
+  </target>
+
+
+  <!--=======================================================================
+      cobertura.xml-report
+      
+      Produces machine-readable xml Cobertura coverage report from results of instrumented tests
+      ====================================================================-->
+  <target name="cobertura.xml-report" depends="cobertura.test-instrumented">
+    <cobertura-report destdir="${coberturareports.xml.dir}" datafile="${cobertura.data.dir}/cobertura.ser" format="xml">
+      <fileset dir="${src.dir}">
+        <include name="**/*.java" />
+      </fileset>
+    </cobertura-report>
+  </target>
+
+
+  <!--=======================================================================
+      cobertura.html-report
+      
+      Produces human-readable html Cobertura coverage report from results of instrumented tests
+      ====================================================================-->
+  <target name="cobertura.html-report" depends="cobertura.test-instrumented">
+    <cobertura-report destdir="${coberturareports.html.dir}"
+                      datafile="${cobertura.data.dir}/cobertura.ser"
+                      format="html">
+      <fileset dir="${src.dir}">
+        <include name="**/*.java" />
+      </fileset>
+    </cobertura-report>
+  </target>
+
+  <!--=======================================================================
+        install-pentaho-ant-tasks
+ 
+        Fetches and installs Pentaho Ant tasks
+      ====================================================================-->
+  <target name="install-pentaho-ant-tasks" depends="install-ivy">
+    <taskdef-with-ivy task-name="dot-classpath" classname="org.pentaho.anttasks.DotClasspath" organisation="pentaho" module="pentaho-ant-tasks" revision="1.1" />
+  </target>
+
+  <!--=======================================================================
+        create-dot-classpath
+ 
+        Creates the Eclipse .classpath file from the resolved
+        classpath from Ant.
+      ====================================================================-->
+  <target name="create-dot-classpath" depends="install-pentaho-ant-tasks,init">
+    <dot-classpath>
+      <!-- Include all lib dirs -->
+      <classpath>
+        <fileset dir="${devlib.dir}">
+          <include name="*.jar" />
+        </fileset>
+        <fileset dir="${testlib.dir}">
+          <include name="*.jar" />
+        </fileset>
+        <fileset dir="${lib.dir}">
+          <include name="*.jar" />
+        </fileset>
+      </classpath>
+    </dot-classpath>
+  </target>
+
+
+  <!--=======================================================================
+        MACRO: taskdef-with-ivy
+        Downloads (using IVY) and defines new Ant tasks
+      
+      NOTE: any task using this macro must depend on "install-antcontrib"
+      
+      parameters:
+      task-name    - Name to give the new Ant task (only used if resource is not set)
+      organisation - Artifact organization (for artifact resolution with IVY)
+      module       - Artifact module (for artifact resolution with IVY)
+      revision     - Artifact revision (for artifact resolution with IVY)
+      classname    - Classname for the Ant task.  Used during taskdef and to check 
+                     if we already have the libraries
+      resource     - (optional) Resource defining the Ant task.  Used during taskdef
+      ====================================================================-->
+  <macrodef name="taskdef-with-ivy">
+    <attribute name="task-name"
+               description="Name to give the new Ant task (only used if resource is not set)"
+               default="unset" />
+    <attribute name="organisation" description="Artifact organization" />
+    <attribute name="module" description="Artifact module" />
+    <attribute name="revision" description="Artifact revision" />
+    <attribute name="classname"
+               description="Classname for the Ant task.  Used during taskdef and to check if we already have the libraries." />
+    <attribute name="resource"
+               description="(optional) Resource defining the Ant task.  Used during taskdef"
+               default="unset" />
+    <sequential>
+      <mkdir dir="${subfloor.resources.dir}/@{module}-@{revision}/" />
+      <!-- if the library does not exist, we must download it -->
+      <if>
+        <not>
+          <and>
+            <available file="${subfloor.resources.dir}/@{module}-@{revision}" />
+            <available classname="@{classname}">
+              <classpath>
+                <fileset dir="${subfloor.resources.dir}/@{module}-@{revision}">
+                  <include name="*.jar" />
+                </fileset>
+              </classpath>
+            </available>
+          </and>
+        </not>
+        <then>
+          <ivy:retrieve inline="true"
+              conf="default"
+                        organisation="@{organisation}"
+                        module="@{module}"
+                        revision="@{revision}"
+                        pattern="${subfloor.resources.dir}/@{module}-@{revision}/[module]-__-[revision](-[classifier]).[ext]" />
+          <!-- in case the artifact pulls in an ant jar, remove it. they cause runtime conflicts -->
+          <delete>
+            <fileset dir="${subfloor.resources.dir}/@{module}-@{revision}">
+              <include name="ant-__-*.jar" />
+              <include name="ant-launcher-__-*.jar" />
+            </fileset>
+          </delete>
+        </then>
+      </if>
+      <path id="taskdef.classpath">
+        <fileset dir="${subfloor.resources.dir}/@{module}-@{revision}">
+          <include name="*.jar" />
+        </fileset>
+      </path>
+      <if>
+        <equals arg1="@{resource}" arg2="unset" />
+        <then>
+          <taskdef classpathref="taskdef.classpath" name="@{task-name}" classname="@{classname}" />
+        </then>
+        <else>
+          <taskdef classpathref="taskdef.classpath" resource="@{resource}" />
+        </else>
+      </if>
+    </sequential>
+  </macrodef>
+
+
+  <!--=======================================================================
+      Macro which will download the specified library. 
+      
+      NOTE: any task using this macro must depend on "install-antcontrib"
+      
+      parameters:
+      name      - The name of the library (the filename w/o extension)
+      url       - The URL from which the library will be downloaded
+      resource  - The name of the resource which should be loaded
+                  as a task definition 
+      classname - A class file name which can be used to detect if the
+                  property library exists
+      extension - The extension of the library being downloaded 
+                  (defaults to zip)
+      ====================================================================-->
+  <macrodef name="download-antlib">
+    <attribute name="name" />
+    <attribute name="url" />
+    <attribute name="classname" />
+    <attribute name="extension" default="zip" />
+    <sequential>
+      <mkdir dir="${subfloor.resources.dir}/@{name}/" />
+      <!-- if the library does not exist, we must download it -->
+      <if>
+        <not>
+          <and>
+            <available file="${subfloor.resources.dir}/@{name}" />
+            <available classname="@{classname}">
+              <classpath>
+                <fileset dir="${subfloor.resources.dir}/@{name}">
+                  <include name="**/*.jar" />
+                </fileset>
+              </classpath>
+            </available>
+          </and>
+        </not>
+        <then>
+          <!-- if it is a zip file, unzip it ... otherwise if a jar, just download it -->
+          <if>
+            <equals arg1="zip" arg2="@{extension}" />
+            <then>
+              <!-- download the source file to a temp directory -->
+              <echo message="downloading library @{name} [@{name}.@{extension} from @{url}]" />
+              <mkdir dir="${subfloor.tmp.dir}" />
+              <get src="@{url}" dest="${subfloor.tmp.dir}/@{name}.@{extension}" usetimestamp="true" />
+              <unzip src="${subfloor.tmp.dir}/@{name}.@{extension}"
+                     dest="${subfloor.resources.dir}/@{name}"
+                     overwrite="true" />
+            </then>
+            <else>
+              <get src="@{url}" dest="${subfloor.resources.dir}/@{name}/@{name}.@{extension}" usetimestamp="true" />
+            </else>
+          </if>
+        </then>
+      </if>
+    </sequential>
+  </macrodef>
+
+  <!--=======================================================================
+    install-tattletale
+    
+    (Fetches and) installs TATTLETALE for use by this ant script
+    ====================================================================-->
+  <target name="install-tattletale" depends="install-antcontrib">
+    <if>
+      <istrue value="${tattletale.isinstalled}" />
+      <then>
+        <echo message="Skipping TATTLETALE install.  TATTLETALE has already been configured by the build" />
+      </then>
+      <else>
+        <download-antlib name="tattletale"
+                         url="${tattletale.url}"
+                         classname="${tattletale.classname}" 
+                         extension="zip"/>
+                          
+        <taskdef name="tattletale.report" classname="${tattletale.classname}">
+          <classpath>
+            <fileset dir="${subfloor.resources.dir}/tattletale">
+              <include name="*.jar" />
+            </fileset>
+          </classpath>
+        </taskdef>
+
+        <property name="tattletale.isinstalled" value="true" />
+      </else>
+    </if>
+  </target>
+  
+  <!--=======================================================================
+    tattletale-report
+    
+    Generates a tattletale report for this project
+    ====================================================================-->
+  <target name="tattletale-report" depends="install-tattletale,jar">
+    <tattletale.report source="${basedir}" destination="${tattletale.reports.dir}"/>
+  </target>
+  
+<!--=======================================================================
+    install-sonar
+    
+    (Fetches and) installs SONAR ant plugin for use by this ant script
+    ====================================================================-->
+  <target name="install-sonar" depends="install-antcontrib">
+    <if>
+      <istrue value="${sonar.isinstalled}" />
+      <then>
+        <echo message="Skipping SONAR install.  SONAR has already been configured by the build" />
+      </then>
+      <else>
+        <download-antlib name="sonar"
+                         url="${sonar.url}"
+                         classname="${sonar.classname}" 
+                         extension="jar"/>
+                          
+        <taskdef uri="antlib:org.sonar.ant" resource="org/sonar/ant/antlib.xml">
+            <classpath>
+              <fileset dir="${subfloor.resources.dir}/sonar">
+                  <include name="*.jar" />
+              </fileset>
+            </classpath> 
+        </taskdef>
+
+        <property name="sonar.isinstalled" value="true" />
+      </else>
+    </if>
+  </target>
+
+  <!--=======================================================================
+    sonar
+      
+    Execute the sonar analysis and publish to a sonar server specified by:
+    sonar.jdbc.url
+    sonar.jdbc.driverClassName
+    sonar.jdbc.username
+    sonar.jdbc.password
+    sonar.host.url
+    ====================================================================-->
+  <target name="sonar" depends="install-sonar, compile, test, cobertura">
+    <property name="sonar.sources" value="${src.dir}" />
+    <property name="sonar.binaries" value="${classes.dir}" />
+    <property name="sonar.tests" value="${testsrc.dir}" />
+    <property name="sonar.libraries" value="${lib.dir}" />
+
+    <property name="sonar.dynamicAnalysis" value="reuseReports" />
+    <property name="sonar.cobertura.reportPath" value="${coberturareports.xml.dir}/coverage.xml" />
+    <property name="sonar.surefire.reportsPath" value="${testreports.xml.dir}" />
+    
+    <sonar:sonar key="${ivy.artifact.group}:${ivy.artifact.id}" version="${project.revision}" xmlns:sonar="antlib:org.sonar.ant"/>
+  </target>
+  
+  <!--
+    =============================================================================
+       checkstyle.xml-report : Produces machine-readable xml Checkstyle report
+    =============================================================================
+  -->
+  <target name="checkstyle.xml-report" depends="install-checkstyle">
+    <delete dir="${checkstyle.reports.dir}/xml"/>
+    <mkdir dir="${checkstyle.dir}/lib"/>
+
+    <taskdef resource="checkstyletask.properties">
+      <classpath refid="checkstyle.classpath" />
+    </taskdef>
+
+    <get usetimestamp="true" src="${checkstyle.config.url}" dest="${checkstyle.config.file}"/>
+    <get usetimestamp="true" src="${checkstyle.suppressions.url}" dest="${checkstyle.suppressions.file}"/>
+
+    <mkdir dir="${checkstyle.reports.dir}/xml"/>
+      <checkstyle config="${checkstyle.config.file}" failonviolation="false">
+        <property key="samedir" value="${checkstyle.dir}"/>
+        <fileset dir="${src.dir}" includes="**/*.java"/>
+        <fileset dir="${testsrc.dir}" includes="**/*.java" erroronmissingdir="false"/>
+        <formatter type="xml" tofile="${checkstyle.reports.dir}/xml/checkstyle-result.xml"/>
+      </checkstyle>
+  </target>
+
+  <!--
+    ==============================================================================
+       checkstyle.html-report :  Produces human-readable html Checkstyle report
+    ==============================================================================
+  -->
+  <target name="checkstyle.html-report" depends="checkstyle.xml-report">
+    <delete dir="${checkstyle.reports.dir}/html"/>
+    <mkdir dir="${checkstyle.reports.dir}/html"/>
+    <get usetimestamp="true" src="${checkstyle.stylesheet.url}" dest="${checkstyle.stylesheet.file}"/>
+    <xslt style="${checkstyle.stylesheet.file}" basedir="${checkstyle.reports.dir}/xml"
+          includes="*checkstyle-result.xml" destdir="${checkstyle.reports.dir}/html"/>
+  </target>
+
+  <!--
+    ==============================================================================
+       checkstyle: Runs CheckStyle on the source and test code
+    ==============================================================================
+  -->
+  <target name="checkstyle" depends="checkstyle.xml-report,checkstyle.html-report"/>
+</project>

--- a/plugins/kettle-monitoring-plugin/build.properties
+++ b/plugins/kettle-monitoring-plugin/build.properties
@@ -1,0 +1,16 @@
+project.revision=TRUNK-SNAPSHOT
+ivy.artifact.group=pentaho-kettle
+ivy.artifact.id=kettle-monitoring-plugin
+impl.vendor=Pentaho Corporation
+impl.title=Monitoring Plugin
+impl.productID=${ivy.artifact.id}
+dev-lib.dir=dev-lib
+
+pentaho.group=pentaho
+kettle.group=pentaho-kettle
+
+dependency.pentaho.revision=${project.revision}
+dependency.kettle.revision=${project.revision}
+dependency.commons.logging.revision=1.1.1
+dependency.commons.lang.revision=2.6
+dependency.commons.io.revision=1.4

--- a/plugins/kettle-monitoring-plugin/build.xml
+++ b/plugins/kettle-monitoring-plugin/build.xml
@@ -1,0 +1,106 @@
+<!--===========================================================================
+  This is the build file for the Pentaho Data Integration (Kettle) PALO plugin.
+  
+  This build file will use the subfloor.xml file as the default build
+  process and should only override the tasks that need to differ from
+  the common build file.
+  
+  See common_build.xml for more details
+============================================================================-->
+<project name="kettle-palo-plugin" basedir="." default="default" xmlns:ivy="antlib:org.apache.ivy.ant">
+
+
+  <description>
+    This build file is used to create the PALO core Kettle plugin
+    and works with the subfloor.xml file.
+  </description>
+
+  <!-- The continuous target is used by CI ... this is the list of -->
+  <!-- tasks that the CI machine will run.                         -->
+  <!-- DO NOT change the CI machine's ant task .. change this list -->
+  <target name="continuous" depends="clean-all,resolve,publish" />
+
+  <!-- Import the common_build.xml file which contains all the default tasks -->
+  <import file="build-res/subfloor-pkg.xml" />
+
+  <!--
+      AS STATED ABOVE, THE ONLY TASKS THAT SHOULD EXIST IN THIS BUILD FILE ARE
+      THE TASKS THAT NEED TO DIFFER FROM THE DEFAULT IMPLEMENTATION OF THE TASKS
+      FOUND IN common_build.xml.
+    -->
+  <target name="default" depends="clean-all,resolve,dist" />
+
+  <target name="create-dot-classpath" depends="resolve,subfloor.create-dot-classpath" />
+
+  <target name="clean" depends="subfloor.clean">
+      <echo message="Deleting... ${dev-lib.dir}"/>
+      <delete dir="${dev-lib.dir}" />
+    </target>
+
+  <target name="stage" depends="jar" description="generate all the kettle plugin jars">
+
+    <echo>Staging the Kettle plugin ${ivy.artifact.id} ...</echo>
+
+    <!-- copy plugin jar -->
+    <mkdir dir="bin/stage/${ivy.artifact.id}" />
+    <copy todir="bin/stage/${ivy.artifact.id}" file="dist/${ivy.artifact.id}-${project.revision}.jar" />
+
+    <!-- external libs (jdbc etc) -->
+    <mkdir dir="bin/stage/${ivy.artifact.id}/lib" />
+    <if>
+      <available file="lib" type="dir" />
+      <then>
+        <echo>Copying files from lib....</echo>
+        <copy todir="bin/stage/${ivy.artifact.id}/lib">
+          <fileset dir="lib" includes="**/*" />
+        </copy>
+      </then>
+    </if>
+
+    <!-- all resources files -->
+    <if>
+      <available file="resources" />
+      <then>
+        <copy todir="bin/stage/${ivy.artifact.id}">
+          <fileset dir="resources" includes="**/*" />
+        </copy>
+      </then>
+    </if>
+
+    <!-- res folder: version.xml file -->
+    <if>
+      <available file="res" />
+      <then>
+        <copy todir="bin/stage/${ivy.artifact.id}">
+          <fileset dir="res" includes="**/*" excludes="**/.vpn" />
+        </copy>
+      </then>
+    </if>
+
+    <!-- Update the version.xml with the current version of this plugin -->
+    <if>
+      <available file="bin/stage/${ivy.artifact.id}/version.xml" />
+      <then>
+        <replace file="bin/stage/${ivy.artifact.id}/version.xml" token="@TRUNK@" value="${project.revision}" />
+      </then>
+    </if>
+  </target>
+
+  <!--=======================================================================
+        resolve-dev
+                
+        Resolves for development and compilation.
+      =====================================================================-->
+  <target name="resolve-dev" depends="install-ivy">
+    <ivy:resolve file="${ivyfile}" conf="dev" />
+    <ivy:retrieve conf="dev" pattern="${dev-lib.dir}/[module]-[revision](-[classifier]).[ext]" />
+    <touch file="${dev-lib.dir}/.kettle-ignore" />
+  </target>
+
+  <target name="resolve" depends="subfloor.resolve,resolve-dev" />
+  <target name="package" depends="stage" description="generate all the kettle plugin jars">
+    <echo>Creating the Kettle plugin zip for ${ivy.artifact.id} ...</echo>
+    <zip destfile="dist/${ivy.artifact.id}-${project.revision}.zip" basedir="bin/stage" includes="**/*" excludes="**/dev-lib/*" />
+  </target>
+
+</project>

--- a/plugins/kettle-monitoring-plugin/ivy.xml
+++ b/plugins/kettle-monitoring-plugin/ivy.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivy-module version="2.0" xmlns:m="http://ant.apache.org/ivy/maven">
+  <info organisation="pentaho-kettle" module="${ivy.artifact.id}" revision="${dependency.kettle.revision}" status="integration" />
+
+  <configurations>
+    <conf name="default"/>
+    <conf name="dev"/>
+    <conf name="test" visibility="private"/>
+    <conf name="source"/>
+    <conf name="zip"/>
+  </configurations>
+
+  <publications>
+    <artifact name="${ivy.artifact.id}" type="jar" conf="dev"/>
+    <artifact name="${ivy.artifact.id}" type="zip" conf="zip" />
+    <artifact name="${ivy.artifact.id}" m:classifier="sources" type="source" ext="jar" conf="source"/>
+    <artifact name="${ivy.artifact.id}" m:classifier="sources" type="source" ext="zip" conf="source"/>
+  </publications>
+
+  <dependencies defaultconf="default->default">
+
+    <!-- dev-lib dependencies -->
+
+    <dependency org="${pentaho.group}"  name="pentaho-platform-api"                 rev="${dependency.pentaho.revision}"          transitive="false"          changing="true"             conf="dev->default"/>
+    <dependency org="${pentaho.group}"  name="pentaho-platform-core"                rev="${dependency.pentaho.revision}"          transitive="false"          changing="true"             conf="dev->default"/>
+    <dependency org="${pentaho.group}"  name="pentaho-platform-extensions"          rev="${dependency.pentaho.revision}"          transitive="false"          changing="true"             conf="dev->default"/>
+
+    <dependency org="${kettle.group}"   name="kettle-core"                          rev="${dependency.kettle.revision}"           transitive="false"          changing="true"             conf="dev->default"/>
+    <dependency org="${kettle.group}"   name="kettle-engine"                        rev="${dependency.kettle.revision}"           transitive="false"          changing="true"             conf="dev->default"/>
+
+    <dependency org="commons-logging"   name="commons-logging"                      rev="${dependency.commons.logging.revision}"  transitive="false"          changing="false"            conf="dev->default"/>
+    <dependency org="commons-lang"      name="commons-lang"                         rev="${dependency.commons.lang.revision}"     transitive="false"          changing="false"            conf="dev->default"/> 
+    <dependency org="commons-io"        name="commons-io"                           rev="${dependency.commons.io.revision}"       transitive="false"          changing="false"            conf="dev->default"/>   
+    <dependency org="log4j"             name="log4j"                                rev="1.2.16"                                  transitive="false"          changing="false"            conf="dev->default"/>
+    <dependency org="org.slf4j"         name="slf4j-api"                            rev="1.7.3"                                   transitive="false"          changing="false"            conf="dev->default"/>
+
+    <dependency org="com.google.guava"  name="guava"                                rev="17.0"                                    transitive="false"          changing="false"            conf="dev->default"/>
+
+    <!-- lib dependencies -->
+    
+
+    <!-- unit test dependencies -->
+    <dependency org="junit"             name="junit"                                rev="4.7"                                                                                             conf="test->default"/> 
+
+  </dependencies>
+
+</ivy-module>

--- a/plugins/kettle-monitoring-plugin/ivysettings.xml
+++ b/plugins/kettle-monitoring-plugin/ivysettings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivysettings>
+  <properties environment="env" />
+  <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
+    override="false" />
+    
+  <!-- Repository for Pentaho-hosted artifacts -->  
+  <property name="pentaho.resolve.repo" value="http://repo.pentaho.org/artifactory/repo" override="false" />
+  <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
+  <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
+
+  <settings defaultResolver="pentaho-chained-resolver" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <resolvers>
+    <chain name="pentaho-chained-resolver">
+      <resolver ref="local" />
+      <dual name="pentaho">
+        <url name="pentaho-ivy">
+          <ivy pattern="${pentaho.resolve.repo}/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />
+        </url>
+        <ibiblio name="pentaho-mvn" m2compatible="true" root="${pentaho.resolve.repo}" />
+      </dual>
+      <ibiblio name="public-maven" root="${public.resolve.repo}" m2compatible="true" />
+    </chain>
+  </resolvers>
+  <caches lockStrategy="artifact-lock" resolutionCacheDir="${ivy.default.ivy.user.dir}/resol-cache${env.EXECUTOR_NUMBER}" />
+</ivysettings>

--- a/plugins/kettle-monitoring-plugin/package-ivy.xml
+++ b/plugins/kettle-monitoring-plugin/package-ivy.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivy-module version="2.0" xmlns:m="http://ant.apache.org/ivy/maven">
+  <info organisation="${ivy.artifact.group}" module="${ivy.artifact.id}" revision="${project.revision}" />
+  <configurations>
+    <conf name="default" />
+  </configurations>
+
+  <publications>
+    <artifact name="${ivy.artifact.id}" type="zip" />
+    <artifact name="${ivy.artifact.id}" type="jar" />
+    <artifact name="${ivy.artifact.id}" m:classifier="sources" type="source" ext="jar"/>
+    <artifact name="${ivy.artifact.id}" m:classifier="sources" type="source" ext="zip"/>
+  </publications>
+
+  <dependencies defaultconf="default->default">
+  </dependencies>
+</ivy-module>

--- a/plugins/kettle-monitoring-plugin/res/version.xml
+++ b/plugins/kettle-monitoring-plugin/res/version.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<version branch='TRUNK'>@TRUNK@</version>

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/IKettleMonitoringEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/IKettleMonitoringEvent.java
@@ -1,0 +1,23 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor;
+
+import org.pentaho.platform.api.monitoring.IMonitoringEvent;
+
+public interface IKettleMonitoringEvent extends IMonitoringEvent {
+
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/IKettleMonitoringSubscriber.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/IKettleMonitoringSubscriber.java
@@ -1,0 +1,23 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor;
+
+import org.pentaho.platform.api.monitoring.IMonitoringSubscriber;
+
+public interface IKettleMonitoringSubscriber extends IMonitoringSubscriber {
+
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/MonitorAbstract.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/MonitorAbstract.java
@@ -1,0 +1,76 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogChannelInterface;
+
+public abstract class MonitorAbstract {
+
+  // kettle's provided log channel
+  private LogChannelInterface logChannelInterface;
+
+  /**
+   * implementing classes use this to transfer data from their specific objects to an IKettleEvent
+   *
+   * @param o implementing class specific object
+   * @return IKettleEvent event object
+   */
+  public abstract IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException;
+
+  /**
+   * This method is the entrance point to a specific event handling. The 'specific event' triggering is defined via the
+   * 'extensionPointId' attribute of each classe's ExtensionPoint annotation.
+   * <p/>
+   * Each implementing class of this abstract then does its own specific event handling, if it wishes so.
+   * <p/>
+   * For detailed information regarding anotation declaration check <br/> http://wiki.pentaho
+   * .com/display/EAI/PDI+Extension+Point+Plugins
+   * <p/>
+   *
+   * @param logChannelInterface spoon's standard log interface channel
+   * @param o                   one of Job/JobMeta/Transformation/TransMeta/... object
+   * @throws KettleException if something goes wrong
+   * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+   * <p/>
+   */
+  public void callExtensionPoint( LogChannelInterface logChannelInterface, Object o ) throws KettleException {
+
+    this.logChannelInterface = logChannelInterface; // kettle's provided log channel
+
+    getLog().logDebug( getClass().getName() + ".callExtensionPoint() triggered" );
+
+    try {
+
+      if ( MonitorEnvironment.getInstance().isEventBusReady() ) {
+
+        MonitorEnvironment.getInstance().getEventBus().post( toKettleEvent( o ) ); // async event bus
+
+      } else {
+        getLog().logBasic( "Monitoring event bus not available; discarding " + getClass().getSimpleName() + " event" );
+      }
+
+    } catch ( Throwable t ) {
+      getLog().logError( getClass().getName(), t );
+      throw new KettleException( t );
+    }
+  }
+
+  protected LogChannelInterface getLog() throws KettleException {
+    return logChannelInterface;
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/MonitorEnvironment.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/MonitorEnvironment.java
@@ -1,0 +1,134 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor;
+
+import org.apache.commons.lang.StringUtils;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPointPluginType;
+import org.pentaho.di.core.plugins.PluginInterface;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.monitor.carte.CarteSubscriber;
+import org.pentaho.di.monitor.database.DatabaseSubscriber;
+import org.pentaho.di.monitor.job.JobSubscriber;
+import org.pentaho.di.monitor.step.StepSubscriber;
+import org.pentaho.di.monitor.trans.TransformationSubscriber;
+import org.pentaho.platform.api.monitoring.IMonitoringService;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+
+import java.util.List;
+
+public class MonitorEnvironment {
+
+  // plugin name ( read: plugin name & plugin's folder name )
+  public static final String MONITORING_PLUGIN_FOLDER_NAME = "kettle-monitoring-plugin"; //$NON-NLS-1$
+
+  public static MonitorEnvironment instance;
+
+  private String pluginBaseDir;
+
+  private MonitorEnvironment() throws KettleException {
+
+    initializeEnvironment();
+
+    if ( isEventBusReady() ) {
+      registerEventHandlers();
+    }
+  }
+
+  public static MonitorEnvironment getInstance() throws KettleException {
+    if ( instance == null ) {
+      instance = new MonitorEnvironment();
+    }
+    return instance;
+  }
+
+  public void initializeEnvironment() throws KettleException {
+
+    try {
+
+      pluginBaseDir = findPluginBaseDir();
+
+    } catch ( Exception e ) {
+      throw new KettleException( e );
+
+    }
+  }
+
+  /**
+   * if eventbus is ready, proceed with registering all subscribers
+   *
+   * @throws KettleException
+   */
+  public void registerEventHandlers() throws KettleException {
+
+    getEventBus().register( new CarteSubscriber() );
+    getEventBus().register( new DatabaseSubscriber() );
+    getEventBus().register( new JobSubscriber() );
+    getEventBus().register( new TransformationSubscriber() );
+    getEventBus().register( new StepSubscriber() );
+
+    //TODO register all kettle subscribers
+  }
+
+  public String getPluginBaseDir() {
+    return pluginBaseDir;
+  }
+
+  public boolean isEventBusReady() {
+    return PentahoSystem.getInitializedOK()
+      && PentahoSystem.getObjectFactory().objectDefined( IMonitoringService.class );
+  }
+
+  public IMonitoringService getEventBus() {
+    return PentahoSystem.get( IMonitoringService.class );
+  }
+
+  private String findPluginBaseDir() {
+
+    List<PluginInterface> plugins = PluginRegistry.getInstance().getPlugins( ExtensionPointPluginType.class );
+
+    if ( plugins != null ) {
+
+      for ( PluginInterface plugin : plugins ) {
+
+        if ( plugin != null && plugin.getPluginDirectory() != null && plugin.getPluginDirectory().getPath() != null ) {
+
+          String path = plugin.getPluginDirectory().getPath();
+
+          if ( path.startsWith( Const.FILE_SEPARATOR + Const.FILE_SEPARATOR ) ) {
+            path = path.replaceFirst( Const.FILE_SEPARATOR + Const.FILE_SEPARATOR, StringUtils.EMPTY );
+          }
+
+          if ( path.endsWith( Const.FILE_SEPARATOR ) ) {
+            path = path.substring( 0, path.length() - 1 );
+          }
+
+          if ( path.endsWith( MONITORING_PLUGIN_FOLDER_NAME ) ) {
+            return path;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private void throwException( String message ) throws KettleException {
+    throw new KettleException( MONITORING_PLUGIN_FOLDER_NAME + " - Error in initialization: " + message );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteEvent.java
@@ -1,0 +1,86 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.carte;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.www.WebServer;
+
+import java.io.Serializable;
+
+public class CarteEvent implements IKettleMonitoringEvent {
+
+  private static final long serialVersionUID = -3589233687711692569L;
+
+  private static final String ID = "1.1.1.1.1.1.1.1"; // TODO replace with an actual oid
+
+  public static enum EventType {STARTUP, SHUTDOWN}
+
+  private Serializable id = ID;
+  private EventType eventType;
+  private String hostname;
+  private int port;
+
+  public CarteEvent( EventType eventType ) {
+    this.eventType = eventType;
+  }
+
+  @Override
+  public Serializable getId() {
+    return id;
+  }
+
+  public void setId( Serializable id ) {
+    this.id = id;
+  }
+
+  public EventType getEventType() {
+    return eventType;
+  }
+
+  public void setEventType( EventType eventType ) {
+    this.eventType = eventType;
+  }
+
+  public String getHostname() {
+    return hostname;
+  }
+
+  public void setHostname( String hostname ) {
+    this.hostname = hostname;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort( int port ) {
+    this.port = port;
+  }
+
+  public CarteEvent build( WebServer ws ) throws KettleException {
+
+    if ( ws == null ) {
+      return this;
+    }
+
+    setPort( ws.getPort() );
+    setHostname( ws.getHostname() );
+
+    return this;
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteShutdownMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteShutdownMonitor.java
@@ -1,0 +1,49 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.carte;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.www.WebServer;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  id = "CarteShutdownMonitor",
+  extensionPointId = "CarteShutdown",
+  description = "Right before the Carte webserver will shut down"
+)
+public class CarteShutdownMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof WebServer ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "CarteShutdownMonitor - " + ( (WebServer) o ).getHostname() + ":" + ( (WebServer) o ).getPort
+      () );
+
+    return new CarteEvent( CarteEvent.EventType.SHUTDOWN ).build( (WebServer) o );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteStartupMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteStartupMonitor.java
@@ -1,0 +1,48 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.carte;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.www.WebServer;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  id = "CarteStartupMonitor",
+  extensionPointId = "CarteStartup",
+  description = "Right after the Carte webserver has started and is fully functional"
+)
+public class CarteStartupMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof WebServer ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "CarteStartupMonitor - " + ( (WebServer) o ).getHostname() + ":" + ( (WebServer) o ).getPort() );
+
+    return new CarteEvent( CarteEvent.EventType.STARTUP ).build( (WebServer) o );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteSubscriber.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteSubscriber.java
@@ -1,0 +1,44 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.carte;
+
+import com.google.common.eventbus.Subscribe;
+import org.pentaho.di.monitor.IKettleMonitoringSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CarteSubscriber implements IKettleMonitoringSubscriber {
+
+  private Logger logger = LoggerFactory.getLogger( CarteSubscriber.class );
+
+  @Override
+  public String getSubscriberId() {
+    return getClass().getName();
+  }
+
+  @Subscribe
+  public void handleEvent( CarteEvent event ) {
+
+    if ( event == null ) {
+      return;
+    }
+
+    logger.warn( " TODO CarteEvent 2 SNMP task " );
+
+    // TODO event 2 SNMP task
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseConnectedMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseConnectedMonitor.java
@@ -1,0 +1,49 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.database;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.pentaho.di.core.database.Database;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  extensionPointId = "DatabaseConnected",
+  id = "DatabaseConnectedMonitor",
+  description = "Job metadata was loaded"
+)
+public class DatabaseConnectedMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof Database ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "DatabaseConnectedMonitor - " + ToStringBuilder.reflectionToString( o ) );
+
+    return new DatabaseEvent( DatabaseEvent.EventType.CONNECTED ).build( ( (Database) o ).getDatabaseMeta() );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseDisconnectedMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseDisconnectedMonitor.java
@@ -1,0 +1,49 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.database;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.pentaho.di.core.database.Database;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  extensionPointId = "DatabaseConnected",
+  id = "DatabaseConnectedMonitor",
+  description = "Job metadata was loaded"
+)
+public class DatabaseDisconnectedMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof Database ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "DatabaseConnectedMonitor - " + ToStringBuilder.reflectionToString( o ) );
+
+    return new DatabaseEvent( DatabaseEvent.EventType.DISCONNECTED ).build( ( (Database) o ).getDatabaseMeta() );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseEvent.java
@@ -1,0 +1,156 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.database;
+
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+
+import java.io.Serializable;
+
+public class DatabaseEvent implements IKettleMonitoringEvent {
+
+  private static final long serialVersionUID = 5995750699747792833L;
+
+  private static final String ID = "1.1.1.1.1.1.1.1"; // TODO replace with an actual oid
+
+  public static enum EventType {CONNECTED, DISCONNECTED}
+
+  private Serializable id = ID;
+  private EventType eventType;
+  private String databaseName;
+  private String driver;
+  private String hostname;
+  private String server;
+  private String port;
+  private int initialPoolSize;
+  private int maxPoolSize;
+  private String connectionUrl;
+  private String username;
+
+  public DatabaseEvent( EventType eventType ) {
+    this.eventType = eventType;
+  }
+
+  @Override
+  public Serializable getId() {
+    return id;
+  }
+
+  public void setId( Serializable id ) {
+    this.id = id;
+  }
+
+  public EventType getEventType() {
+    return eventType;
+  }
+
+  public void setEventType( EventType eventType ) {
+    this.eventType = eventType;
+  }
+
+  public String getDatabaseName() {
+    return databaseName;
+  }
+
+  public void setDatabaseName( String databaseName ) {
+    this.databaseName = databaseName;
+  }
+
+  public String getDriver() {
+    return driver;
+  }
+
+  public void setDriver( String driver ) {
+    this.driver = driver;
+  }
+
+  public String getHostname() {
+    return hostname;
+  }
+
+  public void setHostname( String hostname ) {
+    this.hostname = hostname;
+  }
+
+  public String getServer() {
+    return server;
+  }
+
+  public void setServer( String server ) {
+    this.server = server;
+  }
+
+  public String getPort() {
+    return port;
+  }
+
+  public void setPort( String port ) {
+    this.port = port;
+  }
+
+  public int getInitialPoolSize() {
+    return initialPoolSize;
+  }
+
+  public void setInitialPoolSize( int initialPoolSize ) {
+    this.initialPoolSize = initialPoolSize;
+  }
+
+  public int getMaxPoolSize() {
+    return maxPoolSize;
+  }
+
+  public void setMaxPoolSize( int maxPoolSize ) {
+    this.maxPoolSize = maxPoolSize;
+  }
+
+  public String getConnectionUrl() {
+    return connectionUrl;
+  }
+
+  public void setConnectionUrl( String connectionUrl ) {
+    this.connectionUrl = connectionUrl;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername( String username ) {
+    this.username = username;
+  }
+
+  public DatabaseEvent build( DatabaseMeta dbm ) throws KettleException {
+
+    if ( dbm == null ) {
+      return this;
+    }
+
+    setConnectionUrl( dbm.getURL() );
+    setDatabaseName( dbm.getDatabaseName() );
+    setPort( dbm.getDatabasePortNumberString() );
+    setHostname( dbm.getHostname() );
+    setServer( dbm.getServername() );
+    setDriver( dbm.getDriverClass() );
+    setInitialPoolSize( dbm.getInitialPoolSize() );
+    setMaxPoolSize( dbm.getMaximumPoolSize() );
+    setUsername( dbm.getUsername() );
+
+    return this;
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseSubscriber.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseSubscriber.java
@@ -1,0 +1,44 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.database;
+
+import com.google.common.eventbus.Subscribe;
+import org.pentaho.di.monitor.IKettleMonitoringSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DatabaseSubscriber implements IKettleMonitoringSubscriber {
+
+  private Logger logger = LoggerFactory.getLogger( DatabaseSubscriber.class );
+
+  @Override
+  public String getSubscriberId() {
+    return getClass().getName();
+  }
+
+  @Subscribe
+  public void handleEvent( DatabaseEvent event ) {
+
+    if ( event == null ) {
+      return;
+    }
+
+    logger.warn( " TODO DatabaseEvent 2 SNMP task " );
+
+    // TODO event 2 SNMP task
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobEvent.java
@@ -1,0 +1,158 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.job;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class JobEvent implements IKettleMonitoringEvent {
+
+  private static final long serialVersionUID = -2727216752120528962L;
+
+  private static final String ID = "1.1.1.1.1.1.1.1"; // TODO replace with an actual oid
+
+  public static enum EventType {META_LOADED, STARTED, BEFORE_JOB_ENTRY, BEGIN_JOB_PROCESSING, AFTER_JOB_ENTRY, FINISH}
+
+  private Serializable id = ID;
+  private EventType eventType;
+  private String name;
+  private String filename;
+  private String filetype;
+  private String xml;
+  private String creationUser;
+  private Date creationDate;
+  private String executingServer;
+  private String executingUser;
+
+  public JobEvent( EventType eventType ) {
+    this.eventType = eventType;
+  }
+
+  @Override
+  public Serializable getId() {
+    return id;
+  }
+
+  public void setId( Serializable id ) {
+    this.id = id;
+  }
+
+  public EventType getEventType() {
+    return eventType;
+  }
+
+  public void setEventType( EventType eventType ) {
+    this.eventType = eventType;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName( String name ) {
+    this.name = name;
+  }
+
+  public String getFilename() {
+    return filename;
+  }
+
+  public void setFilename( String filename ) {
+    this.filename = filename;
+  }
+
+  public String getFiletype() {
+    return filetype;
+  }
+
+  public void setFiletype( String filetype ) {
+    this.filetype = filetype;
+  }
+
+  public String getXml() {
+    return xml;
+  }
+
+  public void setXml( String xml ) {
+    this.xml = xml;
+  }
+
+  public String getCreationUser() {
+    return creationUser;
+  }
+
+  public void setCreationUser( String creationUser ) {
+    this.creationUser = creationUser;
+  }
+
+  public Date getCreationDate() {
+    return creationDate;
+  }
+
+  public void setCreationDate( Date creationDate ) {
+    this.creationDate = creationDate;
+  }
+
+  public String getExecutingServer() {
+    return executingServer;
+  }
+
+  public void setExecutingServer( String executingServer ) {
+    this.executingServer = executingServer;
+  }
+
+  public String getExecutingUser() {
+    return executingUser;
+  }
+
+  public void setExecutingUser( String executingUser ) {
+    this.executingUser = executingUser;
+  }
+
+  public JobEvent build( Job job ) throws KettleException {
+
+    if ( job == null ) {
+      return this;
+    }
+
+    setExecutingServer( job.getExecutingServer() );
+    setExecutingUser( job.getExecutingUser() );
+
+    return build( job.getJobMeta() );
+  }
+
+  public JobEvent build( JobMeta meta ) throws KettleException {
+
+    if ( meta == null ) {
+      return this;
+    }
+
+    setName( meta.getName() );
+    setFilename( meta.getFilename() );
+    setFiletype( meta.getFileType() );
+    setCreationUser( meta.getCreatedUser() );
+    setCreationDate( meta.getCreatedDate() );
+    setXml( meta.getXML() );
+
+    return this;
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobMetaLoadedMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobMetaLoadedMonitor.java
@@ -1,0 +1,48 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.job;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  id = "JobMetaLoadedMonitor",
+  extensionPointId = "JobMetaLoaded",
+  description = "Job metadata was loaded"
+)
+public class JobMetaLoadedMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof JobMeta ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "JobMetaLoadedMonitor - " + ( (JobMeta) o ).getXML() );
+
+    return new JobEvent( JobEvent.EventType.META_LOADED ).build( (JobMeta) o );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobStartMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobStartMonitor.java
@@ -1,0 +1,48 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.job;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  id = "JobStartMonitor",
+  extensionPointId = "JobStart",
+  description = "A job starts"
+)
+public class JobStartMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof Job ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "JobStartMonitor - " + ( (Job) o ).getName() );
+
+    return new JobEvent( JobEvent.EventType.META_LOADED ).build( (Job) o );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobSubscriber.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobSubscriber.java
@@ -1,0 +1,44 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.job;
+
+import com.google.common.eventbus.Subscribe;
+import org.pentaho.di.monitor.IKettleMonitoringSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JobSubscriber implements IKettleMonitoringSubscriber {
+
+  private Logger logger = LoggerFactory.getLogger( JobSubscriber.class );
+
+  @Override
+  public String getSubscriberId() {
+    return getClass().getName();
+  }
+
+  @Subscribe
+  public void handleEvent( JobEvent event ) {
+
+    if ( event == null ) {
+      return;
+    }
+
+    logger.warn( " TODO JobEvent 2 SNMP task " );
+
+    // TODO event 2 SNMP task
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/spoon/SpoonJobMetaExecutionStartMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/spoon/SpoonJobMetaExecutionStartMonitor.java
@@ -1,0 +1,48 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.spoon;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  extensionPointId = "SpoonJobMetaExecutionStart",
+  id = "SpoonJobMetaExecutionStartMonitor",
+  description = "A transformation begins to prepare execution"
+)
+public class SpoonJobMetaExecutionStartMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof JobMeta ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "SpoonJobMetaExecutionStartMonitor - " + ( (JobMeta) o ).getXML() );
+
+    return null;
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepAfterInitializeMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepAfterInitializeMonitor.java
@@ -1,0 +1,50 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.step;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.trans.step.StepInitThread;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  id = "StepAfterInitializeMonitor",
+  extensionPointId = "StepAfterInitialize",
+  description = "After a step is initialized"
+)
+public class StepAfterInitializeMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof StepInitThread ) ) {
+      return null;
+    }
+
+    getLog()
+      .logDebug( "StepAfterInitMonitor - " + ToStringBuilder.reflectionToString( ( (StepInitThread) o ).getCombi() ) );
+
+    return new StepEvent( StepEvent.EventType.AFTER_INIT ).build( ( (StepInitThread) o ).getCombi() );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepBeforeInitializeMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepBeforeInitializeMonitor.java
@@ -1,0 +1,50 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.step;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.trans.step.StepInitThread;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  id = "StepBeforeInitializeMonitor",
+  extensionPointId = "StepBeforeInitialize",
+  description = "Before a step is about to be initialized"
+)
+public class StepBeforeInitializeMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof StepInitThread ) ) {
+      return null;
+    }
+
+    getLog()
+      .logDebug( "StepBeforeInitMonitor - " + ToStringBuilder.reflectionToString( ( (StepInitThread) o ).getCombi() ) );
+
+    return new StepEvent( StepEvent.EventType.BEFORE_INIT ).build( ( (StepInitThread) o ).getCombi() );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepBeforeStartMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepBeforeStartMonitor.java
@@ -1,0 +1,49 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.step;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.trans.step.StepMetaDataCombi;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  id = "StepBeforeStartMonitor",
+  extensionPointId = "StepBeforeStart",
+  description = "Before a step is about to be started"
+)
+public class StepBeforeStartMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof StepMetaDataCombi ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "StepBeforeStartMonitor - " + ToStringBuilder.reflectionToString( ( o ) ) );
+
+    return new StepEvent( StepEvent.EventType.BEFORE_START ).build( ( (StepMetaDataCombi) o ) );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepEvent.java
@@ -1,0 +1,119 @@
+package org.pentaho.di.monitor.step;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.trans.step.StepMetaDataCombi;
+
+import java.io.Serializable;
+
+public class StepEvent implements IKettleMonitoringEvent {
+
+  private static final long serialVersionUID = 3171013674678295934L;
+
+  private static final String ID = "1.1.1.1.1.1.1.1"; // TODO replace with an actual oid
+
+  public static enum EventType {BEFORE_INIT, AFTER_INIT, BEFORE_START, FINIHED}
+
+  private Serializable id = ID;
+  private EventType eventType;
+  private String name;
+  private String xmlContent;
+  private boolean clustered;
+  private boolean distributed;
+  private boolean doesErrorHandling;
+  private boolean usesThreadPriorityManagement;
+
+  public StepEvent( EventType eventType ) {
+    this.eventType = eventType;
+  }
+
+  @Override
+  public Serializable getId() {
+    return null;
+  }
+
+  public void setId( Serializable id ) {
+    this.id = id;
+  }
+
+  public EventType getEventType() {
+    return eventType;
+  }
+
+  public void setEventType( EventType eventType ) {
+    this.eventType = eventType;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName( String name ) {
+    this.name = name;
+  }
+
+  public String getXmlContent() {
+    return xmlContent;
+  }
+
+  public void setXmlContent( String xmlContent ) {
+    this.xmlContent = xmlContent;
+  }
+
+  public boolean isClustered() {
+    return clustered;
+  }
+
+  public void setClustered( boolean clustered ) {
+    this.clustered = clustered;
+  }
+
+  public boolean isDistributed() {
+    return distributed;
+  }
+
+  public void setDistributed( boolean distributed ) {
+    this.distributed = distributed;
+  }
+
+  public boolean isDoesErrorHandling() {
+    return doesErrorHandling;
+  }
+
+  public void setDoesErrorHandling( boolean doesErrorHandling ) {
+    this.doesErrorHandling = doesErrorHandling;
+  }
+
+  public boolean isUsesThreadPriorityManagement() {
+    return usesThreadPriorityManagement;
+  }
+
+  public void setUsesThreadPriorityManagement( boolean usesThreadPriorityManagement ) {
+    this.usesThreadPriorityManagement = usesThreadPriorityManagement;
+  }
+
+  public StepEvent build( StepMetaDataCombi combi ) throws KettleException {
+
+    if ( combi == null ) {
+      return this;
+    }
+
+    setName( combi.stepname );
+
+    if ( combi.stepMeta != null ) {
+
+      setClustered( combi.stepMeta.isClustered() );
+      setDistributed( combi.stepMeta.isDistributes() );
+      setDoesErrorHandling( combi.stepMeta.isDoingErrorHandling() );
+      setXmlContent( combi.stepMeta.getXML() );
+    }
+
+    if ( combi.step != null ) {
+
+      setUsesThreadPriorityManagement( combi.step.isUsingThreadPriorityManagment() );
+    }
+
+    return this;
+  }
+
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepFinishedMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepFinishedMonitor.java
@@ -1,0 +1,48 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.step;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.trans.step.StepMetaDataCombi;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  id = "StepFinishedMonitor",
+  extensionPointId = "StepFinished",
+  description = "After a step has finished"
+)
+public class StepFinishedMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof StepMetaDataCombi ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "StepFinishedMonitor - " + ( o ).toString() );
+
+    return new StepEvent( StepEvent.EventType.FINIHED ).build( ( (StepMetaDataCombi) o ) );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepSubscriber.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepSubscriber.java
@@ -1,0 +1,44 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.step;
+
+import com.google.common.eventbus.Subscribe;
+import org.pentaho.di.monitor.IKettleMonitoringSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StepSubscriber implements IKettleMonitoringSubscriber {
+
+  private Logger logger = LoggerFactory.getLogger( StepSubscriber.class );
+
+  @Override
+  public String getSubscriberId() {
+    return getClass().getName();
+  }
+
+  @Subscribe
+  public void handleEvent( StepEvent event ) {
+
+    if ( event == null ) {
+      return;
+    }
+
+    logger.warn( " TODO StepEvent 2 SNMP task " );
+
+    // TODO event 2 SNMP task
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationEvent.java
@@ -1,0 +1,144 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.trans;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class TransformationEvent implements IKettleMonitoringEvent {
+
+  private static final String ID = "1.1.1.1.1.1.1.1"; // TODO replace with an actual oid
+
+  public static enum EventType { META_LOADED, BEGIN_PREPARE_EXECUTION, BEGIN_START, STARTED, FINISHED }
+
+  private Serializable id = ID;
+  private EventType eventType;
+  private String name;
+  private String filename;
+  private String filetype;
+  private String xml;
+  private String creationUser;
+  private Date creationDate;
+  private String executingServer;
+  private String executingUser;
+
+  public TransformationEvent( EventType eventType ) {
+    this.eventType = eventType;
+  }
+
+  @Override
+  public Serializable getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName( String name ) {
+    this.name = name;
+  }
+
+  public String getFilename() {
+    return filename;
+  }
+
+  public void setFilename( String filename ) {
+    this.filename = filename;
+  }
+
+  public String getFiletype() {
+    return filetype;
+  }
+
+  public void setFiletype( String filetype ) {
+    this.filetype = filetype;
+  }
+
+  public String getXml() {
+    return xml;
+  }
+
+  public void setXml( String xml ) {
+    this.xml = xml;
+  }
+
+  public String getCreationUser() {
+    return creationUser;
+  }
+
+  public void setCreationUser( String creationUser ) {
+    this.creationUser = creationUser;
+  }
+
+  public Date getCreationDate() {
+    return creationDate;
+  }
+
+  public void setCreationDate( Date creationDate ) {
+    this.creationDate = creationDate;
+  }
+
+  public String getExecutingServer() {
+    return executingServer;
+  }
+
+  public void setExecutingServer( String executingServer ) {
+    this.executingServer = executingServer;
+  }
+
+  public String getExecutingUser() {
+    return executingUser;
+  }
+
+  public void setExecutingUser( String executingUser ) {
+    this.executingUser = executingUser;
+  }
+
+  public TransformationEvent build( Trans trans ) throws KettleException {
+
+    if ( trans == null ) {
+      return this;
+    }
+
+    setExecutingServer( trans.getExecutingServer() );
+    setExecutingUser( trans.getExecutingUser() );
+
+    return build( trans.getTransMeta() );
+  }
+
+  public TransformationEvent build( TransMeta meta ) throws KettleException {
+
+    if ( meta == null ) {
+      return this;
+    }
+
+    setName( meta.getName() );
+    setFilename( meta.getFilename() );
+    setFiletype( meta.getFileType() );
+    setCreationUser( meta.getCreatedUser() );
+    setCreationDate( meta.getCreatedDate() );
+    setXml( meta.getXML() );
+
+    return this;
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationPrepareExecutionMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationPrepareExecutionMonitor.java
@@ -1,0 +1,49 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.trans;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.trans.Trans;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  extensionPointId = "TransformationPrepareExecution",
+  id = "TransformationPrepareExecutionMonitor",
+  description = "A transformation begins to prepare execution"
+)
+public class TransformationPrepareExecutionMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof Trans ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "TransformationPrepareExecutionMonitor - " + ToStringBuilder.reflectionToString( o ) );
+
+    return new TransformationEvent( TransformationEvent.EventType.BEGIN_PREPARE_EXECUTION ).build( (Trans) o );
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationSubscriber.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationSubscriber.java
@@ -1,0 +1,44 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.trans;
+
+import com.google.common.eventbus.Subscribe;
+import org.pentaho.di.monitor.IKettleMonitoringSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TransformationSubscriber implements IKettleMonitoringSubscriber {
+
+  private Logger logger = LoggerFactory.getLogger( TransformationSubscriber.class );
+
+  @Override
+  public String getSubscriberId() {
+    return getClass().getName();
+  }
+
+  @Subscribe
+  public void handleEvent( TransformationEvent event ) {
+
+    if ( event == null ) {
+      return;
+    }
+
+    logger.warn( " TODO TransformationEvent 2 SNMP task " );
+
+    // TODO event 2 SNMP task
+  }
+}


### PR DESCRIPTION
```
- created kettle-monitoring-plugin as the first step ( read: entry-point ) to PDI monitoring story
- uses PDI Extension Point Plugins mechanism ( see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins )    
    - uses event bus plugin work @ https://github.com/pentaho/pentaho-platform/tree/monitoring
- when the PDI Extension Point Plugins mechanism is triggered at a specific event, an Event object is built and posted to the eventbus, where an EventSubscriber for this type of event has been previously subscribed
```
