### PR TITLE
[BACKLOG-838] Fix for repository name and description. Switch fields for...

### DIFF
--- a/ui/src/org/pentaho/di/ui/repository/filerep/KettleFileRepositoryDialog.java
+++ b/ui/src/org/pentaho/di/ui/repository/filerep/KettleFileRepositoryDialog.java
@@ -284,8 +284,8 @@ public class KettleFileRepositoryDialog implements RepositoryDialogInterface {
    * Copy information from the meta-data input to the dialog fields.
    */
   public void getData() {
-    wId.setText( Const.NVL( input.getName(), "" ) );
-    wName.setText( Const.NVL( input.getDescription(), "" ) );
+    wName.setText( Const.NVL( input.getName(), "" ) );
+    wId.setText( Const.NVL( input.getDescription(), "" ) );
     wBaseDir.setText( Const.NVL( input.getBaseDirectory(), "" ) );
     wReadOnly.setSelection( input.isReadOnly() );
     wHidesHiddenFiles.setSelection( input.isHidingHiddenFiles() );
@@ -297,8 +297,8 @@ public class KettleFileRepositoryDialog implements RepositoryDialogInterface {
   }
 
   private void getInfo( KettleFileRepositoryMeta info ) {
-    info.setName( wId.getText() );
-    info.setDescription( wName.getText() );
+    info.setName( wName.getText() );
+    info.setDescription( wId.getText() );
     info.setBaseDirectory( wBaseDir.getText() );
     info.setReadOnly( wReadOnly.getSelection() );
     info.setHidingHiddenFiles( wHidesHiddenFiles.getSelection() );

--- a/ui/src/org/pentaho/di/ui/repository/kdr/KettleDatabaseRepositoryDialog.java
+++ b/ui/src/org/pentaho/di/ui/repository/kdr/KettleDatabaseRepositoryDialog.java
@@ -346,10 +346,10 @@ public class KettleDatabaseRepositoryDialog implements RepositoryDialogInterface
    */
   public void getData() {
     if ( input.getName() != null ) {
-      wId.setText( input.getName() );
+      wName.setText( input.getName() );
     }
     if ( input.getDescription() != null ) {
-      wName.setText( input.getDescription() );
+      wId.setText( input.getDescription() );
     }
     if ( input.getConnection() != null ) {
       wConnection.setText( input.getConnection().getName() );
@@ -362,8 +362,8 @@ public class KettleDatabaseRepositoryDialog implements RepositoryDialogInterface
   }
 
   private void getInfo( KettleDatabaseRepositoryMeta info ) {
-    info.setName( wId.getText() );
-    info.setDescription( wName.getText() );
+    info.setName( wName.getText() );
+    info.setDescription( wId.getText() );
 
     int idx = wConnection.getSelectionIndex();
     if ( idx >= 0 ) {

--- a/ui/src/org/pentaho/di/ui/repository/xul/repositories.xul
+++ b/ui/src/org/pentaho/di/ui/repository/xul/repositories.xul
@@ -20,7 +20,7 @@
 			<button id="repository-add" image="images/Add.png" pen:disabledimage="images/dAdd.png" onclick="repositoryLoginController.newRepository()"/>
 			<button id="repository-remove" image="images/Remove.png" pen:disabledimage="images/dRemove.png" onclick="repositoryLoginController.deleteRepository()" disabled="true"/>
 		</hbox>
-       	<listbox id="available-repository-list" pen:binding="description" disabled="false" flex="1" command="repositoryLoginController.login()"/>
+       	<listbox id="available-repository-list" pen:binding="name" disabled="false" flex="1" command="repositoryLoginController.login()"/>
 		<label value="${RepositoryLoginDialog.UserName}" />
 		<textbox id="user-name" multiline="false" command="repositoryLoginController.login()"/>
 		<label value="${RepositoryLoginDialog.Password}"/>


### PR DESCRIPTION
... name and description so that name is displayed in spoon window title, repo list, and used in kitchen command line
