### PR TITLE
PDI-11217: Multiway Merge Join Get Key Fields can get wrong fields. T…

### DIFF
--- a/ui/src/org/pentaho/di/ui/trans/steps/multimerge/MultiMergeJoinDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/multimerge/MultiMergeJoinDialog.java
@@ -372,13 +372,13 @@ public class MultiMergeJoinDialog extends BaseStepDialog implements StepDialogIn
 
     final Runnable runnable = new Runnable() {
       public void run() {
-        StepMeta stepMeta = transMeta.getStep( inputStreamIndex );
         try {
-
+          String[] prevSteps = transMeta.getPrevStepNames( stepname );
+          String stepName = prevSteps[inputStreamIndex];
+          StepMeta stepMeta = transMeta.findStep( stepName );
           if ( stepMeta != null ) {
             prev = transMeta.getStepFields( stepMeta );
             if ( prev != null ) {
-
               // Remember these fields...
               for ( int i = 0; i < prev.size(); i++ ) {
                 inputFields.put( prev.getValueMeta( i ).getName(), Integer.valueOf( i ) );


### PR DESCRIPTION
…he dialog correctly used prevStepNames() to generate the widgets for each input (actually info) step. Later in, indexe from that list were incorrectly used as argument to transMeta.getStep( inputStreamIndex ); from which the fields where then queried. This resulted in seemingly unpredictable but usually incorrect fields.