### PR TITLE
[SP-1934] - Text File Input - 1 extra line read when using wrapped lines

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInputData.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInputData.java
@@ -23,9 +23,9 @@
 package org.pentaho.di.trans.steps.textfileinput;
 
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -137,7 +137,8 @@ public class TextFileInputData extends BaseStepData implements StepDataInterface
   public TextFileInputData() {
     super();
 
-    lineBuffer = new ArrayList<TextFileLine>();
+    // linked list is better, as usually .remove(0) is applied to this list
+    lineBuffer = new LinkedList<TextFileLine>();
 
     nr_repeats = 0;
     previous_row = null;

--- a/engine/test-src/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
@@ -22,16 +22,37 @@
 
 package org.pentaho.di.trans.steps.textfileinput;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Collections;
 
+import org.apache.commons.io.IOUtils;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.di.core.BlockingRowSet;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.fileinput.FileInputList;
+import org.pentaho.di.core.playlist.FilePlayListAll;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.trans.step.errorhandling.FileErrorHandler;
+import org.pentaho.di.trans.steps.StepMockUtil;
+
+import static org.junit.Assert.*;
 
 public class TextFileInputTest {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
 
   private static InputStreamReader getInputStreamReader( String data ) throws UnsupportedEncodingException {
     return new InputStreamReader( new ByteArrayInputStream( data.getBytes( ( "UTF-8" ) ) ) );
@@ -42,7 +63,7 @@ public class TextFileInputTest {
     String input = "col1\tcol2\tcol3\r\ndata1\tdata2\tdata3\r\n";
     String expected = "col1\tcol2\tcol3";
     String output = TextFileInput.getLine( null, getInputStreamReader( input ),
-          TextFileInputMeta.FILE_FORMAT_DOS, new StringBuilder( 1000 ) );
+      TextFileInputMeta.FILE_FORMAT_DOS, new StringBuilder( 1000 ) );
     assertEquals( expected, output );
   }
 
@@ -51,7 +72,7 @@ public class TextFileInputTest {
     String input = "col1\tcol2\tcol3\ndata1\tdata2\tdata3\n";
     String expected = "col1\tcol2\tcol3";
     String output = TextFileInput.getLine( null, getInputStreamReader( input ),
-          TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) );
+      TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) );
     assertEquals( expected, output );
   }
 
@@ -60,7 +81,7 @@ public class TextFileInputTest {
     String input = "col1\tcol2\tcol3\rdata1\tdata2\tdata3\r";
     String expected = "col1\tcol2\tcol3";
     String output = TextFileInput.getLine( null, getInputStreamReader( input ),
-          TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) );
+      TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) );
     assertEquals( expected, output );
   }
 
@@ -69,7 +90,7 @@ public class TextFileInputTest {
     String input = "col1\tcol2\tcol3\r\ndata1\tdata2\tdata3\r";
     String expected = "col1\tcol2\tcol3";
     String output = TextFileInput.getLine( null, getInputStreamReader( input ),
-          TextFileInputMeta.FILE_FORMAT_MIXED, new StringBuilder( 1000 ) );
+      TextFileInputMeta.FILE_FORMAT_MIXED, new StringBuilder( 1000 ) );
     assertEquals( expected, output );
   }
 
@@ -81,10 +102,87 @@ public class TextFileInputTest {
     String expected = "col1\tcol2\tcol3";
 
     assertEquals( expected, TextFileInput.getLine( null, getInputStreamReader( inputDOS ),
-            TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) ) );
+      TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) ) );
     assertEquals( expected, TextFileInput.getLine( null, getInputStreamReader( inputUnix ),
-            TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) ) );
+      TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) ) );
     assertEquals( expected, TextFileInput.getLine( null, getInputStreamReader( inputOSX ),
-            TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) ) );
+      TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder( 1000 ) ) );
+  }
+
+  @Test
+  public void readWrappedInputWithoutHeaders() throws Exception {
+    final String virtualFile = "ram://pdi-2607.txt";
+    KettleVFS.getFileObject( virtualFile ).createFile();
+
+    final String content = new StringBuilder()
+      .append( "r1c1" ).append( '\n' ).append( ";r1c2\n" )
+      .append( "r2c1" ).append( '\n' ).append( ";r2c2" )
+      .toString();
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write( content.getBytes() );
+
+    OutputStream os = KettleVFS.getFileObject( virtualFile ).getContent().getOutputStream();
+    IOUtils.copy( new ByteArrayInputStream( bos.toByteArray() ), os );
+    os.close();
+
+
+    TextFileInputMeta meta = new TextFileInputMeta();
+    meta.setLineWrapped( true );
+    meta.setNrWraps( 1 );
+    meta.setInputFields( new TextFileInputField[] {
+      new TextFileInputField( "col1", -1, -1 ),
+      new TextFileInputField( "col2", -1, -1 )
+    } );
+    meta.setFileCompression( "None" );
+    meta.setFileType( "CSV" );
+    meta.setHeader( false );
+    meta.setNrHeaderLines( -1 );
+    meta.setFooter( false );
+    meta.setNrFooterLines( -1 );
+
+    TextFileInputData data = new TextFileInputData();
+    data.setFiles( new FileInputList() );
+    data.getFiles().addFile( KettleVFS.getFileObject( virtualFile ) );
+
+    data.outputRowMeta = new RowMeta();
+    data.outputRowMeta.addValueMeta( new ValueMetaString( "col1" ) );
+    data.outputRowMeta.addValueMeta( new ValueMetaString( "col2" ) );
+
+    data.dataErrorLineHandler = Mockito.mock( FileErrorHandler.class );
+    data.fileFormatType = TextFileInputMeta.FILE_FORMAT_UNIX;
+    data.separator = ";";
+    data.filterProcessor = new TextFileFilterProcessor( new TextFileFilter[ 0 ] );
+    data.filePlayList = new FilePlayListAll();
+
+
+    RowSet output = new BlockingRowSet( 5 );
+    TextFileInput input = StepMockUtil.getStep( TextFileInput.class, TextFileInputMeta.class, "test" );
+    input.setOutputRowSets( Collections.singletonList( output ) );
+    while ( input.processRow( meta, data ) ) {
+      // wait until the step completes executing
+    }
+
+    Object[] row1 = output.getRowImmediate();
+    assertRow( row1, "r1c1", "r1c2" );
+
+    Object[] row2 = output.getRowImmediate();
+    assertRow( row2, "r2c1", "r2c2" );
+
+
+    KettleVFS.getFileObject( virtualFile ).delete();
+  }
+
+  private static void assertRow( Object[] row, Object... values ) {
+    assertNotNull( row );
+    assertTrue( String.format( "%d < %d", row.length, values.length ), row.length >= values.length );
+    int i = 0;
+    while ( i < values.length ) {
+      assertEquals( values[ i ], row[ i ] );
+      i++;
+    }
+    while ( i < row.length ) {
+      assertNull( row[ i ] );
+      i++;
+    }
   }
 }


### PR DESCRIPTION
[SP-1934] - Text File Input - 1 extra line read when using wrapped lines and 1 header line

- force reading from input when breaks' buffer is empty
- add a test for scenario of wrapped input with no headers

picked from https://github.com/pentaho/pentaho-kettle/pull/1362/

@mattyb149 @brosander @rmansoor please merge