### PR TITLE
[PDI-13279]: Pass correct object from JobEntryJobRunner to extension points

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/job/JobEntryJobRunner.java
+++ b/engine/src/org/pentaho/di/job/entries/job/JobEntryJobRunner.java
@@ -31,8 +31,6 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.Job;
 
 /**
- *
- *
  * @author Matt
  * @since 6-apr-2005
  */
@@ -46,8 +44,8 @@ public class JobEntryJobRunner implements Runnable {
   private boolean finished;
 
   /**
-     *
-     */
+   *
+   */
   public JobEntryJobRunner( Job job, Result result, int entryNr, LogChannelInterface log ) {
     this.job = job;
     this.result = result;
@@ -58,14 +56,14 @@ public class JobEntryJobRunner implements Runnable {
 
   public void run() {
     try {
-      if ( job.isStopped() || job.getParentJob() != null && job.getParentJob().isStopped() ) {
+      if ( job.isStopped() || ( job.getParentJob() != null && job.getParentJob().isStopped() ) ) {
         return;
       }
 
       // This JobEntryRunner is a replacement for the Job thread.
       // The job thread is never started because we simply want to wait for the result.
       //
-      ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobStart.id, this );
+      ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobStart.id, getJob() );
 
       job.fireJobStartListeners(); // Fire the start listeners
       result = job.execute( entryNr + 1, result );
@@ -76,7 +74,7 @@ public class JobEntryJobRunner implements Runnable {
       result.setNrErrors( 1 );
     } finally {
       try {
-        ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobFinish.id, this );
+        ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobFinish.id, getJob() );
 
         job.fireJobFinishListeners();
       } catch ( KettleException e ) {
@@ -90,8 +88,7 @@ public class JobEntryJobRunner implements Runnable {
   }
 
   /**
-   * @param result
-   *          The result to set.
+   * @param result The result to set.
    */
   public void setResult( Result result ) {
     this.result = result;
@@ -112,8 +109,7 @@ public class JobEntryJobRunner implements Runnable {
   }
 
   /**
-   * @param log
-   *          The log to set.
+   * @param log The log to set.
    */
   public void setLog( LogChannelInterface log ) {
     this.log = log;
@@ -127,8 +123,7 @@ public class JobEntryJobRunner implements Runnable {
   }
 
   /**
-   * @param job
-   *          The job to set.
+   * @param job The job to set.
    */
   public void setJob( Job job ) {
     this.job = job;
@@ -142,8 +137,7 @@ public class JobEntryJobRunner implements Runnable {
   }
 
   /**
-   * @param entryNr
-   *          The entryNr to set.
+   * @param entryNr The entryNr to set.
    */
   public void setEntryNr( int entryNr ) {
     this.entryNr = entryNr;

--- a/engine/test-src/org/pentaho/di/job/entries/job/JobEntryJobRunnerTest.java
+++ b/engine/test-src/org/pentaho/di/job/entries/job/JobEntryJobRunnerTest.java
@@ -1,0 +1,137 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.job;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.job.Job;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JobEntryJobRunnerTest {
+
+  private JobEntryJobRunner jobRunner;
+  private Job mockJob;
+  private Result mockResult;
+  private LogChannelInterface mockLog;
+  private Job parentJob;
+
+  @Before
+  public void setUp() throws Exception {
+    mockJob = mock( Job.class );
+    mockResult = mock( Result.class );
+    mockLog = mock( LogChannelInterface.class );
+    jobRunner = new JobEntryJobRunner( mockJob, mockResult, 0, mockLog );
+    parentJob = mock( Job.class );
+  }
+
+  @Test
+  public void testRun() throws Exception {
+    // Call all the NO-OP paths
+    when( mockJob.isStopped() ).thenReturn( true );
+    jobRunner.run();
+    when( mockJob.isStopped() ).thenReturn( false );
+    when( mockJob.getParentJob() ).thenReturn( null );
+    jobRunner.run();
+    when( parentJob.isStopped() ).thenReturn( true );
+    when( mockJob.getParentJob() ).thenReturn( parentJob );
+    jobRunner.run();
+    when( parentJob.isStopped() ).thenReturn( false );
+    when( mockJob.execute( Mockito.anyInt(), Mockito.any( Result.class ) ) ).thenReturn( mockResult );
+    jobRunner.run();
+
+  }
+
+  @Test
+  public void testRunWithException() throws Exception {
+    when( mockJob.isStopped() ).thenReturn( false );
+    when( mockJob.getParentJob() ).thenReturn( parentJob );
+    when( parentJob.isStopped() ).thenReturn( false );
+    when( mockJob.execute( Mockito.anyInt(), Mockito.any( Result.class ) ) ).thenThrow( KettleException.class );
+    jobRunner.run();
+    verify( mockResult, times( 1 ) ).setNrErrors( Mockito.anyInt() );
+    doThrow( KettleException.class ).when( mockJob ).fireJobFinishListeners();
+    jobRunner.run();
+
+  }
+
+  @Test
+  public void testGetSetResult() throws Exception {
+    assertEquals( mockResult, jobRunner.getResult() );
+    jobRunner.setResult( null );
+    assertNull( jobRunner.getResult() );
+  }
+
+  @Test
+  public void testGetSetLog() throws Exception {
+    assertEquals( mockLog, jobRunner.getLog() );
+    jobRunner.setLog( null );
+    assertNull( jobRunner.getLog() );
+  }
+
+  @Test
+  public void testGetSetJob() throws Exception {
+    assertEquals( mockJob, jobRunner.getJob() );
+    jobRunner.setJob( null );
+    assertNull( jobRunner.getJob() );
+  }
+
+  @Test
+  public void testGetSetEntryNr() throws Exception {
+    assertEquals( 0, jobRunner.getEntryNr() );
+    jobRunner.setEntryNr( 1 );
+    assertEquals( 1, jobRunner.getEntryNr() );
+  }
+
+  @Test
+  public void testIsFinished() throws Exception {
+    assertFalse( jobRunner.isFinished() );
+    when( mockJob.isStopped() ).thenReturn( false );
+    when( mockJob.getParentJob() ).thenReturn( parentJob );
+    when( parentJob.isStopped() ).thenReturn( false );
+    when( mockJob.execute( Mockito.anyInt(), Mockito.any( Result.class ) ) ).thenReturn( mockResult );
+    jobRunner.run();
+    assertTrue( jobRunner.isFinished() );
+  }
+
+  @Test
+  public void testWaitUntilFinished() throws Exception {
+    when( mockJob.isStopped() ).thenReturn( true );
+    when( mockJob.getParentJob() ).thenReturn( parentJob );
+    when( parentJob.isStopped() ).thenReturn( false );
+    when( mockJob.execute( Mockito.anyInt(), Mockito.any( Result.class ) ) ).thenReturn( mockResult );
+    jobRunner.waitUntilFinished();
+  }
+}


### PR DESCRIPTION
The real change is from passing "this" to passing "getJob()", the rest of the edits are formatting and unit tests.
