### PR TITLE
[PDI-12375] - Could not find "find" command

### DIFF
--- a/assembly/package-res/Spoon.bat
+++ b/assembly/package-res/Spoon.bat
@@ -51,7 +51,7 @@ goto USEJAVAFROMPATH
 FOR /F %%a IN ('.\java.exe -version 2^>^&1^|%windir%\system32\find /C "64-Bit"') DO (SET /a IS64BITJAVA=%%a)
 GOTO CHECK32VS64BITJAVA
 :USEJAVAFROMPATH
-FOR /F %%a IN ('java -version 2^>^&1^|find /C "64-Bit"') DO (SET /a IS64BITJAVA=%%a)
+FOR /F %%a IN ('java -version 2^>^&1^|%windir%\system32\find /C "64-Bit"') DO (SET /a IS64BITJAVA=%%a)
 GOTO CHECK32VS64BITJAVA
 :CHECK32VS64BITJAVA
 


### PR DESCRIPTION
The .bat file had inconsistent use of %windir%\system32\ for finding the
"find" command. Only one of the checks was using it.
