### PR TITLE
BACKLOG-1621 Send kettle.properties across Carte cluster

### DIFF
--- a/core/src/org/pentaho/di/i18n/PackageMessages.java
+++ b/core/src/org/pentaho/di/i18n/PackageMessages.java
@@ -1,0 +1,37 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.i18n;
+
+public class PackageMessages {
+
+  private final Class<?> packageClass;
+  private final String prefix;
+
+  public PackageMessages( final Class<?> packageClass ) {
+    this.packageClass = packageClass;
+    prefix = packageClass.getSimpleName() + ".";
+  }
+
+  public String getString( final String key, final String... parameters ) {
+    return BaseMessages.getString( packageClass, prefix + key, parameters );
+  }
+}

--- a/engine/src/kettle-servlets.xml
+++ b/engine/src/kettle-servlets.xml
@@ -43,6 +43,7 @@
   
   <servlet id="registerSlave"> <description>Register a slave server</description> <classname>org.pentaho.di.www.RegisterSlaveServlet</classname> </servlet>
   <servlet id="getSlaves"> <description>List all registered slave servers</description> <classname>org.pentaho.di.www.GetSlavesServlet</classname> </servlet>
+  <servlet id="properties"> <description>Get properties from kettle.properties</description> <classname>org.pentaho.di.www.GetPropertiesServlet</classname> </servlet>
 
   <!-- Easier remote execution ... -->
 

--- a/engine/src/org/pentaho/di/www/BodyHttpServlet.java
+++ b/engine/src/org/pentaho/di/www/BodyHttpServlet.java
@@ -1,0 +1,124 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.www;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.owasp.esapi.ESAPI;
+import org.owasp.esapi.Encoder;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.i18n.PackageMessages;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public abstract class BodyHttpServlet extends BaseHttpServlet implements CartePluginInterface {
+
+  private static final long serialVersionUID = 6576714217004890327L;
+  private static final Encoder ENCODER = ESAPI.encoder();
+
+  private final PackageMessages messages;
+
+  public BodyHttpServlet() {
+    messages = new PackageMessages( this.getClass() );
+  }
+
+  public void doGet( HttpServletRequest request, HttpServletResponse response ) throws IOException {
+    if ( isJettyMode() && !request.getContextPath().startsWith( getContextPath() ) ) {
+      return;
+    }
+
+    if ( log.isDebug() ) {
+      logDebug( messages.getString( "Log.Execute" ) );
+    }
+
+    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    PrintWriter out = new PrintWriter( response.getOutputStream() );
+
+    try {
+
+      if ( useXML ) {
+        startXml( response, out );
+      } else {
+        beginHtml( response, out );
+      }
+
+      generateBody( request, response, useXML );
+
+    } catch ( Exception e ) {
+      String st = ExceptionUtils.getFullStackTrace( e );
+      if ( useXML ) {
+        out.println( new WebResult( WebResult.STRING_ERROR, st ).getXML() );
+      } else {
+        out.println( "<p><pre>" );
+        out.println( ENCODER.encodeForHTML( st ) );
+        out.println( "</pre>" );
+      }
+    } finally {
+      if ( !useXML ) {
+        endHtml( out );
+      }
+      out.flush();
+      out.close();
+    }
+  }
+
+  protected void beginHtml( HttpServletResponse response, PrintWriter out ) throws IOException {
+    response.setContentType( "text/html;charset=UTF-8" );
+    out.println( "<HTML>" );
+    out.println( "<HEAD>" );
+    out.println( "<TITLE>" );
+    out.println( ENCODER.encodeForHTML( getTitle() ) );
+    out.println( "</TITLE>" );
+    out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+    out.println( "</HEAD>" );
+    out.println( "<BODY>" );
+  }
+
+  protected void endHtml( PrintWriter out ) {
+    out.println( "<p>" );
+    out.println( "</BODY>" );
+    out.println( "</HTML>" );
+  }
+
+  protected void startXml( HttpServletResponse response, PrintWriter out ) throws IOException {
+    response.setContentType( "text/xml" );
+    response.setCharacterEncoding( Const.XML_ENCODING );
+    out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
+  }
+
+  abstract void generateBody( HttpServletRequest request, HttpServletResponse response, boolean useXML )
+    throws Exception;
+
+  @Override
+  public String getService() {
+    return getContextPath() + " (" + getTitle() + ")";
+  }
+
+  private String getTitle() {
+    return messages.getString( "Title" );
+  }
+
+}

