### PR TITLE
[BACKLOG-1096]  Correcting issue where a registered logging source with ...

### DIFF
--- a/core/src/org/pentaho/di/core/logging/LoggingRegistry.java
+++ b/core/src/org/pentaho/di/core/logging/LoggingRegistry.java
@@ -65,7 +65,8 @@ public class LoggingRegistry {
       LoggingObject loggingSource = new LoggingObject( object );
 
       LoggingObjectInterface found = findExistingLoggingSource( loggingSource );
-      if ( ( found != null ) && ( found.getParent() != null ) ) {
+      if ( ( found != null ) &&
+        ( found.getParent() != null || loggingSource.getParent() == null ) ) {
         return found.getLogChannelId();
       }
 


### PR DESCRIPTION
...a null parent would always result in a new registration.

In DataServiceExecutor, this was resulting in the gen and service Trans objects being registered multiple times, while their child objects would only be registered once, with the _first_ parent channel ID that was used.
