### PR TITLE
[PDI-12870]: Fixed issue with null metadata from PreparedStatement

### DIFF
--- a/core/src/org/pentaho/di/core/database/Database.java
+++ b/core/src/org/pentaho/di/core/database/Database.java
@@ -2133,7 +2133,12 @@ public class Database implements VariableSpace, LoggingObjectInterface {
           setValues( par, data, ps );
         }
         ResultSet r = ps.executeQuery();
-        fields = getRowInfo( ps.getMetaData(), false, false );
+        ResultSetMetaData metadata = ps.getMetaData();
+        // If the PreparedStatement can't get us the metadata, try using the ResultSet's metadata
+        if( metadata == null ) {
+          metadata = r.getMetaData();
+        }
+        fields = getRowInfo( metadata, false, false );
         r.close();
         ps.close();
       }


### PR DESCRIPTION
Some drivers' PreparedStatement objects do not return metadata via getMetaData(). In our fallback code, we eventually try executing the query, then getting the metadata. If it is still not available via PreparedStatement.getMetaData(), since we have the ResultSet we should again fall back to ResultSet.getMetaData().