--- a/engine/src/org/pentaho/di/www/Carte.java
+++ b/engine/src/org/pentaho/di/www/Carte.java
@@ -25,7 +25,9 @@ package org.pentaho.di.www;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs.FileObject;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.Const;
@@ -36,6 +38,7 @@ import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -90,10 +93,12 @@ public class Carte {
     // The master might be dead or not alive yet at the time we send this message.
     // Repeating the registration over and over every few minutes might harden this sort of problems.
     //
+    Properties masterProperties = null;
     if ( config.isReportingToMasters() ) {
       final SlaveServer client =
-        new SlaveServer( "Dynamic slave [" + hostname + ":" + port + "]", hostname, "" + port, slaveServer
-          .getUsername(), slaveServer.getPassword() );
+          new SlaveServer( "Dynamic slave [" + hostname + ":" + port + "]", hostname, "" + port, slaveServer
+              .getUsername(), slaveServer.getPassword() );
+      String propertiesMaster = slaveServer.getPropertiesMasterName();
       for ( final SlaveServer master : config.getMasters() ) {
         // Here we use the username/password specified in the slave server section of the configuration.
         // This doesn't have to be the same pair as the one used on the master!
@@ -101,14 +106,32 @@ public class Carte {
         try {
           SlaveServerDetection slaveServerDetection = new SlaveServerDetection( client );
           master.sendXML( slaveServerDetection.getXML(), RegisterSlaveServlet.CONTEXT_PATH + "/" );
-          log.logBasic( "Registered this slave server to master slave server ["
-            + master.toString() + "] on address [" + master.getServerAndPort() + "]" );
+          log.logBasic( "Registered this slave server to master slave server [" + master.toString() + "] on address ["
+              + master.getServerAndPort() + "]" );
         } catch ( Exception e ) {
-          log.logError( "Unable to register to master slave server ["
-            + master.toString() + "] on address [" + master.getServerAndPort() + "]" );
+          log.logError( "Unable to register to master slave server [" + master.toString() + "] on address ["
+              + master.getServerAndPort() + "]" );
+          allOK = false;
+        }
+        try {
+          if ( !StringUtils.isBlank( propertiesMaster ) && propertiesMaster.equalsIgnoreCase( master.getName() ) ) {
+            if ( masterProperties != null ) {
+              log.logError( "More than one primary master server. Master name is " + propertiesMaster );
+            } else {
+              masterProperties = master.getKettleProperties();
+              log.logBasic( "Got properties from master server [" + master.toString() + "], address ["
+                  + master.getServerAndPort() + "]" );
+            }
+          }
+        } catch ( Exception e ) {
+          log.logError( "Unable to get properties from master server [" + master.toString() + "], address ["
+              + master.getServerAndPort() + "]" );
           allOK = false;
         }
       }
+    }
+    if ( masterProperties != null ) {
+      EnvUtil.applyKettleProperties( masterProperties, slaveServer.isOverrideExistingProperties() );
     }
 
     // If we need to time out finished or idle objects, we should create a timer in the background to clean

--- a/engine/src/org/pentaho/di/www/CarteServlet.java
+++ b/engine/src/org/pentaho/di/www/CarteServlet.java
@@ -70,6 +70,8 @@ public class CarteServlet extends HttpServlet {
     if ( plugin != null ) {
       try {
         plugin.doGet( req, resp );
+      } catch ( ServletException e ) {
+        throw e;
       } catch ( Exception e ) {
         throw new ServletException( e );
       }

--- a/engine/src/org/pentaho/di/www/GetPropertiesServlet.java
+++ b/engine/src/org/pentaho/di/www/GetPropertiesServlet.java
@@ -1,0 +1,63 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.util.EnvUtil;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Properties;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class GetPropertiesServlet extends BodyHttpServlet {
+
+  private static final long serialVersionUID = 4872614637561572356L;
+
+  public static final String CONTEXT_PATH = "/kettle/properties";
+
+  @Override
+  public String getContextPath() {
+    return CONTEXT_PATH;
+  }
+
+  @Override
+  void generateBody( HttpServletRequest request, HttpServletResponse response, boolean useXML ) throws Exception {
+    ServletOutputStream out = response.getOutputStream();
+    Properties kettleProperties = EnvUtil.readProperties( Const.KETTLE_PROPERTIES );
+    if ( useXML ) {
+      kettleProperties.storeToXML( out, "" );
+    } else {
+      kettleProperties.store( out, "" );
+    }
+  }
+
+  @Override
+  protected void startXml( HttpServletResponse response, PrintWriter out ) throws IOException {
+    response.setContentType( "text/xml" );
+    response.setCharacterEncoding( Const.XML_ENCODING );
+  }
+}

--- a/engine/src/org/pentaho/di/www/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/www/messages/messages_en_US.properties
@@ -130,3 +130,5 @@ GetJobImageServlet.Log.JobImageRequested=Image of job requested
 GetJobImageServlet.GetJobImage=Show an image of the job
 GetStatusServlet.Parameter.RepositoryName=Repository name
 GetStatusServlet.Parameter.RepositoryName.UnableToConnect=Unable to connect to repository: {0}
+GetVariablesServlet.Log.Execute=Variables requested
+GetVariablesServlet.Title=Variables

--- a/ui/src/org/pentaho/di/ui/core/dialog/KettlePropertiesFileDialog.java
+++ b/ui/src/org/pentaho/di/ui/core/dialog/KettlePropertiesFileDialog.java
@@ -51,6 +51,7 @@ import org.eclipse.swt.widgets.TableItem;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleVariablesList;
 import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.PropsUI;
@@ -213,10 +214,7 @@ public class KettlePropertiesFileDialog extends Dialog {
     try {
       // Load the Kettle properties file...
       //
-      String filename = getKettlePropertiesFilename();
-      File file = new File( filename );
-      Properties properties = new Properties();
-      properties.load( new FileInputStream( file ) );
+      Properties properties = EnvUtil.readProperties( getKettlePropertiesFilename() );
 
       // These are the standard Kettle variables...
       //


### PR DESCRIPTION
What was done:
1) added new servlet, that shows running server kettle.properties
2) added 2 configuration parameters telling slave which master to use for
obtaining properties on startup
3) added changes to startup logic, based on configuration