### PR TITLE
PDI-13054 - Execute SQL Script ignores Oracle hint

### DIFF
--- a/core/src/org/pentaho/di/core/database/SqlScriptParser.java
+++ b/core/src/org/pentaho/di/core/database/SqlScriptParser.java
@@ -151,11 +151,12 @@ public class SqlScriptParser {
     for ( int i = 0; i < script.length(); i++ ) {
       char ch = script.charAt( i );
       char nextCh = i < script.length() - 1 ? script.charAt( i + 1 ) : 0;
+      char nextPlusOneCh = i < script.length() - 2 ? script.charAt( i + 2 ) : 0;
       switch ( mode ) {
         case SQL:
           switch ( ch ) {
             case '/':
-              if ( nextCh == '*' ) {
+              if ( nextCh == '*' && nextPlusOneCh != '+' ) {
                 mode = MODE.BLOCK_COMMENT;
                 i++;
                 ch = 0;

--- a/core/test-src/org/pentaho/di/core/database/SqlScriptParserTest.java
+++ b/core/test-src/org/pentaho/di/core/database/SqlScriptParserTest.java
@@ -42,6 +42,12 @@ public class SqlScriptParserTest {
       "SELECT INSTR('/loader/*/*.txt', '/') - INSTR('/loader/*/*.txt', '/') " );
     testRemoveComments( "SELECT /* my data*/ col1, col2, col3 FROM account WHERE name = 'Pentaho'",
       "SELECT  col1, col2, col3 FROM account WHERE name = 'Pentaho'" );
+    testRemoveComments( "SELECT /*+ ORACLE hint*/ col1, col2, col3 FROM account WHERE name = 'Pentaho'",
+        "SELECT /*+ ORACLE hint*/ col1, col2, col3 FROM account WHERE name = 'Pentaho'" );
+    testRemoveComments( "SELECT \n/*+ ORACLE hint*/ col1, col2, col3 FROM account WHERE name = 'Pentaho'",
+        "SELECT \n/*+ ORACLE hint*/ col1, col2, col3 FROM account WHERE name = 'Pentaho'" );
+    testRemoveComments( "SELECT \n/*+ ORACLE hint*/\n col1, col2, col3 FROM account WHERE name = 'Pentaho'",
+        "SELECT \n/*+ ORACLE hint*/\n col1, col2, col3 FROM account WHERE name = 'Pentaho'" );
   }
 
   private void testRemoveComments( String input, String expected ) {


### PR DESCRIPTION
What was done:
1) added unit test
2) changed comments parsing logic -- added support for /*+  construction