### PR TITLE
[PDI-12593] SFTP Target Directory with Variables

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -877,6 +877,8 @@
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.cluster.SlaveSequenceTest" haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.concatfields.ConcatFields_PDI_10856_Test" haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.www.CarteTest" haltonerror="false"/>
+      <test todir="${testreports.xml.dir}" name="org.pentaho.di.job.entries.sftp.SFTPClientTest" haltonerror="false"/>
+      <test todir="${testreports.xml.dir}" name="org.pentaho.di.job.entries.sftp.JobEntrySFTPTest" haltonerror="false"/>
 
       <!-- Some extra things to run -->
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.job.entries.copyfiles.CopyFilesTest"

--- a/engine/src/org/pentaho/di/job/entries/sftp/JobEntrySFTP.java
+++ b/engine/src/org/pentaho/di/job/entries/sftp/JobEntrySFTP.java
@@ -680,15 +680,16 @@ public class JobEntrySFTP extends JobEntryBase implements Cloneable, JobEntryInt
             logDebug( BaseMessages.getString( PKG, "JobSFTP.Log.GettingFiles", filelist[i], realTargetDirectory ) );
           }
 
-          String targetFilename = realTargetDirectory + Const.FILE_SEPARATOR + filelist[i];
-          sftpclient.get( targetFilename, filelist[i] );
+          FileObject targetFile = KettleVFS.getFileObject(
+            realTargetDirectory + Const.FILE_SEPARATOR + filelist[i], this );
+          sftpclient.get( targetFile, filelist[i] );
           filesRetrieved++;
 
           if ( isaddresult ) {
             // Add to the result files...
             ResultFile resultFile =
               new ResultFile(
-                ResultFile.FILE_TYPE_GENERAL, KettleVFS.getFileObject( targetFilename, this ), parentJob
+                ResultFile.FILE_TYPE_GENERAL, targetFile, parentJob
                   .getJobname(), toString() );
             result.getResultFiles().put( resultFile.getFile().toString(), resultFile );
             if ( log.isDetailed() ) {

--- a/engine/src/org/pentaho/di/job/entries/sftp/SFTPClient.java
+++ b/engine/src/org/pentaho/di/job/entries/sftp/SFTPClient.java
@@ -24,6 +24,7 @@ package org.pentaho.di.job.entries.sftp;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.InetAddress;
 
 import org.apache.commons.vfs.FileObject;
@@ -212,6 +213,27 @@ public class SFTPClient {
     return fileList;
   }
 
+  public void get( FileObject localFile, String remoteFile ) throws KettleJobException {
+    OutputStream localStream = null;
+    try {
+      localStream = KettleVFS.getOutputStream( localFile, false );
+      c.get( remoteFile, localStream );
+    } catch ( SftpException e ) {
+      throw new KettleJobException( e );
+    } catch ( IOException e ) {
+      throw new KettleJobException( e );
+    } finally {
+      if ( localStream != null ) {
+        try {
+          localStream.close();
+        } catch ( IOException ignore ) {
+          // Ignore any IOException, as we're trying to close the stream anyways
+        }
+      }
+    }
+  }
+
+  @Deprecated
   public void get( String localFilePath, String remoteFile ) throws KettleJobException {
     int mode = ChannelSftp.OVERWRITE;
     try {

--- a/ivy.xml
+++ b/ivy.xml
@@ -10,7 +10,10 @@
   <dependencies defaultconf="default->default">
     <!-- Kettle module dependencies-->
     <dependency org="${ivy.artifact.group}" name="kettle-core"     rev="${project.revision}" changing="true"/>
-    <dependency org="${ivy.artifact.group}" name="kettle-engine"   rev="${project.revision}" changing="true"/>
+    <dependency org="${ivy.artifact.group}" name="kettle-engine"   rev="${project.revision}" changing="true">
+      <!-- Apache SSHD need more recent version -->
+      <exclude org="bouncycastle" conf="test" />
+    </dependency>
     <dependency org="${ivy.artifact.group}" name="kettle-dbdialog" rev="${project.revision}" changing="true"/>
     <dependency org="${ivy.artifact.group}" name="kettle-ui-swt"   rev="${project.revision}" changing="true">
       <exclude name="swt-linux-x86_64"/>
@@ -23,5 +26,10 @@
     <dependency org="org.mortbay.jetty"        name="jetty-servlet-tester" rev="6.1.21" transitive="false" conf="test->default"/>
     <dependency org="net.sourceforge.nekohtml" name="nekohtml"             rev="1.9.7"  transitive="false" conf="test->default"/>
     <dependency org="com.puppycrawl.tools"     name="checkstyle"           rev="5.7"    transitive="true"  conf="checkstyle->default"/>
+
+    <!-- Apache Mina for settling up SFTP server instance -->
+    <dependency org="org.apache.sshd"     name="sshd-sftp"     rev="0.11.0"  conf="test->default" transitive="true" />
+    <dependency org="org.bouncycastle"    name="bcprov-jdk14"  rev="1.51"    conf="test->default" transitive="true" />
+
   </dependencies>
 </ivy-module>

--- a/test/org/pentaho/di/job/entries/sftp/JobEntrySFTPTest.java
+++ b/test/org/pentaho/di/job/entries/sftp/JobEntrySFTPTest.java
@@ -1,0 +1,126 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.sftp;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+
+import org.apache.commons.vfs.FileObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.utils.TestUtils;
+
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.Session;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class JobEntrySFTPTest {
+
+  private static TemporaryFolder folder;
+
+  private static SftpServer server;
+
+  @BeforeClass
+  public static void prepareEnv() throws Exception {
+    KettleEnvironment.init();
+
+    folder = new TemporaryFolder();
+    folder.create();
+
+    server = SftpServer.createDefaultServer( folder );
+    server.start();
+  }
+
+  @AfterClass
+  public static void stopServer() throws Exception {
+    server.stop();
+    server = null;
+
+    folder.delete();
+    folder = null;
+  }
+
+  @Test
+  public void getFile_WhenDestinationIsSetViaVariable() throws Exception {
+    final String localDir = TestUtils.createTempDir();
+    KettleVFS.getFileObject( localDir ).createFolder();
+
+    final String myVar = "my-var";
+
+    final String sftpDir = "job-entry-sftp-test";
+    final String fileName = "file.txt";
+
+    uploadFile( sftpDir, fileName );
+
+    JobEntrySFTP job = new JobEntrySFTP();
+    job.setVariable( myVar, localDir );
+
+    Job parent = mock( Job.class );
+    when( parent.isStopped() ).thenReturn( false );
+    job.setParentJob( parent );
+    job.setLogLevel( LogLevel.NOTHING );
+
+    job.setUserName( server.getUsername() );
+    job.setPassword( server.getPassword() );
+    job.setServerName( "localhost" );
+    job.setServerPort( Integer.toString( server.getPort() ) );
+    job.setScpDirectory( sftpDir );
+    job.setTargetDirectory( String.format( "${%s}", myVar ) );
+
+    job.execute( new Result(), 1 );
+
+    FileObject downloaded = KettleVFS.getFileObject( localDir + "/" + fileName );
+    assertTrue( downloaded.exists() );
+    downloaded.delete();
+  }
+
+  private void uploadFile( String dir, String file ) throws Exception {
+    Session session = server.createJschSession();
+    session.connect();
+    try {
+      ChannelSftp sftp = (ChannelSftp) session.openChannel( "sftp" );
+      sftp.connect();
+      try {
+        sftp.mkdir( dir );
+        sftp.cd( dir );
+        sftp.put( new ByteArrayInputStream( "data".getBytes() ), file );
+      } finally {
+        sftp.disconnect();
+      }
+    } finally {
+      session.disconnect();
+    }
+  }
+}

--- a/test/org/pentaho/di/job/entries/sftp/SFTPClientTest.java
+++ b/test/org/pentaho/di/job/entries/sftp/SFTPClientTest.java
@@ -1,0 +1,139 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.sftp;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.InetAddress;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.vfs.FileObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.vfs.KettleVFS;
+
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.Session;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class SFTPClientTest {
+
+  // @ClassRule
+  public static TemporaryFolder folder;
+
+  private static SftpServer server;
+
+  @BeforeClass
+  public static void startServer() throws Exception {
+    KettleEnvironment.init();
+
+    folder = new TemporaryFolder();
+    folder.create();
+
+    server = SftpServer.createDefaultServer( folder );
+    server.start();
+  }
+
+  @AfterClass
+  public static void stopServer() throws Exception {
+    server.stop();
+    server = null;
+
+    folder.delete();
+    folder = null;
+  }
+
+
+  private SFTPClient client;
+  private Session session;
+  private ChannelSftp channel;
+
+  @Before
+  public void setUp() throws Exception {
+    session = server.createJschSession();
+    session.connect();
+
+    client = new SFTPClient( InetAddress.getByName( "localhost" ), server.getPort(), server.getUsername() );
+    client.login( server.getPassword() );
+
+    channel = (ChannelSftp) session.openChannel( "sftp" );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if ( channel != null && channel.isConnected() ) {
+      channel.disconnect();
+    }
+    channel = null;
+
+    if ( session.isConnected() ) {
+      session.disconnect();
+    }
+    session = null;
+  }
+
+
+  @Test
+  public void putFile() throws Exception {
+    final byte[] data = "putFile()".getBytes();
+
+    client.put( new ByteArrayInputStream( data ), "uploaded.txt" );
+
+    ByteArrayOutputStream uploaded = new ByteArrayOutputStream();
+    channel.connect();
+    InputStream inputStream = channel.get( "uploaded.txt" );
+    try {
+      IOUtils.copy( inputStream, uploaded );
+    } finally {
+      inputStream.close();
+    }
+
+    assertTrue(
+      IOUtils.contentEquals( new ByteArrayInputStream( data ), new ByteArrayInputStream( uploaded.toByteArray() ) ) );
+  }
+
+  @Test
+  public void getFile() throws Exception {
+    final byte[] data = "getFile()".getBytes();
+
+    channel.connect();
+    channel.put( new ByteArrayInputStream( data ), "downloaded.txt" );
+
+    client.get( KettleVFS.getFileObject( "ram://downloaded.txt" ), "downloaded.txt" );
+
+    FileObject downloaded = KettleVFS.getFileObject( "ram://downloaded.txt" );
+    assertTrue( downloaded.exists() );
+    assertTrue( IOUtils.contentEquals( downloaded.getContent().getInputStream(), new ByteArrayInputStream( data ) ) );
+  }
+
+}

--- a/test/org/pentaho/di/job/entries/sftp/SftpServer.java
+++ b/test/org/pentaho/di/job/entries/sftp/SftpServer.java
@@ -1,0 +1,139 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.sftp;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.Random;
+import java.util.UUID;
+
+import org.apache.sshd.SshServer;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.PasswordAuthenticator;
+import org.apache.sshd.server.command.ScpCommandFactory;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.session.ServerSession;
+import org.apache.sshd.sftp.subsystem.SftpSubsystem;
+import org.junit.rules.TemporaryFolder;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class SftpServer implements PasswordAuthenticator {
+
+  /**
+   * Creates a server's instance for <tt>localhost</tt> using random values for username, password, and port.
+   *
+   * @param folder temporary folder
+   * @return server's instance
+   * @throws IOException
+   */
+  public static SftpServer createDefaultServer( TemporaryFolder folder ) throws IOException {
+    return new SftpServer( "fakeuser", UUID.randomUUID().toString(), new Random().nextInt( 20000 ) + 1024,
+      folder.getRoot().getAbsolutePath(), folder.newFile( "server.key" ).getAbsolutePath() );
+  }
+
+  private final String username;
+  private final String password;
+
+  private final SshServer server;
+
+  /**
+   * Creates a server's instance for <tt>localhost</tt>, using supplied values for username, password, and port.
+   * 
+   * @param username
+   *   The username that will be allowed for authentication
+   * @param password
+   *   The password that will be allowed for authentication
+   * @param port
+   *   The port number that the SSH Server should listen on
+   * @param homeDir
+   *   The local directory that should be the SSH Server's root directory
+   * @param hostKeyPath
+   *   The file that should be used to store the SSH Host Key
+   * @return
+   *   An SftpServer instance
+   * @throws IOException
+   */
+  public SftpServer( String username, String password, int port, String homeDir, String hostKeyPath ) {
+    this.username = username;
+    this.password = password;
+    this.server = createSshServer( port, homeDir, hostKeyPath );
+  }
+
+  private SshServer createSshServer( int port, String homeDir, String hostKeyPath ) {
+    SshServer server = SshServer.setUpDefaultServer();
+    server.setHost( "localhost" );
+    server.setPort( port );
+    server.setFileSystemFactory( new VirtualFileSystemFactory( homeDir ) );
+    server.setSubsystemFactories( Collections.<NamedFactory<Command>>singletonList( new SftpSubsystem.Factory() ) );
+    server.setCommandFactory( new ScpCommandFactory() );
+    server.setKeyPairProvider( new SimpleGeneratorHostKeyProvider( hostKeyPath ) );
+    server.setPasswordAuthenticator( this );
+    return server;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public int getPort() {
+    return server.getPort();
+  }
+
+  public void start() throws IOException {
+    server.start();
+  }
+
+  public void stop() throws InterruptedException {
+    server.stop();
+  }
+
+  public Session createJschSession() throws JSchException {
+    JSch jsch = new JSch();
+    com.jcraft.jsch.Session session = jsch.getSession( username, server.getHost(), server.getPort() );
+    session.setPassword( password );
+
+    Properties config = new java.util.Properties();
+    config.put( "StrictHostKeyChecking", "no" );
+    session.setConfig( config );
+
+    return session;
+  }
+
+  @Override
+  public boolean authenticate( String username, String password, ServerSession session ) {
+    return this.username.equals( username ) && this.password.equals( password );
+  }
+}


### PR DESCRIPTION
Use KettleVFS for the target file in SFTP Get job entry, so that target files that use variables in the path are parsed correctly