### PR TITLE
PDI - Jobexecutor and transexecutor bug.  Moved the add row to the beginning of the if checks for new group tes…

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
+++ b/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
@@ -129,6 +129,7 @@ public class JobExecutor extends BaseStep implements StepInterface {
       }
 
       boolean newGroup = false;
+      data.groupBuffer.add( new RowMetaAndData( getInputRowMeta(), row ) ); // should we clone for safety?
       if ( data.groupSize >= 0 ) {
         // Pass the input rows in blocks to the job result rows...
         //
@@ -158,7 +159,6 @@ public class JobExecutor extends BaseStep implements StepInterface {
         executeJob();
       }
 
-      data.groupBuffer.add( new RowMetaAndData( getInputRowMeta(), row ) ); // should we clone for safety?
 
       return true;
     } catch ( Exception e ) {

--- a/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
+++ b/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
@@ -93,6 +93,7 @@ public class TransExecutor extends BaseStep implements StepInterface {
       if ( transExecutorData.getExecutorStepOutputRowMeta() != null ) {
         putRowTo( transExecutorData.getExecutorStepOutputRowMeta(), row, transExecutorData.getExecutorStepOutputRowSet() );
       }
+      transExecutorData.groupBuffer.add( new RowMetaAndData( getInputRowMeta(), row ) ); // should we clone for safety?
 
       boolean newGroup = false;
       if ( transExecutorData.groupSize >= 0 ) {
@@ -121,7 +122,6 @@ public class TransExecutor extends BaseStep implements StepInterface {
         executeTransformation();
       }
 
-      transExecutorData.groupBuffer.add( new RowMetaAndData( getInputRowMeta(), row ) ); // should we clone for safety?
 
       return true;
     } catch ( Exception e ) {


### PR DESCRIPTION
Both the Trans Executor step and the Job executor step is always off by one when submitting rows to the sub transforms they are executing.

This example is for the Trans executor step.  If you set a root Trans to have the first step to continuously generate rows every 5 second and then put a log in front of the trans executor you will see that the row will not be passed until the next row is generated.  This is a problem if you are reading from a stream that never terminates and flushes the results to the executor.   So if your grouping is for N rows it will not send the N rows until the N+1 row read. 

I have moved the groupBuffer.add above the if checks so that they will work properly and create a newGroup.

