### PR TITLE
[PDI-13609] Database Dialect Sequence Support

### DIFF
--- a/core/src/org/pentaho/di/core/database/AS400DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/AS400DatabaseMeta.java
@@ -272,6 +272,11 @@ public class AS400DatabaseMeta extends BaseDatabaseMeta implements DatabaseInter
     return true;
   }
 
+  @Override
+  public String getSQLListOfSequences() {
+    return "SELECT SEQNAME FROM SYSCAT.SEQUENCES";
+  }
+
   /**
    * Check if a sequence exists.
    *

--- a/core/src/org/pentaho/di/core/database/DB2DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/DB2DatabaseMeta.java
@@ -357,6 +357,11 @@ public class DB2DatabaseMeta extends BaseDatabaseMeta implements DatabaseInterfa
     return true;
   }
 
+  @Override
+  public String getSQLListOfSequences() {
+    return "SELECT SEQNAME FROM SYSCAT.SEQUENCES";
+  }
+
   /**
    * Check if a sequence exists.
    *

--- a/core/src/org/pentaho/di/core/database/HypersonicDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/HypersonicDatabaseMeta.java
@@ -269,6 +269,11 @@ public class HypersonicDatabaseMeta extends BaseDatabaseMeta implements Database
     return "SELECT * FROM INFORMATION_SCHEMA.SYSTEM_SEQUENCES WHERE SEQUENCE_NAME = '" + sequenceName + "'";
   }
 
+  @Override
+  public String getSQLListOfSequences() {
+    return "SELECT SEQUENCE_NAME FROM INFORMATION_SCHEMA.SYSTEM_SEQUENCES";
+  }
+
   /**
    * Get the current value of a database sequence
    * 

--- a/core/src/org/pentaho/di/core/database/KingbaseESDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/KingbaseESDatabaseMeta.java
@@ -160,6 +160,11 @@ public class KingbaseESDatabaseMeta extends BaseDatabaseMeta implements Database
     return "SELECT relname AS sequence_name FROM sys_class WHERE relname = '" + sequenceName.toLowerCase() + "'";
   }
 
+  @Override
+  public String getSQLListOfSequences() {
+    return "SELECT relname AS sequence_name FROM sys_class";
+  }
+
   /**
    * Generates the SQL statement to add a column to the specified table
    *

--- a/core/src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta.java
@@ -467,6 +467,31 @@ public class MSSQLServerDatabaseMeta extends BaseDatabaseMeta implements Databas
     return "insert into " + schemaTable + "(" + versionField + ") values (1)";
   }
 
+  @Override
+  public String getSQLNextSequenceValue( String sequenceName ) {
+    return String.format( "SELECT NEXT VALUE FOR %s", sequenceName );
+  }
+
+  @Override
+  public String getSQLCurrentSequenceValue( String sequenceName ) {
+    return String.format( "SELECT current_value FROM sys.sequences WHERE name = '%s'", sequenceName );
+  }
+
+  @Override
+  public String getSQLSequenceExists( String sequenceName ) {
+    return String.format( "SELECT * FROM sys.sequences WHERE name = '%s'", sequenceName );
+  }
+
+  @Override
+  public boolean supportsSequences() {
+    return true;
+  }
+
+  @Override
+  public String getSQLListOfSequences() {
+    return "SELECT name FROM sys.sequences";
+  }
+
   /**
    * @param string
    * @return A string that is properly quoted for use in an Oracle SQL statement (insert, update, delete, etc)

--- a/core/src/org/pentaho/di/core/database/NetezzaDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/NetezzaDatabaseMeta.java
@@ -182,6 +182,11 @@ public class NetezzaDatabaseMeta extends BaseDatabaseMeta implements DatabaseInt
     return "SELECT seqname AS sequence_name from _v_sequence where seqname = '" + sequenceName.toLowerCase() + "'";
   }
 
+  @Override
+  public String getSQLListOfSequences() {
+    return "SELECT seqname AS sequence_name from _v_sequence";
+  }
+
   /**
    * Generates the SQL statement to add a column to the specified table Note: Netezza does not allow adding columns to
    * tables

--- a/core/src/org/pentaho/di/core/database/OracleRDBDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/OracleRDBDatabaseMeta.java
@@ -102,6 +102,11 @@ public class OracleRDBDatabaseMeta extends BaseDatabaseMeta implements DatabaseI
     return true;
   }
 
+  @Override
+  public String getSQLListOfSequences() {
+    return "SELECT SEQUENCE_NAME FROM USER_SEQUENCES";
+  }
+
   /**
    * Check if a sequence exists.
    *

--- a/core/src/org/pentaho/di/core/database/VerticaDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/VerticaDatabaseMeta.java
@@ -300,6 +300,16 @@ public class VerticaDatabaseMeta extends BaseDatabaseMeta implements DatabaseInt
     return true;
   }
 
+  @Override
+  public String getSQLSequenceExists( String sequenceName ) {
+    return "SELECT sequence_name FROM sequences WHERE sequence_name = '" + sequenceName + "'";
+  }
+
+  @Override
+  public String getSQLListOfSequences() {
+    return "SELECT sequence_name FROM sequences";
+  }
+
   /**
    * Get the SQL to get the next value of a sequence. (Vertica version)
    *

--- a/test/org/pentaho/di/core/database/SequenceMetaTests.java
+++ b/test/org/pentaho/di/core/database/SequenceMetaTests.java
@@ -42,6 +42,8 @@ public class SequenceMetaTests {
       new GreenplumDatabaseMeta(),
       new HypersonicDatabaseMeta(),
       new KingbaseESDatabaseMeta(),
+      new MSSQLServerDatabaseMeta(),
+      new MSSQLServerNativeDatabaseMeta(),
       new NetezzaDatabaseMeta(),
       new OracleDatabaseMeta(),
       new OracleRDBDatabaseMeta(),
@@ -73,8 +75,6 @@ public class SequenceMetaTests {
       new MondrianNativeDatabaseMeta(),
       new MonetDBDatabaseMeta(),
       new MSAccessDatabaseMeta(),
-      new MSSQLServerDatabaseMeta(),
-      new MSSQLServerNativeDatabaseMeta(),
       new MySQLDatabaseMeta(),
       new NeoviewDatabaseMeta(),
       new RemedyActionRequestSystemDatabaseMeta(),
@@ -178,6 +178,24 @@ public class SequenceMetaTests {
     assertEquals( "SELECT nextval('sequence_name')", databaseInterface.getSQLNextSequenceValue( sequenceName ) );
     assertEquals( "SELECT currval('sequence_name')", databaseInterface.getSQLCurrentSequenceValue( sequenceName ) );
 
+    databaseInterface = new MSSQLServerDatabaseMeta();
+    assertEquals( "SELECT NEXT VALUE FOR sequence_name",
+      databaseInterface.getSQLNextSequenceValue( sequenceName ) );
+    assertEquals( "SELECT current_value FROM sys.sequences WHERE name = 'sequence_name'",
+      databaseInterface.getSQLCurrentSequenceValue( sequenceName ) );
+    assertEquals( "SELECT name FROM sys.sequences", databaseInterface.getSQLListOfSequences() );
+    assertEquals( "SELECT * FROM sys.sequences WHERE name = 'sequence_name'",
+      databaseInterface.getSQLSequenceExists( sequenceName ) );
+
+    databaseInterface = new MSSQLServerNativeDatabaseMeta();
+    assertEquals( "SELECT NEXT VALUE FOR sequence_name",
+      databaseInterface.getSQLNextSequenceValue( sequenceName ) );
+    assertEquals( "SELECT current_value FROM sys.sequences WHERE name = 'sequence_name'",
+      databaseInterface.getSQLCurrentSequenceValue( sequenceName ) );
+    assertEquals( "SELECT name FROM sys.sequences", databaseInterface.getSQLListOfSequences() );
+    assertEquals( "SELECT * FROM sys.sequences WHERE name = 'sequence_name'",
+      databaseInterface.getSQLSequenceExists( sequenceName ) );
+
     databaseInterface = new NetezzaDatabaseMeta();
     assertEquals( "select next value for sequence_name", databaseInterface.getSQLNextSequenceValue( sequenceName ) );
     assertEquals( "select last_value from sequence_name", databaseInterface
@@ -246,14 +264,6 @@ public class SequenceMetaTests {
     assertEquals( "", databaseInterface.getSQLCurrentSequenceValue( sequenceName ) );
 
     databaseInterface = new MSAccessDatabaseMeta();
-    assertEquals( "", databaseInterface.getSQLNextSequenceValue( sequenceName ) );
-    assertEquals( "", databaseInterface.getSQLCurrentSequenceValue( sequenceName ) );
-
-    databaseInterface = new MSSQLServerDatabaseMeta();
-    assertEquals( "", databaseInterface.getSQLNextSequenceValue( sequenceName ) );
-    assertEquals( "", databaseInterface.getSQLCurrentSequenceValue( sequenceName ) );
-
-    databaseInterface = new MSSQLServerNativeDatabaseMeta();
     assertEquals( "", databaseInterface.getSQLNextSequenceValue( sequenceName ) );
     assertEquals( "", databaseInterface.getSQLCurrentSequenceValue( sequenceName ) );
 

--- a/test/org/pentaho/di/core/database/SequenceMetaTests.java
+++ b/test/org/pentaho/di/core/database/SequenceMetaTests.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.pentaho.di.core.Const;
 
 public class SequenceMetaTests {
 
@@ -36,38 +37,45 @@ public class SequenceMetaTests {
     // According to our Meta, Oracle, PostGres,
     // Greenplum and Vertica support sequences
     DatabaseInterface[] support = new DatabaseInterface[] {
-      new OracleDatabaseMeta(),
-      new OracleRDBDatabaseMeta(),
-      new VerticaDatabaseMeta(),
-      new PostgreSQLDatabaseMeta(),
-      new GreenplumDatabaseMeta(),
       new AS400DatabaseMeta(),
       new DB2DatabaseMeta(),
+      new GreenplumDatabaseMeta(),
       new HypersonicDatabaseMeta(),
       new KingbaseESDatabaseMeta(),
-      new NetezzaDatabaseMeta()
+      new NetezzaDatabaseMeta(),
+      new OracleDatabaseMeta(),
+      new OracleRDBDatabaseMeta(),
+      new PostgreSQLDatabaseMeta(),
+      new RedshiftDatabaseMeta(),
+      new VerticaDatabaseMeta(),
+      new Vertica5DatabaseMeta(),
     };
 
     // the rest of the database metas say they don't support sequences
     DatabaseInterface[] doNotSupport = new DatabaseInterface[] {
-      new MySQLDatabaseMeta(),
-      new InfiniDbDatabaseMeta(),
-      new InfobrightDatabaseMeta(),
+      new CacheDatabaseMeta(),
       new DbaseDatabaseMeta(),
       new DerbyDatabaseMeta(),
+      new Exasol4DatabaseMeta(),
+      new ExtenDBDatabaseMeta(),
       new ExtenDBDatabaseMeta(),
       new FirebirdDatabaseMeta(),
       new GenericDatabaseMeta(),
       new GuptaDatabaseMeta(),
       new H2DatabaseMeta(),
+      new InfiniDbDatabaseMeta(),
+      new InfobrightDatabaseMeta(),
       new InformixDatabaseMeta(),
       new IngresDatabaseMeta(),
       new InterbaseDatabaseMeta(),
+      new KettleDatabaseMeta(),
       new LucidDBDatabaseMeta(),
+      new MondrianNativeDatabaseMeta(),
       new MonetDBDatabaseMeta(),
       new MSAccessDatabaseMeta(),
       new MSSQLServerDatabaseMeta(),
       new MSSQLServerNativeDatabaseMeta(),
+      new MySQLDatabaseMeta(),
       new NeoviewDatabaseMeta(),
       new RemedyActionRequestSystemDatabaseMeta(),
       new SAPDBDatabaseMeta(),
@@ -76,7 +84,8 @@ public class SequenceMetaTests {
       new SybaseDatabaseMeta(),
       new SybaseIQDatabaseMeta(),
       new TeradataDatabaseMeta(),
-      new UniVerseDatabaseMeta()
+      new UniVerseDatabaseMeta(),
+      new VectorWiseDatabaseMeta()
     };
 
     for ( DatabaseInterface db : support ) {
@@ -89,10 +98,19 @@ public class SequenceMetaTests {
   }
 
   private static void assertSupports( DatabaseInterface db, boolean expected ) {
+    String dbType = db.getClass().getSimpleName();
     if (expected) {
-      assertTrue( db.getClass().getSimpleName(), db.supportsSequences() );
+      assertTrue( dbType, db.supportsSequences() );
+      assertFalse( dbType + ": List of Sequences", Const.isEmpty( db.getSQLListOfSequences() ) );
+      assertFalse( dbType + ": Sequence Exists", Const.isEmpty( db.getSQLSequenceExists( "testSeq" ) ) );
+      assertFalse( dbType + ": Current Value", Const.isEmpty( db.getSQLCurrentSequenceValue( "testSeq" ) ) );
+      assertFalse( dbType + ": Next Value", Const.isEmpty( db.getSQLNextSequenceValue( "testSeq" ) ) );
     } else {
       assertFalse( db.getClass().getSimpleName(), db.supportsSequences() );
+      assertTrue( dbType + ": List of Sequences", Const.isEmpty( db.getSQLListOfSequences() ) );
+      assertTrue( dbType + ": Sequence Exists", Const.isEmpty( db.getSQLSequenceExists( "testSeq" ) ) );
+      assertTrue( dbType + ": Current Value", Const.isEmpty( db.getSQLCurrentSequenceValue( "testSeq" ) ) );
+      assertTrue( dbType + ": Next Value", Const.isEmpty( db.getSQLNextSequenceValue( "testSeq" ) ) );
     }
   }
 


### PR DESCRIPTION
Added missing dialect methods to provide full support for various database sequences.

This is needed mostly for the "Add Sequence" step UI dialog, in order to get a list of available sequences.