### PR TITLE
[SP-1779] - Backport of PDI-13654 - Regression: Execute SQL Script with ...

### DIFF
--- a/core/src/org/pentaho/di/core/database/SqlScriptParser.java
+++ b/core/src/org/pentaho/di/core/database/SqlScriptParser.java
@@ -116,7 +116,13 @@ public class SqlScriptParser {
           }
           break;
         case STRING:
-          if ( ch == currentStringChar ) {
+          if ( ch == '\\' && nextCh == currentStringChar ) {
+            /*
+             * The user is hard-coding a quote character into the string.
+             * Pass the hard-coded quote character through, and skip over the quote on next loop
+             */
+            i++;
+          } else if ( ch == currentStringChar ) {
             mode = MODE.SQL;
           }
           break;
@@ -193,7 +199,16 @@ public class SqlScriptParser {
           }
           break;
         case STRING:
-          if ( ch == currentStringChar ) {
+          if ( ch == '\\' && nextCh == currentStringChar ) {
+            /*
+             * The user is hard-coding a quote character into the string.
+             * Pass the hard-coded quote character through, and skip over the quote on next loop
+             */
+            result.append( ch );
+            result.append( nextCh );
+            ch = 0;
+            i++;
+          } else if ( ch == currentStringChar ) {
             mode = MODE.SQL;
           }
           break;

--- a/core/test-src/org/pentaho/di/core/database/SqlScriptParserTest.java
+++ b/core/test-src/org/pentaho/di/core/database/SqlScriptParserTest.java
@@ -11,6 +11,9 @@ public class SqlScriptParserTest {
 
   @Test
   public void testSplit() {
+    testSplit( (String) null, new String[0] );
+    testSplit( "", new String[0] );
+    testSplit( " ", new String[0] );
     testSplit( "SELECT 1;SELECT 2", "SELECT 1", "SELECT 2" );
     testSplit( "SELECT '1;2'", "SELECT '1;2'" );
     testSplit( "SELECT \"1;2\"", "SELECT \"1;2\"" );
@@ -19,6 +22,13 @@ public class SqlScriptParserTest {
     testSplit( "SELECT /1;2", "SELECT /1", "2" );
     testSplit( "SELECT /1;;;;2", "SELECT /1", "2" );
     testSplit( "SELECT /1;\n  \n", "SELECT /1" );
+    testSplit( "SELECT \"hello\\\"world\" FROM dual", "SELECT \"hello\\\"world\" FROM dual" );
+    testSplit( "CREATE TABLE test1 (col1 STRING) TBLPROPERTIES (\"prop1\" = \"my\\\"value\");",
+      "CREATE TABLE test1 (col1 STRING) TBLPROPERTIES (\"prop1\" = \"my\\\"value\")" );
+    testSplit( "CREATE TABLE test1 (col1 STRING) TBLPROPERTIES ('prop1' = 'my\\\"value');",
+      "CREATE TABLE test1 (col1 STRING) TBLPROPERTIES ('prop1' = 'my\\\"value')" );
+    testSplit( "SELECT \"test\\\";SELECT 1", "SELECT \"test\\\";SELECT 1" );
+    testSplit( "SELECT 'test\\';SELECT 1", "SELECT 'test\\';SELECT 1" );
   }
 
   private void testSplit( String sql, String... result ) {
@@ -48,6 +58,11 @@ public class SqlScriptParserTest {
         "SELECT \n/*+ ORACLE hint*/ col1, col2, col3 FROM account WHERE name = 'Pentaho'" );
     testRemoveComments( "SELECT \n/*+ ORACLE hint*/\n col1, col2, col3 FROM account WHERE name = 'Pentaho'",
         "SELECT \n/*+ ORACLE hint*/\n col1, col2, col3 FROM account WHERE name = 'Pentaho'" );
+    testRemoveComments( "SELECT \"hello\\\"world\" FROM dual", "SELECT \"hello\\\"world\" FROM dual" );
+    testRemoveComments( "CREATE TABLE test1 (col1 STRING) TBLPROPERTIES (\"prop1\" = \"my\\\"value\")",
+      "CREATE TABLE test1 (col1 STRING) TBLPROPERTIES (\"prop1\" = \"my\\\"value\")" );
+    testRemoveComments( "CREATE TABLE test1 (col1 STRING) TBLPROPERTIES ('prop1' = 'my\\\"value')",
+      "CREATE TABLE test1 (col1 STRING) TBLPROPERTIES ('prop1' = 'my\\\"value')" );
   }
 
   private void testRemoveComments( String input, String expected ) {


### PR DESCRIPTION
...escaped double-quote causes parsing issue (5.3 Suite)

Correctly passes through hard-coded quotes that appear within a string,
instead of blindly switching back to SQL mode.