### PR TITLE
[PDI-13315] Clear out result rows on first iteration of JobEntryJob

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -997,9 +997,11 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
 
         if ( iteration == 0 ) {
           result.clear();
+          result.setRows( new ArrayList<RowMetaAndData>() );
         }
 
         result.add( oneResult );
+
 
         // if one of them fails (in the loop), increase the number of errors
         //


### PR DESCRIPTION
This is only a proposed patch to fix the one case, it should be tested against the other execution paths (per-row, e.g.)