### PR TITLE
[PDI-13315] [v2] Subjobs called from jobs are duplicating result rows

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -995,11 +995,13 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
 
         }
 
-        if ( iteration == 0 ) {
-          result.clear();
-        }
-
+        result.clear(); // clear only the numbers, NOT the files or rows.
         result.add( oneResult );
+
+        // Set the result rows too, if any ...
+        if ( !Const.isEmpty( oneResult.getRows() ) ) {
+          result.setRows( new ArrayList<RowMetaAndData>( oneResult.getRows() ) );
+        }
 
         // if one of them fails (in the loop), increase the number of errors
         //


### PR DESCRIPTION
@mattyb149 review it please.
This is suggested instead of https://github.com/pentaho/pentaho-kettle/pull/889
The behavior implemented is like in JobEntryTrans when execute transformation on the local machine:
  if subjob result contains rows, they are used as the JobEntryJob result rows
  if subjob result contains no rows, JobEntryJob result rows stay unchanged