### PR TITLE
[PDI-13633] Regression: Database Connections with JNDI mix up JNDI name ...

### DIFF
--- a/core/ivy.xml
+++ b/core/ivy.xml
@@ -63,5 +63,6 @@
 
     <dependency org="xml-apis" name="xml-apis-ext" rev="${dependency.xml-apis-ext.revision}" transitive="false"/>
 
+    <dependency org="org.springframework" name="spring-test"         rev="2.5.6"            transitive="false" conf="test->default"/>
   </dependencies>
 </ivy-module>

--- a/core/test-src/org/pentaho/di/core/database/DatabaseConnectUnitTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseConnectUnitTest.java
@@ -1,0 +1,71 @@
+package org.pentaho.di.core.database;
+
+import static org.mockito.Mockito.mock;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactoryBuilder;
+import javax.naming.spi.NamingManager;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.logging.LoggingObjectType;
+import org.pentaho.di.core.logging.SimpleLoggingObject;
+import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+
+public class DatabaseConnectUnitTest {
+
+  static LoggingObjectInterface log = new SimpleLoggingObject( "junit", LoggingObjectType.GENERAL, null );
+  String name = "testName";
+  String jndiName = "testJNDIName";
+  String fullJndiName = "jdbc/testJNDIName";
+  String displayName = "testDisplayName";
+
+  @BeforeClass
+  public static void beforeClass() throws NamingException {
+    if ( !NamingManager.hasInitialContextFactoryBuilder() ) {
+      // If JNDI is not initialized, use simpleJNDI
+      System.setProperty( Context.INITIAL_CONTEXT_FACTORY, "org.osjava.jndi.PropertiesFactory" );
+      InitialContextFactoryBuilder simpleBuilder = new SimpleNamingContextBuilder();
+      NamingManager.setInitialContextFactoryBuilder( simpleBuilder );
+    }
+  }
+
+  @After
+  public void after() throws NamingException {
+    InitialContext ctx = new InitialContext();
+    ctx.unbind( fullJndiName );
+  }
+
+  @Test
+  public void testConnect2() throws SQLException, NamingException, KettleDatabaseException {
+    InitialContext ctx = new InitialContext();
+
+    DatabaseMeta meta = Mockito.mock( DatabaseMeta.class );
+    Mockito.when( meta.getName() ).thenReturn( name );
+    Mockito.when( meta.getDatabaseName() ).thenReturn( jndiName );
+    Mockito.when( meta.getDisplayName() ).thenReturn( displayName );
+    Mockito.when( meta.getAccessType() ).thenReturn( DatabaseMeta.TYPE_ACCESS_JNDI );
+    Mockito.when( meta.environmentSubstitute( jndiName ) ).thenReturn( jndiName );
+
+    Connection connection = mock( Connection.class );
+    TestDataSource ds = new TestDataSource( connection );
+    ctx.bind( fullJndiName, ds );
+
+    Database db = new Database( log, meta );
+
+    db.connect();
+    Assert.assertEquals( connection, db.getConnection() );
+  }
+
+}

--- a/engine/src/org/pentaho/di/trans/steps/mondrianinput/MondrianHelper.java
+++ b/engine/src/org/pentaho/di/trans/steps/mondrianinput/MondrianHelper.java
@@ -55,6 +55,7 @@ import org.pentaho.di.core.DBCache;
 import org.pentaho.di.core.DBCacheEntry;
 import org.pentaho.di.core.database.DataSourceProviderFactory;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.database.util.DatabaseUtil;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -99,9 +100,7 @@ public class MondrianHelper {
     String realRole = space.environmentSubstitute( role );
 
     if ( databaseMeta.getAccessType() == DatabaseMeta.TYPE_ACCESS_JNDI ) {
-      DataSource dataSource =
-        DataSourceProviderFactory.getDataSourceProviderInterface().getNamedDataSource(
-          databaseMeta.getDatabaseName() );
+      DataSource dataSource = ( new DatabaseUtil() ).getNamedDataSource( databaseMeta.getDatabaseName() );
       mondrian.olap.Util.PropertyList propList = new mondrian.olap.Util.PropertyList();
       propList.put( "Provider", "mondrian" );
       propList.put( "Catalog", space.environmentSubstitute( catalog ) );


### PR DESCRIPTION
...with Connection name
@mattcasters, @brosander, @mattyb149 could your review it?
Interface is unchanged.
Kettle core looks for JNDI datasource itself (not querying the server's datasource provider).
So, there is no chance for collisions of names.
