### PR TITLE
[SP-1823] - Backport of PDI-13434 - Pentaho Reporting Output step - E…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -744,7 +744,7 @@
             haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.numberrange.NumberRangeSetTest"
             haltonerror="false"/>
-      <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.pentahoreporting.PentahoReportingOutput"
+      <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.pentahoreporting.PentahoReportingOutputTest"
             haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.regexeval.RegexEvalTest"
             haltonerror="false"/>


### PR DESCRIPTION
…xcel output formatting is different from PRD Excel output (5.3 Suite)

- fix tests' config typo

@mattyb149, @brosander, @deinspanjer, @dkincade, merge it please. This fixes an error in tests' configuration and the backport of https://github.com/pentaho/pentaho-kettle/pull/1303