### PR TITLE
PDI-11217: Multiway Merge Join Get Key Fields can get wrong fields (5…

### DIFF
--- a/ui/src/org/pentaho/di/ui/trans/steps/multimerge/MultiMergeJoinDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/multimerge/MultiMergeJoinDialog.java
@@ -373,8 +373,8 @@ public class MultiMergeJoinDialog extends BaseStepDialog implements StepDialogIn
     final Runnable runnable = new Runnable() {
       public void run() {
         try {
-          String[] prevSteps = transMeta.getPrevStepNames( stepname );
-          String stepName = prevSteps[inputStreamIndex];
+          CCombo wInputStep = wInputStepArray[inputStreamIndex];
+          String stepName = wInputStep.getText();
           StepMeta stepMeta = transMeta.findStep( stepName );
           if ( stepMeta != null ) {
             prev = transMeta.getStepFields( stepMeta );
@@ -391,7 +391,7 @@ public class MultiMergeJoinDialog extends BaseStepDialog implements StepDialogIn
         }
       }
     };
-    new Thread( runnable ).start();
+    Display.getDefault().asyncExec( runnable );
 
     Button getKeyButton = new Button( subShell, SWT.PUSH );
     getKeyButton.setText( BaseMessages.getString( PKG, "MultiMergeJoinDialog.KeyFields.Button" ) );


### PR DESCRIPTION
….4 Suite).

- Initial fix looked at the input steps rather than the values in the combobox - this corrects that.
- Original code ran the key dialog in a new thread. this runs it in the default swt thread.