### PR TITLE
[BACKLOG-1938]Lazy ValueMeta name caching

### DIFF
--- a/core/src/org/pentaho/di/core/row/RowMeta.java
+++ b/core/src/org/pentaho/di/core/row/RowMeta.java
@@ -129,7 +129,10 @@ public class RowMeta implements RowMetaInterface {
   public void setValueMetaList( List<ValueMetaInterface> valueMetaList ) {
     this.valueMetaList = valueMetaList;
     // we have new list and we need re-hash
-    indexValueMap();
+    valueIndexMap.clear();
+    for ( int i = 0; i < this.valueMetaList.size(); i++ ) {
+      valueIndexMap.put( this.valueMetaList.get( i ).getName().toLowerCase(), i );
+    }
   }
 
   /**
@@ -150,7 +153,7 @@ public class RowMeta implements RowMetaInterface {
 
   @Override
   public boolean exists( ValueMetaInterface meta ) {
-    return ( meta != null ) ? searchValueMeta( meta.getName() ) != null : false;
+    return ( meta != null ) && searchValueMeta( meta.getName() ) != null;
   }
 
   /**
@@ -161,16 +164,7 @@ public class RowMeta implements RowMetaInterface {
    */
   @Override
   public void addValueMeta( ValueMetaInterface meta ) {
-    if ( meta != null ) {
-      ValueMetaInterface newMeta;
-      if ( !exists( meta ) ) {
-        newMeta = meta;
-      } else {
-        newMeta = renameValueMetaIfInRow( meta );
-      }
-      valueMetaList.add( newMeta );
-      valueIndexMap.put( newMeta.getName().toLowerCase(), valueMetaList.size() - 1 );
-    }
+    addValueMeta( valueMetaList.size(), meta );
   }
 
   /**
@@ -192,18 +186,7 @@ public class RowMeta implements RowMetaInterface {
         newMeta = renameValueMetaIfInRow( meta );
       }
       valueMetaList.add( index, newMeta );
-
-      indexValueMap();
-    }
-  }
-
-  /**
-   *  re-index the map
-   */
-  private void indexValueMap() {
-    valueIndexMap.clear();
-    for ( int i = 0; i < valueMetaList.size(); i++ ) {
-      valueIndexMap.put( valueMetaList.get( i ).getName().toLowerCase(), i );
+      valueIndexMap.put( newMeta.getName().toLowerCase(), index );
     }
   }
 
@@ -235,9 +218,9 @@ public class RowMeta implements RowMetaInterface {
   public void setValueMeta( int index, ValueMetaInterface valueMeta ) {
     if ( valueMeta != null ) {
       valueMetaList.set( index, valueMeta );
+      // add value meta to cache
+      valueIndexMap.put( valueMeta.getName().toLowerCase(), index );
     }
-    // array list got shifted - so we can't avoid re-hash!
-    indexValueMap();
   }
 
   /**
@@ -469,7 +452,21 @@ public class RowMeta implements RowMetaInterface {
    */
   @Override
   public int indexOfValue( String valueName ) {
-    Integer index = valueIndexMap.get( valueName.toLowerCase() );
+    String key = valueName.toLowerCase();
+    Integer index = valueIndexMap.get( key );
+    if( index != null ) {
+      ValueMetaInterface value = valueMetaList.get( index );
+      if ( !valueName.equalsIgnoreCase( value.getName() ) ) {
+        index = null;
+        valueIndexMap.remove( key );
+      }
+    }
+    for ( int i = 0; ( index == null ) && ( i < valueMetaList.size() ); i++ ) {
+      if ( valueName.equalsIgnoreCase( valueMetaList.get( i ).getName() ) ) {
+        index = i;
+        valueIndexMap.put( key, index );
+      }
+    }
     if ( index == null ) {
       return -1;
     }
@@ -485,9 +482,8 @@ public class RowMeta implements RowMetaInterface {
    */
   @Override
   public ValueMetaInterface searchValueMeta( String valueName ) {
-
-    Integer index = valueIndexMap.get( valueName.toLowerCase() );
-    if ( index == null ) {
+    Integer index = indexOfValue( valueName );
+    if ( index < 0 ) {
       return null;
     }
     return valueMetaList.get( index );
@@ -678,7 +674,7 @@ public class RowMeta implements RowMetaInterface {
   @Override
   public void removeValueMeta( int index ) {
     valueMetaList.remove( index );
-    indexValueMap();
+    valueIndexMap.clear();
   }
 
   /**

--- a/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
@@ -2,6 +2,8 @@ package org.pentaho.di.core.database;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -11,6 +13,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMeta;
 
 public class DatabaseMetaTest {
   @Test
@@ -48,5 +53,37 @@ public class DatabaseMetaTest {
     String expectedJndi = "JNDI";
     String access = DatabaseMeta.getAccessTypeDesc( DatabaseMeta.getAccessType( expectedJndi ) );
     assertEquals( expectedJndi, access );
+  }
+
+  @Test
+  public void testQuoteReservedWords() {
+    DatabaseMeta databaseMeta = mock( DatabaseMeta.class );
+    doCallRealMethod().when( databaseMeta ).quoteReservedWords( any( RowMetaInterface.class ) );
+    doCallRealMethod().when( databaseMeta ).quoteField( anyString() );
+    doCallRealMethod().when( databaseMeta ).setDatabaseInterface( any( DatabaseInterface.class ) );
+    doReturn( "\"" ).when( databaseMeta ).getStartQuote();
+    doReturn( "\"" ).when( databaseMeta ).getEndQuote();
+    final DatabaseInterface databaseInterface = mock( DatabaseInterface.class );
+    doReturn( true ).when( databaseInterface ).isQuoteAllFields();
+    databaseMeta.setDatabaseInterface( databaseInterface );
+
+    final RowMeta fields = new RowMeta();
+    for ( int i = 0; i < 10; i++ ) {
+      final ValueMeta valueMeta = new ValueMeta( "test_" + i );
+      fields.addValueMeta( valueMeta );
+    }
+
+    for ( int i = 0; i < 10; i++ ) {
+      databaseMeta.quoteReservedWords( fields );
+    }
+
+    for ( int i = 0; i < 10; i++ ) {
+      databaseMeta.quoteReservedWords( fields );
+      final String name = fields.getValueMeta( i ).getName();
+      // check valueMeta index in list
+      assertTrue( name.contains( "test_" + i ) );
+      // check valueMeta is found by quoted name
+      assertNotNull( fields.searchValueMeta( name ) );
+    }
   }
 }

--- a/core/test-src/org/pentaho/di/core/row/RowMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/row/RowMetaTest.java
@@ -3,6 +3,7 @@ package org.pentaho.di.core.row;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -210,12 +211,19 @@ public class RowMetaTest {
   public void testExternalValueMetaModification() {
     ValueMetaInterface vmi = rowMeta.searchValueMeta( "string" );
     vmi.setName( "string2" );
-    // index become corrupted!
-    assertNull( rowMeta.searchValueMeta( vmi.getName() ) );
-    // a hack
-    rowMeta.setValueMetaList( rowMeta.getValueMetaList() );
-    // and now it can be found again
     assertNotNull( rowMeta.searchValueMeta( vmi.getName() ) );
+  }
+
+  @Test
+  public void testSwapNames() throws KettlePluginException {
+    ValueMetaInterface string2 = ValueMetaFactory.createValueMeta( "string2", ValueMeta.TYPE_STRING );
+    rowMeta.addValueMeta( string2 );
+    assertSame( string, rowMeta.searchValueMeta( "string" ) );
+    assertSame( string2, rowMeta.searchValueMeta( "string2" ) );
+    string.setName( "string2" );
+    string2.setName( "string" );
+    assertSame( string2, rowMeta.searchValueMeta( "string" ) );
+    assertSame( string, rowMeta.searchValueMeta( "string2" ) );
   }
 
   // @Test


### PR DESCRIPTION
When searching for value index, verify name is correct before returning.
Add/remove cached value metas while searching and modifying instead of complete reindex

http://jira.pentaho.com/browse/BACKLOG-1938