### PR TITLE
[BACKLOG-3857]Embedded MetaStore impl

### DIFF
--- a/engine/ivy.xml
+++ b/engine/ivy.xml
@@ -120,10 +120,11 @@
     <dependency org="jaxen"               name="jaxen"         rev="1.1.1"   conf="test->default" transitive="false"/>
     <dependency org="junit"               name="junit"         rev="4.7"     conf="test->default" transitive="false"/>
     <dependency org="org.mockito"         name="mockito-all"   rev="1.9.5"   conf="test->default" transitive="false" />
+    <dependency org="pentaho"             name="metastore-test" rev="${dependency.pentaho-metastore.revision}"
+                conf="test->default" transitive="false"/>
     <dependency org="javax.servlet" name="javax.servlet-api" rev="3.0.1"     conf="test->default" transitive="false" />
 
     
 	<exclude org="org.eclipse.jetty.orbit" module="javax.servlet"/>
-  
   </dependencies>
 </ivy-module>

--- a/engine/src/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/org/pentaho/di/base/AbstractMeta.java
@@ -22,19 +22,13 @@
 
 package org.pentaho.di.base;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.AttributesInterface;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.EngineMetaInterface;
 import org.pentaho.di.core.NotePadMeta;
 import org.pentaho.di.core.Props;
+import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
 import org.pentaho.di.core.changed.ChangedFlag;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -75,6 +69,13 @@ import org.pentaho.metastore.api.IMetaStoreElement;
 import org.pentaho.metastore.api.IMetaStoreElementType;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.util.PentahoDefaults;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public abstract class AbstractMeta extends ChangedFlag implements UndoInterface, HasDatabasesInterface, VariableSpace,
     EngineMetaInterface, NamedParams, HasSlaveServersInterface, AttributesInterface, HasRepositoryInterface,
@@ -130,6 +131,8 @@ public abstract class AbstractMeta extends ChangedFlag implements UndoInterface,
   protected List<TransAction> undo;
 
   protected Map<String, Map<String, String>> attributesMap;
+
+  protected EmbeddedMetaStore embeddedMetaStore = new EmbeddedMetaStore( this );
 
   protected VariableSpace variables = new Variables();
 
@@ -772,6 +775,10 @@ public abstract class AbstractMeta extends ChangedFlag implements UndoInterface,
       return 0;
     }
     return undo.size();
+  }
+
+  public EmbeddedMetaStore getEmbeddedMetaStore() {
+    return embeddedMetaStore;
   }
 
   @Override

--- a/engine/src/org/pentaho/di/core/attributes/metastore/AttributesInterfaceEntry.java
+++ b/engine/src/org/pentaho/di/core/attributes/metastore/AttributesInterfaceEntry.java
@@ -1,0 +1,38 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.attributes.metastore;
+
+import org.codehaus.jackson.annotate.JsonIgnore;
+
+import java.io.IOException;
+
+/**
+ * @author nhudak
+ */
+interface AttributesInterfaceEntry {
+  @JsonIgnore String groupName();
+
+  @JsonIgnore String key();
+
+  @JsonIgnore String jsonValue() throws IOException;
+}

