### PR TITLE
PDI-11215: Cannot Edit Multiway Merge Join After Deleting an Input Ho…

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/multimerge/MultiMergeJoin.java
+++ b/engine/src/org/pentaho/di/trans/steps/multimerge/MultiMergeJoin.java
@@ -22,9 +22,13 @@
 
 package org.pentaho.di.trans.steps.multimerge;
 
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Set;
 
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.exception.KettleException;
@@ -68,86 +72,102 @@ public class MultiMergeJoin extends BaseStep implements StepInterface {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
 
+  private void processFirstRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
+    meta = (MultiMergeJoinMeta) smi;
+    data = (MultiMergeJoinData) sdi;
+    // Find the RowSet to read from
+    //
+    String[] prevStepNames = getTransMeta().getPrevStepNames( getStepname() );
+    Set<String> infoStepNameSet = new HashSet<String>();
+    if ( prevStepNames != null ) {
+      Collections.addAll(infoStepNameSet, prevStepNames);
+    }
+    String[] infoStepNames = meta.getStepIOMeta().getInfoStepnames();
+    infoStepNameSet.retainAll( Arrays.asList(infoStepNames) );
+
+    int streamSize = infoStepNameSet.size();
+    String[] inputStepNames = infoStepNameSet.toArray( new String[streamSize] );
+    String inputStepName;
+
+    data.rowSets = new RowSet[streamSize];
+    data.rows = new Object[streamSize][];
+    data.metas = new RowMetaInterface[streamSize];
+    data.rowLengths = new int[streamSize];
+    data.queue =
+      new PriorityQueue<MultiMergeJoinData.QueueEntry>( streamSize, new MultiMergeJoinData.QueueComparator(
+        data ) );
+    data.results = new ArrayList<List<Object[]>>( streamSize );
+    data.queueEntries = new MultiMergeJoinData.QueueEntry[streamSize];
+    data.drainIndices = new int[streamSize];
+    for ( int i = 0; i < streamSize; i++ ) {
+      inputStepName = inputStepNames[i];
+      data.queueEntries[i] = new MultiMergeJoinData.QueueEntry();
+      data.queueEntries[i].index = i;
+      data.results.add( new ArrayList<Object[]>() );
+      data.rowSets[i] = findInputRowSet( inputStepName );
+      if ( data.rowSets[i] == null ) {
+        throw new KettleException( BaseMessages.getString(
+          PKG, "MultiMergeJoin.Exception.UnableToFindSpecifiedStep", inputStepName ) );
+      }
+      data.rows[i] = getRowFrom( data.rowSets[i] );
+      if ( data.rows[i] == null ) {
+        data.metas[i] = getTransMeta().getStepFields( inputStepName );
+      } else {
+        data.queueEntries[i].row = data.rows[i];
+        data.metas[i] = data.rowSets[i].getRowMeta();
+      }
+
+      data.rowLengths[i] = data.metas[i].size();
+    }
+
+    //
+    data.outputRowMeta = new RowMeta();
+    for ( int i = 0; i < streamSize; i++ ) {
+      data.outputRowMeta.mergeRowMeta( data.metas[i].clone() );
+    }
+
+    data.keyNrs = new int[streamSize][];
+
+    for ( int j = 0; j < streamSize; j++ ) {
+      if ( data.rows[j] != null ) {
+        /*
+         * // Find the key indexes: data.keyNrs[j] = new int[meta.getKeyFields().length]; for (int
+         * i=0;i<meta.getKeyFields().length; i++) { data.keyNrs[j][i] =
+         * data.metas[j].indexOfValue(meta.getKeyFields()[i]); if (data.keyNrs[j][i]<0) { String message =
+         * BaseMessages.getString(PKG,
+         * "MultiMergeJoin.Exception.UnableToFindFieldInReferenceStream",meta.getKeyFields()[i]); logError(message);
+         * throw new KettleStepException(message); } }
+         */
+        String[] keyFields = meta.getKeyFields()[j].split( "," );
+        data.keyNrs[j] = new int[keyFields.length];
+        for ( int i = 0; i < keyFields.length; i++ ) {
+          data.keyNrs[j][i] = data.metas[j].indexOfValue( keyFields[i] );
+          if ( data.keyNrs[j][i] < 0 ) {
+            String message =
+              BaseMessages.getString( PKG, "MultiMergeJoin.Exception.UnableToFindFieldInReferenceStream", meta
+                .getKeyFields()[i] );
+            logError( message );
+            throw new KettleStepException( message );
+          }
+        }
+        data.queue.add( data.queueEntries[j] );
+      }
+    }
+
+    data.dummy = new Object[streamSize][];
+    for ( int i = 0; i < streamSize; i++ ) {
+      // Calculate dummy... defaults to null
+      data.dummy[i] = RowDataUtil.allocateRowData( data.metas[i].size() );
+    }
+  }
+
   public boolean processRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
     meta = (MultiMergeJoinMeta) smi;
     data = (MultiMergeJoinData) sdi;
 
     if ( first ) {
+      processFirstRow( smi, sdi );
       first = false;
-
-      // Find the RowSet to read from
-      //
-      List<StreamInterface> infoStreams = meta.getStepIOMeta().getInfoStreams();
-      int streamSize = infoStreams.size();
-      data.rowSets = new RowSet[streamSize];
-      data.rows = new Object[streamSize][];
-      data.metas = new RowMetaInterface[streamSize];
-      data.rowLengths = new int[streamSize];
-      data.queue =
-        new PriorityQueue<MultiMergeJoinData.QueueEntry>( streamSize, new MultiMergeJoinData.QueueComparator(
-          data ) );
-      data.results = new ArrayList<List<Object[]>>( streamSize );
-      data.queueEntries = new MultiMergeJoinData.QueueEntry[streamSize];
-      data.drainIndices = new int[streamSize];
-      for ( int i = 0; i < streamSize; i++ ) {
-        data.queueEntries[i] = new MultiMergeJoinData.QueueEntry();
-        data.queueEntries[i].index = i;
-        data.results.add( new ArrayList<Object[]>() );
-        data.rowSets[i] = findInputRowSet( infoStreams.get( i ).getStepname() );
-        if ( data.rowSets[i] == null ) {
-          throw new KettleException( BaseMessages.getString(
-            PKG, "MultiMergeJoin.Exception.UnableToFindSpecifiedStep", infoStreams.get( 0 ).getStepname() ) );
-        }
-        data.rows[i] = getRowFrom( data.rowSets[i] );
-        if ( data.rows[i] == null ) {
-          data.metas[i] = getTransMeta().getStepFields( infoStreams.get( i ).getStepname() );
-        } else {
-          data.queueEntries[i].row = data.rows[i];
-          data.metas[i] = data.rowSets[i].getRowMeta();
-        }
-
-        data.rowLengths[i] = data.metas[i].size();
-      }
-
-      //
-      data.outputRowMeta = new RowMeta();
-      for ( int i = 0; i < streamSize; i++ ) {
-        data.outputRowMeta.mergeRowMeta( data.metas[i].clone() );
-      }
-
-      data.keyNrs = new int[streamSize][];
-
-      for ( int j = 0; j < streamSize; j++ ) {
-        if ( data.rows[j] != null ) {
-          /*
-           * // Find the key indexes: data.keyNrs[j] = new int[meta.getKeyFields().length]; for (int
-           * i=0;i<meta.getKeyFields().length; i++) { data.keyNrs[j][i] =
-           * data.metas[j].indexOfValue(meta.getKeyFields()[i]); if (data.keyNrs[j][i]<0) { String message =
-           * BaseMessages.getString(PKG,
-           * "MultiMergeJoin.Exception.UnableToFindFieldInReferenceStream",meta.getKeyFields()[i]); logError(message);
-           * throw new KettleStepException(message); } }
-           */
-          String[] keyFields = meta.getKeyFields()[j].split( "," );
-          data.keyNrs[j] = new int[keyFields.length];
-          for ( int i = 0; i < keyFields.length; i++ ) {
-            data.keyNrs[j][i] = data.metas[j].indexOfValue( keyFields[i] );
-            if ( data.keyNrs[j][i] < 0 ) {
-              String message =
-                BaseMessages.getString( PKG, "MultiMergeJoin.Exception.UnableToFindFieldInReferenceStream", meta
-                  .getKeyFields()[i] );
-              logError( message );
-              throw new KettleStepException( message );
-            }
-          }
-          data.queue.add( data.queueEntries[j] );
-        }
-      }
-
-      data.dummy = new Object[streamSize][];
-      for ( int i = 0; i < streamSize; i++ ) {
-        // Calculate dummy... defaults to null
-        data.dummy[i] = RowDataUtil.allocateRowData( data.metas[i].size() );
-      }
     }
 
     if ( log.isRowLevel() ) {

--- a/ui/src/org/pentaho/di/ui/trans/steps/multimerge/MultiMergeJoinDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/multimerge/MultiMergeJoinDialog.java
@@ -23,7 +23,9 @@
 package org.pentaho.di.ui.trans.steps.multimerge;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -89,8 +91,25 @@ public class MultiMergeJoinDialog extends BaseStepDialog implements StepDialogIn
   public MultiMergeJoinDialog( Shell parent, Object in, TransMeta tr, String sname ) {
     super( parent, (BaseStepMeta) in, tr, sname );
     joinMeta = (MultiMergeJoinMeta) in;
-    wInputStepArray = new CCombo[tr.getPrevStepNames( stepname ).length];
-    keyValTextBox = new Text[wInputStepArray.length];
+
+    String[] inputStepNames = getInputStepNames();
+
+    wInputStepArray = new CCombo[inputStepNames.length];
+    keyValTextBox = new Text[inputStepNames.length];
+  }
+
+  private String[] getInputStepNames() {
+    Set<String> nameSet = new HashSet<String>();
+
+    String[] infoStepNames = joinMeta.getStepIOMeta().getInfoStepnames();
+    Collections.addAll( nameSet, infoStepNames );
+
+    String[] prevStepNames = transMeta.getPrevStepNames( stepname );
+    if ( prevStepNames != null ) {
+      Collections.addAll( nameSet, prevStepNames );
+    }
+
+    return nameSet.toArray( new String[ nameSet.size() ] );
   }
 
   /*
@@ -152,7 +171,7 @@ public class MultiMergeJoinDialog extends BaseStepDialog implements StepDialogIn
     wCancel = new Button( shell, SWT.PUSH );
     wCancel.setText( BaseMessages.getString( PKG, "System.Button.Cancel" ) );
 
-    setButtonPositions( new Button[] { wOK, wCancel }, margin, joinTypeCombo );
+    setButtonPositions( new Button[] { wOK, wCancel }, margin, null );
 
     // Add listeners
     lsCancel = new Listener() {
@@ -240,8 +259,7 @@ public class MultiMergeJoinDialog extends BaseStepDialog implements StepDialogIn
    */
   private void createInputStreamWidgets( final ModifyListener lsMod ) {
     // Get the previous steps ...
-    inputSteps = transMeta.getPrevStepNames( stepname );
-
+    inputSteps = getInputStepNames();
     for ( int index = 0; index < inputSteps.length; index++ ) {
       Label wlStep;
       FormData fdlStep, fdStep1;
@@ -474,10 +492,9 @@ public class MultiMergeJoinDialog extends BaseStepDialog implements StepDialogIn
    * Copy information from the meta-data input to the dialog fields.
    */
   public void getData() {
-    List<StreamInterface> infoStreams = joinMeta.getStepIOMeta().getInfoStreams();
-
-    for ( int i = 0; i < infoStreams.size(); i++ ) {
-      wInputStepArray[i].setText( joinMeta.getInputSteps()[i] );
+    String[] infoStepNames = joinMeta.getStepIOMeta().getInfoStepnames();
+    for ( int i = 0; i < infoStepNames.length; i++ ) {
+      wInputStepArray[i].setText( infoStepNames[i] );
     }
     String joinType = joinMeta.getJoinType();
     if ( joinType != null && joinType.length() > 0 ) {
@@ -488,7 +505,13 @@ public class MultiMergeJoinDialog extends BaseStepDialog implements StepDialogIn
 
     String[] keyFields = joinMeta.getKeyFields();
     for ( int i = 0; i < keyFields.length; i++ ) {
-      keyValTextBox[i].setText( Const.NVL( keyFields[i], "" ) );
+      String keyField = keyFields[i];
+      Text kvTextBox = keyValTextBox[i];
+      if ( kvTextBox == null ) {
+        continue;
+      }
+      keyField = Const.NVL( keyField, "" );
+      kvTextBox.setText( keyField );
     }
     wStepname.selectAll();
     wStepname.setFocus();


### PR DESCRIPTION
…p. Error occurred because different parts of the dialog had a different idea of what the input steps were (previous steps according to transformation vs infosteps as per step meta configuration). This fix takes both into account so that any newly linked input steps can be configured, and any saved configuration does not get lost when the incoming hop is disabled.

To make this work the step's rowprocessor needed to be modified as well and this now takes all input steps into account that are also present as info stream. This allows a disabled incoming hop to be ignored during row processing (as it should).