### PR TITLE
[PDI-12659] Fuzzy Match uses matching field instead of lookup fields

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/fuzzymatch/FuzzyMatch.java
+++ b/engine/src/org/pentaho/di/trans/steps/fuzzymatch/FuzzyMatch.java
@@ -149,7 +149,7 @@ public class FuzzyMatch extends BaseStep implements StepInterface {
         if ( fromStreamRowMeta.isStorageBinaryString() ) {
           storeData[i] = fromStreamRowMeta.convertToNormalStorageType( rowData[data.indexOfCachedFields[i]] );
         } else {
-          storeData[i] = rowData[data.indexOfCachedFields[0]];
+          storeData[i] = rowData[data.indexOfCachedFields[i]];
         }
       }
       if ( isDebug() ) {


### PR DESCRIPTION
Fixed copy&paste issue introduced in https://github.com/pentaho/pentaho-kettle/blob/ef324480143287430ceb351212d6c8d78f92bd06/engine/src/org/pentaho/di/trans/steps/fuzzymatch/FuzzyMatch.java#L152
