### PR TITLE
[BACKLOG-186] - Need to provide user with a decent message when the repo...

### DIFF
--- a/engine/src/org/pentaho/di/repository/KettleRepositoryLostException.java
+++ b/engine/src/org/pentaho/di/repository/KettleRepositoryLostException.java
@@ -24,12 +24,15 @@ package org.pentaho.di.repository;
 
 import org.pentaho.di.i18n.BaseMessages;
 
+@SuppressWarnings( "serial" )
 public class KettleRepositoryLostException extends RuntimeException {
-  
+
   private static Class<?> PKG = KettleRepositoryLostException.class;
+  private static final String MSG = BaseMessages.getString( PKG, "Repository.Lost.Error.Message" );
+  private static final String PREFACE = BaseMessages.getString( PKG, "Repository.Lost.Error.Preface" );
 
   public KettleRepositoryLostException() {
-    super();
+    super( MSG );
   }
 
   public KettleRepositoryLostException( String message ) {
@@ -37,27 +40,32 @@ public class KettleRepositoryLostException extends RuntimeException {
   }
 
   public KettleRepositoryLostException( Throwable cause ) {
-    super( cause );
+    super( MSG, cause );
   }
 
   public KettleRepositoryLostException( String message, Throwable cause ) {
     super( message, cause );
   }
-  
+
   public static KettleRepositoryLostException lookupStackStrace( Throwable root ) {
-    while( root != null ) {
-      if( root instanceof KettleRepositoryLostException ) {
-        return (KettleRepositoryLostException)root;
+    while ( root != null ) {
+      if ( root instanceof KettleRepositoryLostException ) {
+        return (KettleRepositoryLostException) root;
       } else {
         root = root.getCause();
       }
     }
-    
+
     return null;
   }
-  
-  @Override
-  public String getLocalizedMessage() {
-    return BaseMessages.getString( PKG, "Repository.Lost.Error.Text" );
+
+  /*
+   * According to UX the verbiage to be displayed to user
+   * should consist of 2 parts: 
+   * the first one is in Exception message
+   * the second one is in the Preface.
+   */
+  public String getPrefaceMessage() {
+    return PREFACE;
   }
 }

--- a/engine/src/org/pentaho/di/repository/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/repository/messages/messages_en_US.properties
@@ -117,4 +117,5 @@ ExportFeedback.Message.Main={0} \: {1} \: ''{2}'' from repository location\: {3}
 ExportFeedback.Message.Simple={0} \: {1}
 ExportFeedback.Message.RuleViolated=   [{0}]
 
-Repository.Lost.Error.Text=Warning. There is a problem communicating with the repository. Select 'Tools|Repository|Connect...' to reestablish communication
+Repository.Lost.Error.Message=Unable to connect to the repository. The repository may not exist or is not operational at this time. Verify your repository and network settings and try again.
+Repository.Lost.Error.Preface=You don''t seem to be getting a connection to the repository.\r\nAny unsaved changes will be lost.

--- a/ui/src/org/pentaho/di/ui/job/dialog/JobDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/dialog/JobDialog.java
@@ -73,6 +73,7 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryInterface;
+import org.pentaho.di.repository.KettleRepositoryLostException;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectory;
@@ -293,6 +294,10 @@ public class JobDialog extends Dialog {
         extraTab.addTab( jobMeta, parent, wTabFolder );
         extraTabs.add( extraTab );
       } catch ( Exception e ) {
+        KettleRepositoryLostException krle = KettleRepositoryLostException.lookupStackStrace( e );
+        if ( krle != null ) {
+          throw krle;
+        }
         new ErrorDialog(
           shell, "Error", "Error loading job dialog plugin with id " + jobDialogPlugin.getIds()[0], e );
       }

--- a/ui/src/org/pentaho/di/ui/repository/messages/messages_en_US.properties
+++ b/ui/src/org/pentaho/di/ui/repository/messages/messages_en_US.properties
@@ -22,3 +22,4 @@ RepositoryLogin.ErrorFindingPlugin=Unable to find repository plugin for id [ {0}
 RepositoryLogin.SelectRepositoryType=Select the repository type
 RepositoryLogin.SelectRepositoryTypeCreate=Select the repository type to create
 Repository.Rename=Renamed from {0} to {1}
+

--- a/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/RepositoryExplorer.java
+++ b/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/RepositoryExplorer.java
@@ -132,7 +132,8 @@ public class RepositoryExplorer {
     }
 
     if ( krle != null ) {
-      return;
+      dispose();
+      throw krle;
     }
 
     try {

--- a/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/controllers/MainController.java
+++ b/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/controllers/MainController.java
@@ -22,11 +22,9 @@
 
 package org.pentaho.di.ui.repository.repositoryexplorer.controllers;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.ArrayList;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.KettleRepositoryLostException;
@@ -163,8 +161,8 @@ public class MainController extends AbstractXulEventHandler implements DialogCon
           new ErrorDialog(
                 shell,
                 BaseMessages.getString( PKG, "RepositoryExplorer.Dialog.Error.Title" ),
-                repLost.getLocalizedMessage(),
-              e );
+                repLost.getPrefaceMessage(),
+                repLost );
           if ( callback != null && callback.error( null ) ) {
             closeDialog();
           }
@@ -177,12 +175,5 @@ public class MainController extends AbstractXulEventHandler implements DialogCon
     }
 
     return false;
-  }
-
-  private void errorBox( String title, String message ) {
-    MessageBox mb = new MessageBox( shell, SWT.ICON_ERROR | SWT.OK );
-    mb.setText( BaseMessages.getString( PKG, title ) );
-    mb.setMessage( BaseMessages.getString( PKG, message ) );
-    mb.open();
   }
 }

--- a/ui/src/org/pentaho/di/ui/spoon/messages/messages_en_US.properties
+++ b/ui/src/org/pentaho/di/ui/spoon/messages/messages_en_US.properties
@@ -965,5 +965,3 @@ Spoon.Dialog.WarnToCloseAllForce.Disconnect.Title=Warning
 Spoon.Dialog.WarnToCloseAllForce.Disconnect.Message=All open files will be closed.
 Spoon.Dialog.WarnToCloseAllOption.Disconnect.Message=Would you like to close all open files?
 Spoon.Dialog.WarnToSaveAllPriorToConnect.Message=You must save files before connecting.
-
-Spoon.RepExplorer.Lost.Error = Cannot open Repository Explorer window.\r\nWarning. There is a problem communicating with the repository. Select 'Tools|Repository|Connect...' to reestablish communication.


### PR DESCRIPTION
...sitory is not availabe

changed error message according to UX feedback
slightly changed logic for process launch of Repository Explorer failure
added failure processing for JobDialog: extraTabs

[BACKLOG-186] - Need to provide user with a decent message when the repository is not availabe

change ctor of KettleRepositoryLostException to rely on super getMessage() and getLocalizedMessage()
checkstyle

[BACKLOG-186] - Need to provide user with a decent message when the repository is not availabe

fix typo in the message

[BACKLOG-186] - Need to provide user with a decent message when the repository is not availabe

move the second message to the same package with repositoryLostException
in order to avoid strings as package names while loading string resources
