### PR TITLE
[PDI-6202] and [PDI-9262] - Get Job/Trans Log Dates via Status Messages

### DIFF
--- a/engine/src/org/pentaho/di/www/GetJobStatusServlet.java
+++ b/engine/src/org/pentaho/di/www/GetJobStatusServlet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -244,6 +244,7 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
         SlaveServerJobStatus jobStatus = new SlaveServerJobStatus( jobName, id, status );
         jobStatus.setFirstLoggingLineNr( startLineNr );
         jobStatus.setLastLoggingLineNr( lastLineNr );
+        jobStatus.setLogDate( job.getLogDate() );
 
         // The log can be quite large at times, we are going to put a base64 encoding around a compressed stream
         // of bytes to handle this one.

--- a/engine/src/org/pentaho/di/www/GetStatusServlet.java
+++ b/engine/src/org/pentaho/di/www/GetStatusServlet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -212,23 +212,21 @@ public class GetStatusServlet extends BaseHttpServlet implements CartePluginInte
       getSystemInfo( serverStatus );
 
       for ( CarteObjectEntry entry : transEntries ) {
-        String name = entry.getName();
-        String id = entry.getId();
         Trans trans = getTransformationMap().getTransformation( entry );
         String status = trans.getStatus();
 
-        SlaveServerTransStatus sstatus = new SlaveServerTransStatus( name, id, status );
+        SlaveServerTransStatus sstatus = new SlaveServerTransStatus( entry.getName(), entry.getId(), status );
+        sstatus.setLogDate( trans.getLogDate() );
         sstatus.setPaused( trans.isPaused() );
         serverStatus.getTransStatusList().add( sstatus );
       }
 
       for ( CarteObjectEntry entry : jobEntries ) {
-        String name = entry.getName();
-        String id = entry.getId();
         Job job = getJobMap().getJob( entry );
         String status = job.getStatus();
-
-        serverStatus.getJobStatusList().add( new SlaveServerJobStatus( name, id, status ) );
+        SlaveServerJobStatus jobStatus = new SlaveServerJobStatus( entry.getName(), entry.getId(), status );
+        jobStatus.setLogDate( job.getLogDate() );
+        serverStatus.getJobStatusList().add( jobStatus );
       }
 
       try {

--- a/engine/src/org/pentaho/di/www/GetTransStatusServlet.java
+++ b/engine/src/org/pentaho/di/www/GetTransStatusServlet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -250,6 +250,7 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
         SlaveServerTransStatus transStatus = new SlaveServerTransStatus( transName, entry.getId(), status );
         transStatus.setFirstLoggingLineNr( startLineNr );
         transStatus.setLastLoggingLineNr( lastLineNr );
+        transStatus.setLogDate( trans.getLogDate() );
 
         for ( int i = 0; i < trans.nrSteps(); i++ ) {
           StepInterface baseStep = trans.getRunThread( i );

--- a/engine/src/org/pentaho/di/www/SlaveServerJobStatus.java
+++ b/engine/src/org/pentaho/di/www/SlaveServerJobStatus.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,6 +23,7 @@
 package org.pentaho.di.www;
 
 import java.io.IOException;
+import java.util.Date;
 
 import org.pentaho.di.cluster.HttpUtil;
 import org.pentaho.di.core.Const;
@@ -43,6 +44,7 @@ public class SlaveServerJobStatus {
   private String loggingString;
   private int firstLoggingLineNr;
   private int lastLoggingLineNr;
+  private Date logDate;
 
   private Result result;
 
@@ -63,22 +65,22 @@ public class SlaveServerJobStatus {
   public String getXML() throws KettleException {
     StringBuilder xml = new StringBuilder();
 
-    xml.append( "<" + XML_TAG + ">" ).append( Const.CR );
-    xml.append( XMLHandler.addTagValue( "jobname", jobName ) );
-    xml.append( XMLHandler.addTagValue( "id", id ) );
-    xml.append( XMLHandler.addTagValue( "status_desc", statusDescription ) );
-    xml.append( XMLHandler.addTagValue( "error_desc", errorDescription ) );
-
-    xml.append( XMLHandler.addTagValue( "logging_string", XMLHandler.buildCDATA( loggingString ) ) );
-    xml.append( XMLHandler.addTagValue( "first_log_line_nr", firstLoggingLineNr ) );
-    xml.append( XMLHandler.addTagValue( "last_log_line_nr", lastLoggingLineNr ) );
+    xml.append( XMLHandler.openTag( XML_TAG ) ).append( Const.CR );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "jobname", jobName ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "id", id ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "status_desc", statusDescription ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "error_desc", errorDescription ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "log_date", XMLHandler.date2string( logDate ) ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "logging_string", XMLHandler.buildCDATA( loggingString ) ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "first_log_line_nr", firstLoggingLineNr ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "last_log_line_nr", lastLoggingLineNr ) );
 
     if ( result != null ) {
       String resultXML = result.getXML();
       xml.append( resultXML );
     }
 
-    xml.append( "</" + XML_TAG + ">" );
+    xml.append( XMLHandler.closeTag( XML_TAG ) );
 
     return xml.toString();
   }
@@ -89,7 +91,7 @@ public class SlaveServerJobStatus {
     id = XMLHandler.getTagValue( jobStatusNode, "id" );
     statusDescription = XMLHandler.getTagValue( jobStatusNode, "status_desc" );
     errorDescription = XMLHandler.getTagValue( jobStatusNode, "error_desc" );
-
+    logDate = XMLHandler.stringToDate( XMLHandler.getTagValue( jobStatusNode, "log_date" ) );
     firstLoggingLineNr = Const.toInt( XMLHandler.getTagValue( jobStatusNode, "first_log_line_nr" ), 0 );
     lastLoggingLineNr = Const.toInt( XMLHandler.getTagValue( jobStatusNode, "last_log_line_nr" ), 0 );
 
@@ -241,6 +243,20 @@ public class SlaveServerJobStatus {
    */
   public void setLastLoggingLineNr( int lastLoggingLineNr ) {
     this.lastLoggingLineNr = lastLoggingLineNr;
+  }
+
+  /**
+   * @return the logDate
+   */
+  public Date getLogDate() {
+    return logDate;
+  }
+
+  /**
+   * @param the logDate
+   */
+  public void setLogDate( Date logDate ) {
+    this.logDate = logDate;
   }
 
   /**

--- a/engine/src/org/pentaho/di/www/SlaveServerTransStatus.java
+++ b/engine/src/org/pentaho/di/www/SlaveServerTransStatus.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,6 +24,7 @@ package org.pentaho.di.www;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.pentaho.di.cluster.HttpUtil;
@@ -54,6 +55,8 @@ public class SlaveServerTransStatus {
 
   private int lastLoggingLineNr;
 
+  private Date logDate;
+
   private List<StepStatus> stepStatusList;
 
   private Result result;
@@ -78,31 +81,32 @@ public class SlaveServerTransStatus {
   public String getXML() throws KettleException {
     StringBuilder xml = new StringBuilder();
 
-    xml.append( "<" + XML_TAG + ">" ).append( Const.CR );
-    xml.append( XMLHandler.addTagValue( "transname", transName ) );
-    xml.append( XMLHandler.addTagValue( "id", id ) );
-    xml.append( XMLHandler.addTagValue( "status_desc", statusDescription ) );
-    xml.append( XMLHandler.addTagValue( "error_desc", errorDescription ) );
-    xml.append( XMLHandler.addTagValue( "paused", paused ) );
+    xml.append( XMLHandler.openTag( XML_TAG ) ).append( Const.CR );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "transname", transName ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "id", id ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "status_desc", statusDescription ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "error_desc", errorDescription ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "log_date", XMLHandler.date2string( logDate ) ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "paused", paused ) );
 
-    xml.append( "  <stepstatuslist>" ).append( Const.CR );
+    xml.append( "  " ).append( XMLHandler.openTag( "stepstatuslist" ) ).append( Const.CR );
     for ( int i = 0; i < stepStatusList.size(); i++ ) {
       StepStatus stepStatus = stepStatusList.get( i );
       xml.append( "    " ).append( stepStatus.getXML() ).append( Const.CR );
     }
-    xml.append( "  </stepstatuslist>" ).append( Const.CR );
+    xml.append( "  " ).append( XMLHandler.closeTag( "stepstatuslist" ) ).append( Const.CR );
 
-    xml.append( XMLHandler.addTagValue( "first_log_line_nr", firstLoggingLineNr ) );
-    xml.append( XMLHandler.addTagValue( "last_log_line_nr", lastLoggingLineNr ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "first_log_line_nr", firstLoggingLineNr ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "last_log_line_nr", lastLoggingLineNr ) );
 
     if ( result != null ) {
       String resultXML = result.getXML();
       xml.append( resultXML );
     }
 
-    xml.append( XMLHandler.addTagValue( "logging_string", XMLHandler.buildCDATA( loggingString ) ) );
+    xml.append( "  " ).append( XMLHandler.addTagValue( "logging_string", XMLHandler.buildCDATA( loggingString ) ) );
 
-    xml.append( "</" + XML_TAG + ">" );
+    xml.append( XMLHandler.closeTag( XML_TAG ) );
 
     return xml.toString();
   }
@@ -113,6 +117,7 @@ public class SlaveServerTransStatus {
     transName = XMLHandler.getTagValue( transStatusNode, "transname" );
     statusDescription = XMLHandler.getTagValue( transStatusNode, "status_desc" );
     errorDescription = XMLHandler.getTagValue( transStatusNode, "error_desc" );
+    logDate = XMLHandler.stringToDate( XMLHandler.getTagValue( transStatusNode, "log_date" ) );
     paused = "Y".equalsIgnoreCase( XMLHandler.getTagValue( transStatusNode, "paused" ) );
 
     Node statusListNode = XMLHandler.getSubNode( transStatusNode, "stepstatuslist" );
@@ -358,6 +363,20 @@ public class SlaveServerTransStatus {
    */
   public void setFirstLoggingLineNr( int firstLoggingLineNr ) {
     this.firstLoggingLineNr = firstLoggingLineNr;
+  }
+
+  /**
+   * @return the logDate
+   */
+  public Date getLogDate() {
+    return logDate;
+  }
+
+  /**
+   * @param the logDate
+   */
+  public void setLogDate( Date logDate ) {
+    this.logDate = logDate;
   }
 
   /**

--- a/engine/test-src/org/pentaho/di/trans/steps/loadsave/validator/DateLoadSaveValidator.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/loadsave/validator/DateLoadSaveValidator.java
@@ -1,0 +1,50 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.loadsave.validator;
+
+import java.util.Date;
+import java.util.Random;
+
+public class DateLoadSaveValidator implements FieldLoadSaveValidator<Date> {
+
+  @Override
+  public Date getTestObject() {
+    boolean future = new Random().nextBoolean();
+    Long time = System.currentTimeMillis();
+    if ( future ) {
+      time += new Random().nextInt( time.intValue() ); // Up to 2*N years after 1970
+    } else {
+      time -= new Random().nextInt( time.intValue() ); // Back to January 1 1970
+    }
+    return new Date( time );
+  }
+
+  @Override
+  public boolean validateTestObject( Date testObject, Object actual ) {
+    if ( !( actual instanceof Date ) ) {
+      return false;
+    }
+    return testObject.equals( actual );
+  }
+
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/loadsave/validator/DefaultFieldLoadSaveValidatorFactory.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/loadsave/validator/DefaultFieldLoadSaveValidatorFactory.java
@@ -24,6 +24,7 @@ package org.pentaho.di.trans.steps.loadsave.validator;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -60,8 +61,10 @@ public class DefaultFieldLoadSaveValidatorFactory implements FieldLoadSaveValida
     registerValidator( DatabaseMeta.class.getCanonicalName(), new DatabaseMetaLoadSaveValidator() );
     registerValidator( DatabaseMeta[].class.getCanonicalName(), new ArrayLoadSaveValidator<DatabaseMeta>(
       new DatabaseMetaLoadSaveValidator() ) );
+    registerValidator( Date.class.getCanonicalName(), new DateLoadSaveValidator() );
   }
 
+  @Override
   public void registerValidator( String typeString, FieldLoadSaveValidator<?> validator ) {
     this.typeMap.put( typeString, validator );
   }

--- a/engine/test-src/org/pentaho/di/www/SlaveServerJobStatusLoadSaveTester.java
+++ b/engine/test-src/org/pentaho/di/www/SlaveServerJobStatusLoadSaveTester.java
@@ -1,0 +1,60 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.pentaho.di.base.LoadSaveBase;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+
+public class SlaveServerJobStatusLoadSaveTester extends LoadSaveBase<SlaveServerJobStatus> {
+
+  public SlaveServerJobStatusLoadSaveTester( Class<SlaveServerJobStatus> clazz, List<String> commonAttributes ) {
+    super( clazz, commonAttributes );
+  }
+
+  public SlaveServerJobStatusLoadSaveTester( Class<SlaveServerJobStatus> clazz, List<String> commonAttributes,
+      Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorAttributeMap ) {
+    super( clazz, commonAttributes, new ArrayList<String>(), new ArrayList<String>(), new HashMap<String, String>(),
+      new HashMap<String, String>(), fieldLoadSaveValidatorAttributeMap,
+      new HashMap<String, FieldLoadSaveValidator<?>>() );
+  }
+
+  public void testSerialization() throws KettleException {
+    testXmlRoundTrip();
+  }
+
+  protected void testXmlRoundTrip() throws KettleException {
+    SlaveServerJobStatus metaToSave = createMeta();
+    Map<String, FieldLoadSaveValidator<?>> validatorMap =
+        createValidatorMapAndInvokeSetters( xmlAttributes, metaToSave );
+
+    String xml = metaToSave.getXML();
+    SlaveServerJobStatus metaLoaded = SlaveServerJobStatus.fromXML( xml );
+    validateLoadedMeta( xmlAttributes, validatorMap, metaToSave, metaLoaded );
+  }
+}

--- a/engine/test-src/org/pentaho/di/www/SlaveServerJobStatusTest.java
+++ b/engine/test-src/org/pentaho/di/www/SlaveServerJobStatusTest.java
@@ -1,0 +1,131 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.cluster.HttpUtil;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+import org.w3c.dom.Node;
+
+public class SlaveServerJobStatusTest {
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws KettleException {
+    KettleEnvironment.init( false );
+  }
+
+  @Test
+  public void testStaticFinal() {
+    assertEquals( "jobstatus", SlaveServerJobStatus.XML_TAG );
+  }
+
+  @Test
+  public void testNoDate() throws KettleException {
+    String jobName = "testNullDate";
+    String id = UUID.randomUUID().toString();
+    String status = Trans.STRING_FINISHED;
+    SlaveServerJobStatus js = new SlaveServerJobStatus( jobName, id, status );
+    String resultXML = js.getXML();
+    Node newJobStatus = XMLHandler.getSubNode( XMLHandler.loadXMLString( resultXML ), SlaveServerJobStatus.XML_TAG );
+
+    assertEquals( "The XML document should match after rebuilding from XML", resultXML,
+      SlaveServerJobStatus.fromXML( resultXML ).getXML() );
+    assertEquals( "There should be one \"log_date\" node in the XML", 1,
+      XMLHandler.countNodes( newJobStatus, "log_date" ) );
+    assertTrue( "The \"log_date\" node should have a null value",
+      Const.isEmpty( XMLHandler.getTagValue( newJobStatus, "log_date" ) ) );
+  }
+
+  @Test
+  public void testWithDate() throws KettleException {
+    String jobName = "testWithDate";
+    String id = UUID.randomUUID().toString();
+    String status = Trans.STRING_FINISHED;
+    Date logDate = new Date();
+    SlaveServerJobStatus js = new SlaveServerJobStatus( jobName, id, status );
+    js.setLogDate( logDate );
+    String resultXML = js.getXML();
+    Node newJobStatus = XMLHandler.getSubNode( XMLHandler.loadXMLString( resultXML ), SlaveServerJobStatus.XML_TAG );
+
+    assertEquals( "The XML document should match after rebuilding from XML", resultXML,
+      SlaveServerJobStatus.fromXML( resultXML ).getXML() );
+    assertEquals( "There should be one \"log_date\" node in the XML", 1,
+      XMLHandler.countNodes( newJobStatus, "log_date" ) );
+    assertEquals( "The \"log_date\" node should match the original value", XMLHandler.date2string( logDate ),
+      XMLHandler.getTagValue( newJobStatus, "log_date" ) );
+  }
+
+  @Test
+  public void testSerialization() throws KettleException {
+    // TODO Add Result
+    List<String> attributes = Arrays.asList( "JobName", "Id", "StatusDescription", "ErrorDescription",
+      "LogDate", "LoggingString", "FirstLoggingLineNr", "LastLoggingLineNr" );
+
+    Map<String, FieldLoadSaveValidator<?>> attributeMap = new HashMap<String, FieldLoadSaveValidator<?>>();
+    attributeMap.put( "LoggingString", new LoggingStringLoadSaveValidator() );
+
+    SlaveServerJobStatusLoadSaveTester tester =
+      new SlaveServerJobStatusLoadSaveTester( SlaveServerJobStatus.class, attributes, attributeMap );
+
+    tester.testSerialization();
+  }
+
+  public static class LoggingStringLoadSaveValidator implements FieldLoadSaveValidator<String> {
+
+    @Override
+    public String getTestObject() {
+      try {
+        return HttpUtil.encodeBase64ZippedString( UUID.randomUUID().toString() );
+      } catch ( IOException e ) {
+        throw new RuntimeException( e );
+      }
+    }
+
+    @Override
+    public boolean validateTestObject( String testObject, Object actual ) {
+      try {
+        return HttpUtil.decodeBase64ZippedString( testObject ).equals( actual );
+      } catch ( IOException e ) {
+        throw new RuntimeException( e );
+      }
+    }
+
+  }
+}

--- a/engine/test-src/org/pentaho/di/www/SlaveServerTransStatusLoadSaveTester.java
+++ b/engine/test-src/org/pentaho/di/www/SlaveServerTransStatusLoadSaveTester.java
@@ -1,0 +1,60 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.pentaho.di.base.LoadSaveBase;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+
+public class SlaveServerTransStatusLoadSaveTester extends LoadSaveBase<SlaveServerTransStatus> {
+
+  public SlaveServerTransStatusLoadSaveTester( Class<SlaveServerTransStatus> clazz, List<String> commonAttributes ) {
+    super( clazz, commonAttributes );
+  }
+
+  public SlaveServerTransStatusLoadSaveTester( Class<SlaveServerTransStatus> clazz, List<String> commonAttributes,
+      Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorAttributeMap ) {
+    super( clazz, commonAttributes, new ArrayList<String>(), new ArrayList<String>(), new HashMap<String, String>(),
+      new HashMap<String, String>(), fieldLoadSaveValidatorAttributeMap,
+      new HashMap<String, FieldLoadSaveValidator<?>>() );
+  }
+
+  public void testSerialization() throws KettleException {
+    testXmlRoundTrip();
+  }
+
+  protected void testXmlRoundTrip() throws KettleException {
+    SlaveServerTransStatus metaToSave = createMeta();
+    Map<String, FieldLoadSaveValidator<?>> validatorMap =
+        createValidatorMapAndInvokeSetters( xmlAttributes, metaToSave );
+
+    String xml = metaToSave.getXML();
+    SlaveServerTransStatus metaLoaded = SlaveServerTransStatus.fromXML( xml );
+    validateLoadedMeta( xmlAttributes, validatorMap, metaToSave, metaLoaded );
+  }
+}

--- a/engine/test-src/org/pentaho/di/www/SlaveServerTransStatusTest.java
+++ b/engine/test-src/org/pentaho/di/www/SlaveServerTransStatusTest.java
@@ -1,0 +1,100 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+import org.pentaho.di.www.SlaveServerJobStatusTest.LoggingStringLoadSaveValidator;
+import org.w3c.dom.Node;
+
+public class SlaveServerTransStatusTest {
+
+  @Test
+  public void testStaticFinal() {
+    assertEquals( "transstatus", SlaveServerTransStatus.XML_TAG );
+  }
+
+  @Test
+  public void testNoDate() throws KettleException {
+    String transName = "testNullDate";
+    String id = UUID.randomUUID().toString();
+    String status = Trans.STRING_FINISHED;
+    SlaveServerTransStatus ts = new SlaveServerTransStatus( transName, id, status );
+    String resultXML = ts.getXML();
+    Node newTransStatus = XMLHandler.getSubNode( XMLHandler.loadXMLString( resultXML ), SlaveServerTransStatus.XML_TAG );
+
+    assertEquals( "The XML document should match after rebuilding from XML", resultXML,
+      SlaveServerTransStatus.fromXML( resultXML ).getXML() );
+    assertEquals( "There should be one \"log_date\" node in the XML", 1,
+      XMLHandler.countNodes( newTransStatus, "log_date" ) );
+    assertTrue( "The \"log_date\" node should have a null value",
+      Const.isEmpty( XMLHandler.getTagValue( newTransStatus, "log_date" ) ) );
+  }
+
+  @Test
+  public void testWithDate() throws KettleException {
+    String transName = "testWithDate";
+    String id = UUID.randomUUID().toString();
+    String status = Trans.STRING_FINISHED;
+    Date logDate = new Date();
+    SlaveServerTransStatus ts = new SlaveServerTransStatus( transName, id, status );
+    ts.setLogDate( logDate );
+    String resultXML = ts.getXML();
+    Node newTransStatus = XMLHandler.getSubNode( XMLHandler.loadXMLString( resultXML ), SlaveServerTransStatus.XML_TAG );
+
+    assertEquals( "The XML document should match after rebuilding from XML", resultXML,
+      SlaveServerTransStatus.fromXML( resultXML ).getXML() );
+    assertEquals( "There should be one \"log_date\" node in the XML", 1,
+      XMLHandler.countNodes( newTransStatus, "log_date" ) );
+    assertEquals( "The \"log_date\" node should match the original value", XMLHandler.date2string( logDate ),
+      XMLHandler.getTagValue( newTransStatus, "log_date" ) );
+  }
+
+  @Test
+  public void testSerialization() throws KettleException {
+    // TODO Add StepStatusList
+    List<String> attributes = Arrays.asList( "TransName", "Id", "StatusDescription", "ErrorDescription",
+      "LogDate", "Paused", "FirstLoggingLineNr", "LastLoggingLineNr", "LoggingString" );
+    Map<String, FieldLoadSaveValidator<?>> attributeMap = new HashMap<String, FieldLoadSaveValidator<?>>();
+    attributeMap.put( "LoggingString", new LoggingStringLoadSaveValidator() );
+
+    SlaveServerTransStatusLoadSaveTester tester =
+      new SlaveServerTransStatusLoadSaveTester( SlaveServerTransStatus.class, attributes, attributeMap );
+
+    tester.testSerialization();
+  }
+}

--- a/ui/src/org/pentaho/di/ui/spoon/SpoonSlave.java
+++ b/ui/src/org/pentaho/di/ui/spoon/SpoonSlave.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -296,7 +296,8 @@ public class SpoonSlave extends Composite implements TabItemInterface {
       new ColumnInfo( BaseMessages.getString( PKG, "SpoonSlave.Column.Time" ), ColumnInfo.COLUMN_TYPE_TEXT, false, true ),
       new ColumnInfo( BaseMessages.getString( PKG, "SpoonSlave.Column.Speed" ), ColumnInfo.COLUMN_TYPE_TEXT, false, true ),
       new ColumnInfo( BaseMessages.getString( PKG, "SpoonSlave.Column.PriorityBufferSizes" ), ColumnInfo.COLUMN_TYPE_TEXT, false, true ),
-      new ColumnInfo( BaseMessages.getString( PKG, "SpoonSlave.Column.CarteObjectId" ), ColumnInfo.COLUMN_TYPE_TEXT, false, true ), };
+      new ColumnInfo( BaseMessages.getString( PKG, "SpoonSlave.Column.CarteObjectId" ), ColumnInfo.COLUMN_TYPE_TEXT, false, true ),
+      new ColumnInfo( BaseMessages.getString( PKG, "SpoonSlave.Column.LogDate" ), ColumnInfo.COLUMN_TYPE_TEXT, false, true ), };
 
     colinf[1].setAllignement( SWT.RIGHT );
     colinf[2].setAllignement( SWT.RIGHT );
@@ -310,6 +311,7 @@ public class SpoonSlave extends Composite implements TabItemInterface {
     colinf[10].setAllignement( SWT.RIGHT );
     colinf[11].setAllignement( SWT.RIGHT );
     colinf[12].setAllignement( SWT.RIGHT );
+    colinf[13].setAllignement( SWT.RIGHT );
 
     wTree = new Tree( sash, SWT.SINGLE | SWT.V_SCROLL | SWT.H_SCROLL );
     wTree.setHeaderVisible( true );
@@ -917,6 +919,7 @@ public class SpoonSlave extends Composite implements TabItemInterface {
       transItem.setText( 0, transStatus.getTransName() );
       transItem.setText( 9, transStatus.getStatusDescription() );
       transItem.setText( 13, Const.NVL( transStatus.getId(), "" ) );
+      transItem.setText( 14, Const.NVL( XMLHandler.date2string( transStatus.getLogDate() ), "" ) );
       transItem.setImage( GUIResource.getInstance().getImageTransGraph() );
       transItem.setData( "transStatus", transStatus );
     }
@@ -927,6 +930,7 @@ public class SpoonSlave extends Composite implements TabItemInterface {
       jobItem.setText( 0, jobStatus.getJobName() );
       jobItem.setText( 9, jobStatus.getStatusDescription() );
       jobItem.setText( 13, Const.NVL( jobStatus.getId(), "" ) );
+      jobItem.setText( 14, Const.NVL( XMLHandler.date2string( jobStatus.getLogDate() ), "" ) );
       jobItem.setImage( GUIResource.getInstance().getImageJobGraph() );
       jobItem.setData( "jobStatus", jobStatus );
     }
@@ -1201,7 +1205,7 @@ public class SpoonSlave extends Composite implements TabItemInterface {
   }
 
   /**
-   * Cancels current timer task if any and schedules new one to be executed immediatelly and then every UPDATE_TIME_VIEW
+   * Cancels current timer task if any and schedules new one to be executed immediately and then every UPDATE_TIME_VIEW
    * milliseconds.
    */
   private void engageViewAndLogUpdateTimer() {

--- a/ui/src/org/pentaho/di/ui/spoon/messages/messages_en_US.properties
+++ b/ui/src/org/pentaho/di/ui/spoon/messages/messages_en_US.properties
@@ -955,6 +955,8 @@ TransPreview.FirstRows.Label=First rows
 TransPreview.LastRows.Label=Last rows
 TransPreview.Off.Label=Off
 
+SpoonSlave.Column.LogDate=Log Date
+
 Spoon.Tab.Close=Close tab
 Spoon.Tab.CloseAll=Close all tabs
 Spoon.Tab.CloseOthers=Close other tabs


### PR DESCRIPTION
PDI-6202 adds the log date to XML responses of the Carte API, to match existing data available via HTML
PDI-9262 takes the functionality added in the PDI-6202 commit, and allows the log date to be displayed as part of Spoon's Slave Server Monitor UI.