--- a/engine/src/org/pentaho/di/core/attributes/metastore/EmbeddedMetaStore.java
+++ b/engine/src/org/pentaho/di/core/attributes/metastore/EmbeddedMetaStore.java
@@ -1,0 +1,358 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.attributes.metastore;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.pentaho.di.core.AttributesInterface;
+import org.pentaho.metastore.api.BaseMetaStore;
+import org.pentaho.metastore.api.IMetaStoreAttribute;
+import org.pentaho.metastore.api.IMetaStoreElement;
+import org.pentaho.metastore.api.IMetaStoreElementType;
+import org.pentaho.metastore.api.exceptions.MetaStoreDependenciesExistsException;
+import org.pentaho.metastore.api.exceptions.MetaStoreElementExistException;
+import org.pentaho.metastore.api.exceptions.MetaStoreElementTypeExistsException;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+import org.pentaho.metastore.api.security.IMetaStoreElementOwner;
+import org.pentaho.metastore.api.security.MetaStoreElementOwnerType;
+import org.pentaho.metastore.stores.memory.MemoryMetaStoreAttribute;
+import org.pentaho.metastore.stores.memory.MemoryMetaStoreElement;
+import org.pentaho.metastore.stores.memory.MemoryMetaStoreElementOwner;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.pentaho.metastore.util.MetaStoreUtil.executeLockedOperation;
+
+/**
+ * @author nhudak
+ */
+public class EmbeddedMetaStore extends BaseMetaStore implements ReadWriteLock {
+  static final String METASTORE_PREFIX = "METASTORE.";
+
+  static final String TYPE_PREFIX = "TYPE.";
+
+  private final AttributesInterface attributesInterface;
+  private final ReadWriteLock lock;
+
+  public EmbeddedMetaStore( AttributesInterface attributesInterface ) {
+    this.attributesInterface = attributesInterface;
+    this.lock = new ReentrantReadWriteLock();
+  }
+
+  @Override public void createNamespace( final String namespace ) throws MetaStoreException {
+    // Optional, namespace will be automatically created if not already existing
+    executeLockedOperation( writeLock(), new Callable<Void>() {
+      @Override public Void call() throws Exception {
+        String groupName = JsonElementType.groupName( namespace );
+        if ( !attributesInterface.getAttributesMap().containsKey( groupName ) ) {
+          attributesInterface.setAttributes( groupName, Maps.<String, String>newHashMap() );
+        }
+        return null;
+      }
+    } );
+  }
+
+  @Override public List<String> getNamespaces() throws MetaStoreException {
+    return executeLockedOperation( readLock(), new Callable<List<String>>() {
+      @Override public List<String> call() throws Exception {
+        return FluentIterable.from( attributesInterface.getAttributesMap().keySet() )
+          .filter( new Predicate<String>() {
+            @Override public boolean apply( String groupName ) {
+              return groupName.startsWith( METASTORE_PREFIX );
+            }
+          } )
+          .transform( new Function<String, String>() {
+            @Override public String apply( String input ) {
+              return input.substring( METASTORE_PREFIX.length() );
+            }
+          } )
+          .toList();
+      }
+    } );
+  }
+
+  @Override public boolean namespaceExists( final String namespace ) throws MetaStoreException {
+    return executeLockedOperation( readLock(), new Callable<Boolean>() {
+      @Override public Boolean call() throws Exception {
+        return attributesInterface.getAttributesMap().containsKey( JsonElementType.groupName( namespace ) );
+      }
+    } );
+  }
+
+  @Override public synchronized void deleteNamespace( final String namespace ) throws MetaStoreException {
+    executeLockedOperation( writeLock(), new Callable<Void>() {
+      @Override public Void call() throws Exception {
+        List<String> dependencies = getElementTypeIds( namespace );
+        if ( !dependencies.isEmpty() ) {
+          throw new MetaStoreDependenciesExistsException( dependencies,
+            "Unable to delete the meta store namespace '" + namespace + "' as it still contains element types" );
+        }
+        attributesInterface.getAttributesMap().remove( JsonElementType.groupName( namespace ) );
+        return null;
+      }
+    } );
+  }
+
+  @Override
+  public JsonElementType newElementType( final String namespace ) {
+    return new EmbeddedElementType( namespace );
+  }
+
+  private class EmbeddedElementType extends JsonElementType {
+    public EmbeddedElementType( String namespace ) {
+      super( namespace );
+    }
+
+    @Override public void save() throws MetaStoreException {
+      update( this );
+    }
+  }
+
+  @Override
+  public void createElementType( String namespace, IMetaStoreElementType elementType ) throws MetaStoreException {
+    elementType.setNamespace( namespace );
+    if ( !create( JsonElementType.from( elementType ) ) ) {
+      throw new MetaStoreElementTypeExistsException( getElementTypes( namespace ) );
+    }
+  }
+
+  @Override public JsonElementType getElementType( final String namespace, final String elementTypeId )
+    throws MetaStoreException {
+    return executeLockedOperation( readLock(), new Callable<JsonElementType>() {
+      @Override public JsonElementType call() throws Exception {
+        JsonElementType type = newElementType( namespace );
+        type.setId( elementTypeId );
+        String jsonData = attributesInterface.getAttribute( type.groupName(), type.key() );
+        return jsonData == null ? null : type.load( jsonData );
+      }
+    } );
+  }
+
+  @Override public List<String> getElementTypeIds( final String namespace ) throws MetaStoreException {
+    return executeLockedOperation( readLock(), new Callable<List<String>>() {
+      @Override public List<String> call() throws Exception {
+        Map<String, String> attributes = attributesInterface.getAttributes( JsonElementType.groupName( namespace ) );
+        return attributes == null ? ImmutableList.<String>of() : ImmutableList.copyOf( attributes.keySet() );
+      }
+    } );
+  }
+
+  @Override public List<IMetaStoreElementType> getElementTypes( final String namespace )
+    throws MetaStoreException {
+    return executeLockedOperation( readLock(), new Callable<List<IMetaStoreElementType>>() {
+      @Override public List<IMetaStoreElementType> call() throws Exception {
+        List<String> ids = getElementTypeIds( namespace );
+        List<IMetaStoreElementType> types = Lists.newArrayListWithExpectedSize( ids.size() );
+        for ( String id : ids ) {
+          types.add( getElementType( namespace, id ) );
+        }
+        return types;
+      }
+    } );
+  }
+
+  @Override public IMetaStoreElementType getElementTypeByName( final String namespace, final String elementTypeName )
+    throws MetaStoreException {
+    return executeLockedOperation( readLock(), new Callable<IMetaStoreElementType>() {
+      @Override public IMetaStoreElementType call() throws Exception {
+        List<IMetaStoreElementType> elementTypes = getElementTypes( namespace );
+        for ( IMetaStoreElementType elementType : elementTypes ) {
+          if ( elementType.getName().equals( elementTypeName ) ) {
+            return elementType;
+          }
+        }
+        return null;
+      }
+    } );
+  }
+
+  @Override public void updateElementType( String namespace, IMetaStoreElementType elementType )
+    throws MetaStoreException {
+    elementType.setNamespace( namespace );
+
+    update( JsonElementType.from( elementType ) );
+  }
+
+  @Override public void deleteElementType( final String namespace,
+                                           final IMetaStoreElementType elementType ) throws MetaStoreException {
+    executeLockedOperation( writeLock(), new Callable<Void>() {
+        @Override public Void call() throws Exception {
+          List<String> dependencies = getElementIds( namespace, elementType );
+          if ( dependencies.isEmpty() ) {
+            attributesInterface.getAttributesMap().remove( JsonElement.groupName( elementType ) );
+            Map<String, String> typeMap = attributesInterface.getAttributes( JsonElementType.groupName( namespace ) );
+            if ( typeMap != null ) {
+              typeMap.remove( elementType.getId() );
+            }
+          } else {
+            throw new MetaStoreDependenciesExistsException( dependencies );
+          }
+          return null;
+        }
+      }
+    );
+  }
+
+  @Override public JsonElement newElement() {
+    return new JsonElement();
+  }
+
+  @Override public JsonElement newElement( IMetaStoreElementType elementType, String id, Object value ) {
+    return new JsonElement( new MemoryMetaStoreElement( elementType, id, value ) );
+  }
+
+  @Override public IMetaStoreAttribute newAttribute( String id, Object value ) {
+    return new MemoryMetaStoreAttribute( id, value );
+  }
+
+  @Override public IMetaStoreElementOwner newElementOwner( String name, MetaStoreElementOwnerType ownerType ) {
+    return new MemoryMetaStoreElementOwner( name, ownerType );
+  }
+
+  @Override public void createElement( String namespace, IMetaStoreElementType elementType,
+                                       IMetaStoreElement element ) throws MetaStoreException {
+    elementType.setNamespace( namespace );
+    element.setElementType( elementType );
+    update( JsonElementType.from( elementType ) );
+    if ( !create( JsonElement.from( element ) ) ) {
+      throw new MetaStoreElementExistException( getElements( namespace, elementType ) );
+    }
+  }
+
+  @Override
+  public List<IMetaStoreElement> getElements( final String namespace,
+                                              final IMetaStoreElementType elementType ) throws MetaStoreException {
+    return executeLockedOperation( readLock(), new Callable<List<IMetaStoreElement>>() {
+      @Override public List<IMetaStoreElement> call() throws Exception {
+        List<String> ids = getElementIds( namespace, elementType );
+        List<IMetaStoreElement> types = Lists.newArrayListWithExpectedSize( ids.size() );
+        for ( String id : ids ) {
+          types.add( getElement( namespace, elementType, id ) );
+        }
+        return types;
+      }
+    } );
+  }
+
+  @Override public List<String> getElementIds( final String namespace,
+                                               final IMetaStoreElementType elementType ) throws MetaStoreException {
+    return executeLockedOperation( readLock(), new Callable<List<String>>() {
+        @Override public List<String> call() throws Exception {
+          elementType.setNamespace( namespace );
+          Map<String, String> attributes = attributesInterface.getAttributes( JsonElement.groupName( elementType ) );
+          return attributes == null ? ImmutableList.<String>of() : ImmutableList.copyOf( attributes.keySet() );
+        }
+      }
+    );
+  }
+
+  @Override public JsonElement getElement( final String namespace, final IMetaStoreElementType elementType,
+                                           final String elementId ) throws MetaStoreException {
+    return executeLockedOperation( readLock(), new Callable<JsonElement>() {
+      @Override public JsonElement call() throws Exception {
+        JsonElement element = newElement();
+        elementType.setNamespace( namespace );
+        element.setId( elementId );
+        element.setElementType( elementType );
+        String jsonData = attributesInterface.getAttribute( element.groupName(), element.key() );
+        return jsonData == null ? null : element.load( jsonData );
+      }
+    } );
+  }
+
+  @Override
+  public IMetaStoreElement getElementByName( String namespace, IMetaStoreElementType elementType, final String name )
+    throws MetaStoreException {
+    for ( IMetaStoreElement element : getElements( namespace, elementType ) ) {
+      if ( element.getName().equals( name ) ) {
+        return element;
+      }
+    }
+    return null;
+  }
+
+  @Override public void updateElement( String namespace, IMetaStoreElementType elementType, String elementId,
+                                       IMetaStoreElement element ) throws MetaStoreException {
+    elementType.setNamespace( namespace );
+    element.setId( elementId );
+    element.setElementType( elementType );
+    update( JsonElementType.from( elementType ) );
+    update( JsonElement.from( element ) );
+  }
+
+  @Override
+  public void deleteElement( final String namespace, final IMetaStoreElementType elementType, final String elementId )
+    throws MetaStoreException {
+    executeLockedOperation( writeLock(), new Callable<Boolean>() {
+      @Override public Boolean call() throws Exception {
+        elementType.setNamespace( namespace );
+        Map<String, String> attributes = attributesInterface.getAttributes( JsonElement.groupName( elementType ) );
+
+        return attributes != null && attributes.remove( elementId ) != null;
+      }
+    } );
+  }
+
+  private boolean create( final AttributesInterfaceEntry entry ) throws MetaStoreException {
+    return executeLockedOperation( writeLock(), new Callable<Boolean>() {
+      @Override public Boolean call() throws Exception {
+        String groupName = entry.groupName();
+        String key = entry.key();
+
+        String existing = attributesInterface.getAttribute( groupName, key );
+        if ( existing == null ) {
+          attributesInterface.setAttribute( groupName, key, entry.jsonValue() );
+          return true;
+        } else {
+          return false;
+        }
+      }
+    } );
+  }
+
+  private void update( final AttributesInterfaceEntry entry ) throws MetaStoreException {
+    executeLockedOperation( writeLock(), new Callable<Void>() {
+      @Override public Void call() throws Exception {
+        attributesInterface.setAttribute( entry.groupName(), entry.key(), entry.jsonValue() );
+        return null;
+      }
+    } );
+  }
+
+  @Override public Lock readLock() {
+    return lock.readLock();
+  }
+
+  @Override public Lock writeLock() {
+    return lock.writeLock();
+  }
+}

