### PR TITLE
PDI-12278 monetdb bulk loader error

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDBBulkLoader.java
+++ b/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDBBulkLoader.java
@@ -502,13 +502,13 @@ public class MonetDBBulkLoader extends BaseStep implements StepInterface {
       if ( error != null ) {
         throw new KettleException( "Error loading data: " + error );
       }
-      data.out.writeLine( "" );
+      // data.out.writeLine( "" );
 
       // and again, making sure we commit all the records
-      error = data.in.waitForPrompt();
-      if ( error != null ) {
-        throw new KettleException( "Error loading data: " + error );
-      }
+      // error = data.in.waitForPrompt();
+      // if ( error != null ) {
+        // throw new KettleException( "Error loading data: " + error );
+      // }
 
       if ( log.isRowLevel() ) {
         logRowlevel( Const.CR );


### PR DESCRIPTION
Apparently a bug fix to monetdb does not require the bulk loader to repeatedly flush the buffer. Doing so was creating a dropped connection error after loading the data.

Tested this fix on Windows.

