### PR TITLE
[BACKLOG-3855] - Using servlet-api 3.0.1 for karaf upgrade

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -198,9 +198,10 @@
     <dependency org="com.sap"              name="sapdbc"                rev="7.4.4"         transitive="false"/>
     <dependency org="org.xerial"           name="sqlite-jdbc"           rev="3.7.2"         transitive="false"/>
     <dependency org="jaxen"                name="jaxen"                 rev="1.1.1"         transitive="false"/>
-
+    <dependency org="javax.servlet"        name="javax.servlet-api"    rev="3.0.1"           transitive="false"/>
     <!-- Other third-party dependencies -->
     <dependency org="asm"                  name="asm"                   rev="3.2"           transitive="false"/>
     <dependency org="net.sf.saxon"         name="saxon-dom"             rev="9.1.0.8"       transitive="false"/>
+    <exclude org="javax.servlet"   module="servlet-api"/>
   </dependencies>
 </ivy-module>

--- a/engine/ivy.xml
+++ b/engine/ivy.xml
@@ -78,7 +78,7 @@
     <dependency org="org.snmp4j"                       name="snmp4j"               rev="1.9.3d"          transitive="false"/>
     <dependency org="org.syslog4j"                     name="syslog4j"             rev="0.9.34"          transitive="false"/>
     <dependency org="trilead-ssh2"                     name="trilead-ssh2"         rev="build213"        transitive="false"/>
-    <dependency org="javax.servlet"                    name="servlet-api"          rev="2.5"             transitive="false"/>
+    <dependency org="javax.servlet"                    name="javax.servlet-api"    rev="3.0.1"           transitive="false"/>
     <dependency org="javax.xml"                        name="jaxrpc-api"           rev="1.1"             transitive="false"/>
     <dependency org="org.olap4j"                       name="olap4j"               rev="1.2.0"           transitive="false"/>
     <dependency org="org.olap4j"                       name="olap4j-xmla"          rev="1.2.0"           transitive="false"/>
@@ -117,5 +117,6 @@
     <dependency org="junit"               name="junit"         rev="4.7"     conf="test->default" transitive="false"/>
     <dependency org="org.mockito"         name="mockito-all"   rev="1.9.5"   conf="test->default" transitive="false" />
     
+    <exclude org="javax.servlet"   module="servlet-api"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
We need to bring in servlet-api 3 for karaf 3.0.3. 