### PR TITLE
[PDI-11360]: REGRESSION:"Error getting list of data services" due saving...

### DIFF
--- a/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepositoryCreationHelper.java
+++ b/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepositoryCreationHelper.java
@@ -2707,9 +2707,8 @@ public class KettleDatabaseRepositoryCreationHelper {
       KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_ELEMENT_TYPE, ValueMetaInterface.TYPE_INTEGER, KEY, 0 ) );
     table.addValueMeta( new ValueMeta(
       KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_NAMESPACE, ValueMetaInterface.TYPE_INTEGER, KEY, 0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_NAME, ValueMetaInterface.TYPE_STRING,
-      KettleDatabaseRepository.REP_STRING_LENGTH, 0 ) );
+    table.addValueMeta( new ValueMeta( KettleDatabaseRepository.FIELD_ELEMENT_TYPE_NAME,
+        ValueMetaInterface.TYPE_STRING, getRepoStringLength(), 0 ) );
     table.addValueMeta( new ValueMeta(
       KettleDatabaseRepository.FIELD_ELEMENT_TYPE_DESCRIPTION, ValueMetaInterface.TYPE_STRING,
       KettleDatabaseRepository.REP_STRING_LENGTH, 0 ) );
@@ -2751,9 +2750,8 @@ public class KettleDatabaseRepositoryCreationHelper {
       KettleDatabaseRepository.FIELD_ELEMENT_ID_ELEMENT, ValueMetaInterface.TYPE_INTEGER, KEY, 0 ) );
     table.addValueMeta( new ValueMeta(
       KettleDatabaseRepository.FIELD_ELEMENT_ID_ELEMENT_TYPE, ValueMetaInterface.TYPE_INTEGER, KEY, 0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_ELEMENT_NAME, ValueMetaInterface.TYPE_STRING,
-      KettleDatabaseRepository.REP_STRING_LENGTH, 0 ) );
+    table.addValueMeta( new ValueMeta( KettleDatabaseRepository.FIELD_ELEMENT_NAME, ValueMetaInterface.TYPE_STRING,
+        getRepoStringLength(), 0 ) );
     sql =
       database
         .getDDL( schemaTable, table, null, false, KettleDatabaseRepository.FIELD_ELEMENT_ID_ELEMENT, false );
@@ -2967,6 +2965,14 @@ public class KettleDatabaseRepositoryCreationHelper {
     log.logBasic( ( upgrade ? "Upgraded" : "Created" )
       + " " + KettleDatabaseRepository.repositoryTableNames.length + " repository tables." );
 
+  }
+
+  /**
+   * Returns max VARCHAR length depending on db interface
+   */
+  protected int getRepoStringLength() {
+    return database.getDatabaseMeta().getDatabaseInterface().getMaxVARCHARLength() - 1 > 0 ? database.getDatabaseMeta()
+        .getDatabaseInterface().getMaxVARCHARLength() - 1 : KettleDatabaseRepository.REP_ORACLE_STRING_LENGTH;
   }
 
   /**

--- a/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepositoryCreationHelperTest.java
+++ b/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepositoryCreationHelperTest.java
@@ -1,0 +1,79 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.repository.kdr;
+
+import junit.framework.TestCase;
+
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.database.OracleDatabaseMeta;
+
+/**
+ * @author Tatsiana_Kasiankova
+ * 
+ */
+public class KettleDatabaseRepositoryCreationHelperTest extends TestCase {
+
+  /**
+   * 
+   */
+  private static final int EXPECTED_ORACLE_DB_REPO_STRING = 1999;
+  private static final int EXPECTED_DEFAULT_DB_REPO_STRING = KettleDatabaseRepository.REP_ORACLE_STRING_LENGTH;
+  private KettleDatabaseRepositoryMeta repositoryMeta;
+  private KettleDatabaseRepository repository;
+
+  public void testOracleDBRepoStringLength() throws Exception {
+
+    KettleEnvironment.init();
+    DatabaseMeta databaseMeta = new DatabaseMeta( "OraRepo", "ORACLE", "JDBC", null, "test", null, null, null );
+    repositoryMeta =
+        new KettleDatabaseRepositoryMeta( "KettleDatabaseRepository", "OraRepo", "Ora Repository", databaseMeta );
+    repository = new KettleDatabaseRepository();
+    repository.init( repositoryMeta );
+    KettleDatabaseRepositoryCreationHelper helper = new KettleDatabaseRepositoryCreationHelper( repository );
+    int repoStringLength = helper.getRepoStringLength();
+    assertEquals( EXPECTED_ORACLE_DB_REPO_STRING, repoStringLength );
+  }
+
+  public void testDefaultDBRepoStringLength() throws Exception {
+
+    KettleEnvironment.init();
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setDatabaseInterface( new TestDatabaseMeta() );
+    repositoryMeta =
+        new KettleDatabaseRepositoryMeta( "KettleDatabaseRepository", "TestRepo", "Test Repository", databaseMeta );
+    repository = new KettleDatabaseRepository();
+    repository.init( repositoryMeta );
+    KettleDatabaseRepositoryCreationHelper helper = new KettleDatabaseRepositoryCreationHelper( repository );
+    int repoStringLength = helper.getRepoStringLength();
+    assertEquals( EXPECTED_DEFAULT_DB_REPO_STRING, repoStringLength );
+  }
+
+  class TestDatabaseMeta extends OracleDatabaseMeta {
+
+    @Override
+    public int getMaxVARCHARLength() {
+      return 1;
+    }
+  }
+
+}


### PR DESCRIPTION
... transformation to DB-repository.

The issue has the same cause as  in the issue PDI-10764 (please see also comment to https://github.com/pentaho/pentaho-kettle/pull/166 commit).
Column NAME has  CLOB type in R_ELEMENT_TYPE table but then in where clause it uses like a usual varchar2.
Fixed with the way accepted in PDI-10764.
