### PR TITLE
[PDI-13080] When no records get sent to a PMR Reducer, the PMR Job Fails with Null Pointer Exceptions

### DIFF
--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -1585,6 +1585,9 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
    */
   public void waitUntilFinished() {
     try {
+      if ( transFinishedBlockingQueue == null ) {
+        return;
+      }
       boolean wait = true;
       while ( wait ) {
         wait = transFinishedBlockingQueue.poll( 1, TimeUnit.DAYS ) == null;


### PR DESCRIPTION
- Added null check

See https://github.com/pentaho/pentaho-hadoop-shims/pull/167
