### PR TITLE
BISERVER-12384 - Operations Mart transformations fail [NullPointerExcept...

### DIFF
--- a/core/src/org/pentaho/di/core/row/RowMeta.java
+++ b/core/src/org/pentaho/di/core/row/RowMeta.java
@@ -453,6 +453,9 @@ public class RowMeta implements RowMetaInterface {
    */
   @Override
   public int indexOfValue( String valueName ) {
+    if( valueName == null ) {
+      return -1;
+    }
     String key = valueName.toLowerCase();
     Integer index = valueIndexMap.get( key );
     if( index != null ) {

--- a/core/test-src/org/pentaho/di/core/row/RowMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/row/RowMetaTest.java
@@ -128,6 +128,11 @@ public class RowMetaTest {
   }
 
   @Test
+  public void testIndexOfNullValue() {
+    assertEquals( -1, rowMeta.indexOfValue( null ) );
+  }
+
+  @Test
   public void testSearchValueMeta() {
     ValueMetaInterface vmi = rowMeta.searchValueMeta( "integer" );
     assertEquals( integer, vmi );


### PR DESCRIPTION
...ion] on the lookup step in 5.3.0 but they work in 5.2.0.1: ProAuditInstanceTransform.ktr and ProAuditComponentTransform.ktr