### PR TITLE
Fix BaseMessages Ambiguous Method call errors

### DIFF
--- a/core/src/org/pentaho/di/i18n/BaseMessages.java
+++ b/core/src/org/pentaho/di/i18n/BaseMessages.java
@@ -82,6 +82,10 @@ public class BaseMessages implements LAFChangeListener<MessageHandler> {
     return getInstanceHandler().getString( packageName, key, resourceClass, parameters );
   }
 
+  public static String getString( Class<?> packageClass, String key ) {
+	    return getInstanceHandler().getString( packageClass.getPackage().getName(), key, packageClass );
+	  }
+
   public static String getString( Class<?> packageClass, String key, String... parameters ) {
     return getInstanceHandler().getString( packageClass.getPackage().getName(), key, packageClass, parameters );
   }


### PR DESCRIPTION
Eclipse was complaining about the BaseMessages.getString method calls being ambiguous.  There were about 125 errors, and creating a method with
no variable arguments fixes the errors.  This was eclipse 4.2.2 and java
1.7.  There was a JDK bug that caused this and an eclipse fix if you want to modify the ecliipse.ini, but this
fixes the code.