### PR TITLE
[TEST]Handle concurrent registration of lifecycle listeners

### DIFF
--- a/engine/src/org/pentaho/di/core/KettleEnvironment.java
+++ b/engine/src/org/pentaho/di/core/KettleEnvironment.java
@@ -22,6 +22,8 @@
 
 package org.pentaho.di.core;
 
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.SettableFuture;
 import org.pentaho.di.core.auth.AuthenticationConsumerPluginType;
 import org.pentaho.di.core.auth.AuthenticationProviderPluginType;
 import org.pentaho.di.core.compress.CompressionPluginType;
@@ -43,6 +45,9 @@ import org.pentaho.di.repository.IUser;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.step.RowDistributionPluginType;
 
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * The KettleEnvironment class contains settings and properties for all of Kettle. Initialization of the environment is
  * done by calling the init() method, which reads in properties file(s), registers plugins, etc. Initialization should
@@ -54,7 +59,7 @@ public class KettleEnvironment {
   private static Class<?> PKG = Const.class; // for i18n purposes, needed by Translator2!!
 
   /** Indicates whether the Kettle environment has been initialized. */
-  private static Boolean initialized;
+  private static AtomicReference<SettableFuture<Boolean>> initialized = new AtomicReference<SettableFuture<Boolean>>( null );
   private static KettleLifecycleSupport kettleLifecycleSupport;
 
   /**
@@ -84,7 +89,8 @@ public class KettleEnvironment {
    *           Any errors that occur during initialization will throw a KettleException.
    */
   public static void init( boolean simpleJndi ) throws KettleException {
-    if ( initialized == null ) {
+    SettableFuture<Boolean> ready;
+    if ( initialized.compareAndSet( null, ready = SettableFuture.create() ) ) {
 
       // This creates .kettle and kettle.properties...
       //
@@ -122,8 +128,17 @@ public class KettleEnvironment {
       // Initialize the Lifecycle Listeners
       //
       initLifecycleListeners();
-
-      initialized = true;
+      ready.set( true );
+    } else {
+      // A different thread is initializing
+      ready = initialized.get();
+      // Block until environment is initialized
+      try {
+        ready.get();
+      } catch ( Throwable e ) {
+        Throwables.propagateIfPossible( e );
+        throw new KettleException( e );
+      }
     }
   }
 
@@ -168,10 +183,11 @@ public class KettleEnvironment {
    * @return true if initialized, false otherwise
    */
   public static boolean isInitialized() {
-    if ( initialized == null ) {
+    Future<Boolean> future = initialized.get();
+    try {
+      return future != null && future.get();
+    } catch ( Throwable e ) {
       return false;
-    } else {
-      return true;
     }
   }
 

--- a/engine/src/org/pentaho/di/core/lifecycle/LifecycleSupport.java
+++ b/engine/src/org/pentaho/di/core/lifecycle/LifecycleSupport.java
@@ -22,11 +22,7 @@
 
 package org.pentaho.di.core.lifecycle;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.plugins.LifecyclePluginType;
@@ -35,7 +31,13 @@ import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.PluginTypeInterface;
 import org.pentaho.di.core.plugins.PluginTypeListener;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 public class LifecycleSupport {
+  @VisibleForTesting protected static PluginRegistry registry = PluginRegistry.getInstance();
   private Set<LifecycleListener> lifeListeners;
   private boolean started;
   private LifeEventHandler handler;
@@ -85,7 +87,6 @@ public class LifecycleSupport {
    */
   static <T> Set<T> loadPlugins( Class<? extends PluginTypeInterface> pluginType, Class<T> mainPluginClass ) {
     Set<T> pluginInstances = new HashSet<T>();
-    PluginRegistry registry = PluginRegistry.getInstance();
     List<PluginInterface> plugins = registry.getPlugins( pluginType );
     for ( PluginInterface plugin : plugins ) {
       try {

--- a/engine/test-src/org/pentaho/di/core/lifecycle/KettleLifecycleSupportTest.java
+++ b/engine/test-src/org/pentaho/di/core/lifecycle/KettleLifecycleSupportTest.java
@@ -1,0 +1,83 @@
+package org.pentaho.di.core.lifecycle;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.pentaho.di.core.plugins.KettleLifecyclePluginType;
+import org.pentaho.di.core.plugins.PluginInterface;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.plugins.PluginTypeListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class KettleLifecycleSupportTest {
+
+  private PluginRegistry registry;
+  private List<PluginInterface> registeredPlugins;
+  private ArgumentCaptor<PluginTypeListener> typeListenerRegistration;
+
+  @Before
+  public void setUpPluginRegistry() throws Exception {
+    // Intercept access to registry
+    registry = LifecycleSupport.registry = KettleLifecycleSupport.registry = mock( PluginRegistry.class );
+    registeredPlugins = new ArrayList<PluginInterface>();
+    when( registry.getPlugins( KettleLifecyclePluginType.class ) ).thenReturn( registeredPlugins );
+    typeListenerRegistration = ArgumentCaptor.forClass( PluginTypeListener.class );
+    doNothing().when( registry ).addPluginListener( eq( KettleLifecyclePluginType.class ), typeListenerRegistration.capture() );
+  }
+
+  @Test
+  public void testOnEnvironmentInit() throws Exception {
+    final List<KettleLifecycleListener> listeners = new ArrayList<KettleLifecycleListener>();
+    listeners.add(  createLifecycleListener() );
+    KettleLifecycleSupport kettleLifecycleSupport = new KettleLifecycleSupport();
+    assertNotNull( typeListenerRegistration.getValue() );
+
+    KettleLifecycleListener preInit = createLifecycleListener();
+    listeners.add( preInit );
+    doAnswer( new Answer() {
+      @Override public Object answer( InvocationOnMock invocation ) throws Throwable {
+        listeners.add( createLifecycleListener() );
+        return null;
+      }
+    } ).when( preInit ).onEnvironmentInit();
+
+    verifyNoMoreInteractions( listeners.toArray() );
+
+    // Init environment
+    kettleLifecycleSupport.onEnvironmentInit();
+    for ( KettleLifecycleListener listener : listeners ) {
+      verify( listener ).onEnvironmentInit();
+    }
+    verifyNoMoreInteractions( listeners.toArray() );
+
+    KettleLifecycleListener postInit = createLifecycleListener();
+    verify( postInit ).onEnvironmentInit();
+
+    verifyNoMoreInteractions( listeners.toArray() );
+  }
+
+  private KettleLifecycleListener createLifecycleListener() throws org.pentaho.di.core.exception.KettlePluginException {
+    PluginInterface pluginInterface = mock( PluginInterface.class );
+    KettleLifecycleListener kettleLifecycleListener = mock( KettleLifecycleListener.class );
+    registeredPlugins.add( pluginInterface );
+    when( registry.loadClass( pluginInterface, KettleLifecycleListener.class ) ).thenReturn( kettleLifecycleListener );
+    when( registry.loadClass( pluginInterface ) ).thenReturn( kettleLifecycleListener );
+    if( !typeListenerRegistration.getAllValues().isEmpty() ) {
+      typeListenerRegistration.getValue().pluginAdded( pluginInterface );
+    }
+    return kettleLifecycleListener;
+  }
+}


### PR DESCRIPTION
Environment init fails when KettleLifecycleListeners are registered while environment init is in progress