### PR TITLE
[PDI-13365] - Spoon.sh: unable to run Spoon outside the spoon home dir (remastered)

### DIFF
--- a/assembly/package-res/spoon.sh
+++ b/assembly/package-res/spoon.sh
@@ -29,7 +29,8 @@ export UBUNTU_MENUPROXY=0
 # ** Set INITIALDIR, BASEDIR AND CURRENTDIR       **
 # **************************************************
 INITIALDIR=`pwd`
-BASEDIR=`dirname $0`
+# set absolute path to data-integration folder
+BASEDIR=$( cd "$( dirname "$0" )" && pwd )
 CURRENTDIR="."
 
 . "$BASEDIR/set-pentaho-env.sh"


### PR DESCRIPTION
@rmansoor, could you review, please
 here is some improvements for https://github.com/pentaho/pentaho-kettle/pull/1023

Now absolute path to file is used. Thus STARTUP variable doesn't depend on current directory. 