### PR TITLE
[CLEANUP] - fixing circular dependency between pentaho-karaf-assembly…

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -43,8 +43,8 @@
     <dependency org="${ivy.artifact.group}" name="kettle5-log4j-plugin" rev="${project.revision}" changing="true" conf="plugins->default">
         <artifact name="kettle5-log4j-plugin" type="zip"/>
     </dependency>
-    <dependency org="pentaho" name="pdi-osgi-bridge" rev="${dependency.pdi-osgi-bridge.revision}" changing="true" conf="plugins->default">
-      <artifact name="pdi-osgi-bridge" type="zip"/>
+    <dependency org="pentaho" name="pdi-osgi-bridge-assembly" rev="${dependency.pdi-osgi-bridge.revision}" changing="true" conf="plugins->default">
+      <artifact name="pdi-osgi-bridge-assembly" type="zip"/>
     </dependency>
 
     <!-- Pentaho dependencies (non-Kettle), launcher, shim, etc. -->


### PR DESCRIPTION
… and pdi-osgi-bridge.

pdi-osgi-bridge assembly pulled in pentaho-karaf-assembly and pentaho-karaf-assembly (in the standard feature file) pulls in pdi-osgi-bridge-activators. This was the source of the circular dependency and is potentially fixed by splitting out the assembly from the core of the bridge.

@lgrill-pentaho _NOTE: It is still required (by the build) to build the pdi-osgi-bridge core and activator FIRST, then pentaho-karaf-assembly, and LAST the pdi-osgi-bridge assembly._