### PR TITLE
[PDI-13605] Use Error log for missing table

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/mssqlbulkload/JobEntryMssqlBulkLoad.java
+++ b/engine/src/org/pentaho/di/job/entries/mssqlbulkload/JobEntryMssqlBulkLoad.java
@@ -590,10 +590,7 @@ public class JobEntryMssqlBulkLoad extends JobEntryBase implements Cloneable, Jo
                 // Of course, the table should have been created already before the bulk load operation
                 db.disconnect();
                 result.setNrErrors( 1 );
-                if ( log.isDetailed() ) {
-                  logDetailed( BaseMessages
-                    .getString( PKG, "JobMssqlBulkLoad.Error.TableNotExists", realTablename ) );
-                }
+                logError( BaseMessages.getString( PKG, "JobMssqlBulkLoad.Error.TableNotExists", realTablename ) );
               }
             } catch ( KettleDatabaseException dbe ) {
               db.disconnect();


### PR DESCRIPTION
Change logging-level of message from "Detailed" to "Error" when the bulk loader doesn't find the destination table.