### PR TITLE
[PDI-11388] - FTPx settings not retested in Dialog

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/ftpsget/FTPSConnection.java
+++ b/engine/src/org/pentaho/di/job/entries/ftpsget/FTPSConnection.java
@@ -156,6 +156,7 @@ public class FTPSConnection implements FTPListener {
       connection.addFTPStatusListener( this );
       connection.connect();
     } catch ( Exception e ) {
+      connection = null;
       throw new KettleException( BaseMessages.getString( PKG, "JobFTPS.Error.Connecting", hostName ), e );
     }
   }

--- a/engine/src/org/pentaho/di/job/entries/sftp/SFTPClient.java
+++ b/engine/src/org/pentaho/di/job/entries/sftp/SFTPClient.java
@@ -359,8 +359,12 @@ public class SFTPClient {
   }
 
   public void disconnect() {
-    c.disconnect();
-    s.disconnect();
+    if ( c != null ) {
+      c.disconnect();
+    }
+    if ( s != null ) {
+      s.disconnect();
+    }
   }
 
   public String GetPrivateKeyFileName() {

--- a/ui/src/org/pentaho/di/ui/job/entries/ftpdelete/JobEntryFTPDeleteDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/ftpdelete/JobEntryFTPDeleteDialog.java
@@ -1260,6 +1260,15 @@ public class JobEntryFTPDeleteDialog extends JobEntryDialog implements JobEntryD
       }
       retval = true;
     } catch ( Exception e ) {
+      if ( ftpclient != null ) {
+        try {
+          ftpclient.quit();
+        } catch ( Exception ignored ) {
+          // We've tried quitting the FTP Client exception
+          // nothing else to be done if the FTP Client was already disconnected
+        }
+        ftpclient = null;
+      }
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobFTPDelete.ErrorConnect.NOK", e.getMessage() ) + Const.CR );
       mb.setText( BaseMessages.getString( PKG, "JobFTPDelete.ErrorConnect.Title.Bad" ) );
@@ -1307,6 +1316,15 @@ public class JobEntryFTPDeleteDialog extends JobEntryDialog implements JobEntryD
       }
       retval = true;
     } catch ( Exception e ) {
+      if ( ftpsclient != null ) {
+        try {
+          ftpsclient.disconnect();
+        } catch ( Exception ignored ) {
+          // We've tried quitting the FTPS Client exception
+          // nothing else to be done if the FTPS Client was already disconnected
+        }
+        ftpsclient = null;
+      }
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobFTPDelete.ErrorConnect.NOK", e.getMessage() ) + Const.CR );
       mb.setText( BaseMessages.getString( PKG, "JobFTPDelete.ErrorConnect.Title.Bad" ) );
@@ -1332,6 +1350,15 @@ public class JobEntryFTPDeleteDialog extends JobEntryDialog implements JobEntryD
 
       retval = true;
     } catch ( Exception e ) {
+      if ( sftpclient != null ) {
+        try {
+          sftpclient.disconnect();
+        } catch ( Exception ignored ) {
+          // We've tried quitting the SFTP Client exception
+          // nothing else to be done if the SFTP Client was already disconnected
+        }
+        sftpclient = null;
+      }
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobFTPDelete.ErrorConnect.NOK", e.getMessage() ) + Const.CR );
       mb.setText( BaseMessages.getString( PKG, "JobFTPDelete.ErrorConnect.Title.Bad" ) );
@@ -1381,6 +1408,15 @@ public class JobEntryFTPDeleteDialog extends JobEntryDialog implements JobEntryD
 
       retval = true;
     } catch ( Exception e ) {
+      if ( conn != null ) {
+        try {
+          conn.close();
+        } catch ( Exception ignored ) {
+          // We've tried quitting the SSH Client exception
+          // nothing else to be done if the SSH Client was already disconnected
+        }
+        conn = null;
+      }
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobFTPDelete.ErrorConnect.NOK", e.getMessage() ) + Const.CR );
       mb.setText( BaseMessages.getString( PKG, "JobFTPDelete.ErrorConnect.Title.Bad" ) );

--- a/ui/src/org/pentaho/di/ui/job/entries/ftpput/JobEntryFTPPUTDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/ftpput/JobEntryFTPPUTDialog.java
@@ -1076,6 +1076,15 @@ public class JobEntryFTPPUTDialog extends JobEntryDialog implements JobEntryDial
 
       retval = true;
     } catch ( Exception e ) {
+      if ( ftpclient != null ) {
+        try {
+          ftpclient.quit();
+        } catch ( Exception ignored ) {
+          // We've tried quitting the FTP Client exception
+          // nothing else can be done if the FTP Client was already disconnected
+        }
+        ftpclient = null;
+      }
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobFTPPUT.ErrorConnect.NOK", e.getMessage() ) + Const.CR );
       mb.setText( BaseMessages.getString( PKG, "JobFTPPUT.ErrorConnect.Title.Bad" ) );

--- a/ui/src/org/pentaho/di/ui/job/entries/ftpsget/JobEntryFTPSGetDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/ftpsget/JobEntryFTPSGetDialog.java
@@ -1355,6 +1355,15 @@ public class JobEntryFTPSGetDialog extends JobEntryDialog implements JobEntryDia
 
     } catch ( Exception e ) {
       retval = false;
+      if ( connection != null ) {
+        try {
+          connection.disconnect();
+        } catch ( Exception ignored ) {
+          // We've tried quitting the FTPS Client exception
+          // nothing else to be done if the FTPS Client was already disconnected
+        }
+        connection = null;
+      }
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobFTPS.ErrorConnect.NOK", e.getMessage() ) + Const.CR );
       mb.setText( BaseMessages.getString( PKG, "JobFTPS.ErrorConnect.Title.Bad" ) );

--- a/ui/src/org/pentaho/di/ui/job/entries/ftpsput/JobEntryFTPSPUTDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/ftpsput/JobEntryFTPSPUTDialog.java
@@ -900,7 +900,6 @@ public class JobEntryFTPSPUTDialog extends JobEntryDialog implements JobEntryDia
   }
 
   private boolean connectToFTP( boolean checkfolder, String remoteFoldername ) {
-    boolean retval = false;
     try {
       String realServername = jobMeta.environmentSubstitute( wServerName.getText() );
       int realPort = Const.toInt( jobMeta.environmentSubstitute( wServerPort.getText() ), 0 );
@@ -940,17 +939,26 @@ public class JobEntryFTPSPUTDialog extends JobEntryDialog implements JobEntryDia
         // move to spool dir ...
         if ( !Const.isEmpty( remoteFoldername ) ) {
           String realFtpDirectory = jobMeta.environmentSubstitute( remoteFoldername );
-          retval = connection.isDirectoryExists( realFtpDirectory );
+          return connection.isDirectoryExists( realFtpDirectory );
         }
       }
-      retval = true;
+      return true;
     } catch ( Exception e ) {
+      if ( connection != null ) {
+        try {
+          connection.disconnect();
+        } catch ( Exception ignored ) {
+          // We've tried quitting the FTPS Client exception
+          // nothing else to be done if the FTPS Client was already disconnected
+        }
+        connection = null;
+      }
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobFTPSPUT.ErrorConnect.NOK", e.getMessage() ) + Const.CR );
       mb.setText( BaseMessages.getString( PKG, "JobFTPSPUT.ErrorConnect.Title.Bad" ) );
       mb.open();
     }
