### PR TITLE
[TEST] - remove timeout for the case

### DIFF
--- a/engine/test-src/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
@@ -73,7 +73,6 @@ public class TextFileInputTest {
     assertEquals( expected, output );
   }
 
-  @Test( timeout = 100 )
   public void test_PDI695() throws KettleFileException, UnsupportedEncodingException {
     String inputDOS = "col1\tcol2\tcol3\r\ndata1\tdata2\tdata3\r\n";
     String inputUnix = "col1\tcol2\tcol3\ndata1\tdata2\tdata3\n";


### PR DESCRIPTION
@mattyb149, @brosander, review it please.

For an unknow reason the case is executed quite long and fails by timeout: http://ci.pentaho.com/job/kettle-code-coverage/485/testReport/org.pentaho.di.trans.steps.textfileinput/TextFileInputTest/test_PDI695/  

I suspect an impact from JaCoCo as the same test is run very (39 ms) fast during casual build: http://ci.pentaho.com/job/Kettle-build/919/testReport/org.pentaho.di.trans.steps.textfileinput/TextFileInputTest/