### PR TITLE
[SP-1696] - Regression PDI-13418 - UDJC step returns an error "Access…

### DIFF
--- a/core/src/org/pentaho/di/core/row/ValueMeta.java
+++ b/core/src/org/pentaho/di/core/row/ValueMeta.java
@@ -39,7 +39,7 @@ import org.w3c.dom.Node;
  *
  *
  */
-public class ValueMeta extends ValueMetaBase implements ValueMetaInterface {
+public class ValueMeta extends ValueMetaBase {
   private static Class<?> PKG = Const.class;
 
   public static final String DEFAULT_DATE_FORMAT_MASK = "yyyy/MM/dd HH:mm:ss.SSS";

--- a/core/test-src/org/pentaho/di/core/row/ValueMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/row/ValueMetaTest.java
@@ -626,4 +626,8 @@ public class ValueMetaTest extends TestCase {
     assertTrue( one.compare( string1, two, string5 ) != 0 );
     assertTrue( one.compare( string5, two, string6 ) == 0 );
   }
+
+  public void testValueMetaInheritance() {
+    assertTrue( new ValueMeta() instanceof ValueMetaInterface );
+  }
 }


### PR DESCRIPTION
… to field "TYPE_STRING" is ambiguous" (5.3 Suite)

Remove the interface implementation, as the super class already
implements the same interface (cherry picked from commit f2b4a82)

@mattyb149, @brosander, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/1307  