### PR TITLE
[PDI-13271] External Ids are not handled properly when incoming key is null

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsert.java
+++ b/engine/src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsert.java
@@ -116,7 +116,7 @@ public class SalesforceInsert extends BaseStep implements StepInterface {
   }
 
   private void writeToSalesForce( Object[] rowData ) throws KettleException {
-	String  upsertFieldNameTemp[] = null;
+	String upsertFieldNameTemp[] = null;
 	String upsertModuleFieldName = null;
 	String fieldToNullFieldName = null;
 
@@ -153,6 +153,8 @@ public class SalesforceInsert extends BaseStep implements StepInterface {
                   upsertModuleFieldName = upsertFieldNameTemp[upsertFieldNameTemp.length-1];
                   if (upsertModuleFieldName.endsWith("__r")) {
                   	upsertModuleFieldName = upsertModuleFieldName.substring(0,upsertModuleFieldName.length()-3) + "__c";
+                  } else { //If the fieldName does not end with __r it must be standard
+			upsertModuleFieldName = upsertModuleFieldName + "Id";
                   }
                   fieldsToNull.add( upsertModuleFieldName);
               }

--- a/engine/src/org/pentaho/di/trans/steps/salesforceupdate/SalesforceUpdate.java
+++ b/engine/src/org/pentaho/di/trans/steps/salesforceupdate/SalesforceUpdate.java
@@ -150,6 +150,8 @@ public class SalesforceUpdate extends BaseStep implements StepInterface {
         		upsertModuleFieldName = upsertFieldNameTemp[upsertFieldNameTemp.length-1];
         		if (upsertModuleFieldName.endsWith("__r")) {
         			upsertModuleFieldName = upsertModuleFieldName.substring(0,upsertModuleFieldName.length()-3) + "__c";
+			} else { //If the fieldName does not end with __r it must be standard
+				upsertModuleFieldName = upsertModuleFieldName + "Id";
         		}
                 fieldsToNull.add( upsertModuleFieldName);
         	}

--- a/engine/src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsert.java
+++ b/engine/src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsert.java
@@ -147,6 +147,8 @@ public class SalesforceUpsert extends BaseStep implements StepInterface {
         		upsertModuleFieldName = upsertFieldNameTemp[upsertFieldNameTemp.length-1];
         		if (upsertModuleFieldName.endsWith("__r")) {
         			upsertModuleFieldName = upsertModuleFieldName.substring(0,upsertModuleFieldName.length()-3) + "__c";
+			} else { //If the fieldName does not end with __r it must be standard
+				upsertModuleFieldName = upsertModuleFieldName + "Id";
         		}
                 fieldsToNull.add( upsertModuleFieldName);
         	}


### PR DESCRIPTION
When a null value is provided as an ExternalId in a Salesforce output step the reference field is cleared as expected.
This PR supersedes PR#434.