--- a/engine/src/org/pentaho/di/core/attributes/metastore/JsonElement.java
+++ b/engine/src/org/pentaho/di/core/attributes/metastore/JsonElement.java
@@ -1,0 +1,106 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.attributes.metastore;
+
+import com.google.common.base.Strings;
+import org.codehaus.jackson.Version;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.module.SimpleModule;
+import org.codehaus.jackson.node.JsonNodeFactory;
+import org.codehaus.jackson.node.ObjectNode;
+import org.pentaho.metastore.api.IMetaStoreAttribute;
+import org.pentaho.metastore.api.IMetaStoreElement;
+import org.pentaho.metastore.api.IMetaStoreElementType;
+import org.pentaho.metastore.api.security.IMetaStoreElementOwner;
+import org.pentaho.metastore.stores.memory.MemoryMetaStoreAttribute;
+import org.pentaho.metastore.stores.memory.MemoryMetaStoreElement;
+import org.pentaho.metastore.stores.memory.MemoryMetaStoreElementOwner;
+
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author nhudak
+ */
+@JsonIgnoreProperties( { "elementType" } )
+public class JsonElement extends MemoryMetaStoreElement implements AttributesInterfaceEntry {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  {
+    SimpleModule module = new SimpleModule( "MetaStore Elements", Version.unknownVersion() );
+    module.addAbstractTypeMapping( IMetaStoreAttribute.class, MemoryMetaStoreAttribute.class );
+    module.addAbstractTypeMapping( IMetaStoreElementOwner.class, EmptyOwner.class );
+
+    objectMapper.registerModule( module );
+  }
+
+  public JsonElement() {
+  }
+
+  public JsonElement( IMetaStoreElement element ) {
+    super( element );
+  }
+
+  static JsonElement from( IMetaStoreElement element ) {
+    return element instanceof JsonElement ? ( (JsonElement) element ) : new JsonElement( element );
+  }
+
+  @Override public String getId() {
+    if ( Strings.isNullOrEmpty( super.getId() ) ) {
+      setId( getName() );
+    }
+    return Strings.emptyToNull( super.getId() );
+  }
+
+  public static String groupName( IMetaStoreElementType elementType ) {
+    ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
+    objectNode.put( "_", "Embedded MetaStore Elements" );
+    objectNode.put( "namespace", checkNotNull( elementType.getNamespace() ) );
+    objectNode.put( "type", checkNotNull( elementType.getId() ) );
+    return objectNode.toString();
+  }
+
+  @Override public String groupName() {
+    return groupName( checkNotNull( getElementType() ) );
+  }
+
+  @Override public String key() {
+    return checkNotNull( getId() );
+  }
+
+  @Override public String jsonValue() throws IOException {
+    return objectMapper.writeValueAsString( this );
+  }
+
+  public JsonElement load( String jsonData ) throws IOException {
+    return objectMapper.readerForUpdating( this ).readValue( jsonData );
+  }
+
+  private static class EmptyOwner extends MemoryMetaStoreElementOwner {
+    public EmptyOwner() {
+      super( null, null );
+    }
+  }
+}

