### PR TITLE
[CLEANUP] Remove import of Drools StringUtils from TextFileOutput

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.vfs.FileObject;
-import org.drools.util.StringUtils;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ResultFile;
 import org.pentaho.di.core.WriterOutputStream;
@@ -173,7 +172,7 @@ public class TextFileOutput extends BaseStep implements StepInterface {
 
     if ( r == null ) {
       // no more input to be expected...
-      if ( !bEndedLineWrote && !StringUtils.isEmpty( meta.getEndedLine() ) ) {
+      if ( !bEndedLineWrote && !Const.isEmpty( meta.getEndedLine() ) ) {
         if ( data.writer == null ) {
           openNewFile( meta.getFileName() );
           data.oneFileOpened = true;


### PR DESCRIPTION
I think this was an IDE picking the wrong import for StringUtils under PDI-11190. To avoid any confusion (and for downstream dependencies not to need Drools), I removed the import and change the code to use Kettle's Const.isEmpty().

@dkincade Per our discuission, can you review and merge? Please and thanks :)
