### PR TITLE
[SP-1830] - Backport of PDI-12749 - PMR: Bad Results in Group-By if a…

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/groupby/GroupBy.java
+++ b/engine/src/org/pentaho/di/trans/steps/groupby/GroupBy.java
@@ -74,7 +74,7 @@ public class GroupBy extends BaseStep implements StepInterface {
   private boolean minNullIsValued = false;
 
   public GroupBy( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
-    Trans trans ) {
+                  Trans trans ) {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
 
     meta = (GroupByMeta) getStepMeta().getStepMetaInterface();
@@ -112,8 +112,8 @@ public class GroupBy extends BaseStep implements StepInterface {
       // Do all the work we can beforehand
       // Calculate indexes, loop up fields, etc.
       //
-      data.counts = new long[meta.getSubjectField().length];
-      data.subjectnrs = new int[meta.getSubjectField().length];
+      data.counts = new long[ meta.getSubjectField().length ];
+      data.subjectnrs = new int[ meta.getSubjectField().length ];
 
       data.cumulativeSumSourceIndexes = new ArrayList<Integer>();
       data.cumulativeSumTargetIndexes = new ArrayList<Integer>();
@@ -122,28 +122,28 @@ public class GroupBy extends BaseStep implements StepInterface {
       data.cumulativeAvgTargetIndexes = new ArrayList<Integer>();
 
       for ( int i = 0; i < meta.getSubjectField().length; i++ ) {
-        if ( meta.getAggregateType()[i] == GroupByMeta.TYPE_GROUP_COUNT_ANY ) {
-          data.subjectnrs[i] = 0;
+        if ( meta.getAggregateType()[ i ] == GroupByMeta.TYPE_GROUP_COUNT_ANY ) {
+          data.subjectnrs[ i ] = 0;
         } else {
-          data.subjectnrs[i] = data.inputRowMeta.indexOfValue( meta.getSubjectField()[i] );
+          data.subjectnrs[ i ] = data.inputRowMeta.indexOfValue( meta.getSubjectField()[ i ] );
         }
-        if ( ( r != null ) && ( data.subjectnrs[i] < 0 ) ) {
-          logError( BaseMessages.getString( PKG, "GroupBy.Log.AggregateSubjectFieldCouldNotFound", meta
-            .getSubjectField()[i] ) );
+        if ( ( r != null ) && ( data.subjectnrs[ i ] < 0 ) ) {
+          logError( BaseMessages.getString( PKG, "GroupBy.Log.AggregateSubjectFieldCouldNotFound",
+              meta.getSubjectField()[ i ] ) );
           setErrors( 1 );
           stopAll();
           return false;
         }
 
-        if ( meta.getAggregateType()[i] == GroupByMeta.TYPE_GROUP_CUMULATIVE_SUM ) {
-          data.cumulativeSumSourceIndexes.add( data.subjectnrs[i] );
+        if ( meta.getAggregateType()[ i ] == GroupByMeta.TYPE_GROUP_CUMULATIVE_SUM ) {
+          data.cumulativeSumSourceIndexes.add( data.subjectnrs[ i ] );
 
           // The position of the target in the output row is the input row size + i
           //
           data.cumulativeSumTargetIndexes.add( data.inputRowMeta.size() + i );
         }
-        if ( meta.getAggregateType()[i] == GroupByMeta.TYPE_GROUP_CUMULATIVE_AVERAGE ) {
-          data.cumulativeAvgSourceIndexes.add( data.subjectnrs[i] );
+        if ( meta.getAggregateType()[ i ] == GroupByMeta.TYPE_GROUP_CUMULATIVE_AVERAGE ) {
+          data.cumulativeAvgSourceIndexes.add( data.subjectnrs[ i ] );
 
           // The position of the target in the output row is the input row size + i
           //
@@ -152,16 +152,16 @@ public class GroupBy extends BaseStep implements StepInterface {
 
       }
 
-      data.previousSums = new Object[data.cumulativeSumTargetIndexes.size()];
+      data.previousSums = new Object[ data.cumulativeSumTargetIndexes.size() ];
 
-      data.previousAvgSum = new Object[data.cumulativeAvgTargetIndexes.size()];
-      data.previousAvgCount = new long[data.cumulativeAvgTargetIndexes.size()];
+      data.previousAvgSum = new Object[ data.cumulativeAvgTargetIndexes.size() ];
+      data.previousAvgCount = new long[ data.cumulativeAvgTargetIndexes.size() ];
 
-      data.groupnrs = new int[meta.getGroupField().length];
+      data.groupnrs = new int[ meta.getGroupField().length ];
       for ( int i = 0; i < meta.getGroupField().length; i++ ) {
-        data.groupnrs[i] = data.inputRowMeta.indexOfValue( meta.getGroupField()[i] );
-        if ( ( r != null ) && ( data.groupnrs[i] < 0 ) ) {
-          logError( BaseMessages.getString( PKG, "GroupBy.Log.GroupFieldCouldNotFound", meta.getGroupField()[i] ) );
+        data.groupnrs[ i ] = data.inputRowMeta.indexOfValue( meta.getGroupField()[ i ] );
+        if ( ( r != null ) && ( data.groupnrs[ i ] < 0 ) ) {
+          logError( BaseMessages.getString( PKG, "GroupBy.Log.GroupFieldCouldNotFound", meta.getGroupField()[ i ] ) );
           setErrors( 1 );
           stopAll();
           return false;
@@ -333,8 +333,8 @@ public class GroupBy extends BaseStep implements StepInterface {
     //
     for ( int i = 0; i < data.cumulativeSumSourceIndexes.size(); i++ ) {
       int sourceIndex = data.cumulativeSumSourceIndexes.get( i );
-      Object previousTarget = data.previousSums[i];
-      Object sourceValue = row[sourceIndex];
+      Object previousTarget = data.previousSums[ i ];
+      Object sourceValue = row[ sourceIndex ];
 
       int targetIndex = data.cumulativeSumTargetIndexes.get( i );
 
@@ -344,17 +344,17 @@ public class GroupBy extends BaseStep implements StepInterface {
       // If the first values where null, or this is the first time around, just take the source value...
       //
       if ( targetMeta.isNull( previousTarget ) ) {
-        row[targetIndex] = sourceMeta.convertToNormalStorageType( sourceValue );
+        row[ targetIndex ] = sourceMeta.convertToNormalStorageType( sourceValue );
       } else {
         // If the source value is null, just take the previous target value
         //
         if ( sourceMeta.isNull( sourceValue ) ) {
-          row[targetIndex] = previousTarget;
+          row[ targetIndex ] = previousTarget;
         } else {
-          row[targetIndex] = ValueDataUtil.plus( targetMeta, data.previousSums[i], sourceMeta, row[sourceIndex] );
+          row[ targetIndex ] = ValueDataUtil.plus( targetMeta, data.previousSums[ i ], sourceMeta, row[ sourceIndex ] );
         }
       }
-      data.previousSums[i] = row[targetIndex];
+      data.previousSums[ i ] = row[ targetIndex ];
     }
 
   }
@@ -365,8 +365,8 @@ public class GroupBy extends BaseStep implements StepInterface {
     //
     for ( int i = 0; i < data.cumulativeAvgSourceIndexes.size(); i++ ) {
       int sourceIndex = data.cumulativeAvgSourceIndexes.get( i );
-      Object previousTarget = data.previousAvgSum[i];
-      Object sourceValue = row[sourceIndex];
+      Object previousTarget = data.previousAvgSum[ i ];
+      Object sourceValue = row[ sourceIndex ];
 
       int targetIndex = data.cumulativeAvgTargetIndexes.get( i );
 
@@ -386,28 +386,28 @@ public class GroupBy extends BaseStep implements StepInterface {
           sum = previousTarget;
         } else {
           if ( sourceMeta.isInteger() ) {
-            sum = ValueDataUtil.plus( data.valueMetaInteger, data.previousAvgSum[i], sourceMeta, row[sourceIndex] );
+            sum = ValueDataUtil.plus( data.valueMetaInteger, data.previousAvgSum[ i ], sourceMeta, row[ sourceIndex ] );
           } else {
-            sum = ValueDataUtil.plus( targetMeta, data.previousAvgSum[i], sourceMeta, row[sourceIndex] );
+            sum = ValueDataUtil.plus( targetMeta, data.previousAvgSum[ i ], sourceMeta, row[ sourceIndex ] );
           }
         }
       }
-      data.previousAvgSum[i] = sum;
+      data.previousAvgSum[ i ] = sum;
 
       if ( !sourceMeta.isNull( sourceValue ) ) {
-        data.previousAvgCount[i]++;
+        data.previousAvgCount[ i ]++;
       }
 
       if ( sourceMeta.isInteger() ) {
         // Change to number as the exception
         //
         if ( sum == null ) {
-          row[targetIndex] = null;
+          row[ targetIndex ] = null;
         } else {
-          row[targetIndex] = new Double( ( (Long) sum ).doubleValue() / data.previousAvgCount[i] );
+          row[ targetIndex ] = new Double( ( (Long) sum ).doubleValue() / data.previousAvgCount[ i ] );
         }
       } else {
-        row[targetIndex] = ValueDataUtil.divide( targetMeta, sum, data.valueMetaInteger, data.previousAvgCount[i] );
+        row[ targetIndex ] = ValueDataUtil.divide( targetMeta, sum, data.valueMetaInteger, data.previousAvgCount[ i ] );
       }
     }
 
@@ -420,74 +420,74 @@ public class GroupBy extends BaseStep implements StepInterface {
 
   /**
    * used for junits in GroupByAggregationNullsTest
+   *
    * @param r
    * @throws KettleValueException
    */
-  @SuppressWarnings( "unchecked" )
-  void calcAggregate( Object[] r ) throws KettleValueException {
+  @SuppressWarnings( "unchecked" ) void calcAggregate( Object[] r ) throws KettleValueException {
     for ( int i = 0; i < data.subjectnrs.length; i++ ) {
-      Object subj = r[data.subjectnrs[i]];
-      ValueMetaInterface subjMeta = data.inputRowMeta.getValueMeta( data.subjectnrs[i] );
-      Object value = data.agg[i];
+      Object subj = r[ data.subjectnrs[ i ] ];
+      ValueMetaInterface subjMeta = data.inputRowMeta.getValueMeta( data.subjectnrs[ i ] );
+      Object value = data.agg[ i ];
       ValueMetaInterface valueMeta = data.aggMeta.getValueMeta( i );
 
-      switch ( meta.getAggregateType()[i] ) {
+      switch ( meta.getAggregateType()[ i ] ) {
         case GroupByMeta.TYPE_GROUP_SUM:
-          data.agg[i] = ValueDataUtil.sum( valueMeta, value, subjMeta, subj );
+          data.agg[ i ] = ValueDataUtil.sum( valueMeta, value, subjMeta, subj );
           break;
         case GroupByMeta.TYPE_GROUP_AVERAGE:
           if ( !subjMeta.isNull( subj ) ) {
-            data.agg[i] = ValueDataUtil.sum( valueMeta, value, subjMeta, subj );
-            data.counts[i]++;
+            data.agg[ i ] = ValueDataUtil.sum( valueMeta, value, subjMeta, subj );
+            data.counts[ i ]++;
           }
           break;
         case GroupByMeta.TYPE_GROUP_MEDIAN:
         case GroupByMeta.TYPE_GROUP_PERCENTILE:
           if ( !subjMeta.isNull( subj ) ) {
-            ( (List<Double>) data.agg[i] ).add( subjMeta.getNumber( subj ) );
+            ( (List<Double>) data.agg[ i ] ).add( subjMeta.getNumber( subj ) );
           }
           break;
         case GroupByMeta.TYPE_GROUP_STANDARD_DEVIATION:
           if ( !subjMeta.isNull( subj ) ) {
-            data.counts[i]++;
-            double n = data.counts[i];
+            data.counts[ i ]++;
+            double n = data.counts[ i ];
             double x = subjMeta.getNumber( subj );
             // for standard deviation null is exact 0
             double sum = value == null ? new Double( 0 ) : (Double) value;
-            double mean = data.mean[i];
+            double mean = data.mean[ i ];
 
             double delta = x - mean;
             mean = mean + ( delta / n );
             sum = sum + delta * ( x - mean );
 
-            data.mean[i] = mean;
-            data.agg[i] = sum;
+            data.mean[ i ] = mean;
+            data.agg[ i ] = sum;
           }
           break;
         case GroupByMeta.TYPE_GROUP_COUNT_DISTINCT:
           if ( !subjMeta.isNull( subj ) ) {
             if ( data.distinctObjs == null ) {
-              data.distinctObjs = new Set[meta.getSubjectField().length];
+              data.distinctObjs = new Set[ meta.getSubjectField().length ];
             }
-            if ( data.distinctObjs[i] == null ) {
-              data.distinctObjs[i] = new TreeSet<Object>();
+            if ( data.distinctObjs[ i ] == null ) {
+              data.distinctObjs[ i ] = new TreeSet<Object>();
             }
             Object obj = subjMeta.convertToNormalStorageType( subj );
-            if ( !data.distinctObjs[i].contains( obj ) ) {
-              data.distinctObjs[i].add( obj );
+            if ( !data.distinctObjs[ i ].contains( obj ) ) {
+              data.distinctObjs[ i ].add( obj );
               // null is exact 0, or we will not be able to ++.
               value = value == null ? new Long( 0 ) : value;
-              data.agg[i] = (Long) value + 1;
+              data.agg[ i ] = (Long) value + 1;
             }
           }
           break;
         case GroupByMeta.TYPE_GROUP_COUNT_ALL:
           if ( !subjMeta.isNull( subj ) ) {
-            data.counts[i]++;
+            data.counts[ i ]++;
           }
           break;
         case GroupByMeta.TYPE_GROUP_COUNT_ANY:
-          data.counts[i]++;
+          data.counts[ i ]++;
           break;
         case GroupByMeta.TYPE_GROUP_MIN: {
           if ( subj == null && !minNullIsValued ) {
@@ -497,11 +497,11 @@ public class GroupBy extends BaseStep implements StepInterface {
           if ( subjMeta.isSortedDescending() ) {
             // Account for negation in ValueMeta.compare() - See PDI-2302
             if ( subjMeta.compare( value, valueMeta, subj ) < 0 ) {
-              data.agg[i] = subj;
+              data.agg[ i ] = subj;
             }
           } else {
             if ( subjMeta.compare( subj, valueMeta, value ) < 0 ) {
-              data.agg[i] = subj;
+              data.agg[ i ] = subj;
             }
           }
           break;
@@ -510,22 +510,22 @@ public class GroupBy extends BaseStep implements StepInterface {
           if ( subjMeta.isSortedDescending() ) {
             // Account for negation in ValueMeta.compare() - See PDI-2302
             if ( subjMeta.compare( value, valueMeta, subj ) > 0 ) {
-              data.agg[i] = subj;
+              data.agg[ i ] = subj;
             }
           } else {
             if ( subjMeta.compare( subj, valueMeta, value ) > 0 ) {
-              data.agg[i] = subj;
+              data.agg[ i ] = subj;
             }
           }
           break;
         case GroupByMeta.TYPE_GROUP_FIRST:
           if ( !( subj == null ) && value == null ) {
-            data.agg[i] = subj;
+            data.agg[ i ] = subj;
           }
           break;
         case GroupByMeta.TYPE_GROUP_LAST:
           if ( !( subj == null ) ) {
-            data.agg[i] = subj;
+            data.agg[ i ] = subj;
           }
           break;
         case GroupByMeta.TYPE_GROUP_FIRST_INCL_NULL:
@@ -535,7 +535,7 @@ public class GroupBy extends BaseStep implements StepInterface {
           // if (linesWritten==0) value.setValue(subj);
           break;
         case GroupByMeta.TYPE_GROUP_LAST_INCL_NULL:
-          data.agg[i] = subj;
+          data.agg[ i ] = subj;
           break;
         case GroupByMeta.TYPE_GROUP_CONCAT_COMMA:
           if ( !( subj == null ) ) {
@@ -549,8 +549,8 @@ public class GroupBy extends BaseStep implements StepInterface {
         case GroupByMeta.TYPE_GROUP_CONCAT_STRING:
           if ( !( subj == null ) ) {
             String separator = "";
-            if ( !Const.isEmpty( meta.getValueField()[i] ) ) {
-              separator = environmentSubstitute( meta.getValueField()[i] );
+            if ( !Const.isEmpty( meta.getValueField()[ i ] ) ) {
+              separator = environmentSubstitute( meta.getValueField()[ i ] );
             }
 
             StringBuilder sb = (StringBuilder) value;
@@ -569,44 +569,45 @@ public class GroupBy extends BaseStep implements StepInterface {
 
   /**
    * used for junits in GroupByAggregationNullsTest
+   *
    * @param r
    */
   void newAggregate( Object[] r ) {
     // Put all the counters at 0
     for ( int i = 0; i < data.counts.length; i++ ) {
-      data.counts[i] = 0;
+      data.counts[ i ] = 0;
     }
     data.distinctObjs = null;
-    data.agg = new Object[data.subjectnrs.length];
-    data.mean = new double[data.subjectnrs.length]; // sets all doubles to 0.0
+    data.agg = new Object[ data.subjectnrs.length ];
+    data.mean = new double[ data.subjectnrs.length ]; // sets all doubles to 0.0
     data.aggMeta = new RowMeta();
 
     for ( int i = 0; i < data.subjectnrs.length; i++ ) {
-      ValueMetaInterface subjMeta = data.inputRowMeta.getValueMeta( data.subjectnrs[i] );
+      ValueMetaInterface subjMeta = data.inputRowMeta.getValueMeta( data.subjectnrs[ i ] );
       Object v = null;
       ValueMetaInterface vMeta = null;
-      int aggType = meta.getAggregateType()[i];
+      int aggType = meta.getAggregateType()[ i ];
       switch ( aggType ) {
         case GroupByMeta.TYPE_GROUP_SUM:
         case GroupByMeta.TYPE_GROUP_AVERAGE:
         case GroupByMeta.TYPE_GROUP_CUMULATIVE_SUM:
         case GroupByMeta.TYPE_GROUP_CUMULATIVE_AVERAGE:
           vMeta =
-            new ValueMeta( meta.getAggregateField()[i], subjMeta.isNumeric()
+            new ValueMeta( meta.getAggregateField()[ i ], subjMeta.isNumeric()
               ? subjMeta.getType() : ValueMetaInterface.TYPE_NUMBER );
           break;
         case GroupByMeta.TYPE_GROUP_MEDIAN:
         case GroupByMeta.TYPE_GROUP_PERCENTILE:
-          vMeta = new ValueMeta( meta.getAggregateField()[i], ValueMetaInterface.TYPE_NUMBER );
+          vMeta = new ValueMeta( meta.getAggregateField()[ i ], ValueMetaInterface.TYPE_NUMBER );
           v = new ArrayList<Double>();
           break;
         case GroupByMeta.TYPE_GROUP_STANDARD_DEVIATION:
-          vMeta = new ValueMeta( meta.getAggregateField()[i], ValueMetaInterface.TYPE_NUMBER );
+          vMeta = new ValueMeta( meta.getAggregateField()[ i ], ValueMetaInterface.TYPE_NUMBER );
           break;
         case GroupByMeta.TYPE_GROUP_COUNT_DISTINCT:
         case GroupByMeta.TYPE_GROUP_COUNT_ANY:
         case GroupByMeta.TYPE_GROUP_COUNT_ALL:
-          vMeta = new ValueMeta( meta.getAggregateField()[i], ValueMetaInterface.TYPE_INTEGER );
+          vMeta = new ValueMeta( meta.getAggregateField()[ i ], ValueMetaInterface.TYPE_INTEGER );
           break;
         case GroupByMeta.TYPE_GROUP_FIRST:
         case GroupByMeta.TYPE_GROUP_LAST:
@@ -615,15 +616,15 @@ public class GroupBy extends BaseStep implements StepInterface {
         case GroupByMeta.TYPE_GROUP_MIN:
         case GroupByMeta.TYPE_GROUP_MAX:
           vMeta = subjMeta.clone();
-          vMeta.setName( meta.getAggregateField()[i] );
-          v = r == null ? null : r[data.subjectnrs[i]];
+          vMeta.setName( meta.getAggregateField()[ i ] );
+          v = r == null ? null : r[ data.subjectnrs[ i ] ];
           break;
         case GroupByMeta.TYPE_GROUP_CONCAT_COMMA:
-          vMeta = new ValueMeta( meta.getAggregateField()[i], ValueMetaInterface.TYPE_STRING );
+          vMeta = new ValueMeta( meta.getAggregateField()[ i ], ValueMetaInterface.TYPE_STRING );
           v = new StringBuilder();
           break;
         case GroupByMeta.TYPE_GROUP_CONCAT_STRING:
-          vMeta = new ValueMeta( meta.getAggregateField()[i], ValueMetaInterface.TYPE_STRING );
+          vMeta = new ValueMeta( meta.getAggregateField()[ i ], ValueMetaInterface.TYPE_STRING );
           v = new StringBuilder();
           break;
         default:
@@ -632,23 +633,23 @@ public class GroupBy extends BaseStep implements StepInterface {
       }
 
       if ( ( subjMeta != null )
-        && ( aggType != GroupByMeta.TYPE_GROUP_COUNT_ALL
-        && aggType != GroupByMeta.TYPE_GROUP_COUNT_DISTINCT
-        && aggType != GroupByMeta.TYPE_GROUP_COUNT_ANY ) ) {
+          && ( aggType != GroupByMeta.TYPE_GROUP_COUNT_ALL
+          && aggType != GroupByMeta.TYPE_GROUP_COUNT_DISTINCT
+          && aggType != GroupByMeta.TYPE_GROUP_COUNT_ANY ) ) {
         vMeta.setLength( subjMeta.getLength(), subjMeta.getPrecision() );
       }
-      data.agg[i] = v;
+      data.agg[ i ] = v;
       data.aggMeta.addValueMeta( vMeta );
     }
 
     // Also clear the cumulative data...
     //
     for ( int i = 0; i < data.previousSums.length; i++ ) {
-      data.previousSums[i] = null;
+      data.previousSums[ i ] = null;
     }
     for ( int i = 0; i < data.previousAvgCount.length; i++ ) {
-      data.previousAvgCount[i] = 0L;
-      data.previousAvgSum[i] = null;
+      data.previousAvgCount[ i ] = 0L;
+      data.previousAvgSum[ i ] = null;
     }
   }
 
@@ -658,7 +659,7 @@ public class GroupBy extends BaseStep implements StepInterface {
       result = RowDataUtil.allocateRowData( data.groupnrs.length );
       if ( r != null ) {
         for ( int i = 0; i < data.groupnrs.length; i++ ) {
-          result[i] = r[data.groupnrs[i]];
+          result[ i ] = r[ data.groupnrs[ i ] ];
         }
       }
 
@@ -671,7 +672,7 @@ public class GroupBy extends BaseStep implements StepInterface {
   private void initGroupMeta( RowMetaInterface previousRowMeta ) throws KettleValueException {
     data.groupMeta = new RowMeta();
     for ( int i = 0; i < data.groupnrs.length; i++ ) {
-      data.groupMeta.addValueMeta( previousRowMeta.getValueMeta( data.groupnrs[i] ) );
+      data.groupMeta.addValueMeta( previousRowMeta.getValueMeta( data.groupnrs[ i ] ) );
     }
 
     return;
@@ -679,40 +680,41 @@ public class GroupBy extends BaseStep implements StepInterface {
 
   /**
    * Used for junits in GroupByAggregationNullsTest
+   *
    * @return
    * @throws KettleValueException
    */
   Object[] getAggregateResult() throws KettleValueException {
-    Object[] result = new Object[data.subjectnrs.length];
+    Object[] result = new Object[ data.subjectnrs.length ];
 
     if ( data.subjectnrs != null ) {
       for ( int i = 0; i < data.subjectnrs.length; i++ ) {
-        Object ag = data.agg[i];
-        switch ( meta.getAggregateType()[i] ) {
+        Object ag = data.agg[ i ];
+        switch ( meta.getAggregateType()[ i ] ) {
           case GroupByMeta.TYPE_GROUP_SUM:
             break;
           case GroupByMeta.TYPE_GROUP_AVERAGE:
             ag =
               ValueDataUtil.divide( data.aggMeta.getValueMeta( i ), ag, new ValueMeta(
-                "c", ValueMetaInterface.TYPE_INTEGER ), new Long( data.counts[i] ) );
+                "c", ValueMetaInterface.TYPE_INTEGER ), new Long( data.counts[ i ] ) );
             break;
           case GroupByMeta.TYPE_GROUP_MEDIAN:
           case GroupByMeta.TYPE_GROUP_PERCENTILE:
             double percentile = 50.0;
-            if ( meta.getAggregateType()[i] == GroupByMeta.TYPE_GROUP_PERCENTILE ) {
-              percentile = Double.parseDouble( meta.getValueField()[i] );
+            if ( meta.getAggregateType()[ i ] == GroupByMeta.TYPE_GROUP_PERCENTILE ) {
+              percentile = Double.parseDouble( meta.getValueField()[ i ] );
             }
             @SuppressWarnings( "unchecked" )
-            List<Double> valuesList = (List<Double>) data.agg[i];
-            double[] values = new double[valuesList.size()];
+            List<Double> valuesList = (List<Double>) data.agg[ i ];
+            double[] values = new double[ valuesList.size() ];
             for ( int v = 0; v < values.length; v++ ) {
-              values[v] = valuesList.get( v );
+              values[ v ] = valuesList.get( v );
             }
             ag = new Percentile().evaluate( values, percentile );
             break;
           case GroupByMeta.TYPE_GROUP_COUNT_ANY:
           case GroupByMeta.TYPE_GROUP_COUNT_ALL:
-            ag = new Long( data.counts[i] );
+            ag = new Long( data.counts[ i ] );
             break;
           case GroupByMeta.TYPE_GROUP_COUNT_DISTINCT:
             break;
@@ -721,7 +723,7 @@ public class GroupBy extends BaseStep implements StepInterface {
           case GroupByMeta.TYPE_GROUP_MAX:
             break;
           case GroupByMeta.TYPE_GROUP_STANDARD_DEVIATION:
-            double sum = (Double) ag / data.counts[i];
+            double sum = (Double) ag / data.counts[ i ];
             ag = Double.valueOf( Math.sqrt( sum ) );
             break;
           case GroupByMeta.TYPE_GROUP_CONCAT_COMMA:
@@ -737,7 +739,7 @@ public class GroupBy extends BaseStep implements StepInterface {
           ValueMetaInterface vm = data.aggMeta.getValueMeta( i );
           ag = ValueDataUtil.getZeroForValueMetaType( vm );
         }
-        result[i] = ag;
+        result[ i ] = ag;
       }
     }
     return result;
@@ -865,6 +867,7 @@ public class GroupBy extends BaseStep implements StepInterface {
 
   /**
    * Used for junits in GroupByAggregationNullsTest
+   *
    * @param allNullsAreZero the allNullsAreZero to set
    */
   void setAllNullsAreZero( boolean allNullsAreZero ) {
@@ -873,6 +876,7 @@ public class GroupBy extends BaseStep implements StepInterface {
 
   /**
    * Used for junits in GroupByAggregationNullsTest
+   *
    * @param minNullIsValued the minNullIsValued to set
    */
   void setMinNullIsValued( boolean minNullIsValued ) {

--- a/engine/src/org/pentaho/di/trans/steps/groupby/GroupByMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/groupby/GroupByMeta.java
@@ -52,7 +52,6 @@ import org.w3c.dom.Node;
 
 /**
  * Created on 02-jun-2003
- *
  */
 
 public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
@@ -122,43 +121,69 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     BaseMessages.getString( PKG, "GroupByMeta.TypeGroupLongDesc.COUNT_DISTINCT" ),
     BaseMessages.getString( PKG, "GroupByMeta.TypeGroupLongDesc.COUNT_ANY" ), };
 
-  /** All rows need to pass, adding an extra row at the end of each group/block. */
+  /**
+   * All rows need to pass, adding an extra row at the end of each group/block.
+   */
   private boolean passAllRows;
 
-  /** Directory to store the temp files */
+  /**
+   * Directory to store the temp files
+   */
   private String directory;
 
-  /** Temp files prefix... */
+  /**
+   * Temp files prefix...
+   */
   private String prefix;
 
-  /** Indicate that some rows don't need to be considered : TODO: make work in GUI & worker */
+  /**
+   * Indicate that some rows don't need to be considered : TODO: make work in GUI & worker
+   */
   private boolean aggregateIgnored;
 
-  /** name of the boolean field that indicates we need to ignore the row : TODO: make work in GUI & worker */
+  /**
+   * name of the boolean field that indicates we need to ignore the row : TODO: make work in GUI & worker
+   */
   private String aggregateIgnoredField;
 
-  /** Fields to group over */
+  /**
+   * Fields to group over
+   */
   private String[] groupField;
 
-  /** Name of aggregate field */
+  /**
+   * Name of aggregate field
+   */
   private String[] aggregateField;
 
-  /** Field name to group over */
+  /**
+   * Field name to group over
+   */
   private String[] subjectField;
 
-  /** Type of aggregate */
+  /**
+   * Type of aggregate
+   */
   private int[] aggregateType;
 
-  /** Value to use as separator for ex */
+  /**
+   * Value to use as separator for ex
+   */
   private String[] valueField;
 
-  /** Add a linenr in the group, resetting to 0 in a new group. */
+  /**
+   * Add a linenr in the group, resetting to 0 in a new group.
+   */
   private boolean addingLineNrInGroup;
 
-  /** The fieldname that will contain the added integer field */
+  /**
+   * The fieldname that will contain the added integer field
+   */
   private String lineNrInGroupField;
 
-  /** Flag to indicate that we always give back one row. Defaults to true for existing transformations. */
+  /**
+   * Flag to indicate that we always give back one row. Defaults to true for existing transformations.
+   */
   private boolean alwaysGivingBackOneRow;
 
   public GroupByMeta() {
@@ -173,8 +198,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param aggregateField
-   *          The aggregateField to set.
+   * @param aggregateField The aggregateField to set.
    */
   public void setAggregateField( String[] aggregateField ) {
     this.aggregateField = aggregateField;
@@ -188,8 +212,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param aggregateIgnored
-   *          The aggregateIgnored to set.
+   * @param aggregateIgnored The aggregateIgnored to set.
    */
   public void setAggregateIgnored( boolean aggregateIgnored ) {
     this.aggregateIgnored = aggregateIgnored;
@@ -203,8 +226,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param aggregateIgnoredField
-   *          The aggregateIgnoredField to set.
+   * @param aggregateIgnoredField The aggregateIgnoredField to set.
    */
   public void setAggregateIgnoredField( String aggregateIgnoredField ) {
     this.aggregateIgnoredField = aggregateIgnoredField;
@@ -218,8 +240,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param aggregateType
-   *          The aggregateType to set.
+   * @param aggregateType The aggregateType to set.
    */
   public void setAggregateType( int[] aggregateType ) {
     this.aggregateType = aggregateType;
@@ -233,8 +254,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param groupField
-   *          The groupField to set.
+   * @param groupField The groupField to set.
    */
   public void setGroupField( String[] groupField ) {
     this.groupField = groupField;
@@ -248,8 +268,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param passAllRows
-   *          The passAllRows to set.
+   * @param passAllRows The passAllRows to set.
    */
   public void setPassAllRows( boolean passAllRows ) {
     this.passAllRows = passAllRows;
@@ -263,8 +282,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param subjectField
-   *          The subjectField to set.
+   * @param subjectField The subjectField to set.
    */
   public void setSubjectField( String[] subjectField ) {
     this.subjectField = subjectField;
@@ -278,8 +296,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param separatorField
-   *          The valueField to set.
+   * @param separatorField The valueField to set.
    */
   public void setValueField( String[] valueField ) {
     this.valueField = valueField;
@@ -290,11 +307,11 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   public void allocate( int sizegroup, int nrfields ) {
-    groupField = new String[sizegroup];
-    aggregateField = new String[nrfields];
-    subjectField = new String[nrfields];
-    aggregateType = new int[nrfields];
-    valueField = new String[nrfields];
+    groupField = new String[ sizegroup ];
+    aggregateField = new String[ nrfields ];
+    subjectField = new String[ nrfields ];
+    aggregateType = new int[ nrfields ];
+    valueField = new String[ nrfields ];
   }
 
   public Object clone() {
@@ -324,22 +341,22 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
 
       for ( int i = 0; i < sizegroup; i++ ) {
         Node fnode = XMLHandler.getSubNodeByNr( groupn, "field", i );
-        groupField[i] = XMLHandler.getTagValue( fnode, "name" );
+        groupField[ i ] = XMLHandler.getTagValue( fnode, "name" );
       }
 
       boolean hasNumberOfValues = false;
       for ( int i = 0; i < nrfields; i++ ) {
         Node fnode = XMLHandler.getSubNodeByNr( fields, "field", i );
-        aggregateField[i] = XMLHandler.getTagValue( fnode, "aggregate" );
-        subjectField[i] = XMLHandler.getTagValue( fnode, "subject" );
-        aggregateType[i] = getType( XMLHandler.getTagValue( fnode, "type" ) );
+        aggregateField[ i ] = XMLHandler.getTagValue( fnode, "aggregate" );
+        subjectField[ i ] = XMLHandler.getTagValue( fnode, "subject" );
+        aggregateType[ i ] = getType( XMLHandler.getTagValue( fnode, "type" ) );
 
-        if ( aggregateType[i] == TYPE_GROUP_COUNT_ALL
-          || aggregateType[i] == TYPE_GROUP_COUNT_DISTINCT || aggregateType[i] == TYPE_GROUP_COUNT_ANY ) {
+        if ( aggregateType[ i ] == TYPE_GROUP_COUNT_ALL
+            || aggregateType[ i ] == TYPE_GROUP_COUNT_DISTINCT || aggregateType[ i ] == TYPE_GROUP_COUNT_ANY ) {
           hasNumberOfValues = true;
         }
 
-        valueField[i] = XMLHandler.getTagValue( fnode, "valuefield" );
+        valueField[ i ] = XMLHandler.getTagValue( fnode, "valuefield" );
       }
 
       String giveBackRow = XMLHandler.getTagValue( stepnode, "give_back_row" );
@@ -356,12 +373,12 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
 
   public static final int getType( String desc ) {
     for ( int i = 0; i < typeGroupCode.length; i++ ) {
-      if ( typeGroupCode[i].equalsIgnoreCase( desc ) ) {
+      if ( typeGroupCode[ i ].equalsIgnoreCase( desc ) ) {
         return i;
       }
     }
     for ( int i = 0; i < typeGroupLongDesc.length; i++ ) {
-      if ( typeGroupLongDesc[i].equalsIgnoreCase( desc ) ) {
+      if ( typeGroupLongDesc[ i ].equalsIgnoreCase( desc ) ) {
         return i;
       }
     }
@@ -372,14 +389,14 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     if ( i < 0 || i >= typeGroupCode.length ) {
       return null;
     }
-    return typeGroupCode[i];
+    return typeGroupCode[ i ];
   }
 
   public static final String getTypeDescLong( int i ) {
     if ( i < 0 || i >= typeGroupLongDesc.length ) {
       return null;
     }
-    return typeGroupLongDesc[i];
+    return typeGroupLongDesc[ i ];
   }
 
   public void setDefault() {
@@ -397,7 +414,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   public void getFields( RowMetaInterface r, String origin, RowMetaInterface[] info, StepMeta nextStep,
-    VariableSpace space, Repository repository, IMetaStore metaStore ) {
+                         VariableSpace space, Repository repository, IMetaStore metaStore ) {
     // re-assemble a new row of metadata
     //
     RowMetaInterface fields = new RowMeta();
@@ -406,7 +423,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
       // Add the grouping fields in the correct order...
       //
       for ( int i = 0; i < groupField.length; i++ ) {
-        ValueMetaInterface valueMeta = r.searchValueMeta( groupField[i] );
+        ValueMetaInterface valueMeta = r.searchValueMeta( groupField[ i ] );
         if ( valueMeta != null ) {
           fields.addValueMeta( valueMeta );
         }
@@ -420,14 +437,14 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     // Re-add aggregates
     //
     for ( int i = 0; i < subjectField.length; i++ ) {
-      ValueMetaInterface subj = r.searchValueMeta( subjectField[i] );
-      if ( subj != null || aggregateType[i] == TYPE_GROUP_COUNT_ANY ) {
-        String value_name = aggregateField[i];
+      ValueMetaInterface subj = r.searchValueMeta( subjectField[ i ] );
+      if ( subj != null || aggregateType[ i ] == TYPE_GROUP_COUNT_ANY ) {
+        String value_name = aggregateField[ i ];
         int value_type = ValueMetaInterface.TYPE_NONE;
         int length = -1;
         int precision = -1;
 
-        switch ( aggregateType[i] ) {
+        switch ( aggregateType[ i ] ) {
           case TYPE_GROUP_SUM:
           case TYPE_GROUP_AVERAGE:
           case TYPE_GROUP_CUMULATIVE_SUM:
@@ -461,17 +478,17 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
 
         // Change type from integer to number in case off averages for cumulative average
         //
-        if ( aggregateType[i] == TYPE_GROUP_CUMULATIVE_AVERAGE && value_type == ValueMetaInterface.TYPE_INTEGER ) {
+        if ( aggregateType[ i ] == TYPE_GROUP_CUMULATIVE_AVERAGE && value_type == ValueMetaInterface.TYPE_INTEGER ) {
           value_type = ValueMetaInterface.TYPE_NUMBER;
           precision = -1;
           length = -1;
-        } else if ( aggregateType[i] == TYPE_GROUP_COUNT_ALL
-          || aggregateType[i] == TYPE_GROUP_COUNT_DISTINCT || aggregateType[i] == TYPE_GROUP_COUNT_ANY ) {
+        } else if ( aggregateType[ i ] == TYPE_GROUP_COUNT_ALL
+            || aggregateType[ i ] == TYPE_GROUP_COUNT_DISTINCT || aggregateType[ i ] == TYPE_GROUP_COUNT_ANY ) {
           length = ValueMetaInterface.DEFAULT_INTEGER_LENGTH;
           precision = 0;
-        } else if ( aggregateType[i] == TYPE_GROUP_SUM
-          && value_type != ValueMetaInterface.TYPE_INTEGER && value_type != ValueMetaInterface.TYPE_NUMBER
-          && value_type != ValueMetaInterface.TYPE_BIGNUMBER ) {
+        } else if ( aggregateType[ i ] == TYPE_GROUP_SUM
+            && value_type != ValueMetaInterface.TYPE_INTEGER && value_type != ValueMetaInterface.TYPE_NUMBER
+            && value_type != ValueMetaInterface.TYPE_BIGNUMBER ) {
           // If it ain't numeric, we change it to Number
           //
           value_type = ValueMetaInterface.TYPE_NUMBER;
@@ -520,7 +537,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     retval.append( "      <group>" ).append( Const.CR );
     for ( int i = 0; i < groupField.length; i++ ) {
       retval.append( "        <field>" ).append( Const.CR );
-      retval.append( "          " ).append( XMLHandler.addTagValue( "name", groupField[i] ) );
+      retval.append( "          " ).append( XMLHandler.addTagValue( "name", groupField[ i ] ) );
       retval.append( "        </field>" ).append( Const.CR );
     }
     retval.append( "      </group>" ).append( Const.CR );
@@ -528,10 +545,10 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     retval.append( "      <fields>" ).append( Const.CR );
     for ( int i = 0; i < subjectField.length; i++ ) {
       retval.append( "        <field>" ).append( Const.CR );
-      retval.append( "          " ).append( XMLHandler.addTagValue( "aggregate", aggregateField[i] ) );
-      retval.append( "          " ).append( XMLHandler.addTagValue( "subject", subjectField[i] ) );
-      retval.append( "          " ).append( XMLHandler.addTagValue( "type", getTypeDesc( aggregateType[i] ) ) );
-      retval.append( "          " ).append( XMLHandler.addTagValue( "valuefield", valueField[i] ) );
+      retval.append( "          " ).append( XMLHandler.addTagValue( "aggregate", aggregateField[ i ] ) );
+      retval.append( "          " ).append( XMLHandler.addTagValue( "subject", subjectField[ i ] ) );
+      retval.append( "          " ).append( XMLHandler.addTagValue( "type", getTypeDesc( aggregateType[ i ] ) ) );
+      retval.append( "          " ).append( XMLHandler.addTagValue( "valuefield", valueField[ i ] ) );
       retval.append( "        </field>" ).append( Const.CR );
     }
     retval.append( "      </fields>" ).append( Const.CR );
@@ -539,7 +556,8 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     return retval.toString();
   }
 
-  public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases ) throws KettleException {
+  public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases )
+    throws KettleException {
     try {
       passAllRows = rep.getStepAttributeBoolean( id_step, "all_rows" );
       aggregateIgnored = rep.getStepAttributeBoolean( id_step, "ignore_aggregate" );
@@ -555,20 +573,20 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
       allocate( groupsize, nrvalues );
 
       for ( int i = 0; i < groupsize; i++ ) {
-        groupField[i] = rep.getStepAttributeString( id_step, i, "group_name" );
+        groupField[ i ] = rep.getStepAttributeString( id_step, i, "group_name" );
       }
 
       boolean hasNumberOfValues = false;
       for ( int i = 0; i < nrvalues; i++ ) {
-        aggregateField[i] = rep.getStepAttributeString( id_step, i, "aggregate_name" );
-        subjectField[i] = rep.getStepAttributeString( id_step, i, "aggregate_subject" );
-        aggregateType[i] = getType( rep.getStepAttributeString( id_step, i, "aggregate_type" ) );
+        aggregateField[ i ] = rep.getStepAttributeString( id_step, i, "aggregate_name" );
+        subjectField[ i ] = rep.getStepAttributeString( id_step, i, "aggregate_subject" );
+        aggregateType[ i ] = getType( rep.getStepAttributeString( id_step, i, "aggregate_type" ) );
 
-        if ( aggregateType[i] == TYPE_GROUP_COUNT_ALL
-          || aggregateType[i] == TYPE_GROUP_COUNT_DISTINCT || aggregateType[i] == TYPE_GROUP_COUNT_ANY ) {
+        if ( aggregateType[ i ] == TYPE_GROUP_COUNT_ALL
+            || aggregateType[ i ] == TYPE_GROUP_COUNT_DISTINCT || aggregateType[ i ] == TYPE_GROUP_COUNT_ANY ) {
           hasNumberOfValues = true;
         }
-        valueField[i] = rep.getStepAttributeString( id_step, i, "aggregate_value_field" );
+        valueField[ i ] = rep.getStepAttributeString( id_step, i, "aggregate_value_field" );
       }
 
       alwaysGivingBackOneRow = rep.getStepAttributeBoolean( id_step, 0, "give_back_row", hasNumberOfValues );
@@ -578,7 +596,8 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     }
   }
 
-  public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
+  public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step )
+    throws KettleException {
     try {
       rep.saveStepAttribute( id_transformation, id_step, "all_rows", passAllRows );
       rep.saveStepAttribute( id_transformation, id_step, "ignore_aggregate", aggregateIgnored );
@@ -590,14 +609,14 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
       rep.saveStepAttribute( id_transformation, id_step, "give_back_row", alwaysGivingBackOneRow );
 
       for ( int i = 0; i < groupField.length; i++ ) {
-        rep.saveStepAttribute( id_transformation, id_step, i, "group_name", groupField[i] );
+        rep.saveStepAttribute( id_transformation, id_step, i, "group_name", groupField[ i ] );
       }
 
       for ( int i = 0; i < subjectField.length; i++ ) {
-        rep.saveStepAttribute( id_transformation, id_step, i, "aggregate_name", aggregateField[i] );
-        rep.saveStepAttribute( id_transformation, id_step, i, "aggregate_subject", subjectField[i] );
-        rep.saveStepAttribute( id_transformation, id_step, i, "aggregate_type", getTypeDesc( aggregateType[i] ) );
-        rep.saveStepAttribute( id_transformation, id_step, i, "aggregate_value_field", valueField[i] );
+        rep.saveStepAttribute( id_transformation, id_step, i, "aggregate_name", aggregateField[ i ] );
+        rep.saveStepAttribute( id_transformation, id_step, i, "aggregate_subject", subjectField[ i ] );
+        rep.saveStepAttribute( id_transformation, id_step, i, "aggregate_type", getTypeDesc( aggregateType[ i ] ) );
+        rep.saveStepAttribute( id_transformation, id_step, i, "aggregate_value_field", valueField[ i ] );
       }
     } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString(
@@ -607,8 +626,8 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta,
-    RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
-    Repository repository, IMetaStore metaStore ) {
+                     RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
+                     Repository repository, IMetaStore metaStore ) {
     CheckResult cr;
 
     if ( input.length > 0 ) {
@@ -625,7 +644,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int cnr,
-    TransMeta transMeta, Trans trans ) {
+                                TransMeta transMeta, Trans trans ) {
     return new GroupBy( stepMeta, stepDataInterface, cnr, transMeta, trans );
   }
 
@@ -641,8 +660,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param directory
-   *          The directory to set.
+   * @param directory The directory to set.
    */
   public void setDirectory( String directory ) {
     this.directory = directory;
@@ -656,8 +674,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param prefix
-   *          The prefix to set.
+   * @param prefix The prefix to set.
    */
   public void setPrefix( String prefix ) {
     this.prefix = prefix;
@@ -671,8 +688,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param addingLineNrInGroup
-   *          the addingLineNrInGroup to set
+   * @param addingLineNrInGroup the addingLineNrInGroup to set
    */
   public void setAddingLineNrInGroup( boolean addingLineNrInGroup ) {
     this.addingLineNrInGroup = addingLineNrInGroup;
@@ -686,8 +702,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param lineNrInGroupField
-   *          the lineNrInGroupField to set
+   * @param lineNrInGroupField the lineNrInGroupField to set
    */
   public void setLineNrInGroupField( String lineNrInGroupField ) {
     this.lineNrInGroupField = lineNrInGroupField;
@@ -701,8 +716,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   /**
-   * @param alwaysGivingBackOneRow
-   *          the alwaysGivingBackOneRow to set
+   * @param alwaysGivingBackOneRow the alwaysGivingBackOneRow to set
    */
   public void setAlwaysGivingBackOneRow( boolean alwaysGivingBackOneRow ) {
     this.alwaysGivingBackOneRow = alwaysGivingBackOneRow;
@@ -713,4 +727,8 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     return new GroupByMetaInjection( this );
   }
 
+  @Override
+  public TransMeta.TransformationType[] getSupportedTransformationTypes() {
+    return new TransMeta.TransformationType[] { TransMeta.TransformationType.Normal };
+  }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/groupby/GroupBySingleThreadedExecutionTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/groupby/GroupBySingleThreadedExecutionTest.java
@@ -1,0 +1,35 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.groupby;
+
+import org.pentaho.test.util.SingleThreadedExecutionGuarder;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class GroupBySingleThreadedExecutionTest extends SingleThreadedExecutionGuarder<GroupByMeta> {
+
+  @Override protected GroupByMeta createMeta() {
+    return new GroupByMeta();
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/stepsmetrics/StepMetricsSingleThreadedExecutionTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/stepsmetrics/StepMetricsSingleThreadedExecutionTest.java
@@ -1,0 +1,32 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.stepsmetrics;
+
+import org.pentaho.test.util.SingleThreadedExecutionGuarder;
+
+public class StepMetricsSingleThreadedExecutionTest extends SingleThreadedExecutionGuarder<StepsMetricsMeta> {
+
+  @Override protected StepsMetricsMeta createMeta() {
+    return new StepsMetricsMeta();
+  }
+}


### PR DESCRIPTION
…n entire key is filtered earlier (5.3 Suite)

- apply formatting for GroupBy and GroupByMeta (cherry picked from commit 446a6a01723f8dfe968e59f143dd9080fe99a810)
- backport the fix (cherry picked from commit 6f3d9f6)
   - prohibit GroupBy step to be executed within single-threaded environment
   - introduce a generic test for guarding the condition above
   - create two test classes of such type

@mattyb149, @brosander, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/1276  