### PR TITLE
[PDI-12278]: MonetDB Bulk Loader error with MonetDB Jan 2014-SP2 bugfix  release

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDBBulkLoader.java
+++ b/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDBBulkLoader.java
@@ -157,6 +157,7 @@ public class MonetDBBulkLoader extends BaseStep implements StepInterface {
           db.disconnect();
         }
       }
+      meta.setCompatibilityDbVersionMode();
     } catch ( Exception ex ) {
       throw new KettleException( ex );
     }
@@ -502,12 +503,16 @@ public class MonetDBBulkLoader extends BaseStep implements StepInterface {
       if ( error != null ) {
         throw new KettleException( "Error loading data: " + error );
       }
-      data.out.writeLine( "" );
 
-      // and again, making sure we commit all the records
-      error = data.in.waitForPrompt();
-      if ( error != null ) {
-        throw new KettleException( "Error loading data: " + error );
+      if ( !meta.isCompatibilityDbVersionMode() ) {
+        // write an empty line, forces the flush of the stream
+        data.out.writeLine( "" );
+
+        // again...
+        error = data.in.waitForPrompt();
+        if ( error != null ) {
+          throw new KettleException( "Error loading data: " + error );
+        }
       }
 
       if ( log.isRowLevel() ) {

--- a/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDbVersion.java
+++ b/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDbVersion.java
@@ -1,0 +1,184 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.monetdbbulkloader;
+
+import static java.util.regex.Pattern.compile;
+
+import java.util.regex.Pattern;
+
+import org.pentaho.di.i18n.BaseMessages;
+
+/**
+ * @author Tatsiana_Kasiankova
+ * 
+ */
+public class MonetDbVersion implements Comparable<MonetDbVersion> {
+  private static Class<?> PKG = MonetDbVersion.class; // for i18n purposes, needed by Translator2!!
+
+  private Integer minorVersion;
+
+  private Integer majorVersion;
+
+  private Integer patchVersion;
+
+  private static final String SEPARATOR = "\\.";
+
+  /**
+   * The pattern to determine if the given string is a valid MonetDB version in the assumption that it should contain
+   * only digits separated by dots. Ideally version should be represented as
+   * <p>
+   * <code>majorVersion.minorVersion.patchVersion</code>
+   * <p>
+   * But also we could have any additional groups of digits after <code>patchVersion</code>. Or have only major and
+   * minor version parts.
+   * <p>
+   * <b>Examples of valid MonetDB versions:</b>
+   * <p>
+   * <code>
+   * <p>11.17.17
+   * <p>11.0
+   * <p>11.5.17.1
+   * </code>
+   * 
+   */
+  private static final Pattern VERSION_PATTERN = compile( "^[0-9]+(\\.[0-9]+)*$" );
+
+  /**
+   * The major version of the Jan2014-SP2 release.
+   */
+  private static final int JAN_2014_SP2_RELEASE_DB_MAJOR_VERSION = 11;
+
+  /**
+   * The minor version of the Jan2014-SP2 release.
+   */
+  private static final int JAN_2014_SP2_RELEASE_DB_MINOR_VERSION = 17;
+
+  /**
+   * The patch version of the Jan2014-SP2 release.
+   */
+  private static final int JAN_2014_SP2_RELEASE_DB_PATCH_VERSION = 17;
+
+  /**
+   * Jan2014-SP2 release MonetDB version.
+   */
+  public static final MonetDbVersion JAN_2014_SP2_DB_VERSION = new MonetDbVersion(
+      JAN_2014_SP2_RELEASE_DB_MAJOR_VERSION, JAN_2014_SP2_RELEASE_DB_MINOR_VERSION,
+      JAN_2014_SP2_RELEASE_DB_PATCH_VERSION );
+
+  public MonetDbVersion() {
+    super();
+  }
+
+  public MonetDbVersion( int majorVersion, int minorVersion, int patchVersion ) {
+    super();
+    this.majorVersion = majorVersion;
+    this.minorVersion = minorVersion;
+    this.patchVersion = patchVersion;
+  }
+
+  /**
+   * @param productVersion
+   * @throws MonetDbVersionException
+   */
+  public MonetDbVersion( String productVersion ) throws MonetDbVersionException {
+    super();
+    parseVersion( productVersion );
+  }
+
+  /**
+   * @return the minorVersion
+   */
+  public Integer getMinorVersion() {
+    return minorVersion;
+  }
+
+  /**
+   * @return the majorVersion
+   */
+  public Integer getMajorVersion() {
+    return majorVersion;
+  }
+
+  /**
+   * @return the patchVersion
+   */
+  public Integer getPatchVersion() {
+    return patchVersion;
+  }
+
+  @Override
+  public int compareTo( MonetDbVersion mDbVersion ) {
+    int result = majorVersion.compareTo( mDbVersion.majorVersion );
+    if ( result != 0 ) {
+      return result;
+    }
+
+    result = minorVersion.compareTo( mDbVersion.minorVersion );
+    if ( result != 0 ) {
+      return result;
+    }
+
+    result = patchVersion.compareTo( mDbVersion.patchVersion );
+    if ( result != 0 ) {
+      return result;
+    }
+    return result;
+  }
+
+  /**
+   * Parses string representation of MonetDb version. Sets up <code>majorVersion</code>. Also <code>minorVersion</code>
+   * and <code>patchVersion</code> if they are present in the product version. Omits all other possible parts as
+   * insignificant.
+   * 
+   * @param productVersion
+   *          a string representation of version
+   * @throws MonetDbVersionException
+   *           if productVersion is null or has incorrect format ( see {@link MonetDbVersion#VERSION_PATTERN} )
+   */
+  private void parseVersion( String productVersion ) throws MonetDbVersionException {
+    if ( productVersion == null ) {
+      throw new MonetDbVersionException( BaseMessages.getString( PKG, "MonetDBVersion.Exception.VersionIsNull" ) );
+    }
+
+    if ( !VERSION_PATTERN.matcher( productVersion ).matches() ) {
+      throw new MonetDbVersionException( BaseMessages.getString( PKG,
+          "MonetDBVersion.Exception.VersionFormatIsInvalid", productVersion ) );
+    }
+
+    int startIndex = 0;
+    String[] versionParts = productVersion.split( SEPARATOR );
+    majorVersion = Integer.valueOf( versionParts[startIndex] );
+    if ( versionParts.length > 1 ) {
+      minorVersion = Integer.valueOf( versionParts[startIndex + 1] );
+    }
+    if ( versionParts.length > 2 ) {
+      patchVersion = Integer.valueOf( versionParts[startIndex + 2] );
+    }
+
+  }
+
+  @Override
+  public String toString() {
+    return "MonetDbVersion: " + majorVersion + "." + minorVersion + "." + patchVersion;
+  }
+
+}

--- a/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDbVersionException.java
+++ b/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDbVersionException.java
@@ -1,0 +1,78 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.monetdbbulkloader;
+
+import org.pentaho.di.core.exception.KettleException;
+
+/**
+ * Custom exception using for processing MonetDB version
+ * 
+ * @author Tatsiana_Kasiankova
+ * 
+ */
+public class MonetDbVersionException extends KettleException {
+
+  private static final long serialVersionUID = 3876078230581782431L;
+
+  /**
+   * Constructs a new throwable with null as its detail message.
+   */
+  public MonetDbVersionException() {
+    super();
+  }
+
+  /**
+   * Constructs a new throwable with the specified detail message and cause.
+   * 
+   * @param message
+   *          the detail message (which is saved for later retrieval by the getMessage() method).
+   * @param cause
+   *          the cause (which is saved for later retrieval by the getCause() method). (A null value is permitted, and
+   *          indicates that the cause is nonexistent or unknown.)
+   */
+  public MonetDbVersionException( String message, Throwable cause ) {
+    super( message, cause );
+  }
+
+  /**
+   * Constructs a new throwable with the specified detail message.
+   * 
+   * @param message
+   *          the detail message. The detail message is saved for later retrieval by the getMessage() method.
+   */
+  public MonetDbVersionException( String message ) {
+    super( message );
+  }
+
+  /**
+   * Constructs a new throwable with the specified cause and a detail message of (cause==null ? null : cause.toString())
+   * (which typically contains the class and detail message of cause).
+   * 
+   * @param cause
+   *          the cause (which is saved for later retrieval by the getCause() method). (A null value is permitted, and
+   *          indicates that the cause is nonexistent or unknown.)
+   */
+  public MonetDbVersionException( Throwable cause ) {
+    super( cause );
+  }
+
+}

--- a/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/trans/steps/monetdbbulkloader/messages/messages_en_US.properties
@@ -82,6 +82,10 @@ MonetDBBulkLoaderDialog.Tab.MonetDBmclientSettings.ParameterGroup.FieldEnclosure
 MonetDBBulkLoaderMeta.DefaultTableName=Table name
 MonetDBBulkLoaderDialog.Tab.MonetDBmclientSettings.ParameterGroup.FieldSeparator.Label=Field separator or delimiter
 MonetDBBulkLoader.Log.ErrorInStep=Error in step, asking everyone to stop because of\:
+MonetDBVersion.Exception.VersionIsNull=DB Version can not be null.
+MonetDBVersion.Exception.VersionFormatIsInvalid=DB Version format is invalid: {0}
+MonetDBVersion.Info.UsingCompatibilityMode=Version DB is after {0}. Using compatibility mode.
+MonetDBBulkLoaderMeta.Exception.ErrorOnGettingDbVersion=Exception occurred on getting DB version: {0}
 MonetDBBulkLoaderDialog.Tab.OutputFields=Output Fields
 BaseStepDialog.EditConnectionButton.Label=Edit
 MonetDBBulkLoaderMeta.CheckResult.AllFieldsFoundInInput=All fields found in the input stream.

--- a/engine/test-src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDbVersionTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDbVersionTest.java
@@ -1,0 +1,151 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.monetdbbulkloader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Tatsiana_Kasiankova
+ * 
+ */
+public class MonetDbVersionTest {
+
+  private MonetDbVersion monetDbVersion;
+
+  @Before
+  public void setup() throws Exception {
+    monetDbVersion = null;
+  }
+
+  @Test
+  public void testDbversionCreatedFromString() throws Exception {
+    String dbVersion = "1.2.3";
+    monetDbVersion = new MonetDbVersion( dbVersion );
+    assertNotNull( monetDbVersion.getMajorVersion() );
+    assertEquals( Integer.valueOf( 1 ), monetDbVersion.getMajorVersion() );
+    assertNotNull( monetDbVersion.getMinorVersion() );
+    assertEquals( Integer.valueOf( 2 ), monetDbVersion.getMinorVersion() );
+    assertNotNull( monetDbVersion.getPatchVersion() );
+    assertEquals( Integer.valueOf( 3 ), monetDbVersion.getPatchVersion() );
+  }
+
+  @Test
+  public void testDbversionCreated() throws Exception {
+    monetDbVersion = new MonetDbVersion( 1, 2, 3 );
+    assertNotNull( monetDbVersion.getMajorVersion() );
+    assertEquals( Integer.valueOf( 1 ), monetDbVersion.getMajorVersion() );
+    assertNotNull( monetDbVersion.getMinorVersion() );
+    assertEquals( Integer.valueOf( 2 ), monetDbVersion.getMinorVersion() );
+    assertNotNull( monetDbVersion.getPatchVersion() );
+    assertEquals( Integer.valueOf( 3 ), monetDbVersion.getPatchVersion() );
+  }
+
+  @Test
+  public void testIllegalArgumentExceptionThrows_IfDbVersionNull() {
+    try {
+      monetDbVersion = new MonetDbVersion( null );
+      fail( "Should throw MonetDbVersionException but it does not. " );
+    } catch ( MonetDbVersionException ex ) {
+      assertTrue( ex.getLocalizedMessage().contains( "DB Version can not be null." ) );
+    }
+  }
+
+  @Test
+  public void testIllegalArgumentExceptionThrows_IfDbVersionNotMatchesVersionPattern() {
+    String dbVersion = "1.8.d";
+    try {
+      monetDbVersion = new MonetDbVersion( dbVersion );
+      fail( "Should throw MonetDbVersionException but it does not. " );
+    } catch ( MonetDbVersionException ex ) {
+      assertTrue( ex.getLocalizedMessage().contains( "DB Version format is invalid: " + dbVersion ) );
+    }
+  }
+
+  @Test
+  public void testDbVersionWithouPatchVersion() throws Exception {
+
+    String dbVersion = "785.2";
+    monetDbVersion = new MonetDbVersion( dbVersion );
+    assertNotNull( monetDbVersion.getMajorVersion() );
+    assertEquals( Integer.valueOf( 785 ), monetDbVersion.getMajorVersion() );
+    assertNotNull( monetDbVersion.getMinorVersion() );
+    assertEquals( Integer.valueOf( 2 ), monetDbVersion.getMinorVersion() );
+    assertNull( monetDbVersion.getPatchVersion() );
+
+  }
+
+  @Test
+  public void testCompareVersions_DiffInPatch() throws Exception {
+
+    String dbVersionBigger = "785.2.3";
+    String dbVersion = "785.2.2";
+    assertEquals( 1, new MonetDbVersion( dbVersionBigger ).compareTo( new MonetDbVersion( dbVersion ) ) );
+  }
+
+  @Test
+  public void testCompareVersions_DiffInMinor() throws Exception {
+
+    String dbVersionBigger = "785.5.3";
+    String dbVersion = "785.2.2";
+    assertEquals( 1, new MonetDbVersion( dbVersionBigger ).compareTo( new MonetDbVersion( dbVersion ) ) );
+  }
+
+  @Test
+  public void testCompareVersions_DiffInMajor() throws Exception {
+
+    String dbVersionBigger = "786.5.3";
+    String dbVersion = "785.2.2";
+    assertEquals( 1, new MonetDbVersion( dbVersionBigger ).compareTo( new MonetDbVersion( dbVersion ) ) );
+  }
+
+  @Test
+  public void testCompareVersions_DiffInMajor_LongVersion() throws Exception {
+
+    String dbVersionBigger = "788.5.3.8.9.7.5";
+    String dbVersion = "785.2.2";
+    assertEquals( 1, new MonetDbVersion( dbVersionBigger ).compareTo( new MonetDbVersion( dbVersion ) ) );
+  }
+
+  @Test
+  public void testCompareVersions_TheSame() throws Exception {
+
+    String dbVersionBigger = "11.11.7";
+    String dbVersion = "11.11.7";
+    assertEquals( 0, new MonetDbVersion( dbVersionBigger ).compareTo( new MonetDbVersion( dbVersion ) ) );
+  }
+
+  @Test
+  public void testCompareVersions_NoPatch() throws Exception {
+
+    String dbVersionBigger = "11.18";
+    String dbVersion = "11.17.17";
+    assertEquals( 1, new MonetDbVersion( dbVersionBigger ).compareTo( new MonetDbVersion( dbVersion ) ) );
+  }
+
+}


### PR DESCRIPTION
The problem was:
Starting from Jan 2014-SP2 bugfix release we should not use double write of empty line (see the sample http://dev.monetdb.org/hg/MonetDB/file/tip/java/example/SQLcopyinto.java).
At the same time for "old" versions of MonetDB (before Jan 2014-SP2) we are still need to do this one otherwise the error appears.

The fix consists of:
1)Getting current MonetDB version (via JDBC property) during execution the step
2)Defining if the current version is before boundary Jan 2014-SP2 version or not (so-called compatibility with old version db mode).
3)Addition condition for such case during writing buffer.

Also there are several unit tests.