### PR TITLE
[TEST] Include integration tests, exclude UI classes for code coverage

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -92,8 +92,9 @@
   </target>
 
   <target name="compile" depends="install-antcontrib">
-    <echo
-        message="The compile target is not supported at the root level. Please see README.txt for instructions on build and compilation"/>
+    <antcall target="call-for-all">
+      <param name="target.name" value="compile"/>
+    </antcall>
   </target>
 
   <target name="compile-tests" depends="install-antcontrib">
@@ -308,6 +309,9 @@
     </if>
   </target>
 
+<target name="cobertura"
+        description="Runs tests in an instrumented environment and produces Cobertura test coverage reports"
+        depends="clean-cobertura,install-cobertura,compile-integration-tests,compile-tests,cobertura.instrument-classes,cobertura.test-instrumented,cobertura.xml-report,cobertura.html-report" />
 
   <!--=======================================================================
       cobertura.instrument-classes
@@ -315,7 +319,10 @@
       Instruments the application classes used by Cobertura during cobertura.test-instrumented
       ====================================================================-->
   <target name="cobertura.instrument-classes" depends="cobertura.clean-instrumented-classes,install-cobertura,compile">
-    <cobertura-instrument todir="${instrumented.classes.dir}" datafile="${cobertura.data.dir}/cobertura.ser">
+    <cobertura-instrument
+            todir="${instrumented.classes.dir}"
+            datafile="${cobertura.data.dir}/cobertura.ser"
+            maxmemory="${junit.maxmemory}"> <!-- This should be at least 2G -->
       <ignore regex="org.apache.log4j.*"/>
       <!--
         Instrument all the application classes, but
@@ -323,8 +330,10 @@
       -->
       <fileset dir="core/bin/classes" includes="**/*.class"/>
       <fileset dir="engine/bin/classes" includes="**/*.class"/>
+      <!-- Omit UI classes (for coverage) as we can't feasibly test them enough
       <fileset dir="dbdialog/bin/classes" includes="**/*.class"/>
       <fileset dir="ui/bin/classes" includes="**/*.class"/>
+      -->
 
     </cobertura-instrument>
   </target>
@@ -355,15 +364,12 @@
     <path id="module-src.classpath">
       <pathelement path="${module-src-class-dirs}"/>
       <pathelement path="${module-test-class-dirs}"/>
-      <pathelement location="core/bin/test/classes"/>
-      <pathelement location="engine/bin/test/classes"/>
-      <pathelement location="dbdialog/bin/test/classes"/>
-      <pathelement location="ui/bin/test/classes"/>
+      <pathelement location="testClasses"/>
     </path>
 
     <junit fork="yes"
            forkmode="${junit.forkmode}"
-           dir="${junit.base.dir}"
+           dir="${basedir}/${dist.dir}"
            maxmemory="${junit.maxmemory}"
            failureProperty="test.failed"
            haltonerror="${junit.haltonerror}"
@@ -386,23 +392,22 @@
       <classpath refid="module-src.classpath"/>
       <classpath refid="test.classpath"/>
       <classpath refid="cobertura.classpath"/>
+      <classpath>
+        <fileset dir="test/libext/" includes="*.jar"/>
+        <pathelement path="${dist.dir}/testfiles"/>
+        <fileset dir="${dist.dir}/${lib.dir}" includes="*.jar *.zip"/>
+        <fileset dir="${dist.dir}/${libswt}" includes="*.jar *.zip"/>
+        <fileset dir="${dist.dir}/${libswt}/win32/" includes="*.jar *.zip"/>
+      </classpath>
 
       <formatter type="xml"/>
       <test name="${testcase}" todir="${testreports.xml.dir}" if="testcase"/>
       <batchtest todir="${testreports.xml.dir}" unless="testcase">
         <fileset dir="core/test-src" includes="**/*Test.java"/>
         <fileset dir="engine/test-src" includes="**/*Test.java"/>
-        <fileset dir="dbdialog/test-src" includes="**/*Test.java"/>
-        <fileset dir="ui/test-src" includes="**/*Test.java"/>
+      <fileset dir="test" includes="**/*Test.java,**/*Tests.java"/>
       </batchtest>
     </junit>
-
-    <junitreport todir="${testreports.html.dir}">
-      <fileset dir="${testreports.xml.dir}">
-        <include name="TEST-*.xml"/>
-      </fileset>
-      <report format="frames" todir="${testreports.html.dir}"/>
-    </junitreport>
   </target>
 
   <!--=======================================================================
@@ -412,7 +417,11 @@
       ====================================================================-->
   <target name="cobertura.xml-report" depends="cobertura.test-instrumented">
 
-    <cobertura-report destdir="${coberturareports.xml.dir}" datafile="${cobertura.data.dir}/cobertura.ser" format="xml">
+    <cobertura-report
+            destdir="${coberturareports.xml.dir}"
+            datafile="${cobertura.data.dir}/cobertura.ser"
+            format="xml"
+            maxmemory="${junit.maxmemory}">
       <fileset dir="core/src" includes="**/*.java"/>
       <fileset dir="engine/src" includes="**/*.java"/>
       <fileset dir="dbdialog/src" includes="**/*.java"/>
@@ -429,7 +438,8 @@
   <target name="cobertura.html-report" depends="cobertura.test-instrumented">
     <cobertura-report destdir="${coberturareports.html.dir}"
                       datafile="${cobertura.data.dir}/cobertura.ser"
-                      format="html">
+                      format="html"
+                      maxmemory="${junit.maxmemory}">
       <fileset dir="core/src" includes="**/*.java"/>
       <fileset dir="engine/src" includes="**/*.java"/>
       <fileset dir="dbdialog/src" includes="**/*.java"/>


### PR DESCRIPTION
The cobertura task(s) now include the integration tests in order to provide higher code coverage. Also, the UI classes (from the ui and dbdialog modules) are not instrumented or reported, this is because it is currently an unfair skew of the coverage metrics as the UIs are very difficult or impossible to test in a headless environment.

The CI job (http://ci.pentaho.com/view/Data%20Integration/job/Kettle-Code_coverage/) should now call the following:

ant -Djunit.maxmemory=2048M -Dmodule.list=core,engine clean-all resolve cobertura

It also does not need to collect test reports (Kettle-build does this), but should report coverage to CI and Sonar.
