### PR TITLE
[PDI-13683] - Regression: Text File Output: Performance decrease using Z...

### DIFF
--- a/engine/src/org/pentaho/di/core/compress/CompressionOutputStream.java
+++ b/engine/src/org/pentaho/di/core/compress/CompressionOutputStream.java
@@ -36,4 +36,13 @@ public abstract class CompressionOutputStream extends OutputStream {
     delegate.write( b );
   }
 
+  @Override
+  public void write( byte[] b ) throws IOException {
+    delegate.write( b );
+  }
+
+  @Override
+  public void write( byte[] b, int off, int len ) throws IOException {
+    delegate.write( b, off, len );
+  }
 }

--- a/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -441,14 +441,13 @@ public class TextFileOutput extends BaseStep implements StepInterface {
   private List<Integer> getEnclosurePositions( byte[] str ) {
     List<Integer> positions = null;
     if ( data.binaryEnclosure != null && data.binaryEnclosure.length > 0 ) {
-      for ( int i = 0; i < str.length - data.binaryEnclosure.length + 1; i++ ) // +1 because otherwise we will not find
-                                                                               // it at the end
-      {
+      // +1 because otherwise we will not find it at the end
+      for ( int i = 0, len = str.length - data.binaryEnclosure.length + 1; i < len; i++) {
         // verify if on position i there is an enclosure
         //
         boolean found = true;
         for ( int x = 0; found && x < data.binaryEnclosure.length; x++ ) {
-          if ( str[i + x] != data.binaryEnclosure[x] ) {
+          if ( str[ i + x ] != data.binaryEnclosure[ x ] ) {
             found = false;
           }
         }
@@ -496,15 +495,17 @@ public class TextFileOutput extends BaseStep implements StepInterface {
           if ( i > 0 && data.binarySeparator.length > 0 ) {
             data.writer.write( data.binarySeparator );
           }
-          if ( ( meta.isEnclosureForced() && data.binaryEnclosure.length > 0 && v != null && v.isString() )
+
+          boolean writeEnclosure =
+            ( meta.isEnclosureForced() && data.binaryEnclosure.length > 0 && v != null && v.isString() )
               || ( ( !meta.isEnclosureFixDisabled() && containsSeparatorOrEnclosure( fieldName.getBytes(),
-                  data.binarySeparator, data.binaryEnclosure ) ) ) ) {
+              data.binarySeparator, data.binaryEnclosure ) ) );
+
+          if ( writeEnclosure ) {
             data.writer.write( data.binaryEnclosure );
           }
           data.writer.write( getBinaryString( fieldName ) );
-          if ( ( meta.isEnclosureForced() && data.binaryEnclosure.length > 0 && v != null && v.isString() )
-              || ( ( !meta.isEnclosureFixDisabled() && containsSeparatorOrEnclosure( fieldName.getBytes(),
-                  data.binarySeparator, data.binaryEnclosure ) ) ) ) {
+          if ( writeEnclosure ) {
             data.writer.write( data.binaryEnclosure );
           }
         }
@@ -517,15 +518,16 @@ public class TextFileOutput extends BaseStep implements StepInterface {
           }
           ValueMetaInterface v = r.getValueMeta( i );
 
-          if ( ( meta.isEnclosureForced() && data.binaryEnclosure.length > 0 && v != null && v.isString() )
+          boolean writeEnclosure =
+            ( meta.isEnclosureForced() && data.binaryEnclosure.length > 0 && v != null && v.isString() )
               || ( ( !meta.isEnclosureFixDisabled() && containsSeparatorOrEnclosure( v.getName().getBytes(),
-                  data.binarySeparator, data.binaryEnclosure ) ) ) ) {
+              data.binarySeparator, data.binaryEnclosure ) ) );
+
+          if ( writeEnclosure ) {
             data.writer.write( data.binaryEnclosure );
           }
           data.writer.write( getBinaryString( v.getName() ) );
-          if ( ( meta.isEnclosureForced() && data.binaryEnclosure.length > 0 && v != null && v.isString() )
-              || ( ( !meta.isEnclosureFixDisabled() && containsSeparatorOrEnclosure( v.getName().getBytes(),
-                  data.binarySeparator, data.binaryEnclosure ) ) ) ) {
+          if ( writeEnclosure ) {
             data.writer.write( data.binaryEnclosure );
           }
         }


### PR DESCRIPTION
...ip and GZip compression

@mattyb149, @brosander review it please.

The trick is all about letting the CompressionStream to use write(int[]) method. It is crucial for DeflaterOutputStream, that does not expect single integers: http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/java/util/zip/DeflaterOutputStream.java#DeflaterOutputStream.write%28int%29

Also I refactored the step class, by extracting boolean value not to be computed twice.

P.S.
Looks like we also need to apply similar changes for CompressionInputStream