### PR TITLE
BACKLOG-674 - CLONE - REG: HDP21:Hive: if we change the db-scheme, then ...

### DIFF
--- a/core/src/org/pentaho/di/core/database/ConnectionPoolUtil.java
+++ b/core/src/org/pentaho/di/core/database/ConnectionPoolUtil.java
@@ -48,7 +48,7 @@ public class ConnectionPoolUtil {
 
   private static boolean isPoolRegistered( DatabaseMeta dbMeta, String partitionId ) throws KettleDatabaseException {
     try {
-      String name = dbMeta.getName() + Const.NVL( partitionId, "" );
+      String name = buildPoolName( dbMeta, partitionId );
       return Const.indexOfString( name, pd.getPoolNames() ) >= 0;
     } catch ( Exception e ) {
       throw new KettleDatabaseException( BaseMessages.getString( PKG,
@@ -118,12 +118,13 @@ public class ConnectionPoolUtil {
       }
     }
 
-    pd.registerPool( databaseMeta.getName(), gpool );
+    pd.registerPool( buildPoolName( databaseMeta, partitionId ), gpool );
 
     log.logBasic( BaseMessages.getString( PKG, "Database.CreatedConnectionPool", databaseMeta.getName() ) );
   }
 
-  public static Connection getConnection( LogChannelInterface log, DatabaseMeta dbMeta, String partitionId ) throws Exception {
+  public static Connection getConnection( LogChannelInterface log, DatabaseMeta dbMeta,
+      String partitionId ) throws Exception {
     return getConnection( log, dbMeta, partitionId, dbMeta.getInitialPoolSize(), dbMeta.getMaximumPoolSize() );
   }
 
@@ -133,8 +134,13 @@ public class ConnectionPoolUtil {
       createPool( log, dbMeta, partitionId, initialSize, maximumSize );
     }
 
-    return DriverManager.getConnection( "jdbc:apache:commons:dbcp:" + dbMeta.getName() );
+    return DriverManager.getConnection( "jdbc:apache:commons:dbcp:" + buildPoolName( dbMeta, partitionId ) );
+  }
 
+  protected static String buildPoolName( DatabaseMeta dbMeta, String partitionId ) {
+    return dbMeta.getName() + Const.NVL( dbMeta.getDatabaseName(), "" )
+        + Const.NVL( dbMeta.getHostname(),  ""  ) + Const.NVL( dbMeta.getDatabasePortNumberString(),  ""  )
+        + Const.NVL( partitionId, "" );
   }
 
 }

--- a/core/test-src/org/pentaho/di/core/database/ConnectionPoolUtilTest.java
+++ b/core/test-src/org/pentaho/di/core/database/ConnectionPoolUtilTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
 
@@ -78,6 +79,29 @@ public class ConnectionPoolUtilTest implements Driver {
     when( dbMeta.getPassword() ).thenReturn( ENCR_PASSWORD );
     Connection conn = ConnectionPoolUtil.getConnection( logChannelInterface, dbMeta, "", 1, 2 );
     assertTrue( conn != null );
+  }
+
+  @Test
+  public void testGetConnectionName() throws Exception {
+    when( dbMeta.getName() ).thenReturn( "CP2" );
+    when( dbMeta.getPassword() ).thenReturn( ENCR_PASSWORD );
+    String connectionName = ConnectionPoolUtil.buildPoolName( dbMeta, "" );
+    assertTrue( connectionName.equals( "CP2" ) );
+    assertFalse( connectionName.equals( "CP2pentaho" ) );
+
+    when( dbMeta.getDatabaseName() ).thenReturn( "pentaho" );
+    connectionName = ConnectionPoolUtil.buildPoolName( dbMeta, "" );
+    assertTrue( connectionName.equals( "CP2pentaho" ) );
+    assertFalse( connectionName.equals( "CP2pentaholocal" ) );
+
+    when( dbMeta.getHostname() ).thenReturn( "local" );
+    connectionName = ConnectionPoolUtil.buildPoolName( dbMeta, "" );
+    assertTrue( connectionName.equals( "CP2pentaholocal" ) );
+    assertFalse( connectionName.equals( "CP2pentaholocal3306" ) );
+
+    when( dbMeta.getDatabasePortNumberString() ).thenReturn( "3306" );
+    connectionName = ConnectionPoolUtil.buildPoolName( dbMeta, "" );
+    assertTrue( connectionName.equals( "CP2pentaholocal3306" ) );
   }
 
   @Override


### PR DESCRIPTION
...it

won't be used until pooling connection has closed; the original will be
used instead.

What was done:
1) changed key for building pool name so it takes host, port and db into consideration  now
