### PR TITLE
[BACKLOG-1793] Send heartbeat information for long running jobs / transf...

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -143,6 +143,11 @@ public class Const {
   public static final int SORT_SIZE = 5000;
 
   /**
+   * job/trans heartbeat scheduled executor periodic interval ( in seconds )
+   */
+  public static final int HEARTBEAT_PERIODIC_INTERVAL_IN_SECS = 10;
+
+  /**
    * What's the file systems file separator on this operating system?
    */
   public static final String FILE_SEPARATOR = System.getProperty( "file.separator" );

--- a/core/src/org/pentaho/di/core/extension/KettleExtensionPoint.java
+++ b/core/src/org/pentaho/di/core/extension/KettleExtensionPoint.java
@@ -29,6 +29,8 @@ public enum KettleExtensionPoint {
     TransformationPrepareExecution( "TransformationPrepareExecution", "A transformation begins to prepare execution" ),
     TransformationStartThreads( "TransformationStartThreads", "A transformation begins to start" ),
     TransformationStart( "TransformationStart", "A transformation has started" ),
+    TransformationHeartbeat( "TransformationHeartbeat",
+      "A signal sent at regular intervals to indicate that the transformation is still active" ),
     TransformationFinish( "TransformationFinish", "A transformation finishes" ),
     TransformationMetaLoaded( "TransformationMetaLoaded", "Transformation metadata was loaded" ),
     TransPainterArrow( "TransPainterArrow", "Draw additional information on top of a transformation hop (arrow)" ),
@@ -51,6 +53,7 @@ public enum KettleExtensionPoint {
       "Right before Spoon configuration of transformation to be executed takes place" ),
 
     JobStart( "JobStart", "A job starts" ),
+    JobHeartbeat( "JobHeartbeat", "A signal sent at regular intervals to indicate that the job is still active" ),
     JobFinish( "JobFinish", "A job finishes" ),
     JobBeforeJobEntryExecution( "JobBeforeJobEntryExecution", "Before a job entry executes" ),
     JobAfterJobEntryExecution( "JobAfterJobEntryExecution", "After a job entry executes" ),

--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -42,6 +42,9 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -402,6 +405,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
   private HttpServletRequest servletRequest;
 
   private Map<String, Object> extensionDataMap;
+
+  private ExecutorService heartbeat = null; // this transformations's heartbeat scheduled executor
 
   /**
    * Instantiates a new transformation.
@@ -1292,6 +1297,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
       public void transFinished( Trans trans ) {
 
         try {
+          shutdownHeartbeat( trans != null ? trans.heartbeat : null );
+
           ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.TransformationFinish.id, trans );
         } catch ( KettleException e ) {
           throw new RuntimeException( "Error calling extension point at end of transformation", e );
@@ -1438,6 +1445,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     }
 
     ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.TransformationStart.id, this );
+
+    heartbeat = startHeartbeat( Const.HEARTBEAT_PERIODIC_INTERVAL_IN_SECS );
 
     if ( log.isDetailed() ) {
       log
@@ -5553,5 +5562,42 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
   @Override
   public Map<String, Object> getExtensionDataMap() {
     return extensionDataMap;
+  }
+
+  protected ExecutorService startHeartbeat( long intervalInSeconds ) {
+
+    ScheduledExecutorService heartbeat = Executors.newSingleThreadScheduledExecutor();
+
+    heartbeat.scheduleAtFixedRate( new Runnable() {
+      public void run() {
+        try {
+
+          log.logDebug( "Triggering heartbeat signal for " + getName() );
+          ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.TransformationHeartbeat.id, getThisInstance() );
+
+        } catch ( KettleException e ) {
+          log.logError( e.getMessage(), e );
+        }
+      }
+    }, intervalInSeconds /* initial delay */, intervalInSeconds /* interval delay */, TimeUnit.SECONDS );
+
+    return heartbeat;
+  }
+
+  protected void shutdownHeartbeat( ExecutorService heartbeat ){
+
+    if( heartbeat != null ) {
+
+      try {
+        heartbeat.shutdownNow(); // prevents waiting tasks from starting and attempts to stop currently executing ones
+
+      } catch( Throwable t ) {
+        /* do nothing */
+      }
+    }
+  }
+
+  private Trans getThisInstance(){
+    return this;
   }
 }


### PR DESCRIPTION
...ormations

	- 2 new extension point plugin ID's : TransformationHeartbeat and JobHeartbeat
	- Job and Trans classes now trigger a ScheduledExecutor service that calls the heartbeat extension point plugin at periodic intervals
	- the heartbeart ScheduledExecutor is started after the JobStarted / TransStarted and it is shutdown immediately before JobFinish / TransFinish