### PR TITLE
[BACKLOG-3294] - Setting parameters in transformation (connected to DI Server) through exception

### DIFF
--- a/ui/src/org/pentaho/di/ui/core/widget/TableView.java
+++ b/ui/src/org/pentaho/di/ui/core/widget/TableView.java
@@ -2669,6 +2669,10 @@ public class TableView extends Composite {
   private void setUndoMenu() {
     TransAction prev = viewPreviousUndo();
     TransAction next = viewNextUndo();
+    
+    if ( miEditUndo.isDisposed() || miEditRedo.isDisposed() ) {
+      return;
+    }
 
     if ( prev != null ) {
       miEditUndo.setEnabled( true );


### PR DESCRIPTION
I wasn't able to figure out how to prevent call of FocusListener when items disposed, so  I just add isDisposed() check.  

@mdamour1976  please review.