### PR TITLE
[PDI-7243] - JSON Output Step throws NullPointerException when previewing no rows

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/jsonoutput/JsonOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/jsonoutput/JsonOutput.java
@@ -225,7 +225,7 @@ public class JsonOutput extends BaseStep implements StepInterface {
     data.jg.put( data.realBlocName, data.ja );
     String value = data.jg.toJSONString();
 
-    if ( data.outputValue ) {
+    if ( data.outputValue && data.outputRowMeta != null ) {
       Object[] outputRowData = RowDataUtil.addValueData( rowData, data.inputRowMetaSize, value );
       incrementLinesOutput();
       putRow( data.outputRowMeta, outputRowData );


### PR DESCRIPTION
Backport of https://github.com/pentaho/pentaho-kettle/pull/680
Related to http://jira.pentaho.com/browse/SP-1385
