### PR TITLE
[BACKLOG-623] Update the extension point plugin to add remaining event m...

### DIFF
--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/base/BaseEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/base/BaseEvent.java
@@ -124,6 +124,29 @@ public abstract class BaseEvent implements IKettleMonitoringEvent {
   /**
    * event logs
    *
+   * @return event logs as a string in the following format
+   * <p/>
+   * "log-line"\n"log-line"\n"log-line"\n...
+   */
+  public String getEventLogsAsString(){
+
+    if( getEventLogs() != null ){
+
+      StringBuffer sb = new StringBuffer();
+
+      for( String log : getEventLogs() ){
+        sb.append( log ).append( "\n" );
+      }
+
+      return sb.toString();
+    }
+
+    return null;
+  }
+
+  /**
+   * event logs
+   *
    * @param eventLogs event logs
    */
   public void setEventLogs( String[] eventLogs ) {

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/base/EventType.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/base/EventType.java
@@ -1,0 +1,107 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.di.monitor.base;
+
+public class EventType {
+
+  public static enum Transformation {
+
+    BEGIN_PREPARE_EXECUTION(1),
+    META_LOADED(2),
+    BEGIN_START(3),
+    STARTED(4),
+    FINISHED(5);
+
+    int snmpId;
+
+    Transformation(int snmpId){
+      this.snmpId = snmpId;
+    }
+
+    public int getSnmpId(){
+      return snmpId;
+    }
+  }
+
+  public static enum Job {
+
+    META_LOADED(1),
+    STARTED(2),
+    BEFORE_JOB_ENTRY(3),
+    BEGIN_JOB_PROCESSING(4),
+    AFTER_JOB_ENTRY(5),
+    FINISHED(6);
+
+    int snmpId;
+
+    Job(int snmpId){
+      this.snmpId = snmpId;
+    }
+
+    public int getSnmpId(){
+      return snmpId;
+    }
+  }
+
+  public static enum Step {
+
+    BEFORE_INIT(1), AFTER_INIT(2), BEFORE_START(3), FINISHED(4);
+
+    int snmpId;
+
+    Step(int snmpId){
+      this.snmpId = snmpId;
+    }
+
+    public int getSnmpId(){
+      return snmpId;
+    }
+  }
+
+  public static enum Database {
+
+    DISCONNECTED(0),
+    CONNECTED(1);
+
+    int snmpId;
+
+    Database(int snmpId){
+      this.snmpId = snmpId;
+    }
+
+    public int getSnmpId(){
+      return snmpId;
+    }
+  }
+
+  public static enum Carte {
+
+    SHUTDOWN(0),
+    STARTUP(1);
+
+    int snmpId;
+
+    Carte(int snmpId){
+      this.snmpId = snmpId;
+    }
+
+    public int getSnmpId(){
+      return snmpId;
+    }
+  }
+
+}

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteEvent.java
@@ -18,21 +18,22 @@ package org.pentaho.di.monitor.carte;
 
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.monitor.base.BaseEvent;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.www.WebServer;
+import org.pentaho.platform.api.monitoring.snmp.SnmpTrapEvent;
 
 import java.io.Serializable;
 
+@SnmpTrapEvent( oid="1.1.1.1.3.1.2.1" )
 public class CarteEvent extends BaseEvent {
 
   private static final long serialVersionUID = -3589233687711692569L;
 
-  public static enum EventType {STARTUP, SHUTDOWN}
-
-  private EventType eventType;
+  private EventType.Carte eventType;
   private String hostname;
   private int port;
 
-  public CarteEvent( EventType eventType ) {
+  public CarteEvent( EventType.Carte eventType ) {
     this.eventType = eventType;
   }
 
@@ -41,11 +42,11 @@ public class CarteEvent extends BaseEvent {
     return getHostname() + ":" + getPort();
   }
 
-  public EventType getEventType() {
+  public EventType.Carte getEventType() {
     return eventType;
   }
 
-  public void setEventType( EventType eventType ) {
+  public void setEventType( EventType.Carte eventType ) {
     this.eventType = eventType;
   }
 
@@ -71,7 +72,7 @@ public class CarteEvent extends BaseEvent {
       return this;
     }
 
-    if( ws.getLog() != null ){
+    if ( ws.getLog() != null ) {
       setLogChannelId( ws.getLog().getLogChannelId() );
       setEventLogs( filterEventLogging( getLogChannelId() ) );
     }

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteShutdownMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteShutdownMonitor.java
@@ -19,6 +19,7 @@ package org.pentaho.di.monitor.carte;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 import org.pentaho.di.www.WebServer;
@@ -41,7 +42,7 @@ public class CarteShutdownMonitor extends MonitorAbstract implements ExtensionPo
       return null;
     }
 
-    CarteEvent event = new CarteEvent( CarteEvent.EventType.SHUTDOWN ).build( (WebServer) o );
+    CarteEvent event = new CarteEvent( EventType.Carte.SHUTDOWN ).build( (WebServer) o );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteStartupMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/carte/CarteStartupMonitor.java
@@ -19,6 +19,7 @@ package org.pentaho.di.monitor.carte;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 import org.pentaho.di.www.WebServer;
@@ -41,7 +42,7 @@ public class CarteStartupMonitor extends MonitorAbstract implements ExtensionPoi
       return null;
     }
 
-    CarteEvent event = new CarteEvent( CarteEvent.EventType.STARTUP ).build( (WebServer) o );
+    CarteEvent event = new CarteEvent( EventType.Carte.STARTUP ).build( (WebServer) o );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseConnectedMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseConnectedMonitor.java
@@ -21,6 +21,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 
 /**
@@ -41,7 +42,7 @@ public class DatabaseConnectedMonitor extends MonitorAbstract implements Extensi
       return null;
     }
 
-    DatabaseEvent event = new DatabaseEvent( DatabaseEvent.EventType.CONNECTED ).build( ( (Database) o ) );
+    DatabaseEvent event = new DatabaseEvent( EventType.Database.CONNECTED ).build( ( (Database) o ) );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseDisconnectedMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseDisconnectedMonitor.java
@@ -21,6 +21,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 
 /**
@@ -41,7 +42,7 @@ public class DatabaseDisconnectedMonitor extends MonitorAbstract implements Exte
       return null;
     }
 
-    DatabaseEvent event = new DatabaseEvent( DatabaseEvent.EventType.DISCONNECTED ).build( ( (Database) o ) );
+    DatabaseEvent event = new DatabaseEvent( EventType.Database.DISCONNECTED ).build( ( (Database) o ) );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/database/DatabaseEvent.java
@@ -20,19 +20,17 @@ import org.pentaho.di.core.database.Database;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.monitor.base.BaseEvent;
+import org.pentaho.di.monitor.base.EventType;
+import org.pentaho.platform.api.monitoring.snmp.SnmpTrapEvent;
 
 import java.io.Serializable;
 
+@SnmpTrapEvent( oid="1.1.1.1.3.1.2.2" )
 public class DatabaseEvent extends BaseEvent {
 
   private static final long serialVersionUID = 5995750699747792833L;
 
-  private static final String ID = "1.1.1.1.1.1.1.1"; // TODO replace with an actual oid
-
-  public static enum EventType {CONNECTED, DISCONNECTED}
-
-  private Serializable id = ID;
-  private EventType eventType;
+  private EventType.Database eventType;
   private String databaseName;
   private String driver;
   private String hostname;
@@ -43,24 +41,20 @@ public class DatabaseEvent extends BaseEvent {
   private String connectionUrl;
   private String username;
 
-  public DatabaseEvent( EventType eventType ) {
+  public DatabaseEvent( EventType.Database eventType ) {
     this.eventType = eventType;
   }
 
   @Override
   public Serializable getId() {
-    return id;
+    return getDriver() + "@" + getHostname() + ":" + getPort() + "/" + getDatabaseName();
   }
 
-  public void setId( Serializable id ) {
-    this.id = id;
-  }
-
-  public EventType getEventType() {
+  public EventType.Database getEventType() {
     return eventType;
   }
 
-  public void setEventType( EventType eventType ) {
+  public void setEventType( EventType.Database eventType ) {
     this.eventType = eventType;
   }
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobEvent.java
@@ -20,17 +20,18 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.monitor.base.BaseEvent;
+import org.pentaho.di.monitor.base.EventType;
+import org.pentaho.platform.api.monitoring.snmp.SnmpTrapEvent;
 
 import java.io.Serializable;
 import java.util.Date;
 
+@SnmpTrapEvent( oid="1.1.1.1.3.1.2.3" )
 public class JobEvent extends BaseEvent {
 
   private static final long serialVersionUID = -2727216752120528962L;
 
-  public static enum EventType {META_LOADED, STARTED, BEFORE_JOB_ENTRY, BEGIN_JOB_PROCESSING, AFTER_JOB_ENTRY, FINISHED}
-
-  private EventType eventType;
+  private EventType.Job eventType;
   private String name;
   private String filename;
   private String filetype;
@@ -42,7 +43,7 @@ public class JobEvent extends BaseEvent {
   private long startTimeMillis;
   private long endTimeMillis;
 
-  public JobEvent( EventType eventType ) {
+  public JobEvent( EventType.Job eventType ) {
     this.eventType = eventType;
   }
 
@@ -51,11 +52,11 @@ public class JobEvent extends BaseEvent {
     return getName();
   }
 
-  public EventType getEventType() {
+  public EventType.Job getEventType() {
     return eventType;
   }
 
-  public void setEventType( EventType eventType ) {
+  public void setEventType( EventType.Job eventType ) {
     this.eventType = eventType;
   }
 
@@ -150,7 +151,7 @@ public class JobEvent extends BaseEvent {
     setStartTimeMillis( job.getCurrentDate() != null ? job.getCurrentDate().getTime() : 0 );
     setLogChannelId( job.getLogChannelId() );
 
-    if ( this.eventType == EventType.FINISHED ) {
+    if ( this.eventType == EventType.Job.FINISHED ) {
       setEndTimeMillis( new Date().getTime() );
     }
 
@@ -188,7 +189,7 @@ public class JobEvent extends BaseEvent {
     long completionTimeSecs =
       ( getStartTimeMillis() > 0 ? ( ( ( getEndTimeMillis() - getStartTimeMillis() ) / 1000 ) % 60 ) : 0 );
 
-    if ( this.eventType == EventType.FINISHED && completionTimeSecs > 0 ) {
+    if ( this.eventType == EventType.Job.FINISHED && completionTimeSecs > 0 ) {
       sb.append( ", executed in: " + completionTimeSecs + " seconds " );
     }
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobFinishMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobFinishMonitor.java
@@ -20,6 +20,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.job.Job;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 
@@ -41,7 +42,7 @@ public class JobFinishMonitor extends MonitorAbstract implements ExtensionPointI
       return null;
     }
 
-    JobEvent event = new JobEvent( JobEvent.EventType.FINISHED ).build( (Job) o );
+    JobEvent event = new JobEvent( EventType.Job.FINISHED ).build( (Job) o );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobMetaLoadedMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobMetaLoadedMonitor.java
@@ -21,6 +21,7 @@ import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 
 /**
@@ -41,7 +42,7 @@ public class JobMetaLoadedMonitor extends MonitorAbstract implements ExtensionPo
       return null;
     }
 
-    JobEvent event = new JobEvent( JobEvent.EventType.META_LOADED ).build( (JobMeta) o );
+    JobEvent event = new JobEvent( EventType.Job.META_LOADED ).build( (JobMeta) o );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobStartMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/job/JobStartMonitor.java
@@ -20,6 +20,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.job.Job;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 
@@ -41,7 +42,7 @@ public class JobStartMonitor extends MonitorAbstract implements ExtensionPointIn
       return null;
     }
 
-    JobEvent event = new JobEvent( JobEvent.EventType.STARTED ).build( (Job) o );
+    JobEvent event = new JobEvent( EventType.Job.STARTED ).build( (Job) o );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepAfterInitializeMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepAfterInitializeMonitor.java
@@ -19,6 +19,7 @@ package org.pentaho.di.monitor.step;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 import org.pentaho.di.trans.step.StepInitThread;
@@ -41,7 +42,7 @@ public class StepAfterInitializeMonitor extends MonitorAbstract implements Exten
       return null;
     }
 
-    StepEvent event = new StepEvent( StepEvent.EventType.AFTER_INIT ).build( ( (StepInitThread) o ).getCombi() );
+    StepEvent event = new StepEvent( EventType.Step.AFTER_INIT ).build( ( (StepInitThread) o ).getCombi() );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepBeforeInitializeMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepBeforeInitializeMonitor.java
@@ -19,6 +19,7 @@ package org.pentaho.di.monitor.step;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 import org.pentaho.di.trans.step.StepInitThread;
@@ -41,7 +42,7 @@ public class StepBeforeInitializeMonitor extends MonitorAbstract implements Exte
       return null;
     }
 
-    StepEvent event = new StepEvent( StepEvent.EventType.BEFORE_INIT ).build( ( (StepInitThread) o ).getCombi() );
+    StepEvent event = new StepEvent( EventType.Step.BEFORE_INIT ).build( ( (StepInitThread) o ).getCombi() );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepBeforeStartMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepBeforeStartMonitor.java
@@ -19,6 +19,7 @@ package org.pentaho.di.monitor.step;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 import org.pentaho.di.trans.step.StepMetaDataCombi;
@@ -41,7 +42,7 @@ public class StepBeforeStartMonitor extends MonitorAbstract implements Extension
       return null;
     }
 
-    StepEvent event = new StepEvent( StepEvent.EventType.BEFORE_START ).build( ( (StepMetaDataCombi) o ) );
+    StepEvent event = new StepEvent( EventType.Step.BEFORE_START ).build( ( (StepMetaDataCombi) o ) );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepEvent.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepEvent.java
@@ -2,17 +2,18 @@ package org.pentaho.di.monitor.step;
 
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.monitor.base.BaseEvent;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.trans.step.StepMetaDataCombi;
+import org.pentaho.platform.api.monitoring.snmp.SnmpTrapEvent;
 
 import java.io.Serializable;
 
+@SnmpTrapEvent( oid="1.1.1.1.3.1.2.5" )
 public class StepEvent extends BaseEvent {
 
   private static final long serialVersionUID = 3171013674678295934L;
 
-  public static enum EventType {BEFORE_INIT, AFTER_INIT, BEFORE_START, FINIHED}
-
-  private EventType eventType;
+  private EventType.Step eventType;
   private String name;
   private String xmlContent;
   private boolean clustered;
@@ -26,7 +27,7 @@ public class StepEvent extends BaseEvent {
   private long linesInput;
   private long linesOutput;
 
-  public StepEvent( EventType eventType ) {
+  public StepEvent( EventType.Step eventType ) {
     this.eventType = eventType;
   }
 
@@ -35,11 +36,11 @@ public class StepEvent extends BaseEvent {
     return getName();
   }
 
-  public EventType getEventType() {
+  public EventType.Step getEventType() {
     return eventType;
   }
 
-  public void setEventType( EventType eventType ) {
+  public void setEventType( EventType.Step eventType ) {
     this.eventType = eventType;
   }
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepFinishedMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/step/StepFinishedMonitor.java
@@ -19,6 +19,7 @@ package org.pentaho.di.monitor.step;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 import org.pentaho.di.trans.step.StepMetaDataCombi;
@@ -41,7 +42,7 @@ public class StepFinishedMonitor extends MonitorAbstract implements ExtensionPoi
       return null;
     }
 
-    StepEvent event = new StepEvent( StepEvent.EventType.FINIHED ).build( ( (StepMetaDataCombi) o ) );
+    StepEvent event = new StepEvent( EventType.Step.FINISHED ).build( ( (StepMetaDataCombi) o ) );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationFinishMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationFinishMonitor.java
@@ -20,6 +20,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.monitor.MonitorAbstract;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.trans.Trans;
 
@@ -41,7 +42,7 @@ public class TransformationFinishMonitor extends MonitorAbstract implements Exte
       return null;
     }
 
-    TransformationEvent event = new TransformationEvent( TransformationEvent.EventType.FINISHED ).build( (Trans) o );
+    TransformationEvent event = new TransformationEvent( EventType.Transformation.FINISHED ).build( (Trans) o );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationPrepareExecutionMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationPrepareExecutionMonitor.java
@@ -19,6 +19,7 @@ package org.pentaho.di.monitor.trans;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 import org.pentaho.di.trans.Trans;
@@ -42,7 +43,7 @@ public class TransformationPrepareExecutionMonitor extends MonitorAbstract imple
     }
 
     TransformationEvent event =
-      new TransformationEvent( TransformationEvent.EventType.BEGIN_PREPARE_EXECUTION ).build( (Trans) o );
+      new TransformationEvent( EventType.Transformation.BEGIN_PREPARE_EXECUTION ).build( (Trans) o );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationStartMonitor.java
+++ b/plugins/kettle-monitoring-plugin/src/org/pentaho/di/monitor/trans/TransformationStartMonitor.java
@@ -19,6 +19,7 @@ package org.pentaho.di.monitor.trans;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.MonitorAbstract;
 import org.pentaho.di.trans.Trans;
@@ -41,7 +42,7 @@ public class TransformationStartMonitor extends MonitorAbstract implements Exten
       return null;
     }
 
-    TransformationEvent event = new TransformationEvent( TransformationEvent.EventType.STARTED ).build( (Trans) o );
+    TransformationEvent event = new TransformationEvent( EventType.Transformation.STARTED ).build( (Trans) o );
 
     //logInfo( "[PDI Extension Point Plugin] Dispathing to Event Bus " + event.toString() );
 

--- a/plugins/kettle-monitoring-plugin/test-src/org/pentaho/di/monitor/JobWithTransformationTest.java
+++ b/plugins/kettle-monitoring-plugin/test-src/org/pentaho/di/monitor/JobWithTransformationTest.java
@@ -24,6 +24,7 @@ import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.util.Assert;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.job.JobEvent;
 import org.pentaho.di.monitor.trans.TransformationEvent;
 import org.pentaho.di.trans.Trans;
@@ -52,7 +53,7 @@ public class JobWithTransformationTest extends BaseEventsTriggeredTest {
     Assert.assertTrue( ( (Job) dummyMonitor.eventObject ).getJobMeta().getName().equals( SAMPLE_JOB_NAME ) );
 
     JobEvent e =
-      new JobEvent( JobEvent.EventType.STARTED ).build( ( (Job) dummyMonitor.eventObject ) );
+      new JobEvent( EventType.Job.STARTED ).build( ( (Job) dummyMonitor.eventObject ) );
 
     Assert.assertNotNull( e );
     Assert.assertTrue( SAMPLE_JOB_NAME.equals( e.getName() ) );
@@ -78,7 +79,7 @@ public class JobWithTransformationTest extends BaseEventsTriggeredTest {
     Assert.assertTrue( ( (Job) dummyMonitor.eventObject ).getJobMeta().getName().contains( SAMPLE_JOB_NAME ) );
 
     JobEvent e =
-      new JobEvent( JobEvent.EventType.STARTED ).build( ( (Job) dummyMonitor.eventObject ) );
+      new JobEvent( EventType.Job.STARTED ).build( ( (Job) dummyMonitor.eventObject ) );
 
     Assert.assertNotNull( e );
     Assert.assertTrue( SAMPLE_JOB_NAME.equals( e.getName() ) );
@@ -104,7 +105,7 @@ public class JobWithTransformationTest extends BaseEventsTriggeredTest {
     Assert.assertTrue( ( (TransMeta) dummyMonitor.eventObject ).getName().equals( SAMPLE_TRANS_NAME ) );
 
     TransformationEvent e =
-      new TransformationEvent( TransformationEvent.EventType.STARTED ).build( ( (TransMeta) dummyMonitor.eventObject ) );
+      new TransformationEvent( EventType.Transformation.STARTED ).build( ( (TransMeta) dummyMonitor.eventObject ) );
 
     Assert.assertNotNull( e );
     Assert.assertTrue( SAMPLE_TRANS_NAME.equals( e.getName() ) );
@@ -131,7 +132,7 @@ public class JobWithTransformationTest extends BaseEventsTriggeredTest {
     Assert.assertTrue( ( (Trans) dummyMonitor.eventObject ).getName().equals( SAMPLE_TRANS_NAME ) );
 
     TransformationEvent e =
-      new TransformationEvent( TransformationEvent.EventType.STARTED ).build( ( (Trans) dummyMonitor.eventObject ) );
+      new TransformationEvent( EventType.Transformation.STARTED ).build( ( (Trans) dummyMonitor.eventObject ) );
 
     Assert.assertNotNull( e );
     Assert.assertTrue( SAMPLE_TRANS_NAME.equals( e.getName() ) );

--- a/plugins/kettle-monitoring-plugin/test-src/org/pentaho/di/monitor/MonitorToKettleEventTest.java
+++ b/plugins/kettle-monitoring-plugin/test-src/org/pentaho/di/monitor/MonitorToKettleEventTest.java
@@ -25,6 +25,7 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.util.Assert;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.monitor.base.EventType;
 import org.pentaho.di.monitor.base.IKettleMonitoringEvent;
 import org.pentaho.di.monitor.carte.CarteEvent;
 import org.pentaho.di.monitor.carte.CarteShutdownMonitor;
@@ -194,7 +195,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof CarteEvent );
-    Assert.assertTrue( CarteEvent.EventType.STARTUP == ( (CarteEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Carte.STARTUP == ( (CarteEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_HOST.equals( ( (CarteEvent) event ).getHostname() ) );
     Assert.assertTrue( DUMMY_PORT == ( (CarteEvent) event ).getPort() );
 
@@ -203,7 +204,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof CarteEvent );
-    Assert.assertTrue( CarteEvent.EventType.SHUTDOWN == ( (CarteEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Carte.SHUTDOWN == ( (CarteEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_HOST.equals( ( (CarteEvent) event ).getHostname() ) );
     Assert.assertTrue( DUMMY_PORT == ( (CarteEvent) event ).getPort() );
   }
@@ -233,7 +234,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof DatabaseEvent );
-    Assert.assertTrue( DatabaseEvent.EventType.CONNECTED == ( (DatabaseEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Database.CONNECTED == ( (DatabaseEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_CONNECTION_URL.equals( ( (DatabaseEvent) event ).getConnectionUrl() ) );
     Assert.assertTrue( DUMMY_DATABASE_NAME == ( (DatabaseEvent) event ).getDatabaseName() );
     Assert.assertTrue( DUMMY_DRIVER_CLASS == ( (DatabaseEvent) event ).getDriver() );
@@ -243,7 +244,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof DatabaseEvent );
-    Assert.assertTrue( DatabaseEvent.EventType.DISCONNECTED == ( (DatabaseEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Database.DISCONNECTED == ( (DatabaseEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_CONNECTION_URL.equals( ( (DatabaseEvent) event ).getConnectionUrl() ) );
     Assert.assertTrue( DUMMY_DATABASE_NAME == ( (DatabaseEvent) event ).getDatabaseName() );
     Assert.assertTrue( DUMMY_DRIVER_CLASS == ( (DatabaseEvent) event ).getDriver() );
@@ -277,7 +278,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof JobEvent );
-    Assert.assertTrue( JobEvent.EventType.STARTED == ( (JobEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Job.STARTED == ( (JobEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_EXECUTING_SERVER.equals( ( (JobEvent) event ).getExecutingServer() ) );
     Assert.assertTrue( DUMMY_EXECUTING_USER.equals( ( (JobEvent) event ).getExecutingUser() ) );
     Assert.assertTrue( DUMMY_JOB_NAME.equals( ( (JobEvent) event ).getName() ) );
@@ -288,7 +289,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof JobEvent );
-    Assert.assertTrue( JobEvent.EventType.META_LOADED == ( (JobEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Job.META_LOADED == ( (JobEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_JOB_NAME.equals( ( (JobEvent) event ).getName() ) );
     Assert.assertTrue( DUMMY_JOB_XML_CONTENT.equals( ( (JobEvent) event ).getXml() ) );
 
@@ -297,7 +298,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof JobEvent );
-    Assert.assertTrue( JobEvent.EventType.FINISHED == ( (JobEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Job.FINISHED == ( (JobEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_EXECUTING_SERVER.equals( ( (JobEvent) event ).getExecutingServer() ) );
     Assert.assertTrue( DUMMY_EXECUTING_USER.equals( ( (JobEvent) event ).getExecutingUser() ) );
     Assert.assertTrue( DUMMY_JOB_NAME.equals( ( (JobEvent) event ).getName() ) );
@@ -334,7 +335,7 @@ public class MonitorToKettleEventTest {
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof TransformationEvent );
     Assert.assertTrue(
-      TransformationEvent.EventType.BEGIN_PREPARE_EXECUTION == ( (TransformationEvent) event ).getEventType() );
+      EventType.Transformation.BEGIN_PREPARE_EXECUTION == ( (TransformationEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_EXECUTING_SERVER.equals( ( (TransformationEvent) event ).getExecutingServer() ) );
     Assert.assertTrue( DUMMY_EXECUTING_USER.equals( ( (TransformationEvent) event ).getExecutingUser() ) );
     Assert.assertTrue( DUMMY_TRANS_NAME.equals( ( (TransformationEvent) event ).getName() ) );
@@ -345,7 +346,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof TransformationEvent );
-    Assert.assertTrue( TransformationEvent.EventType.STARTED == ( (TransformationEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Transformation.STARTED == ( (TransformationEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_EXECUTING_SERVER.equals( ( (TransformationEvent) event ).getExecutingServer() ) );
     Assert.assertTrue( DUMMY_EXECUTING_USER.equals( ( (TransformationEvent) event ).getExecutingUser() ) );
     Assert.assertTrue( DUMMY_TRANS_NAME.equals( ( (TransformationEvent) event ).getName() ) );
@@ -356,7 +357,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof TransformationEvent );
-    Assert.assertTrue( TransformationEvent.EventType.FINISHED == ( (TransformationEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Transformation.FINISHED == ( (TransformationEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_EXECUTING_SERVER.equals( ( (TransformationEvent) event ).getExecutingServer() ) );
     Assert.assertTrue( DUMMY_EXECUTING_USER.equals( ( (TransformationEvent) event ).getExecutingUser() ) );
     Assert.assertTrue( DUMMY_TRANS_NAME.equals( ( (TransformationEvent) event ).getName() ) );
@@ -394,7 +395,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof StepEvent );
-    Assert.assertTrue( StepEvent.EventType.BEFORE_INIT == ( (StepEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Step.BEFORE_INIT == ( (StepEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_STEP_NAME.equals( ( (StepEvent) event ).getName() ) );
     Assert.assertTrue( DUMMY_STEP_XML_CONTENT.equals( ( (StepEvent) event ).getXmlContent() ) );
     Assert.assertTrue( DUMMY_STEP_IS_CLUSTERED == ( (StepEvent) event ).isClustered() );
@@ -404,7 +405,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof StepEvent );
-    Assert.assertTrue( StepEvent.EventType.AFTER_INIT == ( (StepEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Step.AFTER_INIT == ( (StepEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_STEP_NAME.equals( ( (StepEvent) event ).getName() ) );
     Assert.assertTrue( DUMMY_STEP_XML_CONTENT.equals( ( (StepEvent) event ).getXmlContent() ) );
     Assert.assertTrue( DUMMY_STEP_IS_CLUSTERED == ( (StepEvent) event ).isClustered() );
@@ -414,7 +415,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof StepEvent );
-    Assert.assertTrue( StepEvent.EventType.BEFORE_START == ( (StepEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Step.BEFORE_START == ( (StepEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_STEP_NAME.equals( ( (StepEvent) event ).getName() ) );
     Assert.assertTrue( DUMMY_STEP_XML_CONTENT.equals( ( (StepEvent) event ).getXmlContent() ) );
     Assert.assertTrue( DUMMY_STEP_IS_CLUSTERED == ( (StepEvent) event ).isClustered() );
@@ -424,7 +425,7 @@ public class MonitorToKettleEventTest {
 
     Assert.assertNotNull( event );
     Assert.assertTrue( event instanceof StepEvent );
-    Assert.assertTrue( StepEvent.EventType.FINIHED == ( (StepEvent) event ).getEventType() );
+    Assert.assertTrue( EventType.Step.FINISHED == ( (StepEvent) event ).getEventType() );
     Assert.assertTrue( DUMMY_STEP_NAME.equals( ( (StepEvent) event ).getName() ) );
     Assert.assertTrue( DUMMY_STEP_XML_CONTENT.equals( ( (StepEvent) event ).getXmlContent() ) );
     Assert.assertTrue( DUMMY_STEP_IS_CLUSTERED == ( (StepEvent) event ).isClustered() );


### PR DESCRIPTION
...etadata for transformations

```
- Events now include the @SnmpTrapEvent annotations ( OID's according to the MIB file )
- TransformationEvent also includes for each attribute the @SnmpVariable ( OID's according to the MIB file )
- [CLEANUP] moved EventTypes enums within each of the event classes to a centralized class ( easier to maintain ); now each eventType also provides its own SNMP value (set in the enum)
```