--- a/engine/src/org/pentaho/di/core/attributes/metastore/JsonElementType.java
+++ b/engine/src/org/pentaho/di/core/attributes/metastore/JsonElementType.java
@@ -1,0 +1,93 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.attributes.metastore;
+
+import com.google.common.base.Strings;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.pentaho.metastore.api.BaseElementType;
+import org.pentaho.metastore.api.IMetaStoreElementType;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author nhudak
+ */
+public abstract class JsonElementType extends BaseElementType implements AttributesInterfaceEntry {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public JsonElementType( String namespace ) {
+    super( namespace );
+  }
+
+  public static JsonElementType from( final IMetaStoreElementType elementType ) {
+    if ( elementType instanceof JsonElementType ) {
+      return (JsonElementType) elementType;
+    } else {
+      return new DerivedJsonElementType( elementType );
+    }
+  }
+
+  @Override public String getId() {
+    if ( Strings.isNullOrEmpty( super.getId() ) ) {
+      setId( getName() );
+    }
+    return Strings.emptyToNull( super.getId() );
+  }
+
+  public static String groupName( String namespace ) {
+    return EmbeddedMetaStore.METASTORE_PREFIX + namespace;
+  }
+
+  @Override public String groupName() {
+    return groupName( getNamespace() );
+  }
+
+  @Override public String key() {
+    return checkNotNull( getId() );
+  }
+
+  @Override public String jsonValue() throws IOException {
+    return objectMapper.writeValueAsString( this );
+  }
+
+  public JsonElementType load( String jsonData ) throws IOException {
+    return objectMapper.readerForUpdating( this ).readValue( jsonData );
+  }
+
+  private static class DerivedJsonElementType extends JsonElementType {
+    private final IMetaStoreElementType elementType;
+
+    public DerivedJsonElementType( IMetaStoreElementType elementType ) {
+      super( elementType.getNamespace() );
+      this.elementType = elementType;
+      copyFrom( elementType );
+    }
+
+    @Override public void save() throws MetaStoreException {
+      elementType.save();
+    }
+  }
+}

