### PR TITLE
[BACKLOG-248] Write extension point plugin producing guava bus events

### DIFF
--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobEvent.java
@@ -30,7 +30,7 @@ public class JobEvent implements IKettleMonitoringEvent {
 
   private static final String ID = "1.1.1.1.1.1.1.1"; // TODO replace with an actual oid
 
-  public static enum EventType {META_LOADED, STARTED, BEFORE_JOB_ENTRY, BEGIN_JOB_PROCESSING, AFTER_JOB_ENTRY, FINISH}
+  public static enum EventType {META_LOADED, STARTED, BEFORE_JOB_ENTRY, BEGIN_JOB_PROCESSING, AFTER_JOB_ENTRY, FINISHED}
 
   private Serializable id = ID;
   private EventType eventType;
@@ -42,6 +42,8 @@ public class JobEvent implements IKettleMonitoringEvent {
   private Date creationDate;
   private String executingServer;
   private String executingUser;
+  private long startTimeMillis;
+  private long endTimeMillis;
 
   public JobEvent( EventType eventType ) {
     this.eventType = eventType;
@@ -128,6 +130,22 @@ public class JobEvent implements IKettleMonitoringEvent {
     this.executingUser = executingUser;
   }
 
+  public long getStartTimeMillis() {
+    return startTimeMillis;
+  }
+
+  public void setStartTimeMillis( long startTimeMillis ) {
+    this.startTimeMillis = startTimeMillis;
+  }
+
+  public long getEndTimeMillis() {
+    return endTimeMillis;
+  }
+
+  public void setEndTimeMillis( long endTimeMillis ) {
+    this.endTimeMillis = endTimeMillis;
+  }
+
   public JobEvent build( Job job ) throws KettleException {
 
     if ( job == null ) {
@@ -136,6 +154,11 @@ public class JobEvent implements IKettleMonitoringEvent {
 
     setExecutingServer( job.getExecutingServer() );
     setExecutingUser( job.getExecutingUser() );
+    setStartTimeMillis( job.getCurrentDate() != null ? job.getCurrentDate().getTime() : 0 );
+
+    if( this.eventType == EventType.FINISHED ){
+      setEndTimeMillis( new Date().getTime() );
+    }
 
     return build( job.getJobMeta() );
   }

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobFinishMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobFinishMonitor.java
@@ -1,0 +1,52 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.job;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  id = "JobFinishMonitor",
+  extensionPointId = "JobFinish",
+  description = "A job finishes"
+)
+public class JobFinishMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof Job ) ) {
+      return null;
+    }
+
+    JobEvent jobEvent = new JobEvent( JobEvent.EventType.FINISHED ).build( (Job) o );
+
+    getLog().logDebug( "JobFinishMonitor - " + ( (Job) o ).getName()
+      + " , completed in " + ( jobEvent.getStartTimeMillis() > 0 ?
+      ( ( ( jobEvent.getEndTimeMillis() - jobEvent.getStartTimeMillis() ) / 1000 ) % 60 ) : 0 ) + " seconds");
+
+    return jobEvent;
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationEvent.java
@@ -28,7 +28,7 @@ public class TransformationEvent implements IKettleMonitoringEvent {
 
   private static final String ID = "1.1.1.1.1.1.1.1"; // TODO replace with an actual oid
 
-  public static enum EventType { META_LOADED, BEGIN_PREPARE_EXECUTION, BEGIN_START, STARTED, FINISHED }
+  public static enum EventType {META_LOADED, BEGIN_PREPARE_EXECUTION, BEGIN_START, STARTED, FINISHED}
 
   private Serializable id = ID;
   private EventType eventType;
@@ -40,6 +40,8 @@ public class TransformationEvent implements IKettleMonitoringEvent {
   private Date creationDate;
   private String executingServer;
   private String executingUser;
+  private long startTimeMillis;
+  private long endTimeMillis;
 
   public TransformationEvent( EventType eventType ) {
     this.eventType = eventType;
@@ -114,6 +116,22 @@ public class TransformationEvent implements IKettleMonitoringEvent {
     this.executingUser = executingUser;
   }
 
+  public long getStartTimeMillis() {
+    return startTimeMillis;
+  }
+
+  public void setStartTimeMillis( long startTimeMillis ) {
+    this.startTimeMillis = startTimeMillis;
+  }
+
+  public long getEndTimeMillis() {
+    return endTimeMillis;
+  }
+
+  public void setEndTimeMillis( long endTimeMillis ) {
+    this.endTimeMillis = endTimeMillis;
+  }
+
   public TransformationEvent build( Trans trans ) throws KettleException {
 
     if ( trans == null ) {
@@ -122,6 +140,11 @@ public class TransformationEvent implements IKettleMonitoringEvent {
 
     setExecutingServer( trans.getExecutingServer() );
     setExecutingUser( trans.getExecutingUser() );
+    setStartTimeMillis( trans.getCurrentDate() != null ? trans.getCurrentDate().getTime() : 0 );
+
+    if( this.eventType == EventType.FINISHED ){
+      setEndTimeMillis( new Date().getTime() );
+    }
 
     return build( trans.getTransMeta() );
   }

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationFinishMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationFinishMonitor.java
@@ -1,0 +1,53 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.trans;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.trans.Trans;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  extensionPointId = "TransformationFinish",
+  id = "TransformationFinishMonitor",
+  description = "A transformation finishes"
+)
+public class TransformationFinishMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof Trans ) ) {
+      return null;
+    }
+
+    TransformationEvent transEvent = new TransformationEvent( TransformationEvent.EventType.FINISHED ).build( (Trans) o );
+
+    getLog().logDebug( "TransformationFinishMonitor - " + ToStringBuilder.reflectionToString( o )
+      + " , completed in " + ( transEvent.getStartTimeMillis() > 0 ?
+      ( ( ( transEvent.getEndTimeMillis() - transEvent.getStartTimeMillis() ) / 1000 ) % 60 ) : 0 ) + " seconds");
+
+    return transEvent;
+  }
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationStartMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationStartMonitor.java
@@ -1,0 +1,49 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.trans;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.extension.ExtensionPoint;
+import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.IKettleMonitoringEvent;
+import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.trans.Trans;
+
+/**
+ * @see http://wiki.pentaho.com/display/EAI/PDI+Extension+Point+Plugins
+ */
+
+@ExtensionPoint(
+  extensionPointId = "TransformationStart",
+  id = "TransformationStartMonitor",
+  description = "A transformation has started"
+)
+public class TransformationStartMonitor extends MonitorAbstract implements ExtensionPointInterface {
+
+  @Override
+  public IKettleMonitoringEvent toKettleEvent( Object o ) throws KettleException {
+
+    if ( o == null || !( o instanceof Trans ) ) {
+      return null;
+    }
+
+    getLog().logDebug( "TransformationStartMonitor - " + ToStringBuilder.reflectionToString( o ) );
+
+    return new TransformationEvent( TransformationEvent.EventType.BEGIN_START ).build( (Trans) o );
+  }
+}


### PR DESCRIPTION
```
- added 2 new attributes to JobEvent and TransformationEvent: startTimeMillis , endTimeMillis
- startTimeMillis is set with the currentDate.getTime() of the given job/transformation, and endTimeMillis is set upon the triggering of the 'JobFinish' / 'TransformationFinish' PDI Extension point listeners
- added 3 more PDI Extension point listeners to the monitoring plugin: JobFinishMonitor, TransformationFinishMonitor, TransformationStartMonitor
```
