### PR TITLE
[BACKLOG-1414] Add support for date DATE and TIMESTAMP literal keywords ...

### DIFF
--- a/core/src/org/pentaho/di/core/jdbc/ThinUtil.java
+++ b/core/src/org/pentaho/di/core/jdbc/ThinUtil.java
@@ -29,6 +29,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.pentaho.di.core.Const;
@@ -168,12 +169,40 @@ public class ThinUtil {
           ValueMetaInterface valueMeta = new ValueMeta( "iif-date", ValueMetaInterface.TYPE_DATE );
           valueMeta.setConversionMask( format );
           return new ValueMetaAndData( valueMeta, date );
-
         }
       }
     }
+
+    Matcher matcher = Pattern.compile( "^([A-Za-z]+) ?'([0-9\\-:\\. ]+)'$" ).matcher( string );
+    if ( matcher.find() ) {
+      if ( matcher.groupCount() == 2 ) {
+        String keyword = matcher.group( 1 );
+        String dateString = matcher.group( 2 );
+        String format = null;
+        if ( keyword.equalsIgnoreCase( "TIMESTAMP" ) ) {
+          format = "yyyy-MM-dd HH:mm:ss";
+        } else if ( keyword.equalsIgnoreCase( "DATE" ) ) {
+          format = "yyyy-MM-dd";
+        }
+        if ( format != null ) {
+          Date date = null;
+          try {
+            date = new SimpleDateFormat( format ).parse( dateString );
+          } catch ( ParseException e ) {
+            // Format does not match
+          }
+          if ( date != null ) {
+            ValueMetaInterface valueMeta = new ValueMeta( "iff-date", ValueMetaInterface.TYPE_DATE );
+            valueMeta.setConversionMask( format );
+            return new ValueMetaAndData( valueMeta, date );
+          }
+        }
+      }
+    }
+
     return null;
   }
+
 
   public static ValueMetaAndData attemptIntegerValueExtraction( String string ) {
     // Try an Integer

--- a/core/test-src/org/pentaho/di/core/jdbc/ThinUtilTest.java
+++ b/core/test-src/org/pentaho/di/core/jdbc/ThinUtilTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.row.ValueMetaAndData;
 
 public class ThinUtilTest {
   @Test
@@ -52,6 +53,18 @@ public class ThinUtilTest {
   @Test
   public void testFindClauseSkipsChars() throws KettleSQLException {
     assertNull( ThinUtil.findClause( "'Select' * From Test", "SELECT", "FROM" ) );
+  }
+
+  @Test
+  public void testAttemptDateValueExtraction() throws Exception {
+    ValueMetaAndData timestamp = ThinUtil.attemptDateValueExtraction( "TIMESTAMP '2014-01-01 00:00:00'" );
+    ValueMetaAndData date = ThinUtil.attemptDateValueExtraction( "DATE '2014-01-01'" );
+
+    assertNotNull( timestamp );
+    assertEquals( "2014-01-01 00:00:00", timestamp.toString() );
+
+    assertNotNull( date );
+    assertEquals( "2014-01-01", date.toString() );
   }
 
   @Test


### PR DESCRIPTION
...in parsed SQL

@bmorrise merging your work into future-develop

pdi-jdbc branch should then be obsolete