-    return retval;
+    return false;
   }
 
   public void dispose() {

--- a/ui/src/org/pentaho/di/ui/job/entries/sftp/JobEntrySFTPDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/sftp/JobEntrySFTPDialog.java
@@ -1014,6 +1014,15 @@ public class JobEntrySFTPDialog extends JobEntryDialog implements JobEntryDialog
         retval = sftpclient.folderExists( Remotefoldername );
       }
     } catch ( Exception e ) {
+      if ( sftpclient != null ) {
+        try {
+          sftpclient.disconnect();
+        } catch ( Exception ignored ) {
+          // We've tried quitting the SFTP Client exception
+          // nothing else to be done if the SFTP Client was already disconnected
+        }
+        sftpclient = null;
+      }
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobSFTP.ErrorConnect.NOK", wServerName.getText(), e
         .getMessage() )

--- a/ui/src/org/pentaho/di/ui/job/entries/sftpput/JobEntrySFTPPUTDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/sftpput/JobEntrySFTPPUTDialog.java
@@ -1165,6 +1165,15 @@ public class JobEntrySFTPPUTDialog extends JobEntryDialog implements JobEntryDia
       }
 
     } catch ( Exception e ) {
+      if ( sftpclient != null ) {
+        try {
+          sftpclient.disconnect();
+        } catch ( Exception ignored ) {
+          // We've tried quitting the SFTP Client exception
+          // nothing else to be done if the SFTP Client was already disconnected
+        }
+        sftpclient = null;
+      }
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobSFTPPUT.ErrorConnect.NOK", wServerName.getText(), e
         .getMessage() )


### PR DESCRIPTION
In several FTP, SFTP, and FTPS job entries, when clicking the Test Connection button, the job entry does not retest the connection after the first test is completed.

This fixes false-positive connections resulting from the test.