### PR TITLE
[BACKLOG-336]: CLONE - "Start or Restart Job From Selected Job Entry Copy" button disabled in 5.1.0

### DIFF
--- a/ui/src/org/pentaho/di/ui/spoon/job/JobGraph.java
+++ b/ui/src/org/pentaho/di/ui/spoon/job/JobGraph.java
@@ -3526,9 +3526,9 @@ public class JobGraph extends AbstractGraph implements XulEventHandler, Redrawab
         // Replay button...
         //
         XulToolbarbutton replayButton = (XulToolbarbutton) toolbar.getElementById( "job-replay" );
-        if ( replayButton != null && !controlDisposed( replayButton ) ) {
-          if ( replayButton.isDisabled() ^ !running ) {
-            replayButton.setDisabled( !running );
+        if ( replayButton != null && !controlDisposed( replayButton ) && !operationsNotAllowed ) {
+          if ( replayButton.isDisabled() ^ running ) {
+            replayButton.setDisabled( running );
           }
         }
 


### PR DESCRIPTION
The fix is just enable this button as it done for Start/Run button
This is a minor change in UI component.
