### PR TITLE
[PDI-13325] Close GZip Files in Text File Output

### DIFF
--- a/engine/src/org/pentaho/di/core/compress/gzip/GZIPCompressionOutputStream.java
+++ b/engine/src/org/pentaho/di/core/compress/gzip/GZIPCompressionOutputStream.java
@@ -28,6 +28,6 @@ public class GZIPCompressionOutputStream extends CompressionOutputStream {
   @Override
   public void close() throws IOException {
     GZIPOutputStream zos = (GZIPOutputStream) delegate;
-    zos.finish();
+    zos.close();
   }
 }

--- a/engine/test-src/org/pentaho/di/core/compress/gzip/GZIPCompressionOutputStreamTest.java
+++ b/engine/test-src/org/pentaho/di/core/compress/gzip/GZIPCompressionOutputStreamTest.java
@@ -2,6 +2,7 @@ package org.pentaho.di.core.compress.gzip;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -64,6 +65,12 @@ public class GZIPCompressionOutputStreamTest {
     outStream = new GZIPCompressionOutputStream( out, provider ) {
     };
     outStream.close();
+    try {
+      outStream.write( "This will throw an Exception if the stream is already closed".getBytes() );
+      fail();
+    } catch (IOException e) {
+      //Success, The Output Stream was already closed
+    }
   }
 
   @Test


### PR DESCRIPTION
Corrected GZip Output Stream handler to properly close the stream, instead of only flushing pending writes.