### PR TITLE
[PDI-13539]: Fixed the setting of origin step in Merge Join

### DIFF
--- a/core/src/org/pentaho/di/core/row/RowMeta.java
+++ b/core/src/org/pentaho/di/core/row/RowMeta.java
@@ -81,11 +81,9 @@ public class RowMeta implements RowMetaInterface {
   /**
    * This method copies the row metadata and sets all values to the specified type (usually String)
    *
-   * @param targetType
-   *          The target type
+   * @param targetType The target type
    * @return The cloned metadata
-   * @throws if
-   *           the target type could not be loaded from the plugin registry
+   * @throws if the target type could not be loaded from the plugin registry
    */
   @Override
   public RowMetaInterface cloneToType( int targetType ) throws KettleValueException {
@@ -123,8 +121,7 @@ public class RowMeta implements RowMetaInterface {
   }
 
   /**
-   * @param valueMetaList
-   *          the list of valueMeta to set
+   * @param valueMetaList the list of valueMeta to set
    */
   @Override
   public void setValueMetaList( List<ValueMetaInterface> valueMetaList ) {
@@ -133,7 +130,7 @@ public class RowMeta implements RowMetaInterface {
     valueIndexMap.clear();
     for ( int i = 0; i < this.valueMetaList.size(); i++ ) {
       ValueMetaInterface valueMeta = this.valueMetaList.get( i );
-      if( !Const.isEmpty( valueMeta.getName() ) ) {
+      if ( !Const.isEmpty( valueMeta.getName() ) ) {
         valueIndexMap.put( valueMeta.getName().toLowerCase(), i );
       }
     }
@@ -163,8 +160,7 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Add a metadata value. If a value with the same name already exists, it gets renamed.
    *
-   * @param meta
-   *          The metadata value to add
+   * @param meta The metadata value to add
    */
   @Override
   public void addValueMeta( ValueMetaInterface meta ) {
@@ -175,10 +171,8 @@ public class RowMeta implements RowMetaInterface {
    * Add a metadata value on a certain location in the row. If a value with the same name already exists, it gets
    * renamed. Remember to change the data row according to this.
    *
-   * @param index
-   *          The index where the metadata value needs to be put in the row
-   * @param meta
-   *          The metadata value to add to the row
+   * @param index The index where the metadata value needs to be put in the row
+   * @param meta  The metadata value to add to the row
    */
   @Override
   public void addValueMeta( int index, ValueMetaInterface meta ) {
@@ -187,10 +181,10 @@ public class RowMeta implements RowMetaInterface {
       if ( !exists( meta ) ) {
         newMeta = meta;
       } else {
-        newMeta = renameValueMetaIfInRow( meta );
+        newMeta = renameValueMetaIfInRow( meta, null );
       }
       valueMetaList.add( index, newMeta );
-      if( !Const.isEmpty( newMeta.getName() ) ) {
+      if ( !Const.isEmpty( newMeta.getName() ) ) {
         valueIndexMap.put( newMeta.getName().toLowerCase(), index );
       }
     }
@@ -199,8 +193,7 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Get the value metadata on the specified index.
    *
-   * @param index
-   *          The index to get the value metadata from
+   * @param index The index to get the value metadata from
    * @return The value metadata specified by the index.
    */
   @Override
@@ -215,17 +208,15 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Replaces a value meta entry in the row metadata with another one
    *
-   * @param index
-   *          The index in the row to replace at
-   * @param valueMeta
-   *          the metadata to replace with
+   * @param index     The index in the row to replace at
+   * @param valueMeta the metadata to replace with
    */
   @Override
   public void setValueMeta( int index, ValueMetaInterface valueMeta ) {
     if ( valueMeta != null ) {
       valueMetaList.set( index, valueMeta );
       // add value meta to cache if name is not null
-      if( !Const.isEmpty( valueMeta.getName() ) ) {
+      if ( !Const.isEmpty( valueMeta.getName() ) ) {
         valueIndexMap.put( valueMeta.getName().toLowerCase(), index );
       }
     }
@@ -234,13 +225,10 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Get a String value from a row of data. Convert data if this needed.
    *
-   * @param rowRow
-   *          the row of data
-   * @param index
-   *          the index
+   * @param rowRow the row of data
+   * @param index  the index
    * @return The string found on that position in the row
-   * @throws KettleValueException
-   *           in case there was a problem converting the data.
+   * @throws KettleValueException in case there was a problem converting the data.
    */
   @Override
   public String getString( Object[] dataRow, int index ) throws KettleValueException {
@@ -254,13 +242,10 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Get an Integer value from a row of data. Convert data if this needed.
    *
-   * @param rowRow
-   *          the row of data
-   * @param index
-   *          the index
+   * @param rowRow the row of data
+   * @param index  the index
    * @return The integer found on that position in the row
-   * @throws KettleValueException
-   *           in case there was a problem converting the data.
+   * @throws KettleValueException in case there was a problem converting the data.
    */
   @Override
   public Long getInteger( Object[] dataRow, int index ) throws KettleValueException {
@@ -274,13 +259,10 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Get a Number value from a row of data. Convert data if this needed.
    *
-   * @param rowRow
-   *          the row of data
-   * @param index
-   *          the index
+   * @param rowRow the row of data
+   * @param index  the index
    * @return The number found on that position in the row
-   * @throws KettleValueException
-   *           in case there was a problem converting the data.
+   * @throws KettleValueException in case there was a problem converting the data.
    */
   @Override
   public Double getNumber( Object[] dataRow, int index ) throws KettleValueException {
@@ -294,13 +276,10 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Get a Date value from a row of data. Convert data if this needed.
    *
-   * @param rowRow
-   *          the row of data
-   * @param index
-   *          the index
+   * @param rowRow the row of data
+   * @param index  the index
    * @return The date found on that position in the row
-   * @throws KettleValueException
-   *           in case there was a problem converting the data.
+   * @throws KettleValueException in case there was a problem converting the data.
    */
   @Override
   public Date getDate( Object[] dataRow, int index ) throws KettleValueException {
@@ -314,13 +293,10 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Get a BigNumber value from a row of data. Convert data if this needed.
    *
-   * @param rowRow
-   *          the row of data
-   * @param index
-   *          the index
+   * @param rowRow the row of data
+   * @param index  the index
    * @return The bignumber found on that position in the row
-   * @throws KettleValueException
-   *           in case there was a problem converting the data.
+   * @throws KettleValueException in case there was a problem converting the data.
    */
   @Override
   public BigDecimal getBigNumber( Object[] dataRow, int index ) throws KettleValueException {
@@ -334,13 +310,10 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Get a Boolean value from a row of data. Convert data if this needed.
    *
-   * @param rowRow
-   *          the row of data
-   * @param index
-   *          the index
+   * @param rowRow the row of data
+   * @param index  the index
    * @return The boolean found on that position in the row
-   * @throws KettleValueException
-   *           in case there was a problem converting the data.
+   * @throws KettleValueException in case there was a problem converting the data.
    */
   @Override
   public Boolean getBoolean( Object[] dataRow, int index ) throws KettleValueException {
@@ -354,13 +327,10 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Get a Binary value from a row of data. Convert data if this needed.
    *
-   * @param rowRow
-   *          the row of data
-   * @param index
-   *          the index
+   * @param rowRow the row of data
+   * @param index  the index
    * @return The binary found on that position in the row
-   * @throws KettleValueException
-   *           in case there was a problem converting the data.
+   * @throws KettleValueException in case there was a problem converting the data.
    */
   @Override
   public byte[] getBinary( Object[] dataRow, int index ) throws KettleValueException {
@@ -374,13 +344,10 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Determines whether a value in a row is null. A value is null when the object is null or when it's an empty String
    *
-   * @param dataRow
-   *          The row of data
-   * @param index
-   *          the index to reference
+   * @param dataRow The row of data
+   * @param index   the index to reference
    * @return true if the value on the index is null.
-   * @throws KettleValueException
-   *           in case there is a conversion error (only thrown in case of lazy conversion)
+   * @throws KettleValueException in case there is a conversion error (only thrown in case of lazy conversion)
    */
   @Override
   public boolean isNull( Object[] dataRow, int index ) throws KettleValueException {
@@ -393,8 +360,7 @@ public class RowMeta implements RowMetaInterface {
 
   /**
    * @return a cloned Object[] object.
-   * @throws KettleValueException
-   *           in case something is not quite right with the expected data
+   * @throws KettleValueException in case something is not quite right with the expected data
    */
   @Override
   public Object[] cloneRow( Object[] objects ) throws KettleValueException {
@@ -403,8 +369,7 @@ public class RowMeta implements RowMetaInterface {
 
   /**
    * @return a cloned Object[] object.
-   * @throws KettleValueException
-   *           in case something is not quite right with the expected data
+   * @throws KettleValueException in case something is not quite right with the expected data
    */
   @Override
   public Object[] cloneRow( Object[] objects, Object[] newObjects ) throws KettleValueException {
@@ -454,18 +419,17 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Searches the index of a value meta with a given name
    *
-   * @param valueName
-   *          the name of the value metadata to look for
+   * @param valueName the name of the value metadata to look for
    * @return the index or -1 in case we didn't find the value
    */
   @Override
   public int indexOfValue( String valueName ) {
-    if( valueName == null ) {
+    if ( valueName == null ) {
       return -1;
     }
     String key = valueName.toLowerCase();
     Integer index = valueIndexMap.get( key );
-    if( index != null ) {
+    if ( index != null ) {
       ValueMetaInterface value = valueMetaList.get( index );
       if ( !valueName.equalsIgnoreCase( value.getName() ) ) {
         index = null;
@@ -487,8 +451,7 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Searches for a value with a certain name in the value meta list
    *
-   * @param valueName
-   *          The value name to search for
+   * @param valueName The value name to search for
    * @return The value metadata or null if nothing was found
    */
   @Override
@@ -511,11 +474,23 @@ public class RowMeta implements RowMetaInterface {
    * Merge the values of row r to this Row. The values that are not yet in the row are added unchanged. The values that
    * are in the row are renamed to name_2, name_3, etc.
    *
-   * @param r
-   *          The row to be merged with this row
+   * @param r The row to be merged with this row
    */
   @Override
   public void mergeRowMeta( RowMetaInterface r ) {
+    mergeRowMeta( r, null );
+  }
+
+  /**
+   * Merge the values of row r to this Row. The fields that are not yet in the row are added unchanged. The fields that
+   * are in the row are renamed to name_2, name_3, etc. If the fields are renamed, the provided originStepName will be
+   * assigned as the origin step for those fields.
+   *
+   * @param r The row to be merged with this row
+   * @param originStepName The name to use as the origin step
+   */
+  @Override
+  public void mergeRowMeta( RowMetaInterface r, String originStepName ) {
     for ( int x = 0; x < r.size(); x++ ) {
       ValueMetaInterface field = r.getValueMeta( x );
       if ( searchValueMeta( field.getName() ) == null ) {
@@ -523,12 +498,12 @@ public class RowMeta implements RowMetaInterface {
       } else {
         // We want to rename the field to Name[2], Name[3], ...
         //
-        addValueMeta( renameValueMetaIfInRow( field ) );
+        addValueMeta( renameValueMetaIfInRow( field, originStepName ) );
       }
     }
   }
 
-  private ValueMetaInterface renameValueMetaIfInRow( ValueMetaInterface valueMeta ) {
+  private ValueMetaInterface renameValueMetaIfInRow( ValueMetaInterface valueMeta, String originStep ) {
     // We want to rename the field to Name[2], Name[3], ...
     //
     int index = 1;
@@ -543,10 +518,12 @@ public class RowMeta implements RowMetaInterface {
     //
     ValueMetaInterface copy = valueMeta.clone();
 
-    // OK, this is the new name to pick
+    // OK, this is the new name and origin to pick
     //
     copy.setName( name );
-
+    if ( originStep != null ) {
+      copy.setOrigin( originStep );
+    }
     return copy;
   }
 
@@ -569,8 +546,7 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Write ONLY the specified data to the outputStream
    *
-   * @throws KettleFileException
-   *           in case things go awry
+   * @throws KettleFileException in case things go awry
    */
   @Override
   public void writeData( DataOutputStream outputStream, Object[] data ) throws KettleFileException {
@@ -594,8 +570,7 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Write ONLY the specified metadata to the outputStream
    *
-   * @throws KettleFileException
-   *           in case things go awry
+   * @throws KettleFileException in case things go awry
    */
   @Override
   public void writeMeta( DataOutputStream outputStream ) throws KettleFileException {
@@ -708,11 +683,9 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Get the string representation of the data in a row of data
    *
-   * @param row
-   *          the row of data to convert to string
+   * @param row the row of data to convert to string
    * @return the row of data in string form
-   * @throws KettleValueException
-   *           in case of a conversion error
+   * @throws KettleValueException in case of a conversion error
    */
   @Override
   public String getString( Object[] row ) throws KettleValueException {
@@ -732,8 +705,7 @@ public class RowMeta implements RowMetaInterface {
    * Get an array of strings showing the name of the values in the row padded to a maximum length, followed by the types
    * of the values.
    *
-   * @param maxlen
-   *          The length to which the name will be padded.
+   * @param maxlen The length to which the name will be padded.
    * @return an array of strings: the names and the types of the fieldnames in the row.
    */
   @Override
@@ -752,12 +724,9 @@ public class RowMeta implements RowMetaInterface {
    * Compare 2 rows with each other using certain values in the rows and also considering the specified ascending
    * clauses of the value metadata.
    *
-   * @param rowData1
-   *          The first row of data
-   * @param rowData2
-   *          The second row of data
-   * @param fieldnrs
-   *          the fields to compare on (in that order)
+   * @param rowData1 The first row of data
+   * @param rowData2 The second row of data
+   * @param fieldnrs the fields to compare on (in that order)
    * @return 0 if the rows are considered equal, -1 is data1 is smaller, 1 if data2 is smaller.
    * @throws KettleValueException
    */
@@ -779,12 +748,9 @@ public class RowMeta implements RowMetaInterface {
    * Compare 2 rows with each other for equality using certain values in the rows and also considering the case
    * sensitivity flag.
    *
-   * @param rowData1
-   *          The first row of data
-   * @param rowData2
-   *          The second row of data
-   * @param fieldnrs
-   *          the fields to compare on (in that order)
+   * @param rowData1 The first row of data
+   * @param rowData2 The second row of data
+   * @param fieldnrs the fields to compare on (in that order)
    * @return true if the rows are considered equal, false if they are not.
    * @throws KettleValueException
    */
@@ -806,19 +772,16 @@ public class RowMeta implements RowMetaInterface {
    * Compare 2 rows with each other using certain values in the rows and also considering the specified ascending
    * clauses of the value metadata.
    *
-   * @param rowData1
-   *          The first row of data
-   * @param rowData2
-   *          The second row of data
-   * @param fieldnrs1
-   *          The indexes of the values to compare in the first row
-   * @param fieldnrs2
-   *          The indexes of the values to compare with in the second row
+   * @param rowData1  The first row of data
+   * @param rowData2  The second row of data
+   * @param fieldnrs1 The indexes of the values to compare in the first row
+   * @param fieldnrs2 The indexes of the values to compare with in the second row
    * @return 0 if the rows are considered equal, -1 is data1 is smaller, 1 if data2 is smaller.
    * @throws KettleValueException
    */
   @Override
-  public int compare( Object[] rowData1, Object[] rowData2, int[] fieldnrs1, int[] fieldnrs2 ) throws KettleValueException {
+  public int compare( Object[] rowData1, Object[] rowData2, int[] fieldnrs1, int[] fieldnrs2 )
+    throws KettleValueException {
     int len = ( fieldnrs1.length < fieldnrs2.length ) ? fieldnrs1.length : fieldnrs2.length;
     for ( int i = 0; i < len; i++ ) {
       ValueMetaInterface valueMeta = getValueMeta( fieldnrs1[i] );
@@ -836,22 +799,17 @@ public class RowMeta implements RowMetaInterface {
    * Compare 2 rows with each other using certain values in the rows and also considering the specified ascending
    * clauses of the value metadata.
    *
-   * @param rowData1
-   *          The first row of data
-   * @param rowMeta2
-   *          the metadata of the second row of data
-   * @param rowData2
-   *          The second row of data
-   * @param fieldnrs1
-   *          The indexes of the values to compare in the first row
-   * @param fieldnrs2
-   *          The indexes of the values to compare with in the second row
+   * @param rowData1  The first row of data
+   * @param rowMeta2  the metadata of the second row of data
+   * @param rowData2  The second row of data
+   * @param fieldnrs1 The indexes of the values to compare in the first row
+   * @param fieldnrs2 The indexes of the values to compare with in the second row
    * @return 0 if the rows are considered equal, -1 is data1 is smaller, 1 if data2 is smaller.
    * @throws KettleValueException
    */
   @Override
   public int compare( Object[] rowData1, RowMetaInterface rowMeta2, Object[] rowData2, int[] fieldnrs1,
-    int[] fieldnrs2 ) throws KettleValueException {
+                      int[] fieldnrs2 ) throws KettleValueException {
     int len = ( fieldnrs1.length < fieldnrs2.length ) ? fieldnrs1.length : fieldnrs2.length;
     for ( int i = 0; i < len; i++ ) {
       ValueMetaInterface valueMeta1 = getValueMeta( fieldnrs1[i] );
@@ -870,10 +828,8 @@ public class RowMeta implements RowMetaInterface {
    * Compare 2 rows with each other using all values in the rows and also considering the specified ascending clauses of
    * the value metadata.
    *
-   * @param rowData1
-   *          The first row of data
-   * @param rowData2
-   *          The second row of data
+   * @param rowData1 The first row of data
+   * @param rowData2 The second row of data
    * @return 0 if the rows are considered equal, -1 is data1 is smaller, 1 if data2 is smaller.
    * @throws KettleValueException
    */
@@ -896,11 +852,9 @@ public class RowMeta implements RowMetaInterface {
    * the individual hashCodes which can result in a lot of collisions for similar types of data (e.g. [A,B] == [B,A] and
    * is not suitable for normal use. It is kept to provide backward compatibility with CombinationLookup.lookupValues()
    *
-   * @param rowData
-   *          The data to calculate a hashCode with
+   * @param rowData The data to calculate a hashCode with
    * @return the calculated hashCode
-   * @throws KettleValueException
-   *           in case there is a data conversion error
+   * @throws KettleValueException in case there is a data conversion error
    * @deprecated
    */
   @Override
@@ -924,11 +878,9 @@ public class RowMeta implements RowMetaInterface {
    * value (as Date yyyy-MM-dd), the hashCodes will be different resulting in the two rows not being considered equal
    * via the hashCode even though compare() or equals() might consider them to be.
    *
-   * @param rowData
-   *          The data to calculate a hashCode with
+   * @param rowData The data to calculate a hashCode with
    * @return the calculated hashCode
-   * @throws KettleValueException
-   *           in case there is a data conversion error
+   * @throws KettleValueException in case there is a data conversion error
    */
   @Override
   public int hashCode( Object[] rowData ) throws KettleValueException {
@@ -941,11 +893,9 @@ public class RowMeta implements RowMetaInterface {
    * ValueMeta converting them into the same value (e.g. ['2008-01-01:12:30'] and ['2008-01-01:00:00'] as Date
    * yyyy-MM-dd)
    *
-   * @param rowData
-   *          The data to calculate a hashCode with
+   * @param rowData The data to calculate a hashCode with
    * @return the calculated hashCode
-   * @throws KettleValueException
-   *           in case there is a data conversion error
+   * @throws KettleValueException in case there is a data conversion error
    */
   @Override
   public int convertedValuesHashCode( Object[] rowData ) throws KettleValueException {
@@ -963,10 +913,8 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Serialize a row of data to byte[]
    *
-   * @param metadata
-   *          the metadata to use
-   * @param row
-   *          the row of data
+   * @param metadata the metadata to use
+   * @param row      the row of data
    * @return a serialized form of the data as a byte array
    */
   public static final byte[] extractData( RowMetaInterface metadata, Object[] row ) {
@@ -985,10 +933,8 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Create a row of data bases on a serialized format (byte[])
    *
-   * @param data
-   *          the serialized data
-   * @param metadata
-   *          the metadata to use
+   * @param data     the serialized data
+   * @param metadata the metadata to use
    * @return a new row of data
    */
   public static final Object[] getRow( RowMetaInterface metadata, byte[] data ) {
@@ -1017,8 +963,7 @@ public class RowMeta implements RowMetaInterface {
 
   /**
    * @return an XML representation of the row metadata
-   * @throws IOException
-   *           Thrown in case there is an (Base64/GZip) encoding problem
+   * @throws IOException Thrown in case there is an (Base64/GZip) encoding problem
    */
   @Override
   public String getMetaXML() throws IOException {
@@ -1038,10 +983,8 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Create a new row metadata object from XML
    *
-   * @param node
-   *          the XML node to deserialize from
-   * @throws IOException
-   *           Thrown in case there is an (Base64/GZip) decoding problem
+   * @param node the XML node to deserialize from
+   * @throws IOException Thrown in case there is an (Base64/GZip) decoding problem
    */
   public RowMeta( Node node ) throws KettleException {
     this();
@@ -1053,11 +996,9 @@ public class RowMeta implements RowMetaInterface {
   }
 
   /**
-   * @param rowData
-   *          the row of data to serialize as XML
+   * @param rowData the row of data to serialize as XML
    * @return an XML representation of the row data
-   * @throws IOException
-   *           Thrown in case there is an (Base64/GZip) encoding problem
+   * @throws IOException Thrown in case there is an (Base64/GZip) encoding problem
    */
   @Override
   public String getDataXML( Object[] rowData ) throws IOException {
@@ -1077,11 +1018,9 @@ public class RowMeta implements RowMetaInterface {
   /**
    * Convert an XML node into binary data using the row metadata supplied.
    *
-   * @param node
-   *          The data row node
-   * @throws IOException
-   *           Thrown in case there is an (Base64/GZip) decoding problem
+   * @param node The data row node
    * @return a row of data, converted from XML
+   * @throws IOException Thrown in case there is an (Base64/GZip) decoding problem
    */
   @Override
   public Object[] getRow( Node node ) throws KettleException {

--- a/core/src/org/pentaho/di/core/row/RowMetaInterface.java
+++ b/core/src/org/pentaho/di/core/row/RowMetaInterface.java
@@ -367,7 +367,17 @@ public interface RowMetaInterface extends Cloneable {
    * @param r
    *          The row to be merged with this row
    */
+  @Deprecated
   public void mergeRowMeta( RowMetaInterface r );
+
+  /**
+   * Merge the values of row r to this Row. The values that are not yet in the row are added unchanged. The values that
+   * are in the row are renamed to name[2], name[3], etc.
+   *
+   * @param r
+   *          The row to be merged with this row
+   */
+  public void mergeRowMeta( RowMetaInterface r, String originStepName );
 
   /**
    * Get an array of the names of all the Values in the Row.

--- a/core/test-src/org/pentaho/di/core/row/RowMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/row/RowMetaTest.java
@@ -53,7 +53,9 @@ public class RowMetaTest {
   private List<ValueMetaInterface> generateVList( String[] names, int[] types ) throws KettlePluginException {
     List<ValueMetaInterface> list = new ArrayList<ValueMetaInterface>();
     for ( int i = 0; i < names.length; i++ ) {
-      list.add( ValueMetaFactory.createValueMeta( names[i], types[i] ) );
+      ValueMetaInterface vm = ValueMetaFactory.createValueMeta( names[i], types[i] );
+      vm.setOrigin( "originStep" );
+      list.add( vm );
     }
     return list;
   }
@@ -68,7 +70,7 @@ public class RowMetaTest {
 
   @Test
   public void testSetValueMetaList() throws KettlePluginException {
-    List<ValueMetaInterface> setList = this.generateVList( new String[] { "alpha", "bravo" }, new int[] { 2, 2 } );
+    List<ValueMetaInterface> setList = this.generateVList( new String[]{ "alpha", "bravo" }, new int[]{ 2, 2 } );
     rowMeta.setValueMetaList( setList );
     assertTrue( setList.contains( rowMeta.searchValueMeta( "alpha" ) ) );
     assertTrue( setList.contains( rowMeta.searchValueMeta( "bravo" ) ) );
@@ -80,7 +82,7 @@ public class RowMetaTest {
 
   @Test
   public void testSetValueMetaListNullName() throws KettlePluginException {
-    List<ValueMetaInterface> setList = this.generateVList( new String[] { "alpha", null }, new int[] { 2, 2 } );
+    List<ValueMetaInterface> setList = this.generateVList( new String[]{ "alpha", null }, new int[]{ 2, 2 } );
     rowMeta.setValueMetaList( setList );
     assertTrue( setList.contains( rowMeta.searchValueMeta( "alpha" ) ) );
     assertFalse( setList.contains( rowMeta.searchValueMeta( null ) ) );
@@ -90,7 +92,7 @@ public class RowMetaTest {
     assertEquals( -1, rowMeta.indexOfValue( null ) );
   }
 
-  @Test(expected=UnsupportedOperationException.class)
+  @Test( expected = UnsupportedOperationException.class )
   public void testDeSynchronizationModifyingOriginalList() {
     // remember 0-based arrays
     int size = rowMeta.size();
@@ -173,7 +175,7 @@ public class RowMetaTest {
   @Test
   public void testAddRowMeta() throws KettlePluginException {
     List<ValueMetaInterface> list =
-        this.generateVList( new String[] { "alfa", "bravo", "charly", "delta" }, new int[] { 2, 2, 3, 4 } );
+      this.generateVList( new String[]{ "alfa", "bravo", "charly", "delta" }, new int[]{ 2, 2, 3, 4 } );
     RowMeta added = new RowMeta();
     added.setValueMetaList( list );
     rowMeta.addRowMeta( added );
@@ -185,7 +187,7 @@ public class RowMetaTest {
   @Test
   public void testMergeRowMeta() throws KettlePluginException {
     List<ValueMetaInterface> list =
-        this.generateVList( new String[] { "phobos", "demos", "mars" }, new int[] { 6, 6, 6 } );
+      this.generateVList( new String[]{ "phobos", "demos", "mars" }, new int[]{ 6, 6, 6 } );
     list.add( 1, integer );
     RowMeta toMerge = new RowMeta();
     toMerge.setValueMetaList( list );
@@ -266,7 +268,7 @@ public class RowMetaTest {
     ValueMetaInterface searchFor = null;
     for ( int i = 0; i < 100000; i++ ) {
       ValueMetaInterface vm =
-          ValueMetaFactory.createValueMeta( UUID.randomUUID().toString(), ValueMetaInterface.TYPE_STRING );
+        ValueMetaFactory.createValueMeta( UUID.randomUUID().toString(), ValueMetaInterface.TYPE_STRING );
       rowMeta.addValueMeta( vm );
       if ( i == 50000 ) {
         searchFor = vm;
@@ -290,7 +292,7 @@ public class RowMetaTest {
     // System.out.println( time1 + ", " + time2 );
 
     assertTrue( "array search is slower then current implementation : " + "for array list: " + time1
-        + ", for hashed rowMeta: " + time2, time1 > time2 );
+      + ", for hashed rowMeta: " + time2, time1 > time2 );
   }
 
   // @Test
@@ -301,7 +303,7 @@ public class RowMetaTest {
     List<ValueMetaInterface> pre = new ArrayList<ValueMetaInterface>( 100000 );
     for ( int i = 0; i < 100000; i++ ) {
       ValueMetaInterface vm =
-          ValueMetaFactory.createValueMeta( UUID.randomUUID().toString(), ValueMetaInterface.TYPE_STRING );
+        ValueMetaFactory.createValueMeta( UUID.randomUUID().toString(), ValueMetaInterface.TYPE_STRING );
       pre.add( vm );
     }
 
@@ -329,6 +331,37 @@ public class RowMetaTest {
 
     // let say finally it is not 10 times slower :(
     assertTrue( "it is not 10 times slower than for original arrayList", time1 * 10 > time2 );
+  }
+
+  @Test
+  public void testMergeRowMetaWithOriginStep() throws Exception {
+
+    List<ValueMetaInterface> list =
+      this.generateVList( new String[]{ "phobos", "demos", "mars" }, new int[]{ 6, 6, 6 } );
+    list.add( 1, integer );
+    RowMeta toMerge = new RowMeta();
+    toMerge.setValueMetaList( list );
+
+    rowMeta.mergeRowMeta( toMerge, "newOriginStep" );
+    assertEquals( 7, rowMeta.size() );
+
+    list = rowMeta.getValueMetaList();
+    assertTrue( list.contains( integer ) );
+    ValueMetaInterface found = null;
+    ValueMetaInterface other = null;
+    for ( ValueMetaInterface vm : list ) {
+      if ( vm.getName().equals( "integer_1" ) ) {
+        found = vm;
+        break;
+      } else {
+        other = vm;
+      }
+    }
+    assertNotNull( found );
+    assertEquals( found.getOrigin(), "newOriginStep" );
+    assertNotNull( other );
+    assertEquals( other.getOrigin(), "originStep" );
+
   }
 
 }

--- a/engine/src/org/pentaho/di/trans/steps/mergejoin/MergeJoinMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/mergejoin/MergeJoinMeta.java
@@ -32,6 +32,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -83,8 +84,7 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
   /**
    * Sets the type of join
    *
-   * @param joinType
-   *          The type of join, e.g. INNER/FULL OUTER
+   * @param joinType The type of join, e.g. INNER/FULL OUTER
    */
   public void setJoinType( String joinType ) {
     this.joinType = joinType;
@@ -98,8 +98,7 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param keyFields1
-   *          The keyFields1 to set.
+   * @param keyFields1 The keyFields1 to set.
    */
   public void setKeyFields1( String[] keyFields1 ) {
     this.keyFields1 = keyFields1;
@@ -113,8 +112,7 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param keyFields2
-   *          The keyFields2 to set.
+   * @param keyFields2 The keyFields2 to set.
    */
   public void setKeyFields2( String[] keyFields2 ) {
     this.keyFields2 = keyFields2;
@@ -255,8 +253,8 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta,
-    RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
-    Repository repository, IMetaStore metaStore ) {
+                     RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
+                     Repository repository, IMetaStore metaStore ) {
     /*
      * @todo Need to check for the following: 1) Join type must be one of INNER / LEFT OUTER / RIGHT OUTER / FULL OUTER
      * 2) Number of input streams must be two (for now at least) 3) The field names of input streams must be unique
@@ -268,26 +266,29 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   public void getFields( RowMetaInterface r, String name, RowMetaInterface[] info, StepMeta nextStep,
-    VariableSpace space, Repository repository, IMetaStore metaStore ) throws KettleStepException {
+                         VariableSpace space, Repository repository, IMetaStore metaStore ) throws KettleStepException {
     // We don't have any input fields here in "r" as they are all info fields.
     // So we just merge in the info fields.
     //
     if ( info != null ) {
       for ( int i = 0; i < info.length; i++ ) {
         if ( info[i] != null ) {
-          r.mergeRowMeta( info[i] );
+          r.mergeRowMeta( info[i], name );
         }
       }
     }
 
     for ( int i = 0; i < r.size(); i++ ) {
-      r.getValueMeta( i ).setOrigin( name );
+      ValueMetaInterface vmi = r.getValueMeta( i );
+      if ( vmi != null && Const.isEmpty( vmi.getName() ) ) {
+        vmi.setOrigin( name );
+      }
     }
     return;
   }
 
   public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int cnr, TransMeta tr,
-    Trans trans ) {
+                                Trans trans ) {
     return new MergeJoin( stepMeta, stepDataInterface, cnr, tr, trans );
   }
 
@@ -317,6 +318,6 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   public TransformationType[] getSupportedTransformationTypes() {
-    return new TransformationType[] { TransformationType.Normal, };
+    return new TransformationType[]{ TransformationType.Normal, };
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/mergejoin/MergeJoinMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/mergejoin/MergeJoinMetaTest.java
@@ -1,0 +1,147 @@
+package org.pentaho.di.trans.steps.mergejoin;
+
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
+import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidatorFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+public class MergeJoinMetaTest {
+
+  LoadSaveTester loadSaveTester;
+
+  public MergeJoinMetaTest() {
+    //SwitchCaseMeta bean-like attributes
+    List<String> attributes = Arrays.asList( "joinType", "keyFields1", "keyFields2" );
+
+    Map<String, FieldLoadSaveValidator<?>> attrValidatorMap = new HashMap<String, FieldLoadSaveValidator<?>>();
+
+    Map<String, FieldLoadSaveValidator<?>> typeValidatorMap = new HashMap<String, FieldLoadSaveValidator<?>>();
+
+    Map<String, String> getterMap = new HashMap<String, String>();
+    getterMap.put( "joinType", "getJoinType" );
+    getterMap.put( "keyFields1", "getKeyFields1" );
+    getterMap.put( "keyFields2", "getKeyFields2" );
+
+    Map<String, String> setterMap = new HashMap<String, String>();
+    setterMap.put( "joinType", "setJoinType" );
+    setterMap.put( "keyFields1", "setKeyFields1" );
+    setterMap.put( "keyFields2", "setKeyFields2" );
+
+    this.loadSaveTester = new LoadSaveTester( MergeJoinMeta.class,
+      attributes,
+      getterMap, setterMap,
+      attrValidatorMap, typeValidatorMap );
+
+    FieldLoadSaveValidatorFactory validatorFactory = loadSaveTester.getFieldLoadSaveValidatorFactory();
+
+    FieldLoadSaveValidator<MergeJoinMeta> targetValidator = new FieldLoadSaveValidator<MergeJoinMeta>() {
+
+      @Override
+      public MergeJoinMeta getTestObject() {
+        return new MergeJoinMeta() {
+          {
+            setJoinType( join_types[0] );
+            setKeyFields1( new String[]{ "field1", "field2" } );
+            setKeyFields2( new String[]{ "field1", "field3" } );
+          }
+        };
+      }
+
+      @Override
+      public boolean validateTestObject( MergeJoinMeta testObject, Object actual ) {
+        return testObject.getJoinType().equals( ( (MergeJoinMeta) actual ).getJoinType() )
+          && Arrays.equals( testObject.getKeyFields1(), ( (MergeJoinMeta) actual ).getKeyFields1() )
+          && Arrays.equals( testObject.getKeyFields2(), ( (MergeJoinMeta) actual ).getKeyFields2() );
+      }
+    };
+
+    validatorFactory.registerValidator( validatorFactory.getName( MergeJoinMeta.class ), targetValidator );
+  }
+
+  @Test
+  public void testLoadSaveXML() throws KettleException {
+    loadSaveTester.testXmlRoundTrip();
+  }
+
+  @Test
+  public void testLoadSaveRepo() throws KettleException {
+    loadSaveTester.testRepoRoundTrip();
+  }
+
+  @Test
+  public void testGetFieldsEmptyInput() throws Exception {
+    RowMeta outputRowMeta = new RowMeta();
+    MergeJoinMeta meta = new MergeJoinMeta();
+
+    RowMeta inputRow1 = new RowMeta();
+    ValueMetaInteger field1_row1 = new ValueMetaInteger( "field1" );
+    field1_row1.setOrigin( "inputStep1" );
+    inputRow1.addValueMeta( field1_row1 );
+    ValueMetaString field2_row1 = new ValueMetaString( "field2" );
+    field2_row1.setOrigin( "inputStep1" );
+    inputRow1.addValueMeta( field2_row1 );
+
+    RowMeta inputRow2 = new RowMeta();
+    ValueMetaString field1_row2 = new ValueMetaString( "field1" );
+    field1_row2.setOrigin( "inputStep2" );
+    inputRow2.addValueMeta( field1_row2 );
+    ValueMetaString field3_row2 = new ValueMetaString( "field3" );
+    field3_row2.setOrigin( "inputStep2" );
+    inputRow2.addValueMeta( field3_row2 );
+
+    StepMeta stepMeta = new StepMeta( "Merge", meta );
+
+    meta.getFields( outputRowMeta, "Merge Join",
+      new RowMetaInterface[]{ inputRow1, inputRow2 }, stepMeta, new Variables(), null, null );
+
+    assertNotNull( outputRowMeta );
+    assertFalse( outputRowMeta.isEmpty() );
+    assertEquals( 4, outputRowMeta.size() );
+    List<ValueMetaInterface> vmi = outputRowMeta.getValueMetaList();
+    assertNotNull( vmi );
+    // Proceed in order
+    ValueMetaInterface field1 = outputRowMeta.getValueMeta( 0 );
+    assertNotNull( field1 );
+    assertEquals( "field1", field1.getName() );
+    assertTrue( field1 instanceof ValueMetaInteger );
+    assertEquals( "inputStep1", field1.getOrigin() );
+
+    ValueMetaInterface field2 = outputRowMeta.getValueMeta( 1 );
+    assertNotNull( field2 );
+    assertEquals( "field2", field2.getName() );
+    assertTrue( field2 instanceof ValueMetaString );
+    assertEquals( "inputStep1", field2.getOrigin() );
+
+    ValueMetaInterface field1_1 = outputRowMeta.getValueMeta( 2 );
+    assertNotNull( field1_1 );
+    assertEquals( "field1_1", field1_1.getName() );
+    assertTrue( field1_1 instanceof ValueMetaString );
+    assertEquals( "Merge Join", field1_1.getOrigin() );
+
+    ValueMetaInterface field3 = outputRowMeta.getValueMeta( 3 );
+    assertNotNull( field3 );
+    assertEquals( "field3", field3.getName() );
+    assertTrue( field3 instanceof ValueMetaString );
+    assertEquals( "inputStep2", field3.getOrigin() );
+
+  }
+}


### PR DESCRIPTION
I deprecated one API method in RowMetaInterface and added a new one (delegating the old to the new), but since this is for 6.0 I figured it was ok.

This change allows the origin step for fields to be retained even if in info streams, and if they are renamed then the origin step is set as the one that is passed in. For this Jira case, I only updated Merge Join. In the future we can change other steps (Join Rows, e.g.) to use the new API method and pass its own name in as the origin.

@mattcasters @hudak @rfellows Do you mind reviewing this? Thanks!

P.S. Sorry about the inline Checkstyle changes, I have a habit of typing quickly then hitting the AutoFormat key combo to get it pretty...