### PR TITLE
[PMD-994] - Add Redshift dialect to Pentaho Metadata

### DIFF
--- a/core/src/kettle-database-types.xml
+++ b/core/src/kettle-database-types.xml
@@ -163,7 +163,12 @@
   <database-type id="POSTGRESQL">
     <description>PostgreSQL</description>
     <classname>org.pentaho.di.core.database.PostgreSQLDatabaseMeta</classname>
-  </database-type>                                                            
+  </database-type>
+
+  <database-type id="REDSHIFT">
+    <description>Redshift</description>
+    <classname>org.pentaho.di.core.database.RedshiftDatabaseMeta</classname>
+  </database-type>
 
   <database-type id="REMEDY-AR-SYSTEM">
     <description>Remedy Action Request System</description>


### PR DESCRIPTION
add Redshift to kettle-database-types.xml

@mbatchelor @lucboudreau this fixes failing projects that use metadata(like PIR)