--- a/engine/test-src/org/pentaho/di/core/attributes/metastore/EmbeddedMetaStoreTest.java
+++ b/engine/test-src/org/pentaho/di/core/attributes/metastore/EmbeddedMetaStoreTest.java
@@ -1,0 +1,94 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.attributes.metastore;
+
+import com.google.common.collect.Maps;
+import org.pentaho.di.core.AttributesInterface;
+import org.pentaho.metastore.test.MetaStoreTestBase;
+
+import java.util.Map;
+
+/**
+ * @author nhudak
+ */
+public class EmbeddedMetaStoreTest extends MetaStoreTestBase {
+  private EmbeddedMetaStore metaStore;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    metaStore = new EmbeddedMetaStore( new TestStorage() );
+    metaStore.setName( META_STORE_NAME );
+  }
+
+  public void test() throws Exception {
+    super.testFunctionality( metaStore );
+  }
+
+  public void testParrallelRetrive() throws Exception {
+    super.testParallelOneStore( metaStore );
+  }
+
+  private class TestStorage implements AttributesInterface {
+    private Map<String, Map<String, String>> attributesMap = Maps.newHashMap();
+
+    @Override
+    public void setAttributesMap( Map<String, Map<String, String>> attributesMap ) {
+      this.attributesMap = attributesMap;
+    }
+
+    @Override
+    public Map<String, Map<String, String>> getAttributesMap() {
+      return attributesMap;
+    }
+
+    @Override
+    public void setAttribute( String groupName, String key, String value ) {
+      Map<String, String> attributes = getAttributes( groupName );
+      if ( attributes == null ) {
+        attributes = Maps.newHashMap();
+        attributesMap.put( groupName, attributes );
+      }
+      attributes.put( key, value );
+    }
+
+    @Override
+    public void setAttributes( String groupName, Map<String, String> attributes ) {
+      attributesMap.put( groupName, attributes );
+    }
+
+    @Override
+    public Map<String, String> getAttributes( String groupName ) {
+      return attributesMap.get( groupName );
+    }
+
+    @Override
+    public String getAttribute( String groupName, String key ) {
+      Map<String, String> attributes = attributesMap.get( groupName );
+      if ( attributes == null ) {
+        return null;
+      }
+      return attributes.get( key );
+    }
+  }
+}


### PR DESCRIPTION
Embeddable metastore for use within TransMeta/JobMeta

Metastore elements and types are stored as entries in the attributes map. Elements and types are serialized as JSON when created or updated.

The following structures are added to the attributes map:
 * `METASTORE.<namespace>`:
   * `<type id>` : `<type as json>`
 * `{'_': 'Embedded MetaStore Elements': 'namespace': '<namespace>': 'type':'<type id>'}`
   * `<element id>` : `<element as json>`