### PR TITLE
[PDI-13434] - Pentaho Reporting Output step - Excel output formatting…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -775,7 +775,7 @@
             haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.numberrange.NumberRangeSetTest"
             haltonerror="false"/>
-      <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.pentahoreporting.PentahoReportingOutput"
+      <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.pentahoreporting.PentahoReportingOutputTest"
             haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.regexeval.RegexEvalTest"
             haltonerror="false"/>


### PR DESCRIPTION
… is different from PRD Excel output

- fix tests' config typo

@mattyb149, @brosander, @deinspanjer, @dkincade, merge it please. This fixes an error in tests' configuration:

http://ci.pentaho.com/job/Kettle-integration-tests/737/testReport/org.pentaho.di.trans.steps.pentahoreporting/PentahoReportingOutput/initializationError/    