### PR TITLE
[PDI-13819] Deprecate ValueMeta

### DIFF
--- a/core/src/org/pentaho/di/core/ResultFile.java
+++ b/core/src/org/pentaho/di/core/ResultFile.java
@@ -26,8 +26,8 @@ import java.util.Date;
 
 import org.apache.commons.vfs.FileObject;
 import org.pentaho.di.core.exception.KettleFileException;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -248,25 +248,25 @@ public class ResultFile implements Cloneable {
     RowMetaAndData row = new RowMetaAndData();
 
     // First the type
-    row.addValue( new ValueMeta( "type", ValueMetaInterface.TYPE_STRING ), getTypeDesc() );
+    row.addValue( new ValueMetaString( "type" ), getTypeDesc() );
 
     // The filename
-    row.addValue( new ValueMeta( "filename", ValueMetaInterface.TYPE_STRING ), file.getName().getBaseName() );
+    row.addValue( new ValueMetaString( "filename" ), file.getName().getBaseName() );
 
     // The path
-    row.addValue( new ValueMeta( "path", ValueMetaInterface.TYPE_STRING ), file.getName().getURI() );
+    row.addValue( new ValueMetaString( "path" ), file.getName().getURI() );
 
     // The origin parent
-    row.addValue( new ValueMeta( "parentorigin", ValueMetaInterface.TYPE_STRING ), originParent );
+    row.addValue( new ValueMetaString( "parentorigin" ), originParent );
 
     // The origin
-    row.addValue( new ValueMeta( "origin", ValueMetaInterface.TYPE_STRING ), origin );
+    row.addValue( new ValueMetaString( "origin" ), origin );
 
     // The comment
-    row.addValue( new ValueMeta( "comment", ValueMetaInterface.TYPE_STRING ), comment );
+    row.addValue( new ValueMetaString( "comment" ), comment );
 
     // The timestamp
-    row.addValue( new ValueMeta( "timestamp", ValueMetaInterface.TYPE_DATE ), timestamp );
+    row.addValue( new ValueMetaDate( "timestamp" ), timestamp );
 
     return row;
   }

--- a/core/src/org/pentaho/di/core/RowMetaAndData.java
+++ b/core/src/org/pentaho/di/core/RowMetaAndData.java
@@ -25,12 +25,13 @@ package org.pentaho.di.core;
 import java.math.BigDecimal;
 import java.util.Date;
 
+import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowDataUtil;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaFactory;
 import org.pentaho.di.repository.LongObjectId;
 import org.pentaho.di.repository.ObjectId;
 
@@ -132,8 +133,12 @@ public class RowMetaAndData implements Cloneable {
     rowMeta.addValueMeta( valueMeta );
   }
 
-  public void addValue( String valueName, int valueType, Object valueData ) {
-    addValue( new ValueMeta( valueName, valueType ), valueData );
+  public void addValue( String valueName, int valueType, Object valueData ) throws KettleValueException {
+    try {
+      addValue( ValueMetaFactory.createValueMeta( valueName, valueType ), valueData );
+    } catch ( KettlePluginException e ) {
+      throw new KettleValueException( e );
+    }
   }
 
   public void clear() {

--- a/core/src/org/pentaho/di/core/database/DatabaseConnectionPoolParameter.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseConnectionPoolParameter.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,8 +28,7 @@ import java.util.List;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 
 public class DatabaseConnectionPoolParameter {
   private String parameter;
@@ -118,9 +117,9 @@ public class DatabaseConnectionPoolParameter {
     String titleParameter, String titleDefaultValue, String titleDescription ) {
     RowMetaInterface rowMeta = new RowMeta();
 
-    rowMeta.addValueMeta( new ValueMeta( titleParameter, ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( titleDefaultValue, ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( titleDescription, ValueMetaInterface.TYPE_STRING ) );
+    rowMeta.addValueMeta( new ValueMetaString( titleParameter ) );
+    rowMeta.addValueMeta( new ValueMetaString( titleDefaultValue ) );
+    rowMeta.addValueMeta( new ValueMetaString( titleDescription ) );
 
     List<RowMetaAndData> list = new ArrayList<RowMetaAndData>();
 

--- a/core/src/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseMeta.java
@@ -50,9 +50,9 @@ import org.pentaho.di.core.plugins.DatabasePluginType;
 import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -1944,44 +1944,44 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     final String par = "Parameter";
     final String val = "Value";
 
-    ValueMetaInterface testValue = new ValueMeta( "FIELD", ValueMetaInterface.TYPE_STRING );
+    ValueMetaInterface testValue = new ValueMetaString( "FIELD" );
     testValue.setLength( 30 );
 
     if ( databaseInterface != null ) {
       // Type of database
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Database type" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getPluginId() );
+      r.addValue( new ValueMetaString( par ), "Database type" );
+      r.addValue( new ValueMetaString( val ), getPluginId() );
       list.add( r );
       // Type of access
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Access type" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getAccessTypeDesc() );
+      r.addValue( new ValueMetaString( par ), "Access type" );
+      r.addValue( new ValueMetaString( val ), getAccessTypeDesc() );
       list.add( r );
       // Name of database
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Database name" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getDatabaseName() );
+      r.addValue( new ValueMetaString( par ), "Database name" );
+      r.addValue( new ValueMetaString( val ), getDatabaseName() );
       list.add( r );
       // server host name
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Server hostname" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getHostname() );
+      r.addValue( new ValueMetaString( par ), "Server hostname" );
+      r.addValue( new ValueMetaString( val ), getHostname() );
       list.add( r );
       // Port number
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Service port" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getDatabasePortNumberString() );
+      r.addValue( new ValueMetaString( par ), "Service port" );
+      r.addValue( new ValueMetaString( val ), getDatabasePortNumberString() );
       list.add( r );
       // Username
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Username" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getUsername() );
+      r.addValue( new ValueMetaString( par ), "Username" );
+      r.addValue( new ValueMetaString( val ), getUsername() );
       list.add( r );
       // Informix server
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Informix server name" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getServername() );
+      r.addValue( new ValueMetaString( par ), "Informix server name" );
+      r.addValue( new ValueMetaString( val ), getServername() );
       list.add( r );
       // Other properties...
       Enumeration<Object> keys = getAttributes().keys();
@@ -1989,15 +1989,15 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
         String key = (String) keys.nextElement();
         String value = getAttributes().getProperty( key );
         r = new RowMetaAndData();
-        r.addValue( par, ValueMetaInterface.TYPE_STRING, "Extra attribute [" + key + "]" );
-        r.addValue( val, ValueMetaInterface.TYPE_STRING, value );
+        r.addValue( new ValueMetaString( par ), "Extra attribute [" + key + "]" );
+        r.addValue( new ValueMetaString( val ), value );
         list.add( r );
       }
 
       // driver class
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Driver class" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getDriverClass() );
+      r.addValue( new ValueMetaString( par ), "Driver class" );
+      r.addValue( new ValueMetaString( val ), getDriverClass() );
       list.add( r );
       // URL
       String pwd = getPassword();
@@ -2009,76 +2009,76 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
         url = "";
       } // SAP etc.
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "URL" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, url );
+      r.addValue( new ValueMetaString( par ), "URL" );
+      r.addValue( new ValueMetaString( val ), url );
       list.add( r );
       setPassword( pwd );
       // SQL: Next sequence value
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "SQL: next sequence value" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getSeqNextvalSQL( "SEQUENCE" ) );
+      r.addValue( new ValueMetaString( par ), "SQL: next sequence value" );
+      r.addValue( new ValueMetaString( val ), getSeqNextvalSQL( "SEQUENCE" ) );
       list.add( r );
       // is set fetch size supported
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "supported: set fetch size" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, isFetchSizeSupported() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "supported: set fetch size" );
+      r.addValue( new ValueMetaString( val ), isFetchSizeSupported() ? "Y" : "N" );
       list.add( r );
       // needs place holder for auto increment
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "auto increment field needs placeholder" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, needsPlaceHolder() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "auto increment field needs placeholder" );
+      r.addValue( new ValueMetaString( val ), needsPlaceHolder() ? "Y" : "N" );
       list.add( r );
       // Sum function
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "SUM aggregate function" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getFunctionSum() );
+      r.addValue( new ValueMetaString( par ), "SUM aggregate function" );
+      r.addValue( new ValueMetaString( val ), getFunctionSum() );
       list.add( r );
       // Avg function
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "AVG aggregate function" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getFunctionAverage() );
+      r.addValue( new ValueMetaString( par ), "AVG aggregate function" );
+      r.addValue( new ValueMetaString( val ), getFunctionAverage() );
       list.add( r );
       // Minimum function
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "MIN aggregate function" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getFunctionMinimum() );
+      r.addValue( new ValueMetaString( par ), "MIN aggregate function" );
+      r.addValue( new ValueMetaString( val ), getFunctionMinimum() );
       list.add( r );
       // Maximum function
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "MAX aggregate function" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getFunctionMaximum() );
+      r.addValue( new ValueMetaString( par ), "MAX aggregate function" );
+      r.addValue( new ValueMetaString( val ), getFunctionMaximum() );
       list.add( r );
       // Count function
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "COUNT aggregate function" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getFunctionCount() );
+      r.addValue( new ValueMetaString( par ), "COUNT aggregate function" );
+      r.addValue( new ValueMetaString( val ), getFunctionCount() );
       list.add( r );
       // Schema-table combination
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Schema / Table combination" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getQuotedSchemaTableCombination( "SCHEMA", "TABLE" ) );
+      r.addValue( new ValueMetaString( par ), "Schema / Table combination" );
+      r.addValue( new ValueMetaString( val ), getQuotedSchemaTableCombination( "SCHEMA", "TABLE" ) );
       list.add( r );
       // Limit clause
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "LIMIT clause for 100 rows" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getLimitClause( 100 ) );
+      r.addValue( new ValueMetaString( par ), "LIMIT clause for 100 rows" );
+      r.addValue( new ValueMetaString( val ), getLimitClause( 100 ) );
       list.add( r );
       // add column statement
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Add column statement" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getAddColumnStatement(
+      r.addValue( new ValueMetaString( par ), "Add column statement" );
+      r.addValue( new ValueMetaString( val ), getAddColumnStatement(
         "TABLE", testValue, null, false, null, false ) );
       list.add( r );
       // drop column statement
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Drop column statement" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getDropColumnStatement(
+      r.addValue( new ValueMetaString( par ), "Drop column statement" );
+      r.addValue( new ValueMetaString( val ), getDropColumnStatement(
         "TABLE", testValue, null, false, null, false ) );
       list.add( r );
       // Modify column statement
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Modify column statement" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getModifyColumnStatement(
+      r.addValue( new ValueMetaString( par ), "Modify column statement" );
+      r.addValue( new ValueMetaString( val ), getModifyColumnStatement(
         "TABLE", testValue, null, false, null, false ) );
       list.add( r );
 
@@ -2090,24 +2090,24 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
         }
       }
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "List of reserved words" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, reserved );
+      r.addValue( new ValueMetaString( par ), "List of reserved words" );
+      r.addValue( new ValueMetaString( val ), reserved );
       list.add( r );
 
       // Quote reserved words?
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Quote reserved words?" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, quoteReservedWords() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "Quote reserved words?" );
+      r.addValue( new ValueMetaString( val ), quoteReservedWords() ? "Y" : "N" );
       list.add( r );
       // Start Quote
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "Start quote for reserved words" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getStartQuote() );
+      r.addValue( new ValueMetaString( par ), "Start quote for reserved words" );
+      r.addValue( new ValueMetaString( val ), getStartQuote() );
       list.add( r );
       // End Quote
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "End quote for reserved words" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getEndQuote() );
+      r.addValue( new ValueMetaString( par ), "End quote for reserved words" );
+      r.addValue( new ValueMetaString( val ), getEndQuote() );
       list.add( r );
 
       // List of table types
@@ -2119,8 +2119,8 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
         }
       }
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "List of JDBC table types" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, types );
+      r.addValue( new ValueMetaString( par ), "List of JDBC table types" );
+      r.addValue( new ValueMetaString( val ), types );
       list.add( r );
 
       // List of view types
@@ -2132,8 +2132,8 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
         }
       }
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "List of JDBC view types" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, types );
+      r.addValue( new ValueMetaString( par ), "List of JDBC view types" );
+      r.addValue( new ValueMetaString( val ), types );
       list.add( r );
 
       // List of synonym types
@@ -2145,56 +2145,56 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
         }
       }
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "List of JDBC synonym types" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, types );
+      r.addValue( new ValueMetaString( par ), "List of JDBC synonym types" );
+      r.addValue( new ValueMetaString( val ), types );
       list.add( r );
 
       // Use schema-name to get list of tables?
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "use schema name to get table list?" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, useSchemaNameForTableList() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "use schema name to get table list?" );
+      r.addValue( new ValueMetaString( val ), useSchemaNameForTableList() ? "Y" : "N" );
       list.add( r );
       // supports view?
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "supports views?" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, supportsViews() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "supports views?" );
+      r.addValue( new ValueMetaString( val ), supportsViews() ? "Y" : "N" );
       list.add( r );
       // supports synonyms?
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "supports synonyms?" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, supportsSynonyms() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "supports synonyms?" );
+      r.addValue( new ValueMetaString( val ), supportsSynonyms() ? "Y" : "N" );
       list.add( r );
       // SQL: get list of procedures?
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "SQL: list of procedures" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, getSQLListOfProcedures() );
+      r.addValue( new ValueMetaString( par ), "SQL: list of procedures" );
+      r.addValue( new ValueMetaString( val ), getSQLListOfProcedures() );
       list.add( r );
       // SQL: get truncate table statement?
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "SQL: truncate table" );
+      r.addValue( new ValueMetaString( par ), "SQL: truncate table" );
       String truncateStatement = getTruncateTableStatement( null, "TABLE" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, truncateStatement != null
+      r.addValue( new ValueMetaString( val ), truncateStatement != null
         ? truncateStatement : "Not supported by this database type" );
       list.add( r );
       // supports float rounding on update?
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "supports floating point rounding on update/insert" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, supportsFloatRoundingOnUpdate() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "supports floating point rounding on update/insert" );
+      r.addValue( new ValueMetaString( val ), supportsFloatRoundingOnUpdate() ? "Y" : "N" );
       list.add( r );
       // supports time stamp to date conversion
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "supports timestamp-date conversion" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, supportsTimeStampToDateConversion() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "supports timestamp-date conversion" );
+      r.addValue( new ValueMetaString( val ), supportsTimeStampToDateConversion() ? "Y" : "N" );
       list.add( r );
       // supports batch updates
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "supports batch updates" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, supportsBatchUpdates() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "supports batch updates" );
+      r.addValue( new ValueMetaString( val ), supportsBatchUpdates() ? "Y" : "N" );
       list.add( r );
       // supports boolean values
       r = new RowMetaAndData();
-      r.addValue( par, ValueMetaInterface.TYPE_STRING, "supports boolean data type" );
-      r.addValue( val, ValueMetaInterface.TYPE_STRING, supportsBooleanDataType() ? "Y" : "N" );
+      r.addValue( new ValueMetaString( par ), "supports boolean data type" );
+      r.addValue( new ValueMetaString( val ), supportsBooleanDataType() ? "Y" : "N" );
       list.add( r );
     }
 

--- a/core/src/org/pentaho/di/core/jdbc/ThinDatabaseMetaData.java
+++ b/core/src/org/pentaho/di/core/jdbc/ThinDatabaseMetaData.java
@@ -36,8 +36,9 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.row.RowDataUtil;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.version.BuildVersion;
@@ -109,29 +110,29 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getAttributes( String arg0, String arg1, String arg2, String arg3 ) throws SQLException {
+  public ResultSet getAttributes( String catalog, String schemaPattern, String arg2, String arg3 ) throws SQLException {
     RowMetaInterface rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta( "TYPE_CAT", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "TYPE_SCHEM", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "TYPE_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "ATTR_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "DATA_TYPE", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "ATTR_TYPE_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "ATTR_SIZE", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "DECIMAL_DIGITS", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "NUM_PREC_RADIX", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "NULLABLE", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "REMARKS", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "ATTR_DEF", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "SQL_DATA_TYPE", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "SQL_DATETIME_SUB", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "CHAR_OCTET_LENGTH", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "ORDINAL_POSITION", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "IS_NULLABLE", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "SCOPE_CATALOG", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "SCOPE_SCHEMA", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "SCOPE_TABLE", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "SOURCE_DATA_TYPE", ValueMetaInterface.TYPE_INTEGER ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TYPE_CAT" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TYPE_SCHEM" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TYPE_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "ATTR_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "DATA_TYPE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "ATTR_TYPE_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "ATTR_SIZE" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "DECIMAL_DIGITS" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "NUM_PREC_RADIX" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "NULLABLE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "REMARKS" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "ATTR_DEF" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "SQL_DATA_TYPE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "SQL_DATETIME_SUB" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "CHAR_OCTET_LENGTH" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "ORDINAL_POSITION" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "IS_NULLABLE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "SCOPE_CATALOG" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "SCOPE_SCHEMA" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "SCOPE_TABLE" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "SOURCE_DATA_TYPE" ) );
 
     return new RowsResultSet( rowMeta, new ArrayList<Object[]>() );
   }
@@ -139,14 +140,14 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getBestRowIdentifier( String arg0, String arg1, String arg2, int arg3, boolean arg4 ) throws SQLException {
     RowMetaInterface rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta( "SCOPE", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "COLUMN_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "DATA_TYPE", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "TYPE_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "COLUMN_SIZE", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "BUFFER_LENGTH", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "DECIMAL_DIGITS", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "PSEUDO_COLUMN", ValueMetaInterface.TYPE_INTEGER ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "SCOPE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "COLUMN_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "DATA_TYPE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TYPE_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "COLUMN_SIZE" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "BUFFER_LENGTH" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "DECIMAL_DIGITS" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "PSEUDO_COLUMN" ) );
 
     return new RowsResultSet( rowMeta, new ArrayList<Object[]>() );
   }
@@ -164,7 +165,7 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getCatalogs() throws SQLException {
     RowMetaInterface rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta( "TABLE_CAT", ValueMetaInterface.TYPE_STRING ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TABLE_CAT" ) );
 
     return new RowsResultSet( rowMeta, new ArrayList<Object[]>() );
   }
@@ -172,10 +173,10 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getClientInfoProperties() throws SQLException {
     RowMetaInterface rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta( "NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "MAX_LEN", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "DEFAULT_VALUE", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "DESCRIPTION", ValueMetaInterface.TYPE_STRING ) );
+    rowMeta.addValueMeta( new ValueMetaString( "NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "MAX_LEN" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "DEFAULT_VALUE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "DESCRIPTION" ) );
 
     return new RowsResultSet( rowMeta, new ArrayList<Object[]>() );
   }
@@ -183,14 +184,14 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getColumnPrivileges( String arg0, String arg1, String arg2, String arg3 ) throws SQLException {
     RowMetaInterface rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta( "TABLE_CAT", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "TABLE_SCHEM", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "TABLE_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "COLUMN_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "GRANTOR", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "GRANTEE", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "PRIVILEGE", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "IS_GRANTABLE", ValueMetaInterface.TYPE_STRING ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TABLE_CAT" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TABLE_SCHEM" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TABLE_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "COLUMN_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "GRANTOR" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "GRANTEE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "PRIVILEGE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "IS_GRANTABLE" ) );
 
     return new RowsResultSet( rowMeta, new ArrayList<Object[]>() );
   }
@@ -199,9 +200,6 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getColumns( String catalog, String schemaPattern, String tableNamePattern,
     String columnNamePattern ) throws SQLException {
 
-    System.out.println( "getColumns("
-      + catalog + ", " + schemaPattern + ", " + tableNamePattern + ", " + columnNamePattern + ")" );
-
     try {
 
       // Get the service information from the remote server...
@@ -209,32 +207,32 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
       List<ThinServiceInformation> services = getServiceInformation();
 
       RowMetaInterface rowMeta = new RowMeta();
-      rowMeta.addValueMeta( new ValueMeta( "TABLE_CAT", ValueMetaInterface.TYPE_STRING ) ); // null
-      rowMeta.addValueMeta( new ValueMeta( "TABLE_SCHEM", ValueMetaInterface.TYPE_STRING ) ); // null
-      rowMeta.addValueMeta( new ValueMeta( "TABLE_NAME", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "COLUMN_NAME", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "DATA_TYPE", ValueMetaInterface.TYPE_INTEGER ) );
-      rowMeta.addValueMeta( new ValueMeta( "TYPE_NAME", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "COLUMN_SIZE", ValueMetaInterface.TYPE_INTEGER ) ); // length
-      rowMeta.addValueMeta( new ValueMeta( "BUFFER_LENGTH", ValueMetaInterface.TYPE_INTEGER ) ); // not used
-      rowMeta.addValueMeta( new ValueMeta( "DECIMAL_DIGITS", ValueMetaInterface.TYPE_INTEGER ) ); // precision
-      rowMeta.addValueMeta( new ValueMeta( "NUM_PREC_RADIX", ValueMetaInterface.TYPE_INTEGER ) ); // Radix, typically
+      rowMeta.addValueMeta( new ValueMetaString( "TABLE_CAT" ) ); // null
+      rowMeta.addValueMeta( new ValueMetaString( "TABLE_SCHEM" ) ); // null
+      rowMeta.addValueMeta( new ValueMetaString( "TABLE_NAME" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "COLUMN_NAME" ) );
+      rowMeta.addValueMeta( new ValueMetaInteger( "DATA_TYPE" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "TYPE_NAME" ) );
+      rowMeta.addValueMeta( new ValueMetaInteger( "COLUMN_SIZE" ) ); // length
+      rowMeta.addValueMeta( new ValueMetaInteger( "BUFFER_LENGTH" ) ); // not used
+      rowMeta.addValueMeta( new ValueMetaInteger( "DECIMAL_DIGITS" ) ); // precision
+      rowMeta.addValueMeta( new ValueMetaInteger( "NUM_PREC_RADIX" ) ); // Radix, typically
                                                                                                   // either 10 or 2
-      rowMeta.addValueMeta( new ValueMeta( "NULLABLE", ValueMetaInterface.TYPE_INTEGER ) ); // columnsNullableUnknown
-      rowMeta.addValueMeta( new ValueMeta( "REMARKS", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "COLUMN_DEF", ValueMetaInterface.TYPE_STRING ) ); // default value, null
-      rowMeta.addValueMeta( new ValueMeta( "SQL_DATA_TYPE", ValueMetaInterface.TYPE_INTEGER ) ); // unused
-      rowMeta.addValueMeta( new ValueMeta( "SQL_DATATIME_SUB", ValueMetaInterface.TYPE_INTEGER ) ); // unused
-      rowMeta.addValueMeta( new ValueMeta( "CHAR_OCTET_LENGTH", ValueMetaInterface.TYPE_INTEGER ) ); // max string
+      rowMeta.addValueMeta( new ValueMetaInteger( "NULLABLE" ) ); // columnsNullableUnknown
+      rowMeta.addValueMeta( new ValueMetaString( "REMARKS" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "COLUMN_DEF" ) ); // default value, null
+      rowMeta.addValueMeta( new ValueMetaInteger( "SQL_DATA_TYPE" ) ); // unused
+      rowMeta.addValueMeta( new ValueMetaInteger( "SQL_DATATIME_SUB" ) ); // unused
+      rowMeta.addValueMeta( new ValueMetaInteger( "CHAR_OCTET_LENGTH" ) ); // max string
                                                                                                      // length in bytes
-      rowMeta.addValueMeta( new ValueMeta( "ORDINAL_POSITION", ValueMetaInterface.TYPE_INTEGER ) ); // column position,
+      rowMeta.addValueMeta( new ValueMetaInteger( "ORDINAL_POSITION" ) ); // column position,
                                                                                                     // 1 based
-      rowMeta.addValueMeta( new ValueMeta( "IS_NULLABLE", ValueMetaInterface.TYPE_STRING ) ); // empty string: nobody
+      rowMeta.addValueMeta( new ValueMetaString( "IS_NULLABLE" ) ); // empty string: nobody
                                                                                               // knows
-      rowMeta.addValueMeta( new ValueMeta( "SCOPE_CATALOG", ValueMetaInterface.TYPE_STRING ) ); // null
-      rowMeta.addValueMeta( new ValueMeta( "SCOPE_SCHEMA", ValueMetaInterface.TYPE_STRING ) ); // null
-      rowMeta.addValueMeta( new ValueMeta( "SCOPE_TABLE", ValueMetaInterface.TYPE_STRING ) ); // null
-      rowMeta.addValueMeta( new ValueMeta( "SOURCE_DATA_TYPE", ValueMetaInterface.TYPE_STRING ) ); // Kettle source data
+      rowMeta.addValueMeta( new ValueMetaString( "SCOPE_CATALOG" ) ); // null
+      rowMeta.addValueMeta( new ValueMetaString( "SCOPE_SCHEMA" ) ); // null
+      rowMeta.addValueMeta( new ValueMetaString( "SCOPE_TABLE" ) ); // null
+      rowMeta.addValueMeta( new ValueMetaString( "SOURCE_DATA_TYPE" ) ); // Kettle source data
                                                                                                    // type description
 
       List<Object[]> rows = new ArrayList<Object[]>();
@@ -289,14 +287,14 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getCrossReference( String arg0, String arg1, String arg2, String arg3, String arg4, String arg5 ) throws SQLException {
     RowMetaInterface rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta( "TABLE_CAT", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "TABLE_SCHEM", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "TABLE_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "COLUMN_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "GRANTOR", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "GRANTEE", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "PRIVILEGE", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "IS_GRANTABLE", ValueMetaInterface.TYPE_STRING ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TABLE_CAT" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TABLE_SCHEM" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TABLE_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "COLUMN_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "GRANTOR" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "GRANTEE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "PRIVILEGE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "IS_GRANTABLE" ) );
 
     return new RowsResultSet( rowMeta, new ArrayList<Object[]>() );
   }
@@ -374,20 +372,20 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getImportedKeys( String arg0, String arg1, String arg2 ) throws SQLException {
     RowMetaInterface rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta( "PKTABLE_CAT", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "PKTABLE_SCHEM", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "PKTABLE_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "PKCOLUMN_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "FKTABLE_CAT", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "FKTABLE_SCHEM", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "FKTABLE_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "FKCOLUMN_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "KEY_SEQ", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "UPDATE_RULE", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "DELETE_RULE", ValueMetaInterface.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "FK_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "PK_NAME", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "DEFERRABILITY", ValueMetaInterface.TYPE_INTEGER ) );
+    rowMeta.addValueMeta( new ValueMetaString( "PKTABLE_CAT" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "PKTABLE_SCHEM" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "PKTABLE_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "PKCOLUMN_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "FKTABLE_CAT" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "FKTABLE_SCHEM" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "FKTABLE_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "FKCOLUMN_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "KEY_SEQ" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "UPDATE_RULE" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "DELETE_RULE" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "FK_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "PK_NAME" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "DEFERRABILITY" ) );
 
     return new RowsResultSet( rowMeta, new ArrayList<Object[]>() );
   }
@@ -628,8 +626,8 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getSchemas( String catalog, String schemaPattern ) throws SQLException {
     RowMetaInterface rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta( "TABLE_SCHEM", ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "TABLE_CATALOG", ValueMetaInterface.TYPE_STRING ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TABLE_SCHEM" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "TABLE_CATALOG" ) );
 
     List<Object[]> rows = new ArrayList<Object[]>();
 
@@ -669,16 +667,16 @@ public class ThinDatabaseMetaData implements DatabaseMetaData {
       List<ThinServiceInformation> services = getServiceInformation();
 
       RowMetaInterface rowMeta = new RowMeta();
-      rowMeta.addValueMeta( new ValueMeta( "TABLE_CAT", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "TABLE_SCHEM", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "TABLE_NAME", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "TABLE_TYPE", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "REMARKS", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "TYPE_CAT", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "TYPE_SCHEM", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "TYPE_NAME", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "SELF_REFERENCING_COL_NAME", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "REF_GENERATION", ValueMetaInterface.TYPE_STRING ) );
+      rowMeta.addValueMeta( new ValueMetaString( "TABLE_CAT" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "TABLE_SCHEM" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "TABLE_NAME" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "TABLE_TYPE" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "REMARKS" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "TYPE_CAT" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "TYPE_SCHEM" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "TYPE_NAME" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "SELF_REFERENCING_COL_NAME" ) );
+      rowMeta.addValueMeta( new ValueMetaString( "REF_GENERATION" ) );
 
       List<Object[]> rows = new ArrayList<Object[]>();
       for ( ThinServiceInformation service : services ) {

--- a/core/src/org/pentaho/di/core/jdbc/ThinPreparedStatement.java
+++ b/core/src/org/pentaho/di/core/jdbc/ThinPreparedStatement.java
@@ -47,8 +47,13 @@ import java.util.Calendar;
 import java.util.List;
 
 import org.pentaho.di.core.exception.KettleSQLException;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBigNumber;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
 
 /**
  * This class is no longer used
@@ -92,7 +97,7 @@ public class ThinPreparedStatement extends ThinStatement implements PreparedStat
       paramMeta = new ValueMetaInterface[placeholderIndexes.size()];
       // Null Strings is the default.
       for ( int i = 0; i < placeholderIndexes.size(); i++ ) {
-        paramMeta[i] = new ValueMeta( "param-" + ( i + 1 ), ValueMetaInterface.TYPE_STRING );
+        paramMeta[i] = new ValueMetaString( "param-" + ( i + 1 ) );
       }
 
     } catch ( Exception e ) {
@@ -215,7 +220,7 @@ public class ThinPreparedStatement extends ThinStatement implements PreparedStat
   @Override
   public void setBigDecimal( int nr, BigDecimal value ) throws SQLException {
     paramData[nr - 1] = value;
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_BIGNUMBER );
+    paramMeta[nr - 1] = new ValueMetaBigNumber( "param-" + nr );
   }
 
   @Override
@@ -251,13 +256,13 @@ public class ThinPreparedStatement extends ThinStatement implements PreparedStat
   @Override
   public void setBoolean( int nr, boolean value ) throws SQLException {
     paramData[nr - 1] = Boolean.valueOf( value );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_BOOLEAN );
+    paramMeta[nr - 1] = new ValueMetaBoolean( "param-" + nr );
   }
 
   @Override
   public void setByte( int nr, byte value ) throws SQLException {
     paramData[nr - 1] = Long.valueOf( value );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_INTEGER );
+    paramMeta[nr - 1] = new ValueMetaInteger( "param-" + nr );
   }
 
   @Override
@@ -298,7 +303,7 @@ public class ThinPreparedStatement extends ThinStatement implements PreparedStat
   @Override
   public void setDate( int nr, Date value ) throws SQLException {
     paramData[nr - 1] = new java.util.Date( value.getTime() );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_DATE );
+    paramMeta[nr - 1] = new ValueMetaDate( "param-" + nr );
   }
 
   @Override
@@ -306,31 +311,31 @@ public class ThinPreparedStatement extends ThinStatement implements PreparedStat
     // TODO: investigate the calendar parameter functionality with regards to time zones.
     //
     paramData[nr - 1] = new java.util.Date( value.getTime() );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_DATE );
+    paramMeta[nr - 1] = new ValueMetaDate( "param-" + nr );
   }
 
   @Override
   public void setDouble( int nr, double value ) throws SQLException {
     paramData[nr - 1] = Double.valueOf( value );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_NUMBER );
+    paramMeta[nr - 1] = new ValueMetaNumber( "param-" + nr );
   }
 
   @Override
   public void setFloat( int nr, float value ) throws SQLException {
     paramData[nr - 1] = Double.valueOf( value );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_NUMBER );
+    paramMeta[nr - 1] = new ValueMetaNumber( "param-" + nr );
   }
 
   @Override
   public void setInt( int nr, int value ) throws SQLException {
     paramData[nr - 1] = Long.valueOf( value );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_INTEGER );
+    paramMeta[nr - 1] = new ValueMetaInteger( "param-" + nr );
   }
 
   @Override
   public void setLong( int nr, long value ) throws SQLException {
     paramData[nr - 1] = Long.valueOf( value );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_INTEGER );
+    paramMeta[nr - 1] = new ValueMetaInteger( "param-" + nr );
   }
 
   @Override
@@ -435,13 +440,13 @@ public class ThinPreparedStatement extends ThinStatement implements PreparedStat
   @Override
   public void setString( int nr, String value ) throws SQLException {
     paramData[nr - 1] = value;
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_STRING );
+    paramMeta[nr - 1] = new ValueMetaString( "param-" + nr );
   }
 
   @Override
   public void setTime( int nr, Time value ) throws SQLException {
     paramData[nr - 1] = new java.util.Date( value.getTime() );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_DATE );
+    paramMeta[nr - 1] = new ValueMetaDate( "param-" + nr );
   }
 
   @Override
@@ -452,7 +457,7 @@ public class ThinPreparedStatement extends ThinStatement implements PreparedStat
   @Override
   public void setTimestamp( int nr, Timestamp value ) throws SQLException {
     paramData[nr - 1] = new java.util.Date( value.getTime() );
-    paramMeta[nr - 1] = new ValueMeta( "param-" + nr, ValueMetaInterface.TYPE_DATE );
+    paramMeta[nr - 1] = new ValueMetaDate( "param-" + nr );
   }
 
   @Override

--- a/core/src/org/pentaho/di/core/plugins/PluginRegistry.java
+++ b/core/src/org/pentaho/di/core/plugins/PluginRegistry.java
@@ -50,8 +50,7 @@ import org.pentaho.di.core.logging.Metrics;
 import org.pentaho.di.core.row.RowBuffer;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.i18n.BaseMessages;
 
@@ -787,28 +786,14 @@ public class PluginRegistry {
   private RowMetaInterface getPluginInformationRowMeta() {
     RowMetaInterface row = new RowMeta();
 
-    row.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "PluginRegistry.Information.Type.Label" ), ValueMetaInterface.TYPE_STRING ) );
-    row.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "PluginRegistry.Information.ID.Label" ), ValueMetaInterface.TYPE_STRING ) );
-    row.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "PluginRegistry.Information.Name.Label" ), ValueMetaInterface.TYPE_STRING ) );
-    row.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "PluginRegistry.Information.Description.Label" ),
-      ValueMetaInterface.TYPE_STRING ) );
-    row.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "PluginRegistry.Information.Libraries.Label" ),
-      ValueMetaInterface.TYPE_STRING ) );
-    row.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "PluginRegistry.Information.ImageFile.Label" ),
-      ValueMetaInterface.TYPE_STRING ) );
-    row.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "PluginRegistry.Information.ClassName.Label" ),
-      ValueMetaInterface.TYPE_STRING ) );
-    row
-      .addValueMeta( new ValueMeta(
-        BaseMessages.getString( PKG, "PluginRegistry.Information.Category.Label" ),
-        ValueMetaInterface.TYPE_STRING ) );
+    row.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "PluginRegistry.Information.Type.Label" ) ) );
+    row.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "PluginRegistry.Information.ID.Label" ) ) );
+    row.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "PluginRegistry.Information.Name.Label" ) ) );
+    row.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "PluginRegistry.Information.Description.Label" ) ) );
+    row.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "PluginRegistry.Information.Libraries.Label" ) ) );
+    row.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "PluginRegistry.Information.ImageFile.Label" ) ) );
+    row.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "PluginRegistry.Information.ClassName.Label" ) ) );
+    row.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "PluginRegistry.Information.Category.Label" ) ) );
 
     return row;
   }

--- a/core/src/org/pentaho/di/core/row/RowMeta.java
+++ b/core/src/org/pentaho/di/core/row/RowMeta.java
@@ -46,6 +46,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.row.value.ValueMetaFactory;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.w3c.dom.Node;
@@ -988,9 +989,9 @@ public class RowMeta implements RowMetaInterface {
   public RowMeta( Node node ) throws KettleException {
     this();
 
-    int nrValues = XMLHandler.countNodes( node, ValueMeta.XML_META_TAG );
+    int nrValues = XMLHandler.countNodes( node, ValueMetaBase.XML_META_TAG );
     for ( int i = 0; i < nrValues; i++ ) {
-      addValueMeta( new ValueMeta( XMLHandler.getSubNodeByNr( node, ValueMeta.XML_META_TAG, i ) ) );
+      addValueMeta( new ValueMeta( XMLHandler.getSubNodeByNr( node, ValueMetaBase.XML_META_TAG, i ) ) );
     }
   }
 
@@ -1026,7 +1027,7 @@ public class RowMeta implements RowMetaInterface {
     Object[] rowData = RowDataUtil.allocateRowData( size() );
 
     for ( int i = 0; i < size(); i++ ) {
-      Node valueDataNode = XMLHandler.getSubNodeByNr( node, ValueMeta.XML_DATA_TAG, i );
+      Node valueDataNode = XMLHandler.getSubNodeByNr( node, ValueMetaBase.XML_DATA_TAG, i );
       rowData[i] = getValueMeta( i ).getValue( valueDataNode );
     }
     return rowData;

--- a/core/src/org/pentaho/di/core/row/SpeedTest.java
+++ b/core/src/org/pentaho/di/core/row/SpeedTest.java
@@ -25,6 +25,11 @@ package org.pentaho.di.core.row;
 import java.util.Date;
 
 import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.util.StringUtil;
 
 public class SpeedTest {
@@ -80,27 +85,31 @@ public class SpeedTest {
   private static void populateMetaAndData( int i, Object[] rowString10, RowMetaInterface metaString10,
     Object[] rowMixed10, RowMetaInterface metaMixed10 ) {
     rowString10[i] = StringUtil.generateRandomString( 20, "", "", false );
-    ValueMetaInterface meta = new ValueMeta( "String" + ( i + 1 ), ValueMetaInterface.TYPE_STRING, 20, 0 );
+    ValueMetaInterface meta = new ValueMetaString( "String" + ( i + 1 ) );
+    meta.setLength( 20 );
     metaString10.addValueMeta( meta );
 
     rowMixed10[i * 5 + 0] = StringUtil.generateRandomString( 20, "", "", false );
-    ValueMetaInterface meta0 = new ValueMeta( "String" + ( i * 5 + 1 ), ValueMetaInterface.TYPE_STRING, 20, 0 );
+    ValueMetaInterface meta0 = new ValueMetaString( "String" + ( i * 5 + 1 ) );
+    meta0.setLength( 20 );
     metaMixed10.addValueMeta( meta0 );
 
     rowMixed10[i * 5 + 1] = new Date();
-    ValueMetaInterface meta1 = new ValueMeta( "String" + ( i * 5 + 1 ), ValueMetaInterface.TYPE_DATE );
+    ValueMetaInterface meta1 = new ValueMetaDate( "String" + ( i * 5 + 1 ) );
     metaMixed10.addValueMeta( meta1 );
 
     rowMixed10[i * 5 + 2] = new Double( Math.random() * 1000000 );
-    ValueMetaInterface meta2 = new ValueMeta( "String" + ( i * 5 + 1 ), ValueMetaInterface.TYPE_NUMBER, 12, 4 );
+    ValueMetaInterface meta2 = new ValueMetaNumber( "String" + ( i * 5 + 1 ) );
+    meta2.setLength( 12, 4 );
     metaMixed10.addValueMeta( meta2 );
 
     rowMixed10[i * 5 + 3] = new Long( (long) ( Math.random() * 1000000 ) );
-    ValueMetaInterface meta3 = new ValueMeta( "String" + ( i * 5 + 1 ), ValueMetaInterface.TYPE_INTEGER, 8, 0 );
+    ValueMetaInterface meta3 = new ValueMetaInteger( "String" + ( i * 5 + 1 ) );
+    meta3.setLength( 8 );
     metaMixed10.addValueMeta( meta3 );
 
     rowMixed10[i * 5 + 4] = Boolean.valueOf( Math.random() > 0.5 ? true : false );
-    ValueMetaInterface meta4 = new ValueMeta( "String" + ( i * 5 + 1 ), ValueMetaInterface.TYPE_BOOLEAN );
+    ValueMetaInterface meta4 = new ValueMetaBoolean( "String" + ( i * 5 + 1 ) );
     metaMixed10.addValueMeta( meta4 );
   }
 

--- a/core/src/org/pentaho/di/core/row/ValueMeta.java
+++ b/core/src/org/pentaho/di/core/row/ValueMeta.java
@@ -30,6 +30,7 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleEOFException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.i18n.BaseMessages;
 import org.w3c.dom.Node;
@@ -39,7 +40,13 @@ import org.w3c.dom.Node;
  *
  *
  */
+@Deprecated
 public class ValueMeta extends ValueMetaBase {
+  @Override
+  public Object convertData( ValueMetaInterface meta2, Object data2 ) throws KettleValueException {
+    return super.convertData( meta2, data2 );
+  }
+
   private static Class<?> PKG = Const.class;
 
   public static final String DEFAULT_DATE_FORMAT_MASK = "yyyy/MM/dd HH:mm:ss.SSS";

--- a/core/src/org/pentaho/di/core/row/ValueMetaAndData.java
+++ b/core/src/org/pentaho/di/core/row/ValueMetaAndData.java
@@ -28,6 +28,14 @@ import java.util.Date;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaBigNumber;
+import org.pentaho.di.core.row.value.ValueMetaBinary;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaSerializable;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.w3c.dom.Node;
 
@@ -52,21 +60,21 @@ public class ValueMetaAndData {
   public ValueMetaAndData( String valueName, Object valueData ) throws KettleValueException {
     this.valueData = valueData;
     if ( valueData instanceof String ) {
-      this.valueMeta = new ValueMeta( valueName, ValueMetaInterface.TYPE_STRING );
+      this.valueMeta = new ValueMetaString( valueName );
     } else if ( valueData instanceof Double ) {
-      this.valueMeta = new ValueMeta( valueName, ValueMetaInterface.TYPE_NUMBER );
+      this.valueMeta = new ValueMetaNumber( valueName );
     } else if ( valueData instanceof Long ) {
-      this.valueMeta = new ValueMeta( valueName, ValueMetaInterface.TYPE_INTEGER );
+      this.valueMeta = new ValueMetaInteger( valueName );
     } else if ( valueData instanceof Date ) {
-      this.valueMeta = new ValueMeta( valueName, ValueMetaInterface.TYPE_DATE );
+      this.valueMeta = new ValueMetaDate( valueName );
     } else if ( valueData instanceof BigDecimal ) {
-      this.valueMeta = new ValueMeta( valueName, ValueMetaInterface.TYPE_BIGNUMBER );
+      this.valueMeta = new ValueMetaBigNumber( valueName );
     } else if ( valueData instanceof Boolean ) {
-      this.valueMeta = new ValueMeta( valueName, ValueMetaInterface.TYPE_BOOLEAN );
+      this.valueMeta = new ValueMetaBoolean( valueName );
     } else if ( valueData instanceof byte[] ) {
-      this.valueMeta = new ValueMeta( valueName, ValueMetaInterface.TYPE_BINARY );
+      this.valueMeta = new ValueMetaBinary( valueName );
     } else {
-      this.valueMeta = new ValueMeta( valueName, ValueMetaInterface.TYPE_SERIALIZABLE );
+      this.valueMeta = new ValueMetaSerializable( valueName );
     }
   }
 
@@ -169,7 +177,7 @@ public class ValueMetaAndData {
       }
 
       if ( valtype != ValueMetaInterface.TYPE_STRING ) {
-        ValueMetaInterface originMeta = new ValueMeta( valname, ValueMetaInterface.TYPE_STRING );
+        ValueMetaInterface originMeta = new ValueMetaString( valname );
         if ( valueMeta.isNumeric() ) {
           originMeta.setDecimalSymbol( "." );
           originMeta.setGroupingSymbol( null );

--- a/core/src/org/pentaho/di/core/sql/SQLCondition.java
+++ b/core/src/org/pentaho/di/core/sql/SQLCondition.java
@@ -32,9 +32,8 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleSQLException;
 import org.pentaho.di.core.jdbc.ThinUtil;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaAndData;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 
 public class SQLCondition {
 
@@ -200,11 +199,8 @@ public class SQLCondition {
    * Creates a Condition object which will act as a container for a Parameter key/value.
    */
   private Condition createParameterCondition( int orConditionOperator, String parameterName, String parameterValue ) {
-    Condition
-        subCondition =
-        new Condition( parameterName, Condition.FUNC_TRUE, parameterName,
-            new ValueMetaAndData( new ValueMeta( "string", ValueMetaInterface.TYPE_STRING ),
-                Const.NVL( parameterValue, "" ) ) );
+    Condition subCondition = new Condition( parameterName, Condition.FUNC_TRUE, parameterName,
+      new ValueMetaAndData( new ValueMetaString( "string" ), Const.NVL( parameterValue, "" ) ) );
     subCondition.setOperator( orConditionOperator );
     return subCondition;
   }
@@ -312,9 +308,7 @@ public class SQLCondition {
 
         valueString.append( part );
       }
-      value =
-          new ValueMetaAndData( new ValueMeta( "constant-in-list", ValueMetaInterface.TYPE_STRING ),
-              valueString.toString() );
+      value = new ValueMetaAndData( new ValueMetaString( "constant-in-list" ), valueString.toString() );
     } else {
 
       // Mondrian, analyzer CONTAINS hack:

--- a/core/src/org/pentaho/di/core/sql/SQLField.java
+++ b/core/src/org/pentaho/di/core/sql/SQLField.java
@@ -28,9 +28,9 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleSQLException;
 import org.pentaho.di.core.jdbc.ThinUtil;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaAndData;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
 
 public class SQLField {
   private String tableAlias;
@@ -182,7 +182,7 @@ public class SQLField {
 
               switch ( selectField.getAggregation() ) {
                 case COUNT:
-                  valueMeta = new ValueMeta( field, ValueMetaInterface.TYPE_INTEGER, 15 );
+                  valueMeta = new ValueMetaInteger( field );
                   break;
                 case MIN:
                 case MAX:

--- a/core/src/org/pentaho/di/core/util/StringEvaluator.java
+++ b/core/src/org/pentaho/di/core/util/StringEvaluator.java
@@ -36,8 +36,12 @@ import java.util.regex.Pattern;
 
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleValueException;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
 
 /**
  * This class evaluates strings and extracts a data type. It allows you to criteria after which the analysis should be
@@ -84,7 +88,7 @@ public class StringEvaluator {
     evaluationResults = new ArrayList<StringEvaluationResult>();
     count = 0;
 
-    stringMeta = new ValueMeta( "string", ValueMetaInterface.TYPE_STRING );
+    stringMeta = new ValueMetaString( "string" );
     this.numberFormats = numberFormats;
     this.dateFormats = dateFormats;
 
@@ -250,7 +254,7 @@ public class StringEvaluator {
 
   public StringEvaluationResult getAdvicedResult() {
     if ( evaluationResults.isEmpty() ) {
-      ValueMetaInterface adviced = new ValueMeta( "adviced", ValueMetaInterface.TYPE_STRING );
+      ValueMetaInterface adviced = new ValueMetaString( "adviced" );
       adviced.setLength( maxLength );
       int nrNulls = 0;
       String min = null;
@@ -366,7 +370,7 @@ public class StringEvaluator {
 
     for ( int trimType : trimTypes ) {
       for ( String format : getDateFormats() ) {
-        ValueMetaInterface conversionMeta = new ValueMeta( "date", ValueMetaInterface.TYPE_DATE );
+        ValueMetaInterface conversionMeta = new ValueMetaDate( "date" );
         conversionMeta.setConversionMask( format );
         conversionMeta.setTrimType( trimType );
         conversionMeta.setDateFormatLenient( false );
@@ -393,7 +397,7 @@ public class StringEvaluator {
       // Try the locale's Currency
       DecimalFormat currencyFormat = ( (DecimalFormat) NumberFormat.getCurrencyInstance() );
 
-      ValueMetaInterface conversionMeta = new ValueMeta( "number-currency", ValueMetaInterface.TYPE_NUMBER );
+      ValueMetaInterface conversionMeta = new ValueMetaNumber( "number-currency" );
       // replace the universal currency symbol with the locale's currency symbol for user recognition
       String currencyMask =
         currencyFormat.toLocalizedPattern().replace( "\u00A4", currencyFormat.getCurrency().getSymbol() );
@@ -418,12 +422,12 @@ public class StringEvaluator {
 
       // Integer
       //
-      conversionMeta = new ValueMeta( "integer", ValueMetaInterface.TYPE_INTEGER );
+      conversionMeta = new ValueMetaInteger( "integer" );
       conversionMeta.setConversionMask( "#" );
       conversionMeta.setLength( 15 );
       evaluationResults.add( new StringEvaluationResult( conversionMeta ) );
 
-      conversionMeta = new ValueMeta( "integer", ValueMetaInterface.TYPE_INTEGER );
+      conversionMeta = new ValueMetaInteger( "integer" );
       conversionMeta.setConversionMask( " #" );
       conversionMeta.setLength( 15 );
       evaluationResults.add( new StringEvaluationResult( conversionMeta ) );
@@ -441,7 +445,7 @@ public class StringEvaluator {
           mask += "0";
         }
 
-        conversionMeta = new ValueMeta( "integer-zero-padded-" + i, ValueMetaInterface.TYPE_INTEGER );
+        conversionMeta = new ValueMetaInteger( "integer-zero-padded-" + i );
         conversionMeta.setConversionMask( mask );
         conversionMeta.setLength( i );
         evaluationResults.add( new StringEvaluationResult( conversionMeta ) );
@@ -449,7 +453,7 @@ public class StringEvaluator {
 
       // Boolean
       //
-      conversionMeta = new ValueMeta( "boolean", ValueMetaInterface.TYPE_BOOLEAN );
+      conversionMeta = new ValueMetaBoolean( "boolean" );
       evaluationResults.add( new StringEvaluationResult( conversionMeta ) );
     }
   }

--- a/core/test-src/org/pentaho/di/core/ResultFileTest.java
+++ b/core/test-src/org/pentaho/di/core/ResultFileTest.java
@@ -1,0 +1,73 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs.FileSystemException;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.vfs.KettleVFS;
+
+public class ResultFileTest {
+
+  @Test
+  public void testGetRow() throws KettleFileException, FileSystemException {
+    File tempDir = new File( new TemporaryFolder().toString() );
+    FileObject tempFile = KettleVFS.createTempFile( "prefix", "suffix", tempDir.toString() );
+    Date timeBeforeFile = Calendar.getInstance().getTime();
+    ResultFile resultFile = new ResultFile( ResultFile.FILE_TYPE_GENERAL, tempFile, "myOriginParent", "myOrigin" );
+    Date timeAfterFile = Calendar.getInstance().getTime();
+
+    assertNotNull( resultFile );
+    RowMetaInterface rm = resultFile.getRow().getRowMeta();
+    assertEquals( 7, rm.getValueMetaList().size() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 0 ).getType() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 1 ).getType() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 2 ).getType() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 3 ).getType() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 4 ).getType() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 5 ).getType() );
+    assertEquals( ValueMetaInterface.TYPE_DATE, rm.getValueMeta( 6 ).getType() );
+
+    assertEquals( ResultFile.FILE_TYPE_GENERAL, resultFile.getType() );
+    assertEquals( "myOrigin", resultFile.getOrigin() );
+    assertEquals( "myOriginParent", resultFile.getOriginParent() );
+    assertTrue( "ResultFile timestamp is created in the expected window",
+      timeBeforeFile.compareTo( resultFile.getTimestamp() ) <= 0
+      && timeAfterFile.compareTo( resultFile.getTimestamp() ) >= 0 );
+
+    tempFile.delete();
+    tempDir.delete();
+  }
+}

--- a/core/test-src/org/pentaho/di/core/database/DatabaseConnectionPoolParameterTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseConnectionPoolParameterTest.java
@@ -1,0 +1,52 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.database;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+public class DatabaseConnectionPoolParameterTest {
+
+  @Test
+  public void testGetRowList() {
+    List<RowMetaAndData> result = DatabaseConnectionPoolParameter.getRowList( BaseDatabaseMeta.poolingParameters,
+      "myTitleParameter", "myTitleDefaultValue", "myTitleDescription" );
+
+    assertNotNull( result );
+    for ( RowMetaAndData rmd : result ) {
+      assertEquals( 3, rmd.getRowMeta().size() );
+      assertEquals( "myTitleParameter", rmd.getRowMeta().getValueMeta( 0 ).getName() );
+      assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getRowMeta().getValueMeta( 0 ).getType() );
+      assertEquals( "myTitleDefaultValue", rmd.getRowMeta().getValueMeta( 1 ).getName() );
+      assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getRowMeta().getValueMeta( 1 ).getType() );
+      assertEquals( "myTitleDescription", rmd.getRowMeta().getValueMeta( 2 ).getName() );
+      assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getRowMeta().getValueMeta( 2 ).getType() );
+    }
+  }
+}

--- a/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
@@ -39,9 +39,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 import org.pentaho.di.core.plugins.DatabasePluginType;
+import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
 
 public class DatabaseMetaTest {
   @Test
@@ -166,5 +168,24 @@ public class DatabaseMetaTest {
     databaseMeta2.verifyAndModifyDatabaseName( list, null );
 
     assertTrue( !databaseMeta.getDisplayName().equals( databaseMeta2.getDisplayName() ) );
+  }
+
+  @Test
+  public void testGetFeatureSummary() throws Exception {
+    DatabaseMeta databaseMeta = mock( DatabaseMeta.class );
+    OracleDatabaseMeta odbm = new OracleDatabaseMeta();
+    doCallRealMethod().when( databaseMeta ).setDatabaseInterface( any( DatabaseInterface.class ) );
+    doCallRealMethod().when( databaseMeta ).getFeatureSummary();
+    doCallRealMethod().when( databaseMeta ).getAttributes();
+    databaseMeta.setDatabaseInterface( odbm );
+    List<RowMetaAndData> result = databaseMeta.getFeatureSummary();
+    assertNotNull( result );
+    for ( RowMetaAndData rmd : result ) {
+      assertEquals( 2, rmd.getRowMeta().size() );
+      assertEquals( "Parameter", rmd.getRowMeta().getValueMeta( 0 ).getName() );
+      assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getRowMeta().getValueMeta( 0 ).getType() );
+      assertEquals( "Value", rmd.getRowMeta().getValueMeta( 1 ).getName() );
+      assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getRowMeta().getValueMeta( 1 ).getType() );
+    }
   }
 }

--- a/core/test-src/org/pentaho/di/core/jdbc/ThinDatabaseMetaDataTest.java
+++ b/core/test-src/org/pentaho/di/core/jdbc/ThinDatabaseMetaDataTest.java
@@ -1,0 +1,325 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.UUID;
+
+import org.junit.Test;
+
+public class ThinDatabaseMetaDataTest {
+
+  static ThinConnection mockConnection = mock( ThinConnection.class );
+  static ThinDatabaseMetaData thinDbmd = new ThinDatabaseMetaData( mockConnection );
+
+  private static String randomString() {
+    return UUID.randomUUID().toString();
+  }
+
+  private boolean isResultSetEmpty( ResultSet result ) {
+    int rowCount = 0;
+    try {
+      while ( result.next() ) {
+        rowCount++;
+      }
+    } catch ( SQLException ignore ) {
+    }
+    return rowCount == 0;
+  }
+  @Test
+  public void testGetAttributes() throws SQLException {
+    ResultSet result = thinDbmd.getAttributes( randomString(), randomString(), randomString(), randomString() );
+    assertTrue( isResultSetEmpty( result ) );
+
+    ResultSetMetaData resultMetaData = result.getMetaData();
+    assertEquals( 21, resultMetaData.getColumnCount() );
+
+    assertEquals( "TYPE_CAT", resultMetaData.getColumnName( 1 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 1 ) );
+
+    assertEquals( "TYPE_SCHEM", resultMetaData.getColumnName( 2 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 2 ) );
+
+    assertEquals( "TYPE_NAME", resultMetaData.getColumnName( 3 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 3 ) );
+
+    assertEquals( "ATTR_NAME", resultMetaData.getColumnName( 4 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 4 ) );
+
+    assertEquals( "DATA_TYPE", resultMetaData.getColumnName( 5 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 5 ) );
+
+    assertEquals( "ATTR_TYPE_NAME", resultMetaData.getColumnName( 6 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 6 ) );
+
+    assertEquals( "ATTR_SIZE", resultMetaData.getColumnName( 7 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 7 ) );
+
+    assertEquals( "DECIMAL_DIGITS", resultMetaData.getColumnName( 8 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 8 ) );
+
+    assertEquals( "NUM_PREC_RADIX", resultMetaData.getColumnName( 9 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 9 ) );
+
+    assertEquals( "NULLABLE", resultMetaData.getColumnName( 10 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 10 ) );
+
+    assertEquals( "REMARKS", resultMetaData.getColumnName( 11 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 11 ) );
+
+    assertEquals( "ATTR_DEF", resultMetaData.getColumnName( 12 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 12 ) );
+
+    assertEquals( "SQL_DATA_TYPE", resultMetaData.getColumnName( 13 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 13 ) );
+
+    assertEquals( "SQL_DATETIME_SUB", resultMetaData.getColumnName( 14 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 14 ) );
+
+    assertEquals( "CHAR_OCTET_LENGTH", resultMetaData.getColumnName( 15 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 15 ) );
+
+    assertEquals( "ORDINAL_POSITION", resultMetaData.getColumnName( 16 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 16 ) );
+
+    assertEquals( "IS_NULLABLE", resultMetaData.getColumnName( 17 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 17 ) );
+
+    assertEquals( "SCOPE_CATALOG", resultMetaData.getColumnName( 18 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 18 ) );
+
+    assertEquals( "SCOPE_SCHEMA", resultMetaData.getColumnName( 19 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 19 ) );
+
+    assertEquals( "SCOPE_TABLE", resultMetaData.getColumnName( 20 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 20 ) );
+
+    assertEquals( "SOURCE_DATA_TYPE", resultMetaData.getColumnName( 21 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 21 ) );
+  }
+
+  @Test
+  public void testGetBestRowIdentifier() throws SQLException {
+    ResultSet result = thinDbmd.getBestRowIdentifier( randomString(), randomString(), randomString(), 0, false );
+    assertTrue( isResultSetEmpty( result ) );
+
+    ResultSetMetaData resultMetaData = result.getMetaData();
+    assertEquals( 8, resultMetaData.getColumnCount() );
+
+    assertEquals( "SCOPE", resultMetaData.getColumnName( 1 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 1 ) );
+
+    assertEquals( "COLUMN_NAME", resultMetaData.getColumnName( 2 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 2 ) );
+
+    assertEquals( "DATA_TYPE", resultMetaData.getColumnName( 3 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 3 ) );
+
+    assertEquals( "TYPE_NAME", resultMetaData.getColumnName( 4 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 4 ) );
+
+    assertEquals( "COLUMN_SIZE", resultMetaData.getColumnName( 5 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 5 ) );
+
+    assertEquals( "BUFFER_LENGTH", resultMetaData.getColumnName( 6 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 6 ) );
+
+    assertEquals( "DECIMAL_DIGITS", resultMetaData.getColumnName( 7 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 7 ) );
+
+    assertEquals( "PSEUDO_COLUMN", resultMetaData.getColumnName( 8 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 8 ) );
+  }
+
+  @Test
+  public void testGetCatalogs() throws SQLException {
+    ResultSet result = thinDbmd.getCatalogs();
+    assertTrue( isResultSetEmpty( result ) );
+
+    ResultSetMetaData resultMetaData = result.getMetaData();
+    assertEquals( 1, resultMetaData.getColumnCount() );
+
+    assertEquals( "TABLE_CAT", resultMetaData.getColumnName( 1 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 1 ) );
+  }
+
+  @Test
+  public void testGetClientInfoProperties() throws SQLException {
+    ResultSet result = thinDbmd.getClientInfoProperties();
+    assertTrue( isResultSetEmpty( result ) );
+
+    ResultSetMetaData resultMetaData = result.getMetaData();
+    assertEquals( 4, resultMetaData.getColumnCount() );
+
+    assertEquals( "NAME", resultMetaData.getColumnName( 1 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 1 ) );
+
+    assertEquals( "MAX_LEN", resultMetaData.getColumnName( 2 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 2 ) );
+
+    assertEquals( "DEFAULT_VALUE", resultMetaData.getColumnName( 3 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 3 ) );
+
+    assertEquals( "DESCRIPTION", resultMetaData.getColumnName( 4 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 4 ) );
+  }
+
+  @Test
+  public void testGetColumnPrivileges() throws SQLException {
+    ResultSet result = thinDbmd.getColumnPrivileges( randomString(), randomString(), randomString(), randomString() );
+    assertTrue( isResultSetEmpty( result ) );
+
+    ResultSetMetaData resultMetaData = result.getMetaData();
+    assertEquals( 8, resultMetaData.getColumnCount() );
+
+    assertEquals( "TABLE_CAT", resultMetaData.getColumnName( 1 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 1 ) );
+
+    assertEquals( "TABLE_SCHEM", resultMetaData.getColumnName( 2 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 2 ) );
+
+    assertEquals( "TABLE_NAME", resultMetaData.getColumnName( 3 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 3 ) );
+
+    assertEquals( "COLUMN_NAME", resultMetaData.getColumnName( 4 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 4 ) );
+
+    assertEquals( "GRANTOR", resultMetaData.getColumnName( 5 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 5 ) );
+
+    assertEquals( "GRANTEE", resultMetaData.getColumnName( 6 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 6 ) );
+
+    assertEquals( "PRIVILEGE", resultMetaData.getColumnName( 7 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 7 ) );
+
+    assertEquals( "IS_GRANTABLE", resultMetaData.getColumnName( 8 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 8 ) );
+  }
+
+  @Test
+  public void testGetColumns() {
+
+  }
+
+  @Test
+  public void testGetCrossReference() throws SQLException {
+    ResultSet result = thinDbmd.getCrossReference( randomString(), randomString(), randomString(), randomString(), randomString(), randomString() );
+    assertTrue( isResultSetEmpty( result ) );
+
+    ResultSetMetaData resultMetaData = result.getMetaData();
+    assertEquals( 8, resultMetaData.getColumnCount() );
+
+    assertEquals( "TABLE_CAT", resultMetaData.getColumnName( 1 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 1 ) );
+
+    assertEquals( "TABLE_SCHEM", resultMetaData.getColumnName( 2 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 2 ) );
+
+    assertEquals( "TABLE_NAME", resultMetaData.getColumnName( 3 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 3 ) );
+
+    assertEquals( "COLUMN_NAME", resultMetaData.getColumnName( 4 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 4 ) );
+
+    assertEquals( "GRANTOR", resultMetaData.getColumnName( 5 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 5 ) );
+
+    assertEquals( "GRANTEE", resultMetaData.getColumnName( 6 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 6 ) );
+
+    assertEquals( "PRIVILEGE", resultMetaData.getColumnName( 7 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 7 ) );
+
+    assertEquals( "IS_GRANTABLE", resultMetaData.getColumnName( 8 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 8 ) );
+  }
+
+  @Test
+  public void testGetImportedKeys() throws SQLException {
+    ResultSet result = thinDbmd.getImportedKeys( randomString(), randomString(), randomString() );
+    assertTrue( isResultSetEmpty( result ) );
+
+    ResultSetMetaData resultMetaData = result.getMetaData();
+    assertEquals( 14, resultMetaData.getColumnCount() );
+
+    assertEquals( "PKTABLE_CAT", resultMetaData.getColumnName( 1 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 1 ) );
+
+    assertEquals( "PKTABLE_SCHEM", resultMetaData.getColumnName( 2 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 2 ) );
+
+    assertEquals( "PKTABLE_NAME", resultMetaData.getColumnName( 3 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 3 ) );
+
+    assertEquals( "PKCOLUMN_NAME", resultMetaData.getColumnName( 4 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 4 ) );
+
+    assertEquals( "FKTABLE_CAT", resultMetaData.getColumnName( 5 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 5 ) );
+
+    assertEquals( "FKTABLE_SCHEM", resultMetaData.getColumnName( 6 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 6 ) );
+
+    assertEquals( "FKTABLE_NAME", resultMetaData.getColumnName( 7 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 7 ) );
+
+    assertEquals( "FKCOLUMN_NAME", resultMetaData.getColumnName( 8 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 8 ) );
+
+    assertEquals( "KEY_SEQ", resultMetaData.getColumnName( 9 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 9 ) );
+
+    assertEquals( "UPDATE_RULE", resultMetaData.getColumnName( 10 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 10 ) );
+
+    assertEquals( "DELETE_RULE", resultMetaData.getColumnName( 11 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 11 ) );
+
+    assertEquals( "FK_NAME", resultMetaData.getColumnName( 12 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 12 ) );
+
+    assertEquals( "PK_NAME", resultMetaData.getColumnName( 13 ) );
+    assertEquals( Types.VARCHAR, resultMetaData.getColumnType( 13 ) );
+
+    assertEquals( "DEFERRABILITY", resultMetaData.getColumnName( 14 ) );
+    assertEquals( Types.BIGINT, resultMetaData.getColumnType( 14 ) );
+  }
+
+  @Test
+  public void testGetSchemas() {
+
+  }
+
+  @Test
+  public void testGetTables() {
+
+  }
+}

--- a/core/test-src/org/pentaho/di/core/jdbc/ThinPreparedStatementTest.java
+++ b/core/test-src/org/pentaho/di/core/jdbc/ThinPreparedStatementTest.java
@@ -1,0 +1,98 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+public class ThinPreparedStatementTest {
+
+  static ThinConnection thinConn = mock( ThinConnection.class );
+
+  @Test
+  public void testParameterTypes() throws SQLException {
+    StringBuilder originalSQL = new StringBuilder();
+    originalSQL.append( "SELECT \"test\" AS colA" ).append(  Const.CR );
+    originalSQL.append( "FROM dual" ).append(  Const.CR );
+    originalSQL.append( "WHERE" ).append(  Const.CR );
+    originalSQL.append( "intID = ?" ).append(  Const.CR );
+    originalSQL.append( "AND StringID = ?" ).append(  Const.CR );
+    originalSQL.append( "AND decimalID = ?" ).append(  Const.CR );
+    ThinPreparedStatement ps = new ThinPreparedStatement( thinConn, originalSQL.toString() );
+
+    assertEquals( 3, ps.getParamMeta().length );
+    for ( ValueMetaInterface paramMeta : ps.getParamMeta() ) {
+      assertEquals( ValueMetaInterface.TYPE_STRING, paramMeta.getType() );
+      assertTrue( paramMeta.getName().startsWith( "param-" ) );
+    }
+
+    ps.setInt( 1, 12345 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, ps.getParamMeta()[0].getType() );
+    assertEquals( Long.valueOf( 12345 ), ps.getParamData()[0] );
+
+    ps.setLong( 2, 56789 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, ps.getParamMeta()[1].getType() );
+    assertEquals( Long.valueOf( 56789 ), ps.getParamData()[1] );
+
+    ps.setShort( 2, (short) 255 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, ps.getParamMeta()[1].getType() );
+    assertEquals( Long.valueOf( 255 ), ps.getParamData()[1] );
+
+    ps.setDouble( 1, Double.valueOf( "12345.6789" ) );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, ps.getParamMeta()[0].getType() );
+    assertEquals( Double.valueOf( "12345.6789" ), ps.getParamData()[0] );
+
+    ps.setFloat( 2, Float.valueOf( "98765.4321" ) );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, ps.getParamMeta()[1].getType() );
+    assertEquals( Float.valueOf( "98765.4321" ).doubleValue(), (Double) ps.getParamData()[1], Float.valueOf( "0.1" ).doubleValue() );
+
+    ps.setTime( 1, new Time( 12345 ) );
+    assertEquals( ValueMetaInterface.TYPE_DATE, ps.getParamMeta()[0].getType() );
+    assertEquals( new Date( 12345 ), ps.getParamData()[0] );
+
+    ps.setTime( 2, new Time( 23456 ), Calendar.getInstance() );
+    assertEquals( ValueMetaInterface.TYPE_DATE, ps.getParamMeta()[1].getType() );
+    assertEquals( new Date( 23456 ), ps.getParamData()[1] );
+
+    ps.setTimestamp( 1, new Timestamp( 98765 ) );
+    assertEquals( ValueMetaInterface.TYPE_DATE, ps.getParamMeta()[0].getType() );
+    assertEquals( new Date( 98765 ), ps.getParamData()[0] );
+
+    ps.setTimestamp( 2, new Timestamp( 87654 ), Calendar.getInstance() );
+    assertEquals( ValueMetaInterface.TYPE_DATE, ps.getParamMeta()[1].getType() );
+    assertEquals( new Date( 87654 ), ps.getParamData()[1] );
+
+    ps.close();
+  }
+}

--- a/core/test-src/org/pentaho/di/core/jdbc/ThinUtilTest.java
+++ b/core/test-src/org/pentaho/di/core/jdbc/ThinUtilTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,9 +29,15 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.sql.Types;
+
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.ValueMetaAndData;
+import org.pentaho.di.core.row.ValueMetaInterface;
 
 public class ThinUtilTest {
   @Test
@@ -84,5 +90,165 @@ public class ThinUtilTest {
     assertTrue( "Regex Escaping", ThinUtil.like( "foo\\*?[]()bar", "%\\*?[]()%" ) );
 
     assertFalse( "False Match", ThinUtil.like( "foo", "bar" ) );
+  }
+
+  @Test
+  public void testGetValueMeta() throws SQLException {
+    ValueMetaInterface testValue;
+    String expectedName = "testName";
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BIGINT );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.INTEGER );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.SMALLINT );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.CHAR );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.VARCHAR );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.CLOB );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.DATE );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_DATE, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.TIMESTAMP );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_DATE, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.TIME );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_DATE, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.DECIMAL );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.DOUBLE );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.FLOAT );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BOOLEAN );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BIT );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BINARY );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BINARY, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BLOB );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BINARY, testValue.getType() );
+
+    try {
+      testValue = ThinUtil.getValueMeta( expectedName, Integer.MIN_VALUE );
+      fail();
+    } catch ( SQLException expected ) {
+      // Do nothing, there is no SQL Type for Integer.MIN_VALUE, an exception was thrown as expected.
+    }
+  }
+
+  @Test
+  public void testAttemptDateValueExtraction2() throws KettleValueException {
+    ValueMetaAndData result = ThinUtil.attemptDateValueExtraction( "[2015/01/02 03:04:56.789]" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_DATE, result.getValueMeta().getType() );
+    assertEquals( "2015/01/02 03:04:56.789", result.getValueMeta().getString( result.getValueData() ) );
+
+    assertNull( ThinUtil.attemptDateValueExtraction( null ) );
+    assertNull( ThinUtil.attemptDateValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptDateValueExtraction( "[]" ) );
+    assertNull( ThinUtil.attemptDateValueExtraction( "[notadate]" ) );
+    assertNull( ThinUtil.attemptDateValueExtraction( "2015/01/02 03:04:56.789" ) );
+  }
+
+  @Test
+  public void testAttemptIntegerValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptIntegerValueExtraction( "12345" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, result.getValueMeta().getType() );
+    assertEquals( Long.valueOf( 12345 ), result.getValueData() );
+
+    assertNull( ThinUtil.attemptIntegerValueExtraction( null ) );
+    assertNull( ThinUtil.attemptIntegerValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptIntegerValueExtraction( "123.45" ) );
+  }
+
+  @Test
+  public void testAttemptNumberValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptNumberValueExtraction( "12345.678" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta().getType() );
+    assertEquals( Double.valueOf( 12345.678 ), result.getValueData() );
+
+    assertNull( ThinUtil.attemptNumberValueExtraction( null ) );
+    assertNull( ThinUtil.attemptNumberValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptNumberValueExtraction( "abcde" ) );
+  }
+
+  @Test
+  public void testAttemptBigNumberValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptBigNumberValueExtraction( "1234567890123456789.0987654321" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, result.getValueMeta().getType() );
+    assertEquals( new BigDecimal( "1234567890123456789.0987654321" ), result.getValueData() );
+
+    assertNull( ThinUtil.attemptBigNumberValueExtraction( null ) );
+    assertNull( ThinUtil.attemptBigNumberValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptBigNumberValueExtraction( "abcde" ) );
+  }
+
+  @Test
+  public void testAttemptStringValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptStringValueExtraction( "'testValue'" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta().getType() );
+    assertEquals( "testValue", result.getValueData() );
+
+    result = ThinUtil.attemptStringValueExtraction( "'test\'\'Value'" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta().getType() );
+    assertEquals( "test\'Value", result.getValueData() );
+
+    assertNull( ThinUtil.attemptStringValueExtraction( null ) );
+    assertNull( ThinUtil.attemptStringValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptStringValueExtraction( "abcde" ) );
+  }
+
+  @Test
+  public void testAttemptBooleanValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptBooleanValueExtraction( "TrUe" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, result.getValueMeta().getType() );
+    assertEquals( Boolean.TRUE, result.getValueData() );
+
+    result = ThinUtil.attemptBooleanValueExtraction( "fAlSe" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, result.getValueMeta().getType() );
+    assertEquals( Boolean.FALSE, result.getValueData() );
+
+    assertNull( ThinUtil.attemptBooleanValueExtraction( null ) );
+    assertNull( ThinUtil.attemptBooleanValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptBooleanValueExtraction( "abcde" ) );
   }
 }

--- a/core/test-src/org/pentaho/di/core/plugins/PluginRegistryTest.java
+++ b/core/test-src/org/pentaho/di/core/plugins/PluginRegistryTest.java
@@ -1,0 +1,45 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.plugins;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettlePluginException;
+import org.pentaho.di.core.row.RowBuffer;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+public class PluginRegistryTest {
+
+  @Test
+  public void getGetPluginInformation() throws KettlePluginException {
+    RowBuffer result = PluginRegistry.getInstance().getPluginInformation( BasePluginType.class );
+    assertNotNull( result );
+    assertEquals( 8, result.getRowMeta().size() );
+
+    for ( ValueMetaInterface vmi : result.getRowMeta().getValueMetaList() ) {
+      assertEquals( ValueMetaInterface.TYPE_STRING, vmi.getType() );
+    }
+  }
+}

--- a/core/test-src/org/pentaho/di/core/row/ValueMetaAndDataTest.java
+++ b/core/test-src/org/pentaho/di/core/row/ValueMetaAndDataTest.java
@@ -1,0 +1,103 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.row;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Random;
+
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.value.ValueMetaString;
+
+public class ValueMetaAndDataTest {
+
+  @Test
+  public void testConstructors() throws KettleValueException {
+    ValueMetaAndData result;
+
+    result = new ValueMetaAndData( new ValueMetaString( "ValueStringName" ), "testValue1" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta().getType() );
+    assertEquals( "ValueStringName", result.getValueMeta().getName() );
+    assertEquals( "testValue1", result.getValueData() );
+
+    result = new ValueMetaAndData( "StringName", "testValue2" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta().getType() );
+    assertEquals( "StringName", result.getValueMeta().getName() );
+    assertEquals( "testValue2", result.getValueData() );
+
+    result = new ValueMetaAndData( "NumberName", Double.valueOf( "123.45" ) );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta().getType() );
+    assertEquals( "NumberName", result.getValueMeta().getName() );
+    assertEquals( Double.valueOf( "123.45" ), result.getValueData() );
+
+    result = new ValueMetaAndData( "IntegerName", Long.valueOf( 234 ) );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, result.getValueMeta().getType() );
+    assertEquals( "IntegerName", result.getValueMeta().getName() );
+    assertEquals( Long.valueOf( 234 ), result.getValueData() );
+
+    Date testDate = Calendar.getInstance().getTime();
+    result = new ValueMetaAndData( "DateName", testDate );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_DATE, result.getValueMeta().getType() );
+    assertEquals( "DateName", result.getValueMeta().getName() );
+    assertEquals( testDate, result.getValueData() );
+
+    result = new ValueMetaAndData( "BigNumberName", new BigDecimal( "123456789.987654321" ) );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, result.getValueMeta().getType() );
+    assertEquals( "BigNumberName", result.getValueMeta().getName() );
+    assertEquals( new BigDecimal( "123456789.987654321" ), result.getValueData() );
+
+    result = new ValueMetaAndData( "BooleanName", Boolean.TRUE );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, result.getValueMeta().getType() );
+    assertEquals( "BooleanName", result.getValueMeta().getName() );
+    assertEquals( Boolean.TRUE, result.getValueData() );
+
+    byte[] testBytes = new byte[50];
+    new Random().nextBytes( testBytes );
+    result = new ValueMetaAndData( "BinaryName", testBytes );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_BINARY, result.getValueMeta().getType() );
+    assertEquals( "BinaryName", result.getValueMeta().getName() );
+    assertEquals( testBytes, result.getValueData() );
+
+    result = new ValueMetaAndData( "SerializableName", new StringBuilder( "serializable test" ) );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_SERIALIZABLE, result.getValueMeta().getType() );
+    assertEquals( "SerializableName", result.getValueMeta().getName() );
+    assertTrue( result.getValueData() instanceof StringBuilder );
+    assertEquals( "serializable test", result.getValueData().toString() );
+
+  }
+}

--- a/core/test-src/org/pentaho/di/core/row/value/ValueMetaFactoryTest.java
+++ b/core/test-src/org/pentaho/di/core/row/value/ValueMetaFactoryTest.java
@@ -1,0 +1,419 @@
+/********************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.row.value;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettlePluginException;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+public class ValueMetaFactoryTest {
+
+  @BeforeClass
+  public static void beforeClassSetUp() throws KettleException {
+    KettleClientEnvironment.init();
+  }
+
+  @Test
+  public void testCreateValueMeta() throws KettlePluginException {
+    ValueMetaInterface testObject;
+
+    try {
+      testObject = ValueMetaFactory.createValueMeta( Integer.MIN_VALUE );
+      fail();
+    } catch ( KettlePluginException expected ) {
+      // Do nothing, Integer.MIN_VALUE is not a valid option
+    }
+
+    try {
+      testObject = ValueMetaFactory.createValueMeta( null, Integer.MIN_VALUE );
+      fail();
+    } catch ( KettlePluginException expected ) {
+      // Do nothing, Integer.MIN_VALUE is not a valid option
+    }
+
+    try {
+      testObject = ValueMetaFactory.createValueMeta( null, Integer.MIN_VALUE, 10, 10 );
+      fail();
+    } catch ( KettlePluginException expected ) {
+      // Do nothing, Integer.MIN_VALUE is not a valid option
+    }
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_NONE );
+    assertTrue( testObject instanceof ValueMetaNone );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testNone", ValueMetaInterface.TYPE_NONE );
+    assertTrue( testObject instanceof ValueMetaNone );
+    assertEquals( "testNone", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testNone", ValueMetaInterface.TYPE_NONE, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaNone );
+    assertEquals( "testNone", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( 20, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_NUMBER );
+    assertTrue( testObject instanceof ValueMetaNumber );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testNumber", ValueMetaInterface.TYPE_NUMBER );
+    assertTrue( testObject instanceof ValueMetaNumber );
+    assertEquals( "testNumber", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testNumber", ValueMetaInterface.TYPE_NUMBER, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaNumber );
+    assertEquals( "testNumber", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( 20, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_STRING );
+    assertTrue( testObject instanceof ValueMetaString );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testString", ValueMetaInterface.TYPE_STRING );
+    assertTrue( testObject instanceof ValueMetaString );
+    assertEquals( "testString", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testString", ValueMetaInterface.TYPE_STRING, 1000, 50 );
+    assertTrue( testObject instanceof ValueMetaString );
+    assertEquals( "testString", testObject.getName() );
+    assertEquals( 1000, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() ); // Special case for String
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_DATE );
+    assertTrue( testObject instanceof ValueMetaDate );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testDate", ValueMetaInterface.TYPE_DATE );
+    assertTrue( testObject instanceof ValueMetaDate );
+    assertEquals( "testDate", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testDate", ValueMetaInterface.TYPE_DATE, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaDate );
+    assertEquals( "testDate", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( 20, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_BOOLEAN );
+    assertTrue( testObject instanceof ValueMetaBoolean );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testBoolean", ValueMetaInterface.TYPE_BOOLEAN );
+    assertTrue( testObject instanceof ValueMetaBoolean );
+    assertEquals( "testBoolean", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testBoolean", ValueMetaInterface.TYPE_BOOLEAN, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaBoolean );
+    assertEquals( "testBoolean", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_INTEGER );
+    assertTrue( testObject instanceof ValueMetaInteger );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( 0, testObject.getPrecision() ); // Special case for Integer
+
+    testObject = ValueMetaFactory.createValueMeta( "testInteger", ValueMetaInterface.TYPE_INTEGER );
+    assertTrue( testObject instanceof ValueMetaInteger );
+    assertEquals( "testInteger", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( 0, testObject.getPrecision() ); // Special case for Integer
+
+    testObject = ValueMetaFactory.createValueMeta( "testInteger", ValueMetaInterface.TYPE_INTEGER, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaInteger );
+    assertEquals( "testInteger", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( 0, testObject.getPrecision() ); // Special case for Integer
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_BIGNUMBER );
+    assertTrue( testObject instanceof ValueMetaBigNumber );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testBigNumber", ValueMetaInterface.TYPE_BIGNUMBER );
+    assertTrue( testObject instanceof ValueMetaBigNumber );
+    assertEquals( "testBigNumber", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testBigNumber", ValueMetaInterface.TYPE_BIGNUMBER, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaBigNumber );
+    assertEquals( "testBigNumber", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( 20, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_SERIALIZABLE );
+    assertTrue( testObject instanceof ValueMetaSerializable );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testSerializable", ValueMetaInterface.TYPE_SERIALIZABLE );
+    assertTrue( testObject instanceof ValueMetaSerializable );
+    assertEquals( "testSerializable", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testSerializable", ValueMetaInterface.TYPE_SERIALIZABLE, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaSerializable );
+    assertEquals( "testSerializable", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( 20, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_BINARY );
+    assertTrue( testObject instanceof ValueMetaBinary );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( 0, testObject.getPrecision() ); // Special case for Binary
+
+    testObject = ValueMetaFactory.createValueMeta( "testBinary", ValueMetaInterface.TYPE_BINARY );
+    assertTrue( testObject instanceof ValueMetaBinary );
+    assertEquals( "testBinary", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( 0, testObject.getPrecision() ); // Special case for Binary
+
+    testObject = ValueMetaFactory.createValueMeta( "testBinary", ValueMetaInterface.TYPE_BINARY, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaBinary );
+    assertEquals( "testBinary", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( 0, testObject.getPrecision() ); // Special case for Binary
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_TIMESTAMP );
+    assertTrue( testObject instanceof ValueMetaTimestamp );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testTimestamp", ValueMetaInterface.TYPE_TIMESTAMP );
+    assertTrue( testObject instanceof ValueMetaTimestamp );
+    assertEquals( "testTimestamp", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testTimestamp", ValueMetaInterface.TYPE_TIMESTAMP, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaTimestamp );
+    assertEquals( "testTimestamp", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( 20, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( ValueMetaInterface.TYPE_INET );
+    assertTrue( testObject instanceof ValueMetaInternetAddress );
+    assertEquals( null, testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testInternetAddress", ValueMetaInterface.TYPE_INET );
+    assertTrue( testObject instanceof ValueMetaInternetAddress );
+    assertEquals( "testInternetAddress", testObject.getName() );
+    assertEquals( -1, testObject.getLength() );
+    assertEquals( -1, testObject.getPrecision() );
+
+    testObject = ValueMetaFactory.createValueMeta( "testInternetAddress", ValueMetaInterface.TYPE_INET, 10, 20 );
+    assertTrue( testObject instanceof ValueMetaInternetAddress );
+    assertEquals( "testInternetAddress", testObject.getName() );
+    assertEquals( 10, testObject.getLength() );
+    assertEquals( 20, testObject.getPrecision() );
+  }
+
+  @Test
+  public void testGetValueMetaNames() {
+    List<String> dataTypes = Arrays.<String>asList( ValueMetaFactory.getValueMetaNames() );
+
+    assertTrue( dataTypes.contains( "Number" ) );
+    assertTrue( dataTypes.contains( "String" ) );
+    assertTrue( dataTypes.contains( "Date" ) );
+    assertTrue( dataTypes.contains( "Boolean" ) );
+    assertTrue( dataTypes.contains( "Integer" ) );
+    assertTrue( dataTypes.contains( "BigNumber" ) );
+    assertFalse( dataTypes.contains( "Serializable" ) );
+    assertTrue( dataTypes.contains( "Binary" ) );
+    assertTrue( dataTypes.contains( "Timestamp" ) );
+    assertTrue( dataTypes.contains( "Internet Address" ) );
+  }
+
+  @Test
+  public void testGetAllValueMetaNames() {
+    List<String> dataTypes = Arrays.<String>asList( ValueMetaFactory.getAllValueMetaNames() );
+
+    assertTrue( dataTypes.contains( "Number" ) );
+    assertTrue( dataTypes.contains( "String" ) );
+    assertTrue( dataTypes.contains( "Date" ) );
+    assertTrue( dataTypes.contains( "Boolean" ) );
+    assertTrue( dataTypes.contains( "Integer" ) );
+    assertTrue( dataTypes.contains( "BigNumber" ) );
+    assertTrue( dataTypes.contains( "Serializable" ) );
+    assertTrue( dataTypes.contains( "Binary" ) );
+    assertTrue( dataTypes.contains( "Timestamp" ) );
+    assertTrue( dataTypes.contains( "Internet Address" ) );
+  }
+
+  @Test
+  public void testGetValueMetaName() {
+    assertEquals( "-", ValueMetaFactory.getValueMetaName( Integer.MIN_VALUE ) );
+    assertEquals( "None", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_NONE ) );
+    assertEquals( "Number", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_NUMBER ) );
+    assertEquals( "String", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_STRING ) );
+    assertEquals( "Date", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_DATE ) );
+    assertEquals( "Boolean", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_BOOLEAN ) );
+    assertEquals( "Integer", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_INTEGER ) );
+    assertEquals( "BigNumber", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_BIGNUMBER ) );
+    assertEquals( "Serializable", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_SERIALIZABLE ) );
+    assertEquals( "Binary", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_BINARY ) );
+    assertEquals( "Timestamp", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_TIMESTAMP ) );
+    assertEquals( "Internet Address", ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_INET ) );
+  }
+
+  @Test
+  public void testGetIdForValueMeta() {
+    assertEquals( ValueMetaInterface.TYPE_NONE, ValueMetaFactory.getIdForValueMeta( null ) );
+    assertEquals( ValueMetaInterface.TYPE_NONE, ValueMetaFactory.getIdForValueMeta( "" ) );
+    assertEquals( ValueMetaInterface.TYPE_NONE, ValueMetaFactory.getIdForValueMeta( "None" ) );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, ValueMetaFactory.getIdForValueMeta( "Number" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, ValueMetaFactory.getIdForValueMeta( "String" ) );
+    assertEquals( ValueMetaInterface.TYPE_DATE, ValueMetaFactory.getIdForValueMeta( "Date" ) );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, ValueMetaFactory.getIdForValueMeta( "Boolean" ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, ValueMetaFactory.getIdForValueMeta( "Integer" ) );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, ValueMetaFactory.getIdForValueMeta( "BigNumber" ) );
+    assertEquals( ValueMetaInterface.TYPE_SERIALIZABLE, ValueMetaFactory.getIdForValueMeta( "Serializable" ) );
+    assertEquals( ValueMetaInterface.TYPE_BINARY, ValueMetaFactory.getIdForValueMeta( "Binary" ) );
+    assertEquals( ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaFactory.getIdForValueMeta( "Timestamp" ) );
+    assertEquals( ValueMetaInterface.TYPE_INET, ValueMetaFactory.getIdForValueMeta( "Internet Address" ) );
+  }
+
+  @Test
+  public void testGetValueMetaPluginClasses() throws KettlePluginException {
+    List<ValueMetaInterface> dataTypes = ValueMetaFactory.getValueMetaPluginClasses();
+
+    boolean numberExists = false;
+    boolean stringExists = false;
+    boolean dateExists = false;
+    boolean booleanExists = false;
+    boolean integerExists = false;
+    boolean bignumberExists = false;
+    boolean serializableExists = false;
+    boolean binaryExists = false;
+    boolean timestampExists = false;
+    boolean inetExists = false;
+
+    for ( ValueMetaInterface obj : dataTypes ) {
+      if ( obj instanceof ValueMetaNumber ) {
+        numberExists = true;
+      }
+      if ( obj.getClass().equals( ValueMetaString.class ) ) {
+        stringExists = true;
+      }
+      if ( obj.getClass().equals( ValueMetaDate.class ) ) {
+        dateExists = true;
+      }
+      if ( obj.getClass().equals( ValueMetaBoolean.class ) ) {
+        booleanExists = true;
+      }
+      if ( obj.getClass().equals( ValueMetaInteger.class ) ) {
+        integerExists = true;
+      }
+      if ( obj.getClass().equals( ValueMetaBigNumber.class ) ) {
+        bignumberExists = true;
+      }
+      if ( obj.getClass().equals( ValueMetaSerializable.class ) ) {
+        serializableExists = true;
+      }
+      if ( obj.getClass().equals( ValueMetaBinary.class ) ) {
+        binaryExists = true;
+      }
+      if ( obj.getClass().equals( ValueMetaTimestamp.class ) ) {
+        timestampExists = true;
+      }
+      if ( obj.getClass().equals( ValueMetaInternetAddress.class ) ) {
+        inetExists = true;
+      }
+    }
+
+    assertTrue( numberExists );
+    assertTrue( stringExists );
+    assertTrue( dateExists );
+    assertTrue( booleanExists );
+    assertTrue( integerExists );
+    assertTrue( bignumberExists );
+    assertTrue( serializableExists );
+    assertTrue( binaryExists );
+    assertTrue( timestampExists );
+    assertTrue( inetExists );
+  }
+
+  @Test
+  public void testGuessValueMetaInterface() {
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( new BigDecimal( 1.0 ) ) instanceof ValueMetaBigNumber );
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( new Double( 1.0 ) ) instanceof ValueMetaNumber );
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( new Long( 1 ) ) instanceof ValueMetaInteger );
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( new String() ) instanceof ValueMetaString );
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( new Date() ) instanceof ValueMetaDate );
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( new Boolean( false ) ) instanceof ValueMetaBoolean );
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( new Boolean( true ) ) instanceof ValueMetaBoolean );
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( false ) instanceof ValueMetaBoolean );
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( true ) instanceof ValueMetaBoolean );
+    assertTrue( ValueMetaFactory.guessValueMetaInterface( new byte[10] ) instanceof ValueMetaBinary );
+
+    // Test Unsupported Data Types
+    assertEquals( null, ValueMetaFactory.guessValueMetaInterface( null ) );
+    assertEquals( null, ValueMetaFactory.guessValueMetaInterface( new Short( (short) 1 ) ) );
+    assertEquals( null, ValueMetaFactory.guessValueMetaInterface( new Byte( (byte) 1 ) ) );
+    assertEquals( null, ValueMetaFactory.guessValueMetaInterface( new Float( 1.0 ) ) );
+    assertEquals( null, ValueMetaFactory.guessValueMetaInterface( new StringBuilder() ) );
+    assertEquals( null, ValueMetaFactory.guessValueMetaInterface( (byte) 1 ) );
+  }
+}

--- a/engine/src/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/org/pentaho/di/base/AbstractMeta.java
@@ -56,7 +56,7 @@ import org.pentaho.di.core.parameters.NamedParams;
 import org.pentaho.di.core.parameters.NamedParamsDefault;
 import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
 import org.pentaho.di.core.undo.TransAction;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
@@ -1237,7 +1237,7 @@ public abstract class AbstractMeta extends ChangedFlag implements UndoInterface,
     if ( !Const.isEmpty( variableName ) ) {
       String value = environmentSubstitute( variableName );
       if ( !Const.isEmpty( value ) ) {
-        return ValueMeta.convertStringToBoolean( value );
+        return ValueMetaBoolean.convertStringToBoolean( value );
       }
     }
     return defaultValue;

--- a/engine/src/org/pentaho/di/cluster/ClusterSchema.java
+++ b/engine/src/org/pentaho/di/cluster/ClusterSchema.java
@@ -32,7 +32,7 @@ import org.pentaho.di.core.changed.ChangedFlag;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -397,7 +397,7 @@ public class ClusterSchema extends ChangedFlag implements Cloneable, SharedObjec
     if ( !Const.isEmpty( variableName ) ) {
       String value = environmentSubstitute( variableName );
       if ( !Const.isEmpty( value ) ) {
-        return ValueMeta.convertStringToBoolean( value );
+        return ValueMetaBoolean.convertStringToBoolean( value );
       }
     }
     return defaultValue;

--- a/engine/src/org/pentaho/di/cluster/SlaveServer.java
+++ b/engine/src/org/pentaho/di/cluster/SlaveServer.java
@@ -57,7 +57,7 @@ import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.vfs.KettleVFS;
@@ -985,7 +985,7 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
     if ( !Const.isEmpty( variableName ) ) {
       String value = environmentSubstitute( variableName );
       if ( !Const.isEmpty( value ) ) {
-        return ValueMeta.convertStringToBoolean( value );
+        return ValueMetaBoolean.convertStringToBoolean( value );
       }
     }
     return defaultValue;

--- a/engine/src/org/pentaho/di/core/logging/ChannelLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/ChannelLogTable.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.variables.VariableSpace;
@@ -173,8 +174,9 @@ public class ChannelLogTable extends BaseLogTable implements Cloneable, LogTable
    *          the id to use or -1 if no id is needed
    * @param status
    *          the log status to use
+   * @throws KettleValueException 
    */
-  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) {
+  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) throws KettleValueException {
     if ( subject == null || subject instanceof LoggingHierarchy ) {
 
       LoggingHierarchy loggingHierarchy = (LoggingHierarchy) subject;

--- a/engine/src/org/pentaho/di/core/logging/JobEntryLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/JobEntryLogTable.java
@@ -30,6 +30,7 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.gui.JobTracker;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -176,8 +177,9 @@ public class JobEntryLogTable extends BaseLogTable implements Cloneable, LogTabl
    *          the object to log
    * @param parent
    *          the parent to which the object belongs
+   * @throws KettleValueException 
    */
-  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) {
+  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) throws KettleValueException {
     if ( subject == null || subject instanceof JobEntryCopy ) {
 
       JobEntryCopy jobEntryCopy = (JobEntryCopy) subject;

--- a/engine/src/org/pentaho/di/core/logging/JobLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/JobLogTable.java
@@ -31,6 +31,7 @@ import org.pentaho.di.core.Result;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
@@ -287,8 +288,9 @@ public class JobLogTable extends BaseLogTable implements Cloneable, LogTableInte
    *          the id to use or -1 if no id is needed
    * @param status
    *          the log status to use
+   * @throws KettleValueException 
    */
-  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) {
+  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) throws KettleValueException {
     if ( subject == null || subject instanceof Job ) {
       Job job = (Job) subject;
       Result result = null;

--- a/engine/src/org/pentaho/di/core/logging/MetricsLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/MetricsLogTable.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.metrics.MetricsSnapshotInterface;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
@@ -150,8 +151,9 @@ public class MetricsLogTable extends BaseLogTable implements Cloneable, LogTable
    *          the id to use or -1 if no id is needed
    * @param status
    *          the log status to use
+   * @throws KettleValueException 
    */
-  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) {
+  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) throws KettleValueException {
     if ( subject == null || subject instanceof LoggingMetric ) {
 
       LoggingMetric loggingMetric = (LoggingMetric) subject;

--- a/engine/src/org/pentaho/di/core/logging/PerformanceLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/PerformanceLogTable.java
@@ -29,6 +29,7 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.variables.VariableSpace;
@@ -196,8 +197,9 @@ public class PerformanceLogTable extends BaseLogTable implements Cloneable, LogT
    *          the id to use or -1 if no id is needed
    * @param status
    *          the log status to use
+   * @throws KettleValueException 
    */
-  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) {
+  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) throws KettleValueException {
     if ( subject == null || subject instanceof StepPerformanceSnapShot ) {
       StepPerformanceSnapShot snapShot = (StepPerformanceSnapShot) subject;
 

--- a/engine/src/org/pentaho/di/core/logging/StepLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/StepLogTable.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.variables.VariableSpace;
@@ -157,8 +158,9 @@ public class StepLogTable extends BaseLogTable implements Cloneable, LogTableInt
    *          the id to use or -1 if no id is needed
    * @param status
    *          the log status to use
+   * @throws KettleValueException 
    */
-  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) {
+  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) throws KettleValueException {
     if ( subject == null || subject instanceof StepMetaDataCombi ) {
 
       StepMetaDataCombi combi = (StepMetaDataCombi) subject;

--- a/engine/src/org/pentaho/di/core/logging/TransLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/TransLogTable.java
@@ -31,6 +31,7 @@ import org.pentaho.di.core.Result;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
@@ -351,8 +352,9 @@ public class TransLogTable extends BaseLogTable implements Cloneable, LogTableIn
    *          the log status to use
    * @param subject
    *          the subject to query, in this case a Trans object
+   * @throws KettleValueException 
    */
-  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) {
+  public RowMetaAndData getLogRecord( LogStatus status, Object subject, Object parent ) throws KettleValueException {
     if ( subject == null || subject instanceof Trans ) {
       Trans trans = (Trans) subject;
       Result result = null;

--- a/engine/src/org/pentaho/di/core/reflection/StringSearchResult.java
+++ b/engine/src/org/pentaho/di/core/reflection/StringSearchResult.java
@@ -25,8 +25,7 @@ package org.pentaho.di.core.reflection;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 
 public class StringSearchResult {
@@ -68,14 +67,10 @@ public class StringSearchResult {
 
   public static final RowMetaInterface getResultRowMeta() {
     RowMetaInterface rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "SearchResult.TransOrJob" ), ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "SearchResult.StepDatabaseNotice" ), ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "SearchResult.String" ), ValueMetaInterface.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "SearchResult.FieldName" ), ValueMetaInterface.TYPE_STRING ) );
+    rowMeta.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "SearchResult.TransOrJob" ) ) );
+    rowMeta.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "SearchResult.StepDatabaseNotice" ) ) );
+    rowMeta.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "SearchResult.String" ) ) );
+    rowMeta.addValueMeta( new ValueMetaString( BaseMessages.getString( PKG, "SearchResult.FieldName" ) ) );
     return rowMeta;
   }
 

--- a/engine/src/org/pentaho/di/core/util/MetaGenerator.java
+++ b/engine/src/org/pentaho/di/core/util/MetaGenerator.java
@@ -23,33 +23,33 @@
 package org.pentaho.di.core.util;
 
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
 
 public class MetaGenerator {
 
   public static final TypeFieldDefinition[] FIELDS = new TypeFieldDefinition[] {
-    new TypeFieldDefinition( ValueMeta.TYPE_BOOLEAN, "UsingLines" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_INTEGER, "MaxNumberOfSuggestions" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_BOOLEAN, "UsingLines" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_INTEGER, "MaxNumberOfSuggestions" ),
 
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "NameField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "OrganizationField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "DepartmentField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "PostBoxField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "SubPremiseField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "PremiseField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "HouseNumberField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "HouseNumberAdditionField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "DependentThoroughfareField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "ThoroughfareField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "DependentLocalityField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "LocalityField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "PostTownField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "DeliveryServiceQualifierField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "PostalCodeField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "SubAdministrativeAreaField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "AdministrativeAreaField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "CountryNameField" ),
-    new TypeFieldDefinition( ValueMeta.TYPE_STRING, "CountryCodeField" ), };
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "NameField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "OrganizationField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "DepartmentField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "PostBoxField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "SubPremiseField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "PremiseField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "HouseNumberField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "HouseNumberAdditionField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "DependentThoroughfareField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "ThoroughfareField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "DependentLocalityField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "LocalityField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "PostTownField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "DeliveryServiceQualifierField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "PostalCodeField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "SubAdministrativeAreaField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "AdministrativeAreaField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "CountryNameField" ),
+    new TypeFieldDefinition( ValueMetaInterface.TYPE_STRING, "CountryCodeField" ), };
 
   private TypeFieldDefinition[] fields;
 
@@ -88,19 +88,19 @@ public class MetaGenerator {
       + "IMetaStore metaStore) throws KettleXMLException {" ).append( Const.CR );
     for ( TypeFieldDefinition field : fields ) {
       switch ( field.getType() ) {
-        case ValueMeta.TYPE_STRING:
+        case ValueMetaInterface.TYPE_STRING:
           code.append(
             "    "
               + field.getMemberName() + " = XMLHandler.getTagValue(stepnode, \"" + field.getFieldName()
               + "\");" ).append( Const.CR );
           break;
-        case ValueMeta.TYPE_BOOLEAN:
+        case ValueMetaInterface.TYPE_BOOLEAN:
           code.append(
             "    "
               + field.getMemberName() + " = \"Y\".equalsIgnoreCase(XMLHandler.getTagValue(stepnode, \""
               + field.getFieldName() + "\"));" ).append( Const.CR );
           break;
-        case ValueMeta.TYPE_INTEGER:
+        case ValueMetaInterface.TYPE_INTEGER:
           code.append(
             "    "
               + field.getMemberName() + " = Const.toInt(XMLHandler.getTagValue(stepnode, \""
@@ -133,19 +133,19 @@ public class MetaGenerator {
       + "List<DatabaseMeta> databases) throws KettleException {" ).append( Const.CR );
     for ( TypeFieldDefinition field : fields ) {
       switch ( field.getType() ) {
-        case ValueMeta.TYPE_STRING:
+        case ValueMetaInterface.TYPE_STRING:
           code.append(
             "    "
               + field.getMemberName() + " = rep.getStepAttributeString(id_step, \"" + field.getFieldName()
               + "\");" ).append( Const.CR );
           break;
-        case ValueMeta.TYPE_BOOLEAN:
+        case ValueMetaInterface.TYPE_BOOLEAN:
           code.append(
             "    "
               + field.getMemberName() + " = rep.getStepAttributeBoolean(id_step, \"" + field.getFieldName()
               + "\");" ).append( Const.CR );
           break;
-        case ValueMeta.TYPE_INTEGER:
+        case ValueMetaInterface.TYPE_INTEGER:
           code.append(
             "    "
               + field.getMemberName() + " = (int) rep.getStepAttributeInteger(id_step, \""
@@ -165,7 +165,7 @@ public class MetaGenerator {
       String getPrefix;
       String setPrefix;
       switch ( field.getType() ) {
-        case ValueMeta.TYPE_BOOLEAN:
+        case ValueMetaInterface.TYPE_BOOLEAN:
           getPrefix = "is";
           setPrefix = "set";
           break;

--- a/engine/src/org/pentaho/di/core/util/TypeFieldDefinition.java
+++ b/engine/src/org/pentaho/di/core/util/TypeFieldDefinition.java
@@ -22,7 +22,8 @@
 
 package org.pentaho.di.core.util;
 
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBase;
 
 public class TypeFieldDefinition {
   private int type;
@@ -69,12 +70,12 @@ public class TypeFieldDefinition {
 
   public String getTypeDescription() {
     switch ( type ) {
-      case ValueMeta.TYPE_BOOLEAN:
+      case ValueMetaInterface.TYPE_BOOLEAN:
         return "boolean";
-      case ValueMeta.TYPE_INTEGER:
+      case ValueMetaInterface.TYPE_INTEGER:
         return "int";
       default:
-        return ValueMeta.getTypeDesc( type );
+        return ValueMetaBase.getTypeDesc( type );
     }
   }
 

--- a/engine/src/org/pentaho/di/imp/Import.java
+++ b/engine/src/org/pentaho/di/imp/Import.java
@@ -42,7 +42,7 @@ import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.RepositoryPluginType;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.imp.rule.ImportRuleInterface;
@@ -333,9 +333,9 @@ public class Import {
     }
 
     final boolean replace =
-      Const.isEmpty( optionReplace ) ? false : ValueMeta.convertStringToBoolean( optionReplace.toString() );
+      Const.isEmpty( optionReplace ) ? false : ValueMetaBoolean.convertStringToBoolean( optionReplace.toString() );
     final boolean continueOnError =
-      Const.isEmpty( optionContinueOnError ) ? false : ValueMeta.convertStringToBoolean( optionContinueOnError
+      Const.isEmpty( optionContinueOnError ) ? false : ValueMetaBoolean.convertStringToBoolean( optionContinueOnError
         .toString() );
 
     // Start the import!

--- a/engine/src/org/pentaho/di/imp/rules/BaseImportRule.java
+++ b/engine/src/org/pentaho/di/imp/rules/BaseImportRule.java
@@ -28,7 +28,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.plugins.ImportRulePluginType;
 import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.imp.rule.ImportRuleInterface;
 import org.pentaho.di.imp.rule.ImportValidationFeedback;
@@ -70,7 +70,7 @@ public abstract class BaseImportRule implements ImportRuleInterface {
 
   public void loadXML( Node ruleNode ) throws KettleException {
     id = XMLHandler.getTagValue( ruleNode, "id" );
-    enabled = ValueMeta.convertStringToBoolean( XMLHandler.getTagValue( ruleNode, "enabled" ) );
+    enabled = ValueMetaBoolean.convertStringToBoolean( XMLHandler.getTagValue( ruleNode, "enabled" ) );
   }
 
   @Override

--- a/engine/src/org/pentaho/di/job/Job.java
+++ b/engine/src/org/pentaho/di/job/Job.java
@@ -81,7 +81,7 @@ import org.pentaho.di.core.parameters.NamedParams;
 import org.pentaho.di.core.parameters.NamedParamsDefault;
 import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
 import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
@@ -1645,7 +1645,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
     if ( !Const.isEmpty( variableName ) ) {
       String value = environmentSubstitute( variableName );
       if ( !Const.isEmpty( value ) ) {
-        return ValueMeta.convertStringToBoolean( value );
+        return ValueMetaBoolean.convertStringToBoolean( value );
       }
     }
     return defaultValue;

--- a/engine/src/org/pentaho/di/job/entries/http/JobEntryHTTP.java
+++ b/engine/src/org/pentaho/di/job/entries/http/JobEntryHTTP.java
@@ -54,8 +54,7 @@ import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleXMLException;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -411,7 +410,7 @@ public class JobEntryHTTP extends JobEntryBase implements Cloneable, JobEntryInt
       resultRows = new ArrayList<RowMetaAndData>();
       RowMetaAndData row = new RowMetaAndData();
       row.addValue(
-        new ValueMeta( urlFieldnameToUse, ValueMetaInterface.TYPE_STRING ), environmentSubstitute( url ) );
+        new ValueMetaString( urlFieldnameToUse ), environmentSubstitute( url ) );
       resultRows.add( row );
     }
 

--- a/engine/src/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEval.java
+++ b/engine/src/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEval.java
@@ -35,7 +35,7 @@ import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleXMLException;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
 import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -942,7 +942,7 @@ public class JobEntrySimpleEval extends JobEntryBase implements Cloneable, JobEn
       case FIELD_TYPE_BOOLEAN:
         boolean valuebool;
         try {
-          valuebool = ValueMeta.convertStringToBoolean( sourcevalue );
+          valuebool = ValueMetaBoolean.convertStringToBoolean( sourcevalue );
         } catch ( Exception e ) {
           logError( BaseMessages.getString( PKG, "JobEntrySimpleEval.Error.UnparsableBoolean", sourcevalue, e
             .getMessage() ) );

--- a/engine/src/org/pentaho/di/job/entry/JobEntryBase.java
+++ b/engine/src/org/pentaho/di/job/entry/JobEntryBase.java
@@ -50,7 +50,7 @@ import org.pentaho.di.core.plugins.JobEntryPluginType;
 import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -726,7 +726,7 @@ public class JobEntryBase implements Cloneable, VariableSpace, CheckResultSource
     if ( !Const.isEmpty( variableName ) ) {
       String value = environmentSubstitute( variableName );
       if ( !Const.isEmpty( value ) ) {
-        return ValueMeta.convertStringToBoolean( value );
+        return ValueMetaBoolean.convertStringToBoolean( value );
       }
     }
     return defaultValue;

--- a/engine/src/org/pentaho/di/lineage/ValueLineage.java
+++ b/engine/src/org/pentaho/di/lineage/ValueLineage.java
@@ -25,7 +25,7 @@ package org.pentaho.di.lineage;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 
@@ -38,7 +38,7 @@ import org.pentaho.di.trans.step.StepMeta;
  */
 public class ValueLineage {
   private TransMeta transMeta;
-  private ValueMeta valueMeta;
+  private ValueMetaInterface valueMeta;
 
   private List<StepMeta> sourceSteps;
 
@@ -47,7 +47,7 @@ public class ValueLineage {
    *
    * @param valueMeta
    */
-  public ValueLineage( TransMeta transMeta, ValueMeta valueMeta ) {
+  public ValueLineage( TransMeta transMeta, ValueMetaInterface valueMeta ) {
     this.transMeta = transMeta;
     this.valueMeta = valueMeta;
     this.sourceSteps = new ArrayList<StepMeta>();
@@ -71,7 +71,7 @@ public class ValueLineage {
   /**
    * @return the valueMeta
    */
-  public ValueMeta getValueMeta() {
+  public ValueMetaInterface getValueMeta() {
     return valueMeta;
   }
 
@@ -79,7 +79,7 @@ public class ValueLineage {
    * @param valueMeta
    *          the valueMeta to set
    */
-  public void setValueMeta( ValueMeta valueMeta ) {
+  public void setValueMeta( ValueMetaInterface valueMeta ) {
     this.valueMeta = valueMeta;
   }
 

--- a/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepository.java
+++ b/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepository.java
@@ -49,9 +49,10 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPointHandler;
 import org.pentaho.di.core.extension.KettleExtensionPoint;
 import org.pentaho.di.core.logging.LogChannel;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaAndData;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryBase;
 import org.pentaho.di.partition.PartitionSchema;
@@ -620,18 +621,12 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
     ObjectId id = connectionDelegate.getNextLogID();
 
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_ID_REPOSITORY_LOG, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_REP_VERSION, ValueMetaInterface.TYPE_STRING ), getVersion() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_DATE, ValueMetaInterface.TYPE_DATE ), new Date() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_USER, ValueMetaInterface.TYPE_STRING ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_ID_REPOSITORY_LOG ), id );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_REP_VERSION ), getVersion() );
+    table.addValue( new ValueMetaDate( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_DATE ), new Date() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_USER ),
       getUserInfo() != null ? getUserInfo().getLogin() : "admin" );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_REPOSITORY_LOG_OPERATION_DESC, ValueMetaInterface.TYPE_STRING ),
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_OPERATION_DESC ),
       description );
 
     connectionDelegate.insertTableRow( KettleDatabaseRepository.TABLE_R_REPOSITORY_LOG, table );
@@ -642,12 +637,9 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
   public synchronized void insertTransNote( ObjectId id_transformation, ObjectId id_note ) throws KettleException {
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_NOTE_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_NOTE_ID_TRANSFORMATION ),
       id_transformation );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_NOTE_ID_NOTE, ValueMetaInterface.TYPE_INTEGER ), id_note );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_NOTE_ID_NOTE ), id_note );
 
     connectionDelegate.insertTableRow( KettleDatabaseRepository.TABLE_R_TRANS_NOTE, table );
   }
@@ -655,10 +647,8 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
   public synchronized void insertJobNote( ObjectId id_job, ObjectId id_note ) throws KettleException {
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_NOTE_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_NOTE_ID_NOTE, ValueMetaInterface.TYPE_INTEGER ), id_note );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_NOTE_ID_JOB ), id_job );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_NOTE_ID_NOTE ), id_note );
 
     connectionDelegate.insertTableRow( KettleDatabaseRepository.TABLE_R_JOB_NOTE, table );
   }
@@ -670,17 +660,11 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
     if ( check.getInteger( 0 ) == null ) {
       RowMetaAndData table = new RowMetaAndData();
 
-      table.addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_STEP_DATABASE_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_DATABASE_ID_TRANSFORMATION ),
         id_transformation );
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_STEP_DATABASE_ID_STEP, ValueMetaInterface.TYPE_INTEGER ), id_step );
-      table
-        .addValue(
-          new ValueMeta(
-            KettleDatabaseRepository.FIELD_STEP_DATABASE_ID_DATABASE, ValueMetaInterface.TYPE_INTEGER ),
-          id_database );
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_DATABASE_ID_STEP ), id_step );
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_DATABASE_ID_DATABASE ),
+        id_database );
 
       connectionDelegate.insertTableRow( KettleDatabaseRepository.TABLE_R_STEP_DATABASE, table );
     }
@@ -694,15 +678,10 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
     if ( check.getInteger( 0 ) == null ) {
       RowMetaAndData table = new RowMetaAndData();
 
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_JOBENTRY_DATABASE_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
-      table.addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_JOBENTRY_DATABASE_ID_JOBENTRY, ValueMetaInterface.TYPE_INTEGER ),
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_DATABASE_ID_JOB ), id_job );
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_DATABASE_ID_JOBENTRY ),
         id_jobentry );
-      table.addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_JOBENTRY_DATABASE_ID_DATABASE, ValueMetaInterface.TYPE_INTEGER ),
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_DATABASE_ID_DATABASE ),
         id_database );
 
       connectionDelegate.insertTableRow( KettleDatabaseRepository.TABLE_R_JOBENTRY_DATABASE, table );
@@ -715,17 +694,12 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_PARTITION_SCHEMA_ID_TRANS_PARTITION_SCHEMA,
-      ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_PARTITION_SCHEMA_ID_TRANSFORMATION,
-        ValueMetaInterface.TYPE_INTEGER ), id_transformation );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_PARTITION_SCHEMA_ID_PARTITION_SCHEMA,
-        ValueMetaInterface.TYPE_INTEGER ), id_partition_schema );
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_TRANS_PARTITION_SCHEMA_ID_TRANS_PARTITION_SCHEMA ), id );
+    table.addValue( new ValueMetaInteger(
+        KettleDatabaseRepository.FIELD_TRANS_PARTITION_SCHEMA_ID_TRANSFORMATION ), id_transformation );
+    table.addValue( new ValueMetaInteger(
+        KettleDatabaseRepository.FIELD_TRANS_PARTITION_SCHEMA_ID_PARTITION_SCHEMA ), id_partition_schema );
 
     connectionDelegate.insertTableRow( KettleDatabaseRepository.TABLE_R_TRANS_PARTITION_SCHEMA, table );
 
@@ -737,14 +711,12 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CLUSTER_SLAVE_ID_CLUSTER_SLAVE, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CLUSTER_SLAVE_ID_CLUSTER, ValueMetaInterface.TYPE_INTEGER ), clusterSchema
-      .getObjectId() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CLUSTER_SLAVE_ID_SLAVE, ValueMetaInterface.TYPE_INTEGER ), slaveServer
-      .getObjectId() );
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_CLUSTER_SLAVE_ID_CLUSTER_SLAVE ), id );
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_CLUSTER_SLAVE_ID_CLUSTER ), clusterSchema.getObjectId() );
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_CLUSTER_SLAVE_ID_SLAVE ), slaveServer.getObjectId() );
 
     connectionDelegate.insertTableRow( KettleDatabaseRepository.TABLE_R_CLUSTER_SLAVE, table );
 
@@ -756,14 +728,14 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_CLUSTER_ID_TRANS_CLUSTER, ValueMetaInterface.TYPE_INTEGER ), id );
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_TRANS_CLUSTER_ID_TRANS_CLUSTER ), id );
     table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_CLUSTER_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+      new ValueMetaInteger(
+        KettleDatabaseRepository.FIELD_TRANS_CLUSTER_ID_TRANSFORMATION ),
       id_transformation );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_CLUSTER_ID_CLUSTER, ValueMetaInterface.TYPE_INTEGER ), id_cluster );
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_TRANS_CLUSTER_ID_CLUSTER ), id_cluster );
 
     connectionDelegate.insertTableRow( KettleDatabaseRepository.TABLE_R_TRANS_CLUSTER, table );
 
@@ -775,14 +747,11 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_SLAVE_ID_TRANS_SLAVE, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_SLAVE_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_TRANS_SLAVE_ID_TRANS_SLAVE ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_SLAVE_ID_TRANSFORMATION ),
       id_transformation );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_SLAVE_ID_SLAVE, ValueMetaInterface.TYPE_INTEGER ), id_slave );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_SLAVE_ID_SLAVE ), id_slave );
 
     connectionDelegate.insertTableRow( KettleDatabaseRepository.TABLE_R_TRANS_SLAVE, table );
 
@@ -793,16 +762,10 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
     ObjectId id_condition ) throws KettleException {
     String tablename = KettleDatabaseRepository.TABLE_R_TRANS_STEP_CONDITION;
     RowMetaAndData table = new RowMetaAndData();
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_TRANS_STEP_CONDITION_ID_TRANSFORMATION,
-          ValueMetaInterface.TYPE_INTEGER ), id_transformation );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_STEP_CONDITION_ID_STEP, ValueMetaInterface.TYPE_INTEGER ), id_step );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_STEP_CONDITION_ID_CONDITION, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_STEP_CONDITION_ID_TRANSFORMATION ),
+      id_transformation );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_STEP_CONDITION_ID_STEP ), id_step );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_STEP_CONDITION_ID_CONDITION ),
       id_condition );
 
     connectionDelegate.insertTableRow( tablename, table );

--- a/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepositoryCreationHelper.java
+++ b/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepositoryCreationHelper.java
@@ -46,6 +46,10 @@ import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.repository.LongObjectId;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.kdr.delegates.KettleDatabaseRepositoryConnectionDelegate;
@@ -114,21 +118,25 @@ public class KettleDatabaseRepositoryCreationHelper {
     if ( monitor != null ) {
       monitor.subTask( "Checking table " + schemaTable );
     }
-    table
-      .addValueMeta( new ValueMeta(
-        KettleDatabaseRepository.FIELD_REPOSITORY_LOG_ID_REPOSITORY_LOG, ValueMetaInterface.TYPE_INTEGER, KEY,
-        0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_REP_VERSION, ValueMetaInterface.TYPE_STRING,
-      KettleDatabaseRepository.REP_STRING_CODE_LENGTH, 0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_DATE, ValueMetaInterface.TYPE_DATE ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_USER, ValueMetaInterface.TYPE_STRING,
-      KettleDatabaseRepository.REP_STRING_CODE_LENGTH, 0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_OPERATION_DESC, ValueMetaInterface.TYPE_STRING,
-      KettleDatabaseRepository.REP_STRING_LENGTH, 0 ) );
+    ValueMetaInterface idRepositoryLog = new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_ID_REPOSITORY_LOG );
+    idRepositoryLog.setLength( KEY, 0 );
+    ValueMetaInterface repoVersion = new ValueMetaString(
+      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_REP_VERSION );
+    repoVersion.setLength( KettleDatabaseRepository.REP_STRING_CODE_LENGTH );
+    ValueMetaInterface logDate = new ValueMetaDate(
+      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_DATE );
+    ValueMetaInterface logUser = new ValueMetaString(
+      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_USER );
+    logUser.setLength( KettleDatabaseRepository.REP_STRING_CODE_LENGTH );
+    ValueMetaInterface logOperationDesc = new ValueMetaString(
+      KettleDatabaseRepository.FIELD_REPOSITORY_LOG_OPERATION_DESC );
+    logOperationDesc.setLength( KettleDatabaseRepository.REP_STRING_CODE_LENGTH );
+    table.addValueMeta( idRepositoryLog );
+    table.addValueMeta( repoVersion );
+    table.addValueMeta( logDate );
+    table.addValueMeta( logUser );
+    table.addValueMeta( logOperationDesc );
     sql =
       database.getDDL(
         schemaTable, table, null, false, KettleDatabaseRepository.FIELD_REPOSITORY_LOG_ID_REPOSITORY_LOG,
@@ -170,16 +178,19 @@ public class KettleDatabaseRepositoryCreationHelper {
     if ( monitor != null ) {
       monitor.subTask( "Checking table " + schemaTable );
     }
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_VERSION_ID_VERSION, ValueMetaInterface.TYPE_INTEGER, KEY, 0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_VERSION_MAJOR_VERSION, ValueMetaInterface.TYPE_INTEGER, 3, 0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_VERSION_MINOR_VERSION, ValueMetaInterface.TYPE_INTEGER, 3, 0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_VERSION_UPGRADE_DATE, ValueMetaInterface.TYPE_DATE, 0, 0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_VERSION_IS_UPGRADE, ValueMetaInterface.TYPE_BOOLEAN, 1, 0 ) );
+    ValueMetaInterface versionId = new ValueMetaInteger( KettleDatabaseRepository.FIELD_VERSION_ID_VERSION );
+    versionId.setLength( KEY );
+    ValueMetaInterface majorVersion = new ValueMetaInteger( KettleDatabaseRepository.FIELD_VERSION_MAJOR_VERSION );
+    majorVersion.setLength( 3 );
+    ValueMetaInterface minorVersion = new ValueMetaInteger( KettleDatabaseRepository.FIELD_VERSION_MINOR_VERSION );
+    minorVersion.setLength( 3 );
+    ValueMetaInterface upgradeDate = new ValueMetaDate( KettleDatabaseRepository.FIELD_VERSION_UPGRADE_DATE );
+    ValueMetaInterface isUpgrade = new ValueMetaBoolean( KettleDatabaseRepository.FIELD_VERSION_IS_UPGRADE );
+    table.addValueMeta( versionId );
+    table.addValueMeta( majorVersion );
+    table.addValueMeta( minorVersion );
+    table.addValueMeta( upgradeDate );
+    table.addValueMeta( isUpgrade );
     sql =
       database
         .getDDL( schemaTable, table, null, false, KettleDatabaseRepository.FIELD_VERSION_ID_VERSION, false );
@@ -305,15 +316,18 @@ public class KettleDatabaseRepositoryCreationHelper {
     if ( monitor != null ) {
       monitor.subTask( "Checking table " + schemaTable );
     }
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_CONTYPE_ID_DATABASE_CONTYPE, ValueMetaInterface.TYPE_INTEGER, KEY,
-      0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_CONTYPE_CODE, ValueMetaInterface.TYPE_STRING,
-      KettleDatabaseRepository.REP_STRING_CODE_LENGTH, 0 ) );
-    table.addValueMeta( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_CONTYPE_DESCRIPTION, ValueMetaInterface.TYPE_STRING,
-      KettleDatabaseRepository.REP_STRING_CODE_LENGTH, 0 ) );
+    ValueMetaInterface idDatabaseConnectionType = new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_DATABASE_CONTYPE_ID_DATABASE_CONTYPE );
+    idDatabaseConnectionType.setLength( KEY );
+    ValueMetaInterface connectionTypeCode = new ValueMetaString(
+        KettleDatabaseRepository.FIELD_DATABASE_CONTYPE_CODE );
+    connectionTypeCode.setLength( KettleDatabaseRepository.REP_STRING_CODE_LENGTH );
+    ValueMetaInterface connectionTypeDesc = new ValueMetaString(
+        KettleDatabaseRepository.FIELD_DATABASE_CONTYPE_DESCRIPTION );
+    connectionTypeDesc.setLength( KettleDatabaseRepository.REP_STRING_CODE_LENGTH );
+    table.addValueMeta( idDatabaseConnectionType );
+    table.addValueMeta( connectionTypeCode );
+    table.addValueMeta( connectionTypeDesc );
     sql =
       database.getDDL(
         schemaTable, table, null, false, KettleDatabaseRepository.FIELD_DATABASE_CONTYPE_ID_DATABASE_CONTYPE,
@@ -2980,17 +2994,11 @@ public class KettleDatabaseRepositoryCreationHelper {
           PluginInterface sp = plugins.get( i );
 
           RowMetaAndData table = new RowMetaAndData();
-          table.addValue( new ValueMeta(
-            KettleDatabaseRepository.FIELD_STEP_TYPE_ID_STEP_TYPE, ValueMetaInterface.TYPE_INTEGER ), id );
-          table.addValue( new ValueMeta(
-            KettleDatabaseRepository.FIELD_STEP_TYPE_CODE, ValueMetaInterface.TYPE_STRING ), sp.getIds()[0] );
-          table
-            .addValue( new ValueMeta(
-              KettleDatabaseRepository.FIELD_STEP_TYPE_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), sp
-              .getName() );
-          table.addValue( new ValueMeta(
-            KettleDatabaseRepository.FIELD_STEP_TYPE_HELPTEXT, ValueMetaInterface.TYPE_STRING ), sp
-            .getDescription() );
+          table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_TYPE_ID_STEP_TYPE ), id );
+          table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_TYPE_CODE ), sp.getIds()[0] );
+          table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_TYPE_DESCRIPTION ), sp.getName() );
+          table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_TYPE_HELPTEXT ),
+            sp.getDescription() );
 
           if ( dryrun ) {
             String sql =
@@ -3052,17 +3060,11 @@ public class KettleDatabaseRepositoryCreationHelper {
           }
 
           RowMetaAndData table = new RowMetaAndData();
-          table
-            .addValue(
-              new ValueMeta(
-                KettleDatabaseRepository.FIELD_DATABASE_TYPE_ID_DATABASE_TYPE,
-                ValueMetaInterface.TYPE_INTEGER ), id );
-          table.addValue(
-            new ValueMeta( KettleDatabaseRepository.FIELD_DATABASE_TYPE_CODE, ValueMetaInterface.TYPE_STRING ),
+          table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_TYPE_ID_DATABASE_TYPE ), id );
+          table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_TYPE_CODE ),
             plugin.getIds()[0] );
-          table.addValue( new ValueMeta(
-            KettleDatabaseRepository.FIELD_DATABASE_TYPE_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), plugin
-            .getName() );
+          table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_TYPE_DESCRIPTION ),
+            plugin.getName() );
 
           if ( dryrun ) {
             String sql =
@@ -3115,16 +3117,9 @@ public class KettleDatabaseRepositoryCreationHelper {
           }
 
           RowMetaAndData table = new RowMetaAndData();
-          table
-            .addValue(
-              new ValueMeta(
-                KettleDatabaseRepository.FIELD_JOBENTRY_TYPE_ID_JOBENTRY_TYPE,
-                ValueMetaInterface.TYPE_INTEGER ), id );
-          table.addValue( new ValueMeta(
-            KettleDatabaseRepository.FIELD_JOBENTRY_TYPE_CODE, ValueMetaInterface.TYPE_STRING ), type_desc );
-          table.addValue(
-            new ValueMeta(
-              KettleDatabaseRepository.FIELD_JOBENTRY_TYPE_DESCRIPTION, ValueMetaInterface.TYPE_STRING ),
+          table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_TYPE_ID_JOBENTRY_TYPE ), id );
+          table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOBENTRY_TYPE_CODE ), type_desc );
+          table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOBENTRY_TYPE_DESCRIPTION ),
             type_desc_long );
 
           if ( dryrun ) {

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryClusterSchemaDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryClusterSchemaDelegate.java
@@ -31,8 +31,9 @@ import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleDependencyException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleObjectExistsException;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.kdr.KettleDatabaseRepository;
 
@@ -160,29 +161,18 @@ public class KettleDatabaseRepositoryClusterSchemaDelegate extends KettleDatabas
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CLUSTER_ID_CLUSTER, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_CLUSTER_NAME, ValueMetaInterface.TYPE_STRING ),
-      clusterSchema.getName() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CLUSTER_BASE_PORT, ValueMetaInterface.TYPE_STRING ), clusterSchema
-      .getBasePort() );
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_BUFFER_SIZE, ValueMetaInterface.TYPE_STRING ),
-        clusterSchema.getSocketsBufferSize() );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_FLUSH_INTERVAL, ValueMetaInterface.TYPE_STRING ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_CLUSTER_ID_CLUSTER ), id );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CLUSTER_NAME ), clusterSchema.getName() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CLUSTER_BASE_PORT ),
+      clusterSchema.getBasePort() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_BUFFER_SIZE ),
+      clusterSchema.getSocketsBufferSize() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_FLUSH_INTERVAL ),
       clusterSchema.getSocketsFlushInterval() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_COMPRESSED, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-      .valueOf( clusterSchema.isSocketsCompressed() ) );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_CLUSTER_DYNAMIC, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-        .valueOf( clusterSchema.isDynamic() ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_COMPRESSED ),
+      Boolean.valueOf( clusterSchema.isSocketsCompressed() ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_CLUSTER_DYNAMIC ),
+      Boolean.valueOf( clusterSchema.isDynamic() ) );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_CLUSTER );
@@ -196,30 +186,20 @@ public class KettleDatabaseRepositoryClusterSchemaDelegate extends KettleDatabas
   public synchronized void updateCluster( ClusterSchema clusterSchema ) throws KettleException {
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CLUSTER_ID_CLUSTER, ValueMetaInterface.TYPE_INTEGER ), clusterSchema
-      .getObjectId() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_CLUSTER_NAME, ValueMetaInterface.TYPE_STRING ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_CLUSTER_ID_CLUSTER ),
+      clusterSchema.getObjectId() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CLUSTER_NAME ),
       clusterSchema.getName() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CLUSTER_BASE_PORT, ValueMetaInterface.TYPE_STRING ), clusterSchema
-      .getBasePort() );
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_BUFFER_SIZE, ValueMetaInterface.TYPE_STRING ),
-        clusterSchema.getSocketsBufferSize() );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_FLUSH_INTERVAL, ValueMetaInterface.TYPE_STRING ),
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CLUSTER_BASE_PORT ),
+      clusterSchema.getBasePort() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_BUFFER_SIZE ),
+      clusterSchema.getSocketsBufferSize() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_FLUSH_INTERVAL ),
       clusterSchema.getSocketsFlushInterval() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_COMPRESSED, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-      .valueOf( clusterSchema.isSocketsCompressed() ) );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_CLUSTER_DYNAMIC, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-        .valueOf( clusterSchema.isDynamic() ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_CLUSTER_SOCKETS_COMPRESSED ),
+      Boolean.valueOf( clusterSchema.isSocketsCompressed() ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_CLUSTER_DYNAMIC ),
+      Boolean.valueOf( clusterSchema.isDynamic() ) );
 
     repository.connectionDelegate.updateTableRow(
       KettleDatabaseRepository.TABLE_R_CLUSTER, KettleDatabaseRepository.FIELD_CLUSTER_ID_CLUSTER, table,

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConditionDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConditionDelegate.java
@@ -25,9 +25,11 @@ package org.pentaho.di.repository.kdr.delegates;
 import org.pentaho.di.core.Condition;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaAndData;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.repository.LongObjectId;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.kdr.KettleDatabaseRepository;
@@ -122,27 +124,19 @@ public class KettleDatabaseRepositoryConditionDelegate extends KettleDatabaseRep
 
     String tablename = KettleDatabaseRepository.TABLE_R_CONDITION;
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CONDITION_ID_CONDITION, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_CONDITION_ID_CONDITION_PARENT, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_CONDITION_ID_CONDITION ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_CONDITION_ID_CONDITION_PARENT ),
       id_condition_parent );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CONDITION_NEGATED, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-      .valueOf( condition.isNegated() ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CONDITION_OPERATOR, ValueMetaInterface.TYPE_STRING ), condition
-      .getOperatorDesc() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CONDITION_LEFT_NAME, ValueMetaInterface.TYPE_STRING ), condition
-      .getLeftValuename() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CONDITION_CONDITION_FUNCTION, ValueMetaInterface.TYPE_STRING ), condition
-      .getFunctionDesc() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CONDITION_RIGHT_NAME, ValueMetaInterface.TYPE_STRING ), condition
-      .getRightValuename() );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_CONDITION_NEGATED ),
+      Boolean.valueOf( condition.isNegated() ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CONDITION_OPERATOR ),
+      condition.getOperatorDesc() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CONDITION_LEFT_NAME ),
+      condition.getLeftValuename() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CONDITION_CONDITION_FUNCTION ),
+      condition.getFunctionDesc() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_CONDITION_RIGHT_NAME ),
+      condition.getRightValuename() );
 
     ObjectId id_value = null;
     ValueMetaAndData v = condition.getRightExact();
@@ -175,8 +169,7 @@ public class KettleDatabaseRepositoryConditionDelegate extends KettleDatabaseRep
           .getValueData() ), condition.getRightExactID() );
       condition.setRightExactID( id_value );
     }
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_CONDITION_ID_VALUE_RIGHT, ValueMetaInterface.TYPE_INTEGER ), id_value );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_CONDITION_ID_VALUE_RIGHT ), id_value );
 
     repository.connectionDelegate.getDatabase().prepareInsert( table.getRowMeta(), tablename );
     repository.connectionDelegate.getDatabase().setValuesInsert( table );
@@ -197,17 +190,12 @@ public class KettleDatabaseRepositoryConditionDelegate extends KettleDatabaseRep
       // Let's see if the same value is not yet available?
       String tablename = KettleDatabaseRepository.TABLE_R_VALUE;
       RowMetaAndData table = new RowMetaAndData();
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_VALUE_ID_VALUE, ValueMetaInterface.TYPE_INTEGER ), id_value );
-      table.addValue(
-        new ValueMeta( KettleDatabaseRepository.FIELD_VALUE_NAME, ValueMetaInterface.TYPE_STRING ), name );
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_VALUE_VALUE_TYPE, ValueMetaInterface.TYPE_STRING ), type );
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_VALUE_VALUE_STR, ValueMetaInterface.TYPE_STRING ), value_str );
-      table.addValue(
-        new ValueMeta( KettleDatabaseRepository.FIELD_VALUE_IS_NULL, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-          .valueOf( isnull ) );
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_VALUE_ID_VALUE ), id_value );
+      table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_VALUE_NAME ), name );
+      table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_VALUE_VALUE_TYPE ), type );
+      table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_VALUE_VALUE_STR ), value_str );
+      table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_VALUE_IS_NULL ),
+        Boolean.valueOf( isnull ) );
 
       repository.connectionDelegate.getDatabase().prepareInsert( table.getRowMeta(), tablename );
       repository.connectionDelegate.getDatabase().setValuesInsert( table );
@@ -220,17 +208,10 @@ public class KettleDatabaseRepositoryConditionDelegate extends KettleDatabaseRep
 
   public synchronized ObjectId lookupValue( String name, String type, String value_str, boolean isnull ) throws KettleException {
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_VALUE_NAME, ValueMetaInterface.TYPE_STRING ), name );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_VALUE_VALUE_TYPE, ValueMetaInterface.TYPE_STRING ), type );
-    table
-      .addValue(
-        new ValueMeta( KettleDatabaseRepository.FIELD_VALUE_VALUE_STR, ValueMetaInterface.TYPE_STRING ),
-        value_str );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_VALUE_IS_NULL, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-        .valueOf( isnull ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_VALUE_NAME ), name );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_VALUE_VALUE_TYPE ), type );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_VALUE_VALUE_STR ), value_str );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_VALUE_IS_NULL ), Boolean.valueOf( isnull ) );
 
     String sql =
       "SELECT "

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConnectionDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConnectionDelegate.java
@@ -48,8 +48,11 @@ import org.pentaho.di.core.logging.SimpleLoggingObject;
 import org.pentaho.di.core.row.RowDataUtil;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.LongObjectId;
 import org.pentaho.di.repository.ObjectId;
@@ -584,13 +587,9 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
   private RowMetaAndData getStepAttributeRow( ObjectId id_step, int nr, String code ) throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
-    par.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP, ValueMetaInterface.TYPE_INTEGER ), id_step );
-    par.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    par.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ),
-      new Long( nr ) );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP ), id_step );
+    par.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_CODE ), code );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_NR ), new Long( nr ) );
 
     if ( psStepAttributesLookup == null ) {
       setLookupStepAttribute();
@@ -603,14 +602,10 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
   public RowMetaAndData getTransAttributeRow( ObjectId id_transformation, int nr, String code ) throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
-    par.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ),
       id_transformation );
-    par.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    par.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ), new Long( nr ) );
+    par.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ), code );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR ), new Long( nr ) );
 
     if ( psTransAttributesLookup == null ) {
       setLookupTransAttribute();
@@ -625,13 +620,9 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
   public RowMetaAndData getJobAttributeRow( ObjectId id_job, int nr, String code ) throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
-    par.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
-    par.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    par.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ),
-      new Long( nr ) );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB ), id_job );
+    par.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE ), code );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_NR ), new Long( nr ) );
 
     if ( psJobAttributesLookup == null ) {
       setLookupJobAttribute();
@@ -705,7 +696,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     if ( v == null || Const.isEmpty( v ) ) {
       return def;
     }
-    return ValueMeta.convertStringToBoolean( v ).booleanValue();
+    return ValueMetaBase.convertStringToBoolean( v ).booleanValue();
   }
 
   public ObjectId saveStepAttribute( ObjectId id_transformation, ObjectId id_step, long nr, String code,
@@ -742,10 +733,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
           + quote( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP ) + " = ? AND "
           + quote( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_CODE ) + " = ?";
       RowMetaAndData table = new RowMetaAndData();
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP, ValueMetaInterface.TYPE_INTEGER ), id_step );
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP ), id_step );
+      table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_CODE ), code );
       RowMetaAndData r = database.getOneRow( sql, table.getRowMeta(), table.getData() );
       if ( r == null || r.getData() == null ) {
         return 0;
@@ -800,12 +789,9 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + " WHERE " + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ) + " = ? AND "
         + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ) + " = ?";
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ),
       id_transformation );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ), code );
     RowMetaAndData r = database.getOneRow( sql, table.getRowMeta(), table.getData() );
     if ( r == null || r.getData() == null ) {
       return 0;
@@ -826,14 +812,10 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_NUM );
 
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ),
       new LongObjectId( id_transformation ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ), new Long( nr ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ), code );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR ), new Long( nr ) );
 
     return database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null );
   }
@@ -849,9 +831,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + "%'";
 
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ),
       new LongObjectId( id_transformation ) );
     return database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null );
   }
@@ -901,10 +881,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + " WHERE " + quote( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB ) + " = ? AND "
         + quote( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE ) + " = ?";
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB ), id_job );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE ), code );
     RowMetaAndData r = database.getOneRow( sql, table.getRowMeta(), table.getData() );
     if ( r == null || r.getData() == null ) {
       return 0;
@@ -924,12 +902,9 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + quote( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_VALUE_NUM );
 
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ), new Long( nr ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB ), id_job );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE ), code );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_NR ), new Long( nr ) );
 
     return database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null );
   }
@@ -943,8 +918,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + quote( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE ) + " LIKE '" + codePrefix + "%'";
 
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB ),
       new LongObjectId( jobId ) );
 
     return database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null );
@@ -983,13 +957,13 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     RowMetaAndData table = new RowMetaAndData();
 
     //CHECKSTYLE:LineLength:OFF
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY_ATTRIBUTE, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY, ValueMetaInterface.TYPE_INTEGER ), id_jobentry );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ), new Long( nr ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_NUM, ValueMetaInterface.TYPE_NUMBER ), new Double( value_num ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_STR, ValueMetaInterface.TYPE_STRING ), value_str );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY_ATTRIBUTE ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOB ), id_job );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ), id_jobentry );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_NR ), new Long( nr ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE ), code );
+    table.addValue( new ValueMetaNumber( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_NUM ), new Double( value_num ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_STR ), value_str );
 
     database.prepareInsert( table.getRowMeta(), KettleDatabaseRepository.TABLE_R_JOBENTRY_ATTRIBUTE );
     database.setValuesInsert( table );
@@ -1065,14 +1039,9 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
   private RowMetaAndData getJobEntryAttributeRow( ObjectId id_jobentry, int nr, String code ) throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
-    par.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY, ValueMetaInterface.TYPE_INTEGER ),
-      id_jobentry );
-    par.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    par.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ), new Long( nr ) );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ), id_jobentry );
+    par.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE ), code );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_NR ), new Long( nr ) );
 
     if ( pstmt_entry_attributes == null ) {
       setLookupJobEntryAttribute();
@@ -1115,7 +1084,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     if ( v == null || Const.isEmpty( v ) ) {
       return def;
     }
-    return ValueMeta.convertStringToBoolean( v ).booleanValue();
+    return ValueMetaBase.convertStringToBoolean( v ).booleanValue();
   }
 
   public synchronized int countNrJobEntryAttributes( ObjectId id_jobentry, String code ) throws KettleException {
@@ -1126,12 +1095,9 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ) + " = ? AND "
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE ) + " = ?";
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ),
       id_jobentry );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE ), code );
     RowMetaAndData r = database.getOneRow( sql, table.getRowMeta(), table.getData() );
     if ( r == null || r.getData() == null ) {
       return 0;
@@ -1151,14 +1117,9 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE ) + " LIKE '" + codePrefix + "%'";
 
     RowMetaAndData table = new RowMetaAndData();
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOB, ValueMetaInterface.TYPE_INTEGER ),
-        new LongObjectId( jobId ) );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOB ),
+      new LongObjectId( jobId ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ),
       new LongObjectId( jobEntryId ) );
 
     return database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null );
@@ -1366,13 +1327,13 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP_ATTRIBUTE, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ), id_transformation );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP, ValueMetaInterface.TYPE_INTEGER ), id_step );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ), new Long( nr ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_VALUE_NUM, ValueMetaInterface.TYPE_NUMBER ), new Double( value_num ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_VALUE_STR, ValueMetaInterface.TYPE_STRING ), value_str );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP_ATTRIBUTE ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_TRANSFORMATION ), id_transformation );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP ), id_step );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_NR ), new Long( nr ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_CODE ), code );
+    table.addValue( new ValueMetaNumber( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_VALUE_NUM ), new Double( value_num ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_VALUE_STR ), value_str );
 
     /*
      * If we have prepared the insert, we don't do it again. We assume that all the step insert statements come one
@@ -1400,12 +1361,14 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANS_ATTRIBUTE, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ), id_transformation );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ), new Long( nr ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_NUM, ValueMetaInterface.TYPE_INTEGER ), new Long( value_num ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_STR, ValueMetaInterface.TYPE_STRING ), value_str );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANS_ATTRIBUTE ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ),
+      id_transformation );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR ), new Long( nr ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ), code );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_NUM ),
+      new Long( value_num ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_STR ), value_str );
 
     /*
      * If we have prepared the insert, we don't do it again. We asume that all the step insert statements come one after
@@ -1435,12 +1398,12 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB_ATTRIBUTE, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_NR, ValueMetaInterface.TYPE_INTEGER ), new Long( nr ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_VALUE_NUM, ValueMetaInterface.TYPE_INTEGER ), new Long( value_num ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_VALUE_STR, ValueMetaInterface.TYPE_STRING ), value_str );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB_ATTRIBUTE ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB ), id_job );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_NR ), new Long( nr ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE ), code );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_VALUE_NUM ), new Long( value_num ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_VALUE_STR ), value_str );
 
     /*
      * If we have prepared the insert, we don't do it again. We asume that all the step insert statements come one after
@@ -1472,7 +1435,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
     database.prepareUpdate( tablename, codes, condition, sets );
 
-    values.addValue( new ValueMeta( idfield, ValueMetaInterface.TYPE_INTEGER ), id );
+    values.addValue( new ValueMetaInteger( idfield ), id );
 
     database.setValuesUpdate( values.getRowMeta(), values.getData() );
     database.updateRow();
@@ -1491,7 +1454,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
     database.prepareUpdate( tablename, codes, condition, sets );
 
-    values.addValue( new ValueMeta( idfield, ValueMetaInterface.TYPE_INTEGER ), new Long( id ) );
+    values.addValue( new ValueMetaInteger( idfield ), new Long( id ) );
 
     database.setValuesUpdate( values.getRowMeta(), values.getData() );
     database.updateRow();
@@ -1569,7 +1532,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     RowMetaInterface parameterMeta = new RowMeta();
     Object[] parameterData = new Object[objectId.length];
     for ( int i = 0; i < objectId.length; i++ ) {
-      parameterMeta.addValueMeta( new ValueMeta( "id" + ( i + 1 ), ValueMetaInterface.TYPE_INTEGER ) );
+      parameterMeta.addValueMeta( new ValueMetaInteger( "id" + ( i + 1 ) ) );
       parameterData[i] = ( (LongObjectId) objectId[i] ).longValue();
     }
 
@@ -1605,7 +1568,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     RowMetaInterface parameterMeta = new RowMeta();
     Object[] parameterData = new Object[objectId.length];
     for ( int i = 0; i < objectId.length; i++ ) {
-      parameterMeta.addValueMeta( new ValueMeta( "id" + ( i + 1 ), ValueMetaInterface.TYPE_INTEGER ) );
+      parameterMeta.addValueMeta( new ValueMetaInteger( "id" + ( i + 1 ) ) );
       parameterData[i] = ( (LongObjectId) objectId[i] ).longValue();
     }
 
@@ -1684,7 +1647,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   public synchronized LongObjectId getIDWithValue( String tablename, String idfield, String lookupfield,
     String value ) throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
-    par.addValue( new ValueMeta( "value", ValueMetaInterface.TYPE_STRING ), value );
+    par.addValue( new ValueMetaString( "value" ), value );
     RowMetaAndData result =
       getOneRow(
         "SELECT " + idfield + " FROM " + tablename + " WHERE " + lookupfield + " = ?", par.getRowMeta(), par
@@ -1726,7 +1689,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
     RowMeta params = new RowMeta();
     for ( int i = 0; i < values.length; i++ ) {
-      ValueMeta value = new ValueMeta( Integer.toString( i ), ValueMetaInterface.TYPE_STRING );
+      ValueMetaInterface value = new ValueMetaString( Integer.toString( i ) );
       params.addValueMeta( value );
     }
 
@@ -1743,8 +1706,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   public synchronized ObjectId getIDWithValue( String tablename, String idfield, String lookupfield, String value,
     String lookupkey, ObjectId key ) throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
-    par.addValue( new ValueMeta( "value", ValueMetaInterface.TYPE_STRING ), value );
-    par.addValue( new ValueMeta( "key", ValueMetaInterface.TYPE_INTEGER ), new LongObjectId( key ) );
+    par.addValue( new ValueMetaString( "value" ), value );
+    par.addValue( new ValueMetaInteger( "key" ), new LongObjectId( key ) );
     RowMetaAndData result =
       getOneRow( "SELECT "
         + idfield + " FROM " + tablename + " WHERE " + lookupfield + " = ? AND " + lookupkey + " = ?", par
@@ -1767,7 +1730,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       } else {
         sql += "AND   ";
       }
-      par.addValue( new ValueMeta( lookupkey[i], ValueMetaInterface.TYPE_INTEGER ), new LongObjectId( key[i] ) );
+      par.addValue( new ValueMetaInteger( lookupkey[i] ), new LongObjectId( key[i] ) );
       sql += lookupkey[i] + " = ? ";
     }
     RowMetaAndData result = getOneRow( sql, par.getRowMeta(), par.getData() );
@@ -1780,12 +1743,12 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   public synchronized LongObjectId getIDWithValue( String tablename, String idfield, String lookupfield,
     String value, String[] lookupkey, ObjectId[] key ) throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
-    par.addValue( new ValueMeta( lookupfield, ValueMetaInterface.TYPE_STRING ), value );
+    par.addValue( new ValueMetaString( lookupfield ), value );
 
     String sql = "SELECT " + idfield + " FROM " + tablename + " WHERE " + lookupfield + " = ? ";
 
     for ( int i = 0; i < lookupkey.length; i++ ) {
-      par.addValue( new ValueMeta( lookupkey[i], ValueMetaInterface.TYPE_INTEGER ), new LongObjectId( key[i] ) );
+      par.addValue( new ValueMetaInteger( lookupkey[i] ), new LongObjectId( key[i] ) );
       sql += "AND " + lookupkey[i] + " = ? ";
     }
 
@@ -1814,7 +1777,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     //
     RowMetaInterface parameterMeta = new RowMeta();
 
-    parameterMeta.addValueMeta( new ValueMeta( "id", ValueMetaInterface.TYPE_INTEGER ) );
+    parameterMeta.addValueMeta( new ValueMetaInteger( "id" ) );
     Object[] parameterData = new Object[] { id != null ? Long.parseLong( id.getId() ) : null, };
 
     ResultSet resultSet = null;
@@ -1846,7 +1809,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   public synchronized String getStringWithID( String tablename, String keyfield, ObjectId id, String fieldname ) throws KettleException {
     String sql = "SELECT " + fieldname + " FROM " + tablename + " WHERE " + keyfield + " = ?";
     RowMetaAndData par = new RowMetaAndData();
-    par.addValue( new ValueMeta( keyfield, ValueMetaInterface.TYPE_INTEGER ), id );
+    par.addValue( new ValueMetaInteger( keyfield ), id );
     RowMetaAndData result = getOneRow( sql, par.getRowMeta(), par.getData() );
     if ( result != null && result.getData() != null ) {
       return result.getString( 0, null );
@@ -1888,7 +1851,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     // Assemble the parameter (if any)
     //
     RowMetaInterface parameterMeta = new RowMeta();
-    parameterMeta.addValueMeta( new ValueMeta( "id", ValueMetaInterface.TYPE_INTEGER ) );
+    parameterMeta.addValueMeta( new ValueMetaInteger( "id" ) );
     Object[] parameterData = new Object[] { ( (LongObjectId) id_database ).longValue(), };
 
     List<RowMetaAndData> attrs = new ArrayList<RowMetaAndData>();
@@ -1918,7 +1881,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     RowMetaInterface parameterMeta = new RowMeta();
     Object[] parameterData = new Object[ids.length];
     for ( int i = 0; i < ids.length; i++ ) {
-      parameterMeta.addValueMeta( new ValueMeta( "id" + ( i + 1 ), ValueMetaInterface.TYPE_INTEGER ) );
+      parameterMeta.addValueMeta( new ValueMetaInteger( "id" + ( i + 1 ) ) );
       parameterData[i] = Long.valueOf( ids[i].getId() );
     }
     return new RowMetaAndData( parameterMeta, parameterData );

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryDatabaseDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryDatabaseDelegate.java
@@ -41,6 +41,8 @@ import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.LongObjectId;
 import org.pentaho.di.repository.ObjectId;
@@ -246,37 +248,22 @@ public class KettleDatabaseRepositoryDatabaseDelegate extends KettleDatabaseRepo
     ObjectId id_database_contype = getDatabaseConTypeID( access );
 
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_DATABASE_NAME, ValueMetaInterface.TYPE_STRING ), name );
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE_TYPE, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE ), id );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_NAME ), name );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE_TYPE ),
         id_database_type );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE_CONTYPE, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE_CONTYPE ),
       id_database_contype );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_HOST_NAME, ValueMetaInterface.TYPE_STRING ), host );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_DATABASE_NAME, ValueMetaInterface.TYPE_STRING ), dbname );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_DATABASE_PORT, ValueMetaInterface.TYPE_INTEGER ), Long.valueOf(
-        Const.toLong( port, -1 ) ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_USERNAME, ValueMetaInterface.TYPE_STRING ), user );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_PASSWORD, ValueMetaInterface.TYPE_STRING ), Encr
-      .encryptPasswordIfNotUsingVariables( pass ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_SERVERNAME, ValueMetaInterface.TYPE_STRING ), servername );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_DATA_TBS, ValueMetaInterface.TYPE_STRING ), data_tablespace );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_INDEX_TBS, ValueMetaInterface.TYPE_STRING ), index_tablespace );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_HOST_NAME ), host );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_DATABASE_NAME ), dbname );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_PORT ),
+      Long.valueOf( Const.toLong( port, -1 ) ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_USERNAME ), user );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_PASSWORD ),
+      Encr.encryptPasswordIfNotUsingVariables( pass ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_SERVERNAME ), servername );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_DATA_TBS ), data_tablespace );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_INDEX_TBS ), index_tablespace );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_DATABASE );
@@ -294,35 +281,21 @@ public class KettleDatabaseRepositoryDatabaseDelegate extends KettleDatabaseRepo
     ObjectId id_database_contype = getDatabaseConTypeID( access );
 
     RowMetaAndData table = new RowMetaAndData();
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_NAME ), name );
     table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_DATABASE_NAME, ValueMetaInterface.TYPE_STRING ), name );
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE_TYPE, ValueMetaInterface.TYPE_INTEGER ),
-        id_database_type );
+      new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE_TYPE ), id_database_type );
     table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE_CONTYPE, ValueMetaInterface.TYPE_INTEGER ),
-      id_database_contype );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_HOST_NAME, ValueMetaInterface.TYPE_STRING ), host );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_DATABASE_NAME, ValueMetaInterface.TYPE_STRING ), dbname );
+      new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE_CONTYPE ), id_database_contype );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_HOST_NAME ), host );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_DATABASE_NAME ), dbname );
     table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_DATABASE_PORT, ValueMetaInterface.TYPE_INTEGER ), Long.valueOf(
-        Const.toLong( port, -1 ) ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_USERNAME, ValueMetaInterface.TYPE_STRING ), user );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_PASSWORD, ValueMetaInterface.TYPE_STRING ), Encr
+      new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_PORT ), Long.valueOf( Const.toLong( port, -1 ) ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_USERNAME ), user );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_PASSWORD ), Encr
       .encryptPasswordIfNotUsingVariables( pass ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_SERVERNAME, ValueMetaInterface.TYPE_STRING ), servername );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_DATA_TBS, ValueMetaInterface.TYPE_STRING ), data_tablespace );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_INDEX_TBS, ValueMetaInterface.TYPE_STRING ), index_tablespace );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_SERVERNAME ), servername );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_DATA_TBS ), data_tablespace );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_INDEX_TBS ), index_tablespace );
 
     repository.connectionDelegate.updateTableRow(
       KettleDatabaseRepository.TABLE_R_DATABASE, KettleDatabaseRepository.FIELD_DATABASE_ID_DATABASE, table,
@@ -455,17 +428,11 @@ public class KettleDatabaseRepositoryDatabaseDelegate extends KettleDatabaseRepo
     RowMetaAndData table = new RowMetaAndData();
 
     table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_DATABASE_ATTRIBUTE_ID_DATABASE_ATTRIBUTE,
-        ValueMetaInterface.TYPE_INTEGER ), id );
+      new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_ATTRIBUTE_ID_DATABASE_ATTRIBUTE ), id );
     table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_DATABASE_ATTRIBUTE_ID_DATABASE, ValueMetaInterface.TYPE_INTEGER ),
-      idDatabase );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_ATTRIBUTE_CODE, ValueMetaInterface.TYPE_STRING ), code );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DATABASE_ATTRIBUTE_VALUE_STR, ValueMetaInterface.TYPE_STRING ), strValue );
+      new ValueMetaInteger( KettleDatabaseRepository.FIELD_DATABASE_ATTRIBUTE_ID_DATABASE ), idDatabase );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_ATTRIBUTE_CODE ), code );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DATABASE_ATTRIBUTE_VALUE_STR ), strValue );
 
     return table;
   }

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryDirectoryDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryDirectoryDelegate.java
@@ -28,8 +28,8 @@ import java.util.List;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.LongObjectId;
 import org.pentaho.di.repository.ObjectId;
@@ -152,14 +152,10 @@ public class KettleDatabaseRepositoryDirectoryDelegate extends KettleDatabaseRep
 
     String tablename = KettleDatabaseRepository.TABLE_R_DIRECTORY;
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DIRECTORY_ID_DIRECTORY, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_DIRECTORY_ID_DIRECTORY_PARENT, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DIRECTORY_ID_DIRECTORY ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DIRECTORY_ID_DIRECTORY_PARENT ),
       id_directory_parent );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DIRECTORY_DIRECTORY_NAME, ValueMetaInterface.TYPE_STRING ), dir.getName() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DIRECTORY_DIRECTORY_NAME ), dir.getName() );
 
     repository.connectionDelegate.getDatabase().prepareInsert( table.getRowMeta(), tablename );
     repository.connectionDelegate.getDatabase().setValuesInsert( table );
@@ -247,8 +243,7 @@ public class KettleDatabaseRepositoryDirectoryDelegate extends KettleDatabaseRep
       if ( newName != null ) {
         additionalParameter = true;
         sql += quote( KettleDatabaseRepository.FIELD_DIRECTORY_DIRECTORY_NAME ) + " = ?";
-        r.addValue( new ValueMeta(
-          KettleDatabaseRepository.FIELD_DIRECTORY_DIRECTORY_NAME, ValueMetaInterface.TYPE_STRING ), newName );
+        r.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DIRECTORY_DIRECTORY_NAME ), newName );
       }
       if ( id_directory_parent != null ) {
         // Add a parameter separator if the first parm was added
@@ -256,15 +251,12 @@ public class KettleDatabaseRepositoryDirectoryDelegate extends KettleDatabaseRep
           sql += ", ";
         }
         sql += quote( KettleDatabaseRepository.FIELD_DIRECTORY_ID_DIRECTORY_PARENT ) + " = ?";
-        r.addValue(
-          new ValueMeta(
-            KettleDatabaseRepository.FIELD_DIRECTORY_ID_DIRECTORY_PARENT, ValueMetaInterface.TYPE_INTEGER ),
+        r.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DIRECTORY_ID_DIRECTORY_PARENT ),
           id_directory_parent );
       }
 
       sql += " WHERE " + quote( KettleDatabaseRepository.FIELD_DIRECTORY_ID_DIRECTORY ) + " = ? ";
-      r.addValue( new ValueMeta( "id_directory", ValueMetaInterface.TYPE_INTEGER ), Long.valueOf( id_directory
-        .toString() ) );
+      r.addValue( new ValueMetaInteger( "id_directory" ), Long.valueOf( id_directory.toString() ) );
 
       repository.connectionDelegate.getDatabase().execStatement( sql, r.getRowMeta(), r.getData() );
     }

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryJobDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryJobDelegate.java
@@ -38,8 +38,10 @@ import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogTableInterface;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobHopMeta;
 import org.pentaho.di.job.JobMeta;
@@ -881,63 +883,39 @@ public class KettleDatabaseRepositoryJobDelegate extends KettleDatabaseRepositor
   private synchronized void insertJob( JobMeta jobMeta ) throws KettleException {
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), jobMeta
-        .getObjectId() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY, ValueMetaInterface.TYPE_INTEGER ), jobMeta
-      .getRepositoryDirectory().getObjectId() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_NAME, ValueMetaInterface.TYPE_STRING ), jobMeta
-        .getName() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), jobMeta
-        .getDescription() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_EXTENDED_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), jobMeta
-      .getExtendedDescription() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_JOB_VERSION, ValueMetaInterface.TYPE_STRING ), jobMeta
-        .getJobversion() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_JOB_STATUS, ValueMetaInterface.TYPE_INTEGER ), new Long(
-        jobMeta.getJobstatus() < 0 ? -1L : jobMeta.getJobstatus() ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ID_JOB ), jobMeta.getObjectId() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY ),
+      jobMeta.getRepositoryDirectory().getObjectId() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_NAME ), jobMeta.getName() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_DESCRIPTION ), jobMeta.getDescription() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_EXTENDED_DESCRIPTION ),
+      jobMeta.getExtendedDescription() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_JOB_VERSION ), jobMeta.getJobversion() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_JOB_STATUS ),
+      new Long( jobMeta.getJobstatus() < 0 ? -1L : jobMeta.getJobstatus() ) );
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_ID_DATABASE_LOG, ValueMetaInterface.TYPE_INTEGER ), jobMeta
-      .getJobLogTable().getDatabaseMeta() != null
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ID_DATABASE_LOG ),
+      jobMeta.getJobLogTable().getDatabaseMeta() != null
       ? jobMeta.getJobLogTable().getDatabaseMeta().getObjectId() : -1L );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_TABLE_NAME_LOG, ValueMetaInterface.TYPE_STRING ), jobMeta
-      .getJobLogTable().getTableName() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_USE_BATCH_ID, ValueMetaInterface.TYPE_BOOLEAN ), jobMeta
-      .getJobLogTable().isBatchIdUsed() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_USE_LOGFIELD, ValueMetaInterface.TYPE_BOOLEAN ), jobMeta
-      .getJobLogTable().isLogFieldUsed() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_TABLE_NAME_LOG ),
+      jobMeta.getJobLogTable().getTableName() );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_JOB_USE_BATCH_ID ),
+      jobMeta.getJobLogTable().isBatchIdUsed() );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_JOB_USE_LOGFIELD ),
+      jobMeta.getJobLogTable().isLogFieldUsed() );
     repository.connectionDelegate.insertJobAttribute(
       jobMeta.getObjectId(), 0, KettleDatabaseRepository.JOB_ATTRIBUTE_LOG_SIZE_LIMIT, 0, jobMeta
         .getJobLogTable().getLogSizeLimit() );
 
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_CREATED_USER, ValueMetaInterface.TYPE_STRING ), jobMeta
-        .getCreatedUser() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_CREATED_DATE, ValueMetaInterface.TYPE_DATE ), jobMeta
-        .getCreatedDate() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_MODIFIED_USER, ValueMetaInterface.TYPE_STRING ), jobMeta
-      .getModifiedUser() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_MODIFIED_DATE, ValueMetaInterface.TYPE_DATE ), jobMeta
-        .getModifiedDate() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_PASS_BATCH_ID, ValueMetaInterface.TYPE_BOOLEAN ), jobMeta
-      .isBatchIdPassed() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_SHARED_FILE, ValueMetaInterface.TYPE_STRING ), jobMeta
-        .getSharedObjectsFile() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_CREATED_USER ), jobMeta.getCreatedUser() );
+    table.addValue( new ValueMetaDate( KettleDatabaseRepository.FIELD_JOB_CREATED_DATE ), jobMeta .getCreatedDate() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_MODIFIED_USER ),
+      jobMeta.getModifiedUser() );
+    table.addValue( new ValueMetaDate( KettleDatabaseRepository.FIELD_JOB_MODIFIED_DATE ), jobMeta.getModifiedDate() );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_JOB_PASS_BATCH_ID ),
+      jobMeta.isBatchIdPassed() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_SHARED_FILE ),
+      jobMeta.getSharedObjectsFile() );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_JOB );
@@ -970,28 +948,19 @@ public class KettleDatabaseRepositoryJobDelegate extends KettleDatabaseRepositor
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_HOP_ID_JOB_HOP, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_HOP_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_JOB_HOP_ID_JOBENTRY_COPY_FROM, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_JOB_HOP_ID_JOB_HOP ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_HOP_ID_JOB ), id_job );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_HOP_ID_JOBENTRY_COPY_FROM ),
       id_jobentry_copy_from );
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_JOB_HOP_ID_JOBENTRY_COPY_TO, ValueMetaInterface.TYPE_INTEGER ),
-        id_jobentry_copy_to );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_HOP_ENABLED, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-        .valueOf( enabled ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_HOP_EVALUATION, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-      .valueOf( evaluation ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOB_HOP_UNCONDITIONAL, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-      .valueOf( unconditional ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_HOP_ID_JOBENTRY_COPY_TO ),
+      id_jobentry_copy_to );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_JOB_HOP_ENABLED ),
+      Boolean.valueOf( enabled ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_JOB_HOP_EVALUATION ),
+      Boolean.valueOf( evaluation ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_JOB_HOP_UNCONDITIONAL ),
+      Boolean.valueOf( unconditional ) );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_JOB_HOP );
@@ -1023,14 +992,9 @@ public class KettleDatabaseRepositoryJobDelegate extends KettleDatabaseRepositor
         + quote( KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY ) + " = ?";
 
     RowMetaAndData par = new RowMetaAndData();
-    par.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY, ValueMetaInterface.TYPE_INTEGER ),
-      id_directory_to );
-    par.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_NAME, ValueMetaInterface.TYPE_STRING ), jobname );
-    par.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY, ValueMetaInterface.TYPE_INTEGER ),
-      id_directory_from );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY ), id_directory_to );
+    par.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_NAME ), jobname );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY ), id_directory_from );
 
     repository.connectionDelegate.getDatabase().execStatement( sql, par.getRowMeta(), par.getData() );
   }
@@ -1047,21 +1011,19 @@ public class KettleDatabaseRepositoryJobDelegate extends KettleDatabaseRepositor
         additionalParameter = true;
         sql += quote( KettleDatabaseRepository.FIELD_JOB_NAME ) + " = ? ";
         table.addValue(
-          new ValueMeta( KettleDatabaseRepository.FIELD_JOB_NAME, ValueMetaInterface.TYPE_STRING ), newname );
+          new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_NAME ), newname );
       }
       if ( newParentDir != null ) {
         if ( additionalParameter ) {
           sql += ", ";
         }
         sql += quote( KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY ) + " = ? ";
-        table.addValue( new ValueMeta(
-          KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY, ValueMetaInterface.TYPE_INTEGER ), newParentDir
-          .getObjectId() );
+        table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ID_DIRECTORY ),
+          newParentDir.getObjectId() );
       }
 
       sql += "WHERE " + quote( KettleDatabaseRepository.FIELD_JOB_ID_JOB ) + " = ?";
-      table.addValue(
-        new ValueMeta( KettleDatabaseRepository.FIELD_JOB_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ID_JOB ), id_job );
 
       log.logBasic( "sql = [" + sql + "]" );
       log.logBasic( "row = [" + table + "]" );

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryJobEntryDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryJobEntryDelegate.java
@@ -35,8 +35,9 @@ import org.pentaho.di.core.plugins.JobEntryPluginType;
 import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryBase;
 import org.pentaho.di.job.entry.JobEntryCopy;
@@ -260,20 +261,20 @@ public class KettleDatabaseRepositoryJobEntryDelegate extends KettleDatabaseRepo
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOBENTRY_ID_JOBENTRY, ValueMetaInterface.TYPE_INTEGER ), id );
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_JOBENTRY_ID_JOBENTRY ), id );
     table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
+      new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ID_JOB ), id_job );
     table
       .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_JOBENTRY_ID_JOBENTRY_TYPE, ValueMetaInterface.TYPE_INTEGER ),
+        new ValueMetaInteger(
+          KettleDatabaseRepository.FIELD_JOBENTRY_ID_JOBENTRY_TYPE ),
         id_jobentry_type );
     table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_NAME, ValueMetaInterface.TYPE_STRING ),
+      new ValueMetaString( KettleDatabaseRepository.FIELD_JOBENTRY_NAME ),
       jobEntryBase.getName() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_JOBENTRY_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), jobEntryBase
+    table.addValue( new ValueMetaString(
+      KettleDatabaseRepository.FIELD_JOBENTRY_DESCRIPTION ), jobEntryBase
       .getDescription() );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
@@ -295,15 +296,15 @@ public class KettleDatabaseRepositoryJobEntryDelegate extends KettleDatabaseRepo
     RowMetaAndData table = new RowMetaAndData();
 
     //CHECKSTYLE:LineLength:OFF
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_ID_JOBENTRY_COPY, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_ID_JOBENTRY, ValueMetaInterface.TYPE_INTEGER ), id_jobentry );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_ID_JOB, ValueMetaInterface.TYPE_INTEGER ), id_job );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_ID_JOBENTRY_TYPE, ValueMetaInterface.TYPE_INTEGER ), id_jobentry_type );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_NR, ValueMetaInterface.TYPE_INTEGER ), new Long( nr ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_GUI_LOCATION_X, ValueMetaInterface.TYPE_INTEGER ), new Long( gui_location_x ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_GUI_LOCATION_Y, ValueMetaInterface.TYPE_INTEGER ), new Long( gui_location_y ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_GUI_DRAW, ValueMetaInterface.TYPE_BOOLEAN ), Boolean.valueOf( gui_draw ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_PARALLEL, ValueMetaInterface.TYPE_BOOLEAN ), Boolean.valueOf( parallel ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_ID_JOBENTRY_COPY ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_ID_JOBENTRY ), id_jobentry );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_ID_JOB ), id_job );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_ID_JOBENTRY_TYPE ), id_jobentry_type );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_NR ), new Long( nr ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_GUI_LOCATION_X ), new Long( gui_location_x ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_GUI_LOCATION_Y ), new Long( gui_location_y ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_GUI_DRAW ), Boolean.valueOf( gui_draw ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_JOBENTRY_COPY_PARALLEL ), Boolean.valueOf( parallel ) );
 
     repository.connectionDelegate.getDatabase().prepareInsert( table.getRowMeta(), KettleDatabaseRepository.TABLE_R_JOBENTRY_COPY );
     repository.connectionDelegate.getDatabase().setValuesInsert( table );

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryMetaStoreDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryMetaStoreDelegate.java
@@ -34,9 +34,9 @@ import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleValueException;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.row.value.timestamp.SimpleTimestampFormat;
 import org.pentaho.di.repository.LongObjectId;
 import org.pentaho.di.repository.ObjectId;
@@ -207,10 +207,8 @@ public class KettleDatabaseRepositoryMetaStoreDelegate extends KettleDatabaseRep
         quote( KettleDatabaseRepository.FIELD_NAMESPACE_ID_NAMESPACE ) );
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_NAMESPACE_ID_NAMESPACE, ValueMetaInterface.TYPE_INTEGER ), idNamespace );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_NAMESPACE_NAME, ValueMetaInterface.TYPE_STRING ), namespace );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NAMESPACE_ID_NAMESPACE ), idNamespace );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_NAMESPACE_NAME ), namespace );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_NAMESPACE );
@@ -232,15 +230,15 @@ public class KettleDatabaseRepositoryMetaStoreDelegate extends KettleDatabaseRep
         quote( KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_ELEMENT_TYPE ) );
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_ELEMENT_TYPE, ValueMetaInterface.TYPE_INTEGER ), idType );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_NAMESPACE, ValueMetaInterface.TYPE_INTEGER ), type
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_ELEMENT_TYPE ), idType );
+    table.addValue( new ValueMetaInteger(
+      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_NAMESPACE ), type
       .getNamespaceId() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_NAME, ValueMetaInterface.TYPE_STRING ), type.getName() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), type
+    table.addValue( new ValueMetaString(
+      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_NAME ), type.getName() );
+    table.addValue( new ValueMetaString(
+      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_DESCRIPTION ), type
       .getDescription() );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
@@ -262,17 +260,12 @@ public class KettleDatabaseRepositoryMetaStoreDelegate extends KettleDatabaseRep
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_ELEMENT_TYPE, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_ELEMENT_TYPE ),
       elementTypeId );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_NAMESPACE, ValueMetaInterface.TYPE_INTEGER ), namespaceId );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_NAME, ValueMetaInterface.TYPE_STRING ), type.getName() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_ELEMENT_TYPE_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), type
-      .getDescription() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_ELEMENT_TYPE_ID_NAMESPACE ), namespaceId );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_ELEMENT_TYPE_NAME ), type.getName() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_ELEMENT_TYPE_DESCRIPTION ),
+      type.getDescription() );
 
     repository.connectionDelegate.updateTableRow(
       KettleDatabaseRepository.TABLE_R_ELEMENT_TYPE,
@@ -438,15 +431,11 @@ public class KettleDatabaseRepositoryMetaStoreDelegate extends KettleDatabaseRep
           quote( KettleDatabaseRepository.FIELD_ELEMENT_ID_ELEMENT ) );
       RowMetaAndData table = new RowMetaAndData();
 
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_ELEMENT_ID_ELEMENT, ValueMetaInterface.TYPE_INTEGER ), elementId
-        .longValue() );
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_ELEMENT_ID_ELEMENT_TYPE, ValueMetaInterface.TYPE_INTEGER ), Long
-        .valueOf( elementType.getId() ) );
-      table.addValue(
-        new ValueMeta( KettleDatabaseRepository.FIELD_ELEMENT_NAME, ValueMetaInterface.TYPE_STRING ), element
-          .getName() );
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_ELEMENT_ID_ELEMENT ),
+        elementId.longValue() );
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_ELEMENT_ID_ELEMENT_TYPE ),
+        Long.valueOf( elementType.getId() ) );
+      table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_ELEMENT_NAME ), element.getName() );
 
       repository.connectionDelegate.getDatabase().prepareInsert(
         table.getRowMeta(), KettleDatabaseRepository.TABLE_R_ELEMENT );
@@ -479,21 +468,14 @@ public class KettleDatabaseRepositoryMetaStoreDelegate extends KettleDatabaseRep
           quote( KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_ID_ELEMENT_ATTRIBUTE ) );
       RowMetaAndData table = new RowMetaAndData();
 
-      table.addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_ID_ELEMENT_ATTRIBUTE,
-          ValueMetaInterface.TYPE_INTEGER ), attributeId.longValue() );
-      table.addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_ID_ELEMENT, ValueMetaInterface.TYPE_INTEGER ),
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_ID_ELEMENT_ATTRIBUTE ),
+        attributeId.longValue() );
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_ID_ELEMENT ),
         elementId.longValue() );
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_ID_ELEMENT_ATTRIBUTE_PARENT,
-        ValueMetaInterface.TYPE_INTEGER ), parentAttributeId.longValue() );
-      table.addValue( new ValueMeta(
-        KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_KEY, ValueMetaInterface.TYPE_STRING ), child.getId() );
-      table.addValue(
-        new ValueMeta( KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_VALUE, ValueMetaInterface.TYPE_STRING ),
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_ID_ELEMENT_ATTRIBUTE_PARENT ),
+        parentAttributeId.longValue() );
+      table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_KEY ), child.getId() );
+      table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_ELEMENT_ATTRIBUTE_VALUE ),
         encodeAttributeValue( child.getValue() ) );
 
       repository.connectionDelegate.getDatabase().prepareInsert(

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryNotePadDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryNotePadDelegate.java
@@ -27,8 +27,9 @@ import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.gui.Point;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.kdr.KettleDatabaseRepository;
 
@@ -141,30 +142,30 @@ public class KettleDatabaseRepositoryNotePadDelegate extends KettleDatabaseRepos
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_ID_NOTE, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_VALUE_STR, ValueMetaInterface.TYPE_STRING ), note );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_GUI_LOCATION_X, ValueMetaInterface.TYPE_INTEGER ), new Long( gui_location_x ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_GUI_LOCATION_Y, ValueMetaInterface.TYPE_INTEGER ), new Long( gui_location_y ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_GUI_LOCATION_WIDTH, ValueMetaInterface.TYPE_INTEGER ), new Long( gui_location_width ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_GUI_LOCATION_HEIGHT, ValueMetaInterface.TYPE_INTEGER ), new Long( gui_location_height ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_ID_NOTE ), id );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_NOTE_VALUE_STR ), note );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_GUI_LOCATION_X ), new Long( gui_location_x ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_GUI_LOCATION_Y ), new Long( gui_location_y ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_GUI_LOCATION_WIDTH ), new Long( gui_location_width ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_GUI_LOCATION_HEIGHT ), new Long( gui_location_height ) );
     // Font
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_FONT_NAME, ValueMetaInterface.TYPE_STRING ), fontname );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_FONT_SIZE, ValueMetaInterface.TYPE_INTEGER ), fontsize );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_FONT_BOLD, ValueMetaInterface.TYPE_BOOLEAN ), Boolean.valueOf( fontbold ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_FONT_ITALIC, ValueMetaInterface.TYPE_BOOLEAN ), Boolean.valueOf( fontitalic ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_NOTE_FONT_NAME ), fontname );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_FONT_SIZE ), fontsize );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_NOTE_FONT_BOLD ), Boolean.valueOf( fontbold ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_NOTE_FONT_ITALIC ), Boolean.valueOf( fontitalic ) );
     // Font color
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_COLOR_RED, ValueMetaInterface.TYPE_INTEGER ), new Long( fontcolorred ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_COLOR_GREEN, ValueMetaInterface.TYPE_INTEGER ), new Long( fontcolorgreen ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_COLOR_BLUE, ValueMetaInterface.TYPE_INTEGER ), new Long( fontcolorblue ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_COLOR_RED ), new Long( fontcolorred ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_COLOR_GREEN ), new Long( fontcolorgreen ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_COLOR_BLUE ), new Long( fontcolorblue ) );
     // Font background color
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_BACK_GROUND_COLOR_RED, ValueMetaInterface.TYPE_INTEGER ), new Long( fontbackcolorred ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_BACK_GROUND_COLOR_GREEN, ValueMetaInterface.TYPE_INTEGER ), new Long( fontbackcolorgreen ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_BACK_GROUND_COLOR_BLUE, ValueMetaInterface.TYPE_INTEGER ), new Long( fontbackcolorblue ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_BACK_GROUND_COLOR_RED ), new Long( fontbackcolorred ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_BACK_GROUND_COLOR_GREEN ), new Long( fontbackcolorgreen ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_BACK_GROUND_COLOR_BLUE ), new Long( fontbackcolorblue ) );
     // Font border color
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_BORDER_COLOR_RED, ValueMetaInterface.TYPE_INTEGER ), new Long( fontbordercolorred ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_BORDER_COLOR_GREEN, ValueMetaInterface.TYPE_INTEGER ), new Long( fontbordercolorgreen ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_BORDER_COLOR_BLUE, ValueMetaInterface.TYPE_INTEGER ), new Long( fontbordercolorblue ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_NOTE_DRAW_SHADOW, ValueMetaInterface.TYPE_BOOLEAN ), Boolean.valueOf( drawshadow ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_BORDER_COLOR_RED ), new Long( fontbordercolorred ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_BORDER_COLOR_GREEN ), new Long( fontbordercolorgreen ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_NOTE_BORDER_COLOR_BLUE ), new Long( fontbordercolorblue ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_NOTE_DRAW_SHADOW ), Boolean.valueOf( drawshadow ) );
 
     repository.connectionDelegate.getDatabase().prepareInsert( table.getRowMeta(), KettleDatabaseRepository.TABLE_R_NOTE );
     repository.connectionDelegate.getDatabase().setValuesInsert( table );

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryPartitionSchemaDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryPartitionSchemaDelegate.java
@@ -27,8 +27,9 @@ import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleDependencyException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleObjectExistsException;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.partition.PartitionSchema;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.kdr.KettleDatabaseRepository;
@@ -152,23 +153,13 @@ public class KettleDatabaseRepositoryPartitionSchemaDelegate extends KettleDatab
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_ID_PARTITION_SCHEMA,
-          ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_NAME, ValueMetaInterface.TYPE_STRING ), partitionSchema
-      .getName() );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_DYNAMIC_DEFINITION, ValueMetaInterface.TYPE_BOOLEAN ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_ID_PARTITION_SCHEMA ), id );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_NAME ),
+      partitionSchema.getName() );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_DYNAMIC_DEFINITION ),
       partitionSchema.isDynamicallyDefined() );
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_PARTITIONS_PER_SLAVE,
-          ValueMetaInterface.TYPE_STRING ), partitionSchema.getNumberOfPartitionsPerSlave() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_PARTITIONS_PER_SLAVE ),
+      partitionSchema.getNumberOfPartitionsPerSlave() );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_PARTITION_SCHEMA );
@@ -181,18 +172,12 @@ public class KettleDatabaseRepositoryPartitionSchemaDelegate extends KettleDatab
 
   public synchronized void updatePartitionSchema( PartitionSchema partitionSchema ) throws KettleException {
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_NAME, ValueMetaInterface.TYPE_STRING ), partitionSchema
-      .getName() );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_DYNAMIC_DEFINITION, ValueMetaInterface.TYPE_BOOLEAN ),
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_NAME ),
+      partitionSchema.getName() );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_DYNAMIC_DEFINITION ),
       partitionSchema.isDynamicallyDefined() );
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_PARTITIONS_PER_SLAVE,
-          ValueMetaInterface.TYPE_STRING ), partitionSchema.getNumberOfPartitionsPerSlave() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_PARTITION_SCHEMA_PARTITIONS_PER_SLAVE ),
+      partitionSchema.getNumberOfPartitionsPerSlave() );
 
     repository.connectionDelegate.updateTableRow(
       KettleDatabaseRepository.TABLE_R_PARTITION_SCHEMA,
@@ -204,14 +189,10 @@ public class KettleDatabaseRepositoryPartitionSchemaDelegate extends KettleDatab
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_PARTITION_ID_PARTITION, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_PARTITION_ID_PARTITION_SCHEMA, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_PARTITION_ID_PARTITION ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_PARTITION_ID_PARTITION_SCHEMA ),
       id_partition_schema );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_PARTITION_PARTITION_ID, ValueMetaInterface.TYPE_STRING ), partition_id );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_PARTITION_PARTITION_ID ), partition_id );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_PARTITION );

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositorySlaveServerDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositorySlaveServerDelegate.java
@@ -28,8 +28,9 @@ import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleObjectExistsException;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.kdr.KettleDatabaseRepository;
@@ -143,38 +144,23 @@ public class KettleDatabaseRepositorySlaveServerDelegate extends KettleDatabaseR
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_ID_SLAVE, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_NAME, ValueMetaInterface.TYPE_STRING ), slaveServer
-        .getName() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_HOST_NAME, ValueMetaInterface.TYPE_STRING ),
-      slaveServer.getHostname() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_PORT, ValueMetaInterface.TYPE_STRING ), slaveServer
-        .getPort() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_SLAVE_WEB_APP_NAME, ValueMetaInterface.TYPE_STRING ), slaveServer
-      .getWebAppName() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_USERNAME, ValueMetaInterface.TYPE_STRING ),
-      slaveServer.getUsername() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_PASSWORD, ValueMetaInterface.TYPE_STRING ), Encr
-        .encryptPasswordIfNotUsingVariables( slaveServer.getPassword() ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_SLAVE_PROXY_HOST_NAME, ValueMetaInterface.TYPE_STRING ), slaveServer
-      .getProxyHostname() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_PROXY_PORT, ValueMetaInterface.TYPE_STRING ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_SLAVE_ID_SLAVE ), id );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_NAME ), slaveServer.getName() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_HOST_NAME ), slaveServer.getHostname() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_PORT ), slaveServer.getPort() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_WEB_APP_NAME ),
+      slaveServer.getWebAppName() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_USERNAME ), slaveServer.getUsername() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_PASSWORD ),
+      Encr.encryptPasswordIfNotUsingVariables( slaveServer.getPassword() ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_PROXY_HOST_NAME ),
+      slaveServer.getProxyHostname() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_PROXY_PORT ),
       slaveServer.getProxyPort() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_SLAVE_NON_PROXY_HOSTS, ValueMetaInterface.TYPE_STRING ), slaveServer
-      .getNonProxyHosts() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_MASTER, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-        .valueOf( slaveServer.isMaster() ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_NON_PROXY_HOSTS ),
+      slaveServer.getNonProxyHosts() );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_SLAVE_MASTER ),
+      Boolean.valueOf( slaveServer.isMaster() ) );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_SLAVE );
@@ -187,36 +173,24 @@ public class KettleDatabaseRepositorySlaveServerDelegate extends KettleDatabaseR
 
   public synchronized void updateSlave( SlaveServer slaveServer ) throws KettleException {
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_NAME, ValueMetaInterface.TYPE_STRING ), slaveServer
-        .getName() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_HOST_NAME, ValueMetaInterface.TYPE_STRING ),
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_NAME ), slaveServer.getName() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_HOST_NAME ),
       slaveServer.getHostname() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_PORT, ValueMetaInterface.TYPE_STRING ), slaveServer
-        .getPort() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_SLAVE_WEB_APP_NAME, ValueMetaInterface.TYPE_STRING ), slaveServer
-      .getWebAppName() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_USERNAME, ValueMetaInterface.TYPE_STRING ),
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_PORT ), slaveServer.getPort() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_WEB_APP_NAME ),
+      slaveServer.getWebAppName() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_USERNAME ),
       slaveServer.getUsername() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_PASSWORD, ValueMetaInterface.TYPE_STRING ), Encr
-        .encryptPasswordIfNotUsingVariables( slaveServer.getPassword() ) );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_SLAVE_PROXY_HOST_NAME, ValueMetaInterface.TYPE_STRING ), slaveServer
-      .getProxyHostname() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_PROXY_PORT, ValueMetaInterface.TYPE_STRING ),
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_PASSWORD ),
+      Encr.encryptPasswordIfNotUsingVariables( slaveServer.getPassword() ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_PROXY_HOST_NAME ),
+      slaveServer.getProxyHostname() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_PROXY_PORT ),
       slaveServer.getProxyPort() );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_SLAVE_NON_PROXY_HOSTS, ValueMetaInterface.TYPE_STRING ), slaveServer
-      .getNonProxyHosts() );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_SLAVE_MASTER, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-        .valueOf( slaveServer.isMaster() ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_SLAVE_NON_PROXY_HOSTS ),
+      slaveServer.getNonProxyHosts() );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_SLAVE_MASTER ),
+      Boolean.valueOf( slaveServer.isMaster() ) );
 
     repository.connectionDelegate.updateTableRow(
       KettleDatabaseRepository.TABLE_R_SLAVE, KettleDatabaseRepository.FIELD_SLAVE_ID_SLAVE, table, slaveServer

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryStepDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryStepDelegate.java
@@ -37,8 +37,9 @@ import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.StepPluginType;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.partition.PartitionSchema;
@@ -369,17 +370,21 @@ public class KettleDatabaseRepositoryStepDelegate extends KettleDatabaseReposito
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ID_STEP, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ), id_transformation );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_NAME, ValueMetaInterface.TYPE_STRING ), name );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), description );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_ID_STEP_TYPE, ValueMetaInterface.TYPE_INTEGER ), id_step_type );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_DISTRIBUTE, ValueMetaInterface.TYPE_BOOLEAN ), Boolean.valueOf( distribute ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_COPIES, ValueMetaInterface.TYPE_INTEGER ), new Long( copies ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_GUI_LOCATION_X, ValueMetaInterface.TYPE_INTEGER ), new Long( gui_location_x ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_GUI_LOCATION_Y, ValueMetaInterface.TYPE_INTEGER ), new Long( gui_location_y ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_GUI_DRAW, ValueMetaInterface.TYPE_BOOLEAN ), Boolean.valueOf( gui_draw ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_STEP_COPIES_STRING, ValueMetaInterface.TYPE_STRING ), copiesString );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ID_STEP ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ID_TRANSFORMATION ), id_transformation );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_NAME ), name );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_DESCRIPTION ), description );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ID_STEP_TYPE ), id_step_type );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_STEP_DISTRIBUTE ),
+      Boolean.valueOf( distribute ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_COPIES ), new Long( copies ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_GUI_LOCATION_X ),
+      new Long( gui_location_x ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_GUI_LOCATION_Y ),
+      new Long( gui_location_y ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_STEP_GUI_DRAW ),
+      Boolean.valueOf( gui_draw ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_COPIES_STRING ), copiesString );
 
     repository.connectionDelegate.getDatabase().prepareInsert( table.getRowMeta(), KettleDatabaseRepository.TABLE_R_STEP );
     repository.connectionDelegate.getDatabase().setValuesInsert( table );

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryTransDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryTransDelegate.java
@@ -39,8 +39,11 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogTableInterface;
 import org.pentaho.di.core.logging.TransLogTable;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.partition.PartitionSchema;
 import org.pentaho.di.repository.LongObjectId;
@@ -1294,41 +1297,41 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
   private synchronized void insertTransformation( TransMeta transMeta ) throws KettleException {
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ), new LongObjectId( transMeta.getObjectId() ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_NAME, ValueMetaInterface.TYPE_STRING ), transMeta.getName() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), transMeta.getDescription() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_EXTENDED_DESCRIPTION, ValueMetaInterface.TYPE_STRING ), transMeta.getExtendedDescription() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_TRANS_VERSION, ValueMetaInterface.TYPE_STRING ), transMeta.getTransversion() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_TRANS_STATUS, ValueMetaInterface.TYPE_INTEGER ), new Long( transMeta.getTransstatus() < 0 ? -1L : transMeta.getTransstatus() ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_TRANSFORMATION ), new LongObjectId( transMeta.getObjectId() ) );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_NAME ), transMeta.getName() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_DESCRIPTION ), transMeta.getDescription() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_EXTENDED_DESCRIPTION ), transMeta.getExtendedDescription() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_TRANS_VERSION ), transMeta.getTransversion() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_TRANS_STATUS ), new Long( transMeta.getTransstatus() < 0 ? -1L : transMeta.getTransstatus() ) );
     TransLogTable logTable = transMeta.getTransLogTable();
     StepMeta step = (StepMeta) logTable.getSubject( TransLogTable.ID.LINES_READ );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_READ, ValueMetaInterface.TYPE_INTEGER ), step == null ? null : step.getObjectId() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_READ ), step == null ? null : step.getObjectId() );
     step = (StepMeta) logTable.getSubject( TransLogTable.ID.LINES_WRITTEN );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_WRITE, ValueMetaInterface.TYPE_INTEGER ), step == null ? null : step.getObjectId() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_WRITE ), step == null ? null : step.getObjectId() );
     step = (StepMeta) logTable.getSubject( TransLogTable.ID.LINES_INPUT );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_INPUT, ValueMetaInterface.TYPE_INTEGER ), step == null ? null : step.getObjectId() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_INPUT ), step == null ? null : step.getObjectId() );
     step = (StepMeta) logTable.getSubject( TransLogTable.ID.LINES_OUTPUT );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_OUTPUT, ValueMetaInterface.TYPE_INTEGER ), step == null ? null : step.getObjectId() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_OUTPUT ), step == null ? null : step.getObjectId() );
     step = (StepMeta) logTable.getSubject( TransLogTable.ID.LINES_UPDATED );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_UPDATE, ValueMetaInterface.TYPE_INTEGER ), step == null ? null : step.getObjectId() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_STEP_UPDATE ), step == null ? null : step.getObjectId() );
 
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DATABASE_LOG, ValueMetaInterface.TYPE_INTEGER ), logTable.getDatabaseMeta() == null ? new LongObjectId( -1L ).longValue() : new LongObjectId( logTable.getDatabaseMeta().getObjectId() ).longValue() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_TABLE_NAME_LOG, ValueMetaInterface.TYPE_STRING ), logTable.getDatabaseMeta() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_USE_BATCHID, ValueMetaInterface.TYPE_BOOLEAN ), Boolean.valueOf( logTable.isBatchIdUsed() ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_USE_LOGFIELD, ValueMetaInterface.TYPE_BOOLEAN ), Boolean.valueOf( logTable.isLogFieldUsed() ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DATABASE_MAXDATE, ValueMetaInterface.TYPE_INTEGER ), transMeta.getMaxDateConnection() == null ? new LongObjectId( -1L ).longValue() : new LongObjectId( transMeta.getMaxDateConnection().getObjectId() ).longValue() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_TABLE_NAME_MAXDATE, ValueMetaInterface.TYPE_STRING ), transMeta.getMaxDateTable() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_FIELD_NAME_MAXDATE, ValueMetaInterface.TYPE_STRING ), transMeta.getMaxDateField() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_OFFSET_MAXDATE, ValueMetaInterface.TYPE_NUMBER ), new Double( transMeta.getMaxDateOffset() ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_DIFF_MAXDATE, ValueMetaInterface.TYPE_NUMBER ), new Double( transMeta.getMaxDateDifference() ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DATABASE_LOG ), logTable.getDatabaseMeta() == null ? new LongObjectId( -1L ).longValue() : new LongObjectId( logTable.getDatabaseMeta().getObjectId() ).longValue() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_TABLE_NAME_LOG ), logTable.getDatabaseMeta() );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_TRANSFORMATION_USE_BATCHID ), Boolean.valueOf( logTable.isBatchIdUsed() ) );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_TRANSFORMATION_USE_LOGFIELD ), Boolean.valueOf( logTable.isLogFieldUsed() ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DATABASE_MAXDATE ), transMeta.getMaxDateConnection() == null ? new LongObjectId( -1L ).longValue() : new LongObjectId( transMeta.getMaxDateConnection().getObjectId() ).longValue() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_TABLE_NAME_MAXDATE ), transMeta.getMaxDateTable() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_FIELD_NAME_MAXDATE ), transMeta.getMaxDateField() );
+    table.addValue( new ValueMetaNumber( KettleDatabaseRepository.FIELD_TRANSFORMATION_OFFSET_MAXDATE ), new Double( transMeta.getMaxDateOffset() ) );
+    table.addValue( new ValueMetaNumber( KettleDatabaseRepository.FIELD_TRANSFORMATION_DIFF_MAXDATE ), new Double( transMeta.getMaxDateDifference() ) );
 
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_CREATED_USER, ValueMetaInterface.TYPE_STRING ), transMeta.getCreatedUser() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_CREATED_DATE, ValueMetaInterface.TYPE_DATE ), transMeta.getCreatedDate() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_CREATED_USER ), transMeta.getCreatedUser() );
+    table.addValue( new ValueMetaDate( KettleDatabaseRepository.FIELD_TRANSFORMATION_CREATED_DATE ), transMeta.getCreatedDate() );
 
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_MODIFIED_USER, ValueMetaInterface.TYPE_STRING ), transMeta.getModifiedUser() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_MODIFIED_DATE, ValueMetaInterface.TYPE_DATE ), transMeta.getModifiedDate() );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_SIZE_ROWSET, ValueMetaInterface.TYPE_INTEGER ), new Long( transMeta.getSizeRowset() ) );
-    table.addValue( new ValueMeta( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY, ValueMetaInterface.TYPE_INTEGER ), transMeta.getRepositoryDirectory().getObjectId() );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_MODIFIED_USER ), transMeta.getModifiedUser() );
+    table.addValue( new ValueMetaDate( KettleDatabaseRepository.FIELD_TRANSFORMATION_MODIFIED_DATE ), transMeta.getModifiedDate() );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_SIZE_ROWSET ), new Long( transMeta.getSizeRowset() ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY ), transMeta.getRepositoryDirectory().getObjectId() );
 
     repository.connectionDelegate.getDatabase().prepareInsert( table.getRowMeta(), KettleDatabaseRepository.TABLE_R_TRANSFORMATION );
     repository.connectionDelegate.getDatabase().setValuesInsert( table );
@@ -1417,20 +1420,13 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_HOP_ID_TRANS_HOP, ValueMetaInterface.TYPE_INTEGER ), id );
-    table
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_TRANS_HOP_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
-        id_transformation );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_HOP_ID_STEP_FROM, ValueMetaInterface.TYPE_INTEGER ), id_step_from );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_HOP_ID_STEP_TO, ValueMetaInterface.TYPE_INTEGER ), id_step_to );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANS_HOP_ENABLED, ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-      .valueOf( enabled ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_HOP_ID_TRANS_HOP ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_HOP_ID_TRANSFORMATION ),
+      id_transformation );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_HOP_ID_STEP_FROM ), id_step_from );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_HOP_ID_STEP_TO ), id_step_to );
+    table.addValue( new ValueMetaBoolean( KettleDatabaseRepository.FIELD_TRANS_HOP_ENABLED ),
+      Boolean.valueOf( enabled ) );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_TRANS_HOP );
@@ -1447,18 +1443,12 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
 
     RowMetaAndData table = new RowMetaAndData();
 
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DEPENDENCY_ID_DEPENDENCY, ValueMetaInterface.TYPE_INTEGER ), id );
-    table.addValue(
-      new ValueMeta(
-        KettleDatabaseRepository.FIELD_DEPENDENCY_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DEPENDENCY_ID_DEPENDENCY ), id );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DEPENDENCY_ID_TRANSFORMATION ),
       id_transformation );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DEPENDENCY_ID_DATABASE, ValueMetaInterface.TYPE_INTEGER ), id_database );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DEPENDENCY_TABLE_NAME, ValueMetaInterface.TYPE_STRING ), tablename );
-    table.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_DEPENDENCY_FIELD_NAME, ValueMetaInterface.TYPE_STRING ), fieldname );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_DEPENDENCY_ID_DATABASE ), id_database );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DEPENDENCY_TABLE_NAME ), tablename );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_DEPENDENCY_FIELD_NAME ), fieldname );
 
     repository.connectionDelegate.getDatabase().prepareInsert(
       table.getRowMeta(), KettleDatabaseRepository.TABLE_R_DEPENDENCY );
@@ -1507,18 +1497,11 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
         + " = ? AND " + quote( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY ) + " = ?";
 
     RowMetaAndData par = new RowMetaAndData();
-    par
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY, ValueMetaInterface.TYPE_INTEGER ),
-        id_directory_to );
-    par.addValue( new ValueMeta(
-      KettleDatabaseRepository.FIELD_TRANSFORMATION_NAME, ValueMetaInterface.TYPE_STRING ), transname );
-    par
-      .addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY, ValueMetaInterface.TYPE_INTEGER ),
-        id_directory_from );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY ),
+      id_directory_to );
+    par.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_NAME ), transname );
+    par.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY ),
+      id_directory_from );
 
     repository.connectionDelegate.getDatabase().execStatement( sql, par.getRowMeta(), par.getData() );
   }
@@ -1534,8 +1517,7 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
       if ( newname != null ) {
         additionalParameter = true;
         sql += quote( KettleDatabaseRepository.FIELD_TRANSFORMATION_NAME ) + " = ? ";
-        table.addValue( new ValueMeta(
-          KettleDatabaseRepository.FIELD_TRANSFORMATION_NAME, ValueMetaInterface.TYPE_STRING ), newname );
+        table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANSFORMATION_NAME ), newname );
       }
 
       if ( newParentDir != null ) {
@@ -1543,16 +1525,12 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
           sql += ", ";
         }
         sql += quote( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY ) + " = ? ";
-        table.addValue(
-          new ValueMeta(
-            KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY, ValueMetaInterface.TYPE_INTEGER ),
+        table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_DIRECTORY ),
           newParentDir.getObjectId() );
       }
 
       sql += "WHERE " + quote( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_TRANSFORMATION ) + " = ?";
-      table.addValue(
-        new ValueMeta(
-          KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_TRANSFORMATION, ValueMetaInterface.TYPE_INTEGER ),
+      table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANSFORMATION_ID_TRANSFORMATION ),
         id_transformation );
 
       log.logBasic( "sql = [" + sql + "]" );

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryUserDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryUserDelegate.java
@@ -27,8 +27,9 @@ import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleAuthException;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.IUser;
 import org.pentaho.di.repository.ObjectId;
@@ -136,14 +137,12 @@ public class KettleDatabaseRepositoryUserDelegate extends KettleDatabaseReposito
 
   public RowMetaAndData fillTableRow( IUser userInfo ) {
     RowMetaAndData r = new RowMetaAndData();
-    r.addValue( new ValueMeta( "ID_USER", ValueMetaInterface.TYPE_INTEGER ), userInfo.getObjectId() );
-    r.addValue( new ValueMeta( "LOGIN", ValueMetaInterface.TYPE_STRING ), userInfo.getLogin() );
-    r.addValue( new ValueMeta( "PASSWORD", ValueMetaInterface.TYPE_STRING ), Encr.encryptPassword( userInfo
-      .getPassword() ) );
-    r.addValue( new ValueMeta( "NAME", ValueMetaInterface.TYPE_STRING ), userInfo.getUsername() );
-    r.addValue( new ValueMeta( "DESCRIPTION", ValueMetaInterface.TYPE_STRING ), userInfo.getDescription() );
-    r.addValue( new ValueMeta( "ENABLED", ValueMetaInterface.TYPE_BOOLEAN ), Boolean
-      .valueOf( userInfo.isEnabled() ) );
+    r.addValue( new ValueMetaInteger( "ID_USER" ), userInfo.getObjectId() );
+    r.addValue( new ValueMetaString( "LOGIN" ), userInfo.getLogin() );
+    r.addValue( new ValueMetaString( "PASSWORD" ), Encr.encryptPassword( userInfo.getPassword() ) );
+    r.addValue( new ValueMetaString( "NAME" ), userInfo.getUsername() );
+    r.addValue( new ValueMetaString( "DESCRIPTION" ), userInfo.getDescription() );
+    r.addValue( new ValueMetaBoolean( "ENABLED" ), Boolean.valueOf( userInfo.isEnabled() ) );
     return r;
   }
 
@@ -171,10 +170,8 @@ public class KettleDatabaseRepositoryUserDelegate extends KettleDatabaseReposito
         + quote( KettleDatabaseRepository.FIELD_USER_ID_USER ) + " = ?";
 
     RowMetaAndData table = new RowMetaAndData();
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_USER_NAME, ValueMetaInterface.TYPE_STRING ), newname );
-    table.addValue(
-      new ValueMeta( KettleDatabaseRepository.FIELD_USER_ID_USER, ValueMetaInterface.TYPE_INTEGER ), id_user );
+    table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_USER_NAME ), newname );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_USER_ID_USER ), id_user );
 
     repository.connectionDelegate.getDatabase().execStatement( sql, table.getRowMeta(), table.getData() );
   }

--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryValueDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryValueDelegate.java
@@ -27,6 +27,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaAndData;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.kdr.KettleDatabaseRepository;
 
@@ -57,7 +58,7 @@ public class KettleDatabaseRepositoryValueDelegate extends KettleDatabaseReposit
         if ( isNull ) {
           valueMetaAndData.setValueData( null );
         } else {
-          ValueMetaInterface stringValueMeta = new ValueMeta( name, ValueMetaInterface.TYPE_STRING );
+          ValueMetaInterface stringValueMeta = new ValueMetaString( name );
           ValueMetaInterface valueMeta = valueMetaAndData.getValueMeta();
           stringValueMeta.setConversionMetadata( valueMeta );
 

--- a/engine/src/org/pentaho/di/trans/DatabaseImpact.java
+++ b/engine/src/org/pentaho/di/trans/DatabaseImpact.java
@@ -23,8 +23,7 @@
 package org.pentaho.di.trans;
 
 import org.pentaho.di.core.RowMetaAndData;
-import org.pentaho.di.core.row.ValueMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 
 public class DatabaseImpact {
@@ -128,46 +127,42 @@ public class DatabaseImpact {
   public RowMetaAndData getRow() {
     RowMetaAndData r = new RowMetaAndData();
     r.addValue(
-      new ValueMeta(
-        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Type" ), ValueMetaInterface.TYPE_STRING ),
+      new ValueMetaString(
+        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Type" ) ),
       getTypeDesc() );
-    r.addValue( new ValueMeta(
-      BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Transformation" ),
-      ValueMetaInterface.TYPE_STRING ), getTransformationName() );
+    r.addValue( new ValueMetaString(
+      BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Transformation" ) ), getTransformationName() );
     r.addValue(
-      new ValueMeta(
-        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Step" ), ValueMetaInterface.TYPE_STRING ),
+      new ValueMetaString(
+        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Step" ) ),
       getStepName() );
     r
       .addValue(
-        new ValueMeta(
-          BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Database" ),
-          ValueMetaInterface.TYPE_STRING ), getDatabaseName() );
+        new ValueMetaString(
+          BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Database" ) ), getDatabaseName() );
     r.addValue(
-      new ValueMeta(
-        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Table" ), ValueMetaInterface.TYPE_STRING ),
+      new ValueMetaString(
+        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Table" ) ),
       getTable() );
     r.addValue(
-      new ValueMeta(
-        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Field" ), ValueMetaInterface.TYPE_STRING ),
+      new ValueMetaString(
+        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Field" ) ),
       getField() );
     r.addValue(
-      new ValueMeta(
-        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Value" ), ValueMetaInterface.TYPE_STRING ),
+      new ValueMetaString(
+        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Value" ) ),
       getValue() );
     r.addValue(
-      new ValueMeta(
-        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.ValueOrigin" ),
-        ValueMetaInterface.TYPE_STRING ), getValueOrigin() );
+      new ValueMetaString(
+        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.ValueOrigin" ) ), getValueOrigin() );
     r.addValue(
-      new ValueMeta(
-        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.SQL" ), ValueMetaInterface.TYPE_STRING ),
+      new ValueMetaString(
+        BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.SQL" ) ),
       getSQL() );
     r
       .addValue(
-        new ValueMeta(
-          BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Remarks" ),
-          ValueMetaInterface.TYPE_STRING ), getRemark() );
+        new ValueMetaString(
+          BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Remarks" ) ), getRemark() );
 
     return r;
   }

--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -81,7 +81,7 @@ import org.pentaho.di.core.parameters.NamedParams;
 import org.pentaho.di.core.parameters.NamedParamsDefault;
 import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
 import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
@@ -791,7 +791,7 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
                 // amounts of rows.
                 //
                 Boolean batchingRowSet =
-                  ValueMeta.convertStringToBoolean( System.getProperty( Const.KETTLE_BATCHING_ROWSET ) );
+                  ValueMetaBoolean.convertStringToBoolean( System.getProperty( Const.KETTLE_BATCHING_ROWSET ) );
                 if ( batchingRowSet != null && batchingRowSet.booleanValue() ) {
                   rowSet = new BlockingBatchingRowSet( transMeta.getSizeRowset() );
                 } else {
@@ -4454,7 +4454,7 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     if ( !Const.isEmpty( variableName ) ) {
       String value = environmentSubstitute( variableName );
       if ( !Const.isEmpty( value ) ) {
-        return ValueMeta.convertStringToBoolean( value );
+        return ValueMetaBoolean.convertStringToBoolean( value );
       }
     }
     return defaultValue;

--- a/engine/src/org/pentaho/di/trans/step/BaseStep.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStep.java
@@ -59,8 +59,11 @@ import org.pentaho.di.core.logging.LoggingObjectType;
 import org.pentaho.di.core.row.RowDataUtil;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.i18n.BaseMessages;
@@ -3048,46 +3051,46 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
     Object[] data = new Object[9];
     int nr = 0;
 
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.Stepname" ), ValueMetaInterface.TYPE_STRING ) );
+    r.addValueMeta( new ValueMetaString(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.Stepname" ) ) );
     data[nr] = sname;
     nr++;
 
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.Copy" ), ValueMetaInterface.TYPE_NUMBER ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.Copy" ) ) );
     data[nr] = new Double( copynr );
     nr++;
 
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesReaded" ), ValueMetaInterface.TYPE_NUMBER ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesReaded" ) ) );
     data[nr] = new Double( lines_read );
     nr++;
 
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesWritten" ), ValueMetaInterface.TYPE_NUMBER ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesWritten" ) ) );
     data[nr] = new Double( lines_written );
     nr++;
 
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesUpdated" ), ValueMetaInterface.TYPE_NUMBER ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesUpdated" ) ) );
     data[nr] = new Double( lines_updated );
     nr++;
 
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesSkipped" ), ValueMetaInterface.TYPE_NUMBER ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesSkipped" ) ) );
     data[nr] = new Double( lines_skipped );
     nr++;
 
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.Errors" ), ValueMetaInterface.TYPE_NUMBER ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.Errors" ) ) );
     data[nr] = new Double( errors );
     nr++;
 
-    r.addValueMeta( new ValueMeta( "start_date", ValueMetaInterface.TYPE_DATE ) );
+    r.addValueMeta( new ValueMetaDate( "start_date" ) );
     data[nr] = start_date;
     nr++;
 
-    r.addValueMeta( new ValueMeta( "end_date", ValueMetaInterface.TYPE_DATE ) );
+    r.addValueMeta( new ValueMetaDate( "end_date" ) );
     data[nr] = end_date;
     nr++;
 
@@ -3104,27 +3107,27 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
   public static final RowMetaInterface getLogFields( String comm ) {
     RowMetaInterface r = new RowMeta();
     ValueMetaInterface sname =
-      new ValueMeta(
-        BaseMessages.getString( PKG, "BaseStep.ColumnName.Stepname" ), ValueMetaInterface.TYPE_STRING );
+      new ValueMetaString(
+        BaseMessages.getString( PKG, "BaseStep.ColumnName.Stepname" ) );
     sname.setLength( 256 );
     r.addValueMeta( sname );
 
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.Copy" ), ValueMetaInterface.TYPE_NUMBER ) );
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesReaded" ), ValueMetaInterface.TYPE_NUMBER ) );
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesWritten" ), ValueMetaInterface.TYPE_NUMBER ) );
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesUpdated" ), ValueMetaInterface.TYPE_NUMBER ) );
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesSkipped" ), ValueMetaInterface.TYPE_NUMBER ) );
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.Errors" ), ValueMetaInterface.TYPE_NUMBER ) );
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.StartDate" ), ValueMetaInterface.TYPE_DATE ) );
-    r.addValueMeta( new ValueMeta(
-      BaseMessages.getString( PKG, "BaseStep.ColumnName.EndDate" ), ValueMetaInterface.TYPE_DATE ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.Copy" ) ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesReaded" ) ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesWritten" ) ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesUpdated" ) ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesSkipped" ) ) );
+    r.addValueMeta( new ValueMetaNumber(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.Errors" ) ) );
+    r.addValueMeta( new ValueMetaDate(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.StartDate" ) ) );
+    r.addValueMeta( new ValueMetaDate(
+      BaseMessages.getString( PKG, "BaseStep.ColumnName.EndDate" ) ) );
 
     for ( int i = 0; i < r.size(); i++ ) {
       r.getValueMeta( i ).setOrigin( comm );
@@ -3601,7 +3604,7 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
     if ( !Const.isEmpty( variableName ) ) {
       String value = environmentSubstitute( variableName );
       if ( !Const.isEmpty( value ) ) {
-        return ValueMeta.convertStringToBoolean( value );
+        return ValueMetaBoolean.convertStringToBoolean( value );
       }
     }
     return defaultValue;

--- a/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
@@ -46,7 +46,7 @@ import org.pentaho.di.core.logging.LoggingObjectType;
 import org.pentaho.di.core.logging.SimpleLoggingObject;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaFactory;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -910,7 +910,7 @@ public class BaseStepMeta implements Cloneable, StepAttributesInterface {
           String repCode = XMLHandler.getTagValue( node, "repcode" );
           String description = XMLHandler.getTagValue( node, "description" );
           String tooltip = XMLHandler.getTagValue( node, "tooltip" );
-          int valueType = ValueMeta.getType( XMLHandler.getTagValue( node, "valuetype" ) );
+          int valueType = ValueMetaFactory.getIdForValueMeta( XMLHandler.getTagValue( node, "valuetype" ) );
           String parentId = XMLHandler.getTagValue( node, "parentid" );
 
           KettleAttribute attribute =

--- a/engine/src/org/pentaho/di/trans/step/StepErrorMeta.java
+++ b/engine/src/org/pentaho/di/trans/step/StepErrorMeta.java
@@ -28,8 +28,9 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.changed.ChangedFlag;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.core.xml.XMLInterface;
@@ -296,23 +297,23 @@ public class StepErrorMeta extends ChangedFlag implements XMLInterface, Cloneabl
 
     String nrErr = variables.environmentSubstitute( getNrErrorsValuename() );
     if ( !Const.isEmpty( nrErr ) ) {
-      ValueMetaInterface v = new ValueMeta( nrErr, ValueMetaInterface.TYPE_INTEGER );
+      ValueMetaInterface v = new ValueMetaInteger( nrErr );
       v.setLength( 3 );
       row.addValueMeta( v );
     }
     String errDesc = variables.environmentSubstitute( getErrorDescriptionsValuename() );
     if ( !Const.isEmpty( errDesc ) ) {
-      ValueMetaInterface v = new ValueMeta( errDesc, ValueMetaInterface.TYPE_STRING );
+      ValueMetaInterface v = new ValueMetaString( errDesc );
       row.addValueMeta( v );
     }
     String errFields = variables.environmentSubstitute( getErrorFieldsValuename() );
     if ( !Const.isEmpty( errFields ) ) {
-      ValueMetaInterface v = new ValueMeta( errFields, ValueMetaInterface.TYPE_STRING );
+      ValueMetaInterface v = new ValueMetaString( errFields );
       row.addValueMeta( v );
     }
     String errCodes = variables.environmentSubstitute( getErrorCodesValuename() );
     if ( !Const.isEmpty( errCodes ) ) {
-      ValueMetaInterface v = new ValueMeta( errCodes, ValueMetaInterface.TYPE_STRING );
+      ValueMetaInterface v = new ValueMetaString( errCodes );
       row.addValueMeta( v );
     }
 

--- a/engine/src/org/pentaho/di/trans/step/StepInjectionMetaEntry.java
+++ b/engine/src/org/pentaho/di/trans/step/StepInjectionMetaEntry.java
@@ -25,7 +25,7 @@ package org.pentaho.di.trans.step;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.value.ValueMetaFactory;
 
 /**
  * This is a single metadata attribute for step metadata injection.
@@ -59,7 +59,7 @@ public class StepInjectionMetaEntry implements Cloneable {
   @Override
   public String toString() {
     return "{"
-      + key + ":" + ValueMeta.getTypeDesc( valueType ) + ( value == null ? "" : "(" + value.toString() + ")" )
+      + key + ":" + ValueMetaFactory.getValueMetaName( valueType ) + ( value == null ? "" : "(" + value.toString() + ")" )
       + "}";
   }
 

--- a/engine/src/org/pentaho/di/trans/steps/getvariable/GetVariableMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/getvariable/GetVariableMeta.java
@@ -29,12 +29,14 @@ import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaFactory;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -208,7 +210,12 @@ public class GetVariableMeta extends BaseStepMeta implements StepMetaInterface {
 
     RowMetaInterface row = new RowMeta();
     for ( int i = 0; i < fieldName.length; i++ ) {
-      ValueMetaInterface v = new ValueMeta( fieldName[i], fieldType[i] );
+      ValueMetaInterface v;
+      try {
+        v = ValueMetaFactory.createValueMeta( fieldName[i], fieldType[i] );
+      } catch ( KettlePluginException e ) {
+        throw new KettleStepException( e );
+      }
       if ( fieldLength[i] < 0 ) {
         v.setLength( length );
       } else {

--- a/engine/test-src/org/pentaho/di/core/reflection/StringSearchResultTest.java
+++ b/engine/test-src/org/pentaho/di/core/reflection/StringSearchResultTest.java
@@ -1,0 +1,52 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.reflection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.i18n.BaseMessages;
+
+public class StringSearchResultTest {
+
+  private static Class<?> PKG = Const.class;
+
+  @Test
+  public void testgetResultRowMeta() {
+    RowMetaInterface rm = StringSearchResult.getResultRowMeta();
+    assertNotNull( rm );
+    assertEquals( 4, rm.getValueMetaList().size() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 0 ).getType() );
+    assertEquals( BaseMessages.getString( PKG, "SearchResult.TransOrJob" ), rm.getValueMeta( 0 ).getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 1 ).getType() );
+    assertEquals( BaseMessages.getString( PKG, "SearchResult.StepDatabaseNotice" ), rm.getValueMeta( 1 ).getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 2 ).getType() );
+    assertEquals( BaseMessages.getString( PKG, "SearchResult.String" ), rm.getValueMeta( 2 ).getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( 3 ).getType() );
+    assertEquals( BaseMessages.getString( PKG, "SearchResult.FieldName" ), rm.getValueMeta( 3 ).getName() );
+  }
+}

--- a/engine/test-src/org/pentaho/di/repository/RepositoryExporterTest.java
+++ b/engine/test-src/org/pentaho/di/repository/RepositoryExporterTest.java
@@ -117,7 +117,7 @@ public class RepositoryExporterTest {
     Mockito.when(
       repository.loadTransformation( Mockito.anyString(), Mockito.any( RepositoryDirectoryInterface.class ), Mockito
         .any( ProgressMonitorListener.class ), Mockito.anyBoolean(), Mockito.anyString() ) ).thenAnswer(
-      transLoader );
+          transLoader );
 
     // export file
     xmlFileName = TestUtils.createRamFile( getClass().getSimpleName() + "/export.xml" );

--- a/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepositoryTest.java
+++ b/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepositoryTest.java
@@ -1,0 +1,319 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository.kdr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.di.cluster.ClusterSchema;
+import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.repository.LongObjectId;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.UserInfo;
+import org.pentaho.di.repository.kdr.delegates.KettleDatabaseRepositoryConnectionDelegate;
+
+public class KettleDatabaseRepositoryTest {
+
+  KettleDatabaseRepository repo;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws KettleException {
+    KettleEnvironment.init();
+  }
+
+  @Before
+  public void setUp() {
+    repo = spy( new KettleDatabaseRepository() );
+    repo.setRepositoryMeta( new KettleDatabaseRepositoryMeta( "myId", "myName", "myDescription", new DatabaseMeta() ) );
+    repo.connectionDelegate = spy( new KettleDatabaseRepositoryConnectionDelegate( repo, new DatabaseMeta() ) );
+  }
+
+  @Test
+  public void testInsertLogEntry() throws KettleException {
+    doReturn( new LongObjectId( 123 ) ).when( repo.connectionDelegate ).getNextLogID();
+    doReturn( "2.4" ).when( repo.connectionDelegate ).getVersion();
+    doReturn( new UserInfo( "John Doe" ) ).when( repo ).getUserInfo();
+
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+
+    Date beforeLogEntryDate = Calendar.getInstance().getTime();
+    repo.insertLogEntry( "testDescription" );
+    Date afterLogEntryDate = Calendar.getInstance().getTime();
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_REPOSITORY_LOG, argumentTableName.getValue() );
+    assertEquals( 5, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_ID_REPOSITORY_LOG, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 123 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_REP_VERSION, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( "2.4", insertRecord.getString( 1, null ) );
+    assertEquals( ValueMetaInterface.TYPE_DATE, insertRecord.getValueMeta( 2 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_DATE, insertRecord.getValueMeta( 2 ).getName() );
+    assertTrue( beforeLogEntryDate.compareTo( insertRecord.getDate( 2, new Date( Long.MIN_VALUE ) ) ) <= 0
+      && afterLogEntryDate.compareTo( insertRecord.getDate( 2, new Date( Long.MIN_VALUE ) ) ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, insertRecord.getValueMeta( 3 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_LOG_USER, insertRecord.getValueMeta( 3 ).getName() );
+    assertEquals( "John Doe", insertRecord.getString( 3, null ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, insertRecord.getValueMeta( 4 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_REPOSITORY_LOG_OPERATION_DESC, insertRecord.getValueMeta( 4 ).getName() );
+    assertEquals( "testDescription", insertRecord.getString( 4, null ) );
+  }
+
+  @Test
+  public void testInsertTransNote() throws KettleException {
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+
+    repo.insertTransNote( new LongObjectId( 456 ), new LongObjectId( 789 ) );
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_TRANS_NOTE, argumentTableName.getValue() );
+    assertEquals( 2, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_NOTE_ID_TRANSFORMATION, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 456 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_NOTE_ID_NOTE, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( Long.valueOf( 789 ), insertRecord.getInteger( 1 ) );
+  }
+
+  @Test
+  public void testInsertJobNote() throws KettleException {
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+
+    repo.insertJobNote( new LongObjectId( 234 ), new LongObjectId( 567 ) );
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_JOB_NOTE, argumentTableName.getValue() );
+    assertEquals( 2, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_JOB_NOTE_ID_JOB, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 234 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_JOB_NOTE_ID_NOTE, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( Long.valueOf( 567 ), insertRecord.getInteger( 1 ) );
+  }
+
+  private RowMetaAndData getNullIntegerRow() {
+    RowMeta rm = new RowMeta();
+    rm.addValueMeta( new ValueMetaInteger() );
+    return new RowMetaAndData( rm, new Object[]{ null } );
+  }
+
+  @Test
+  public void testInsertStepDatabase() throws KettleException {
+    doReturn( getNullIntegerRow() ).when( repo.connectionDelegate ).getOneRow(
+      anyString(), anyString(), any( ObjectId.class ) );
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+
+    repo.insertStepDatabase( new LongObjectId( 654 ), new LongObjectId( 765 ), new LongObjectId( 876 ) );
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_STEP_DATABASE, argumentTableName.getValue() );
+    assertEquals( 3, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_STEP_DATABASE_ID_TRANSFORMATION, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 654 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_STEP_DATABASE_ID_STEP, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( Long.valueOf( 765 ), insertRecord.getInteger( 1 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 2 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_STEP_DATABASE_ID_DATABASE, insertRecord.getValueMeta( 2 ).getName() );
+    assertEquals( Long.valueOf( 876 ), insertRecord.getInteger( 2 ) );
+  }
+
+  @Test
+  public void testInsertJobEntryDatabase() throws KettleException {
+    doReturn( getNullIntegerRow() ).when( repo.connectionDelegate ).getOneRow(
+      anyString(), anyString(), any( ObjectId.class ) );
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+
+    repo.insertJobEntryDatabase( new LongObjectId( 234 ), new LongObjectId( 345 ), new LongObjectId( 456 ) );
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_JOBENTRY_DATABASE, argumentTableName.getValue() );
+    assertEquals( 3, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_JOBENTRY_DATABASE_ID_JOB, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 234 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_JOBENTRY_DATABASE_ID_JOBENTRY, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( Long.valueOf( 345 ), insertRecord.getInteger( 1 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 2 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_JOBENTRY_DATABASE_ID_DATABASE, insertRecord.getValueMeta( 2 ).getName() );
+    assertEquals( Long.valueOf( 456 ), insertRecord.getInteger( 2 ) );
+  }
+
+  @Test
+  public void testInsertTransformationPartitionSchema() throws KettleException {
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+    doReturn( new LongObjectId( 456 ) ).when( repo.connectionDelegate ).getNextTransformationPartitionSchemaID();
+
+    ObjectId result = repo.insertTransformationPartitionSchema( new LongObjectId( 147 ), new LongObjectId( 258 ) );
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_TRANS_PARTITION_SCHEMA, argumentTableName.getValue() );
+    assertEquals( 3, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_PARTITION_SCHEMA_ID_TRANS_PARTITION_SCHEMA, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 456 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_PARTITION_SCHEMA_ID_TRANSFORMATION, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( Long.valueOf( 147 ), insertRecord.getInteger( 1 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 2 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_PARTITION_SCHEMA_ID_PARTITION_SCHEMA, insertRecord.getValueMeta( 2 ).getName() );
+    assertEquals( Long.valueOf( 258 ), insertRecord.getInteger( 2 ) );
+    assertEquals( new LongObjectId( 456 ), result );
+  }
+
+  @Test
+  public void testInsertClusterSlave() throws KettleException {
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+    doReturn( new LongObjectId( 357 ) ).when( repo.connectionDelegate ).getNextClusterSlaveID();
+
+    SlaveServer testSlave = new SlaveServer( "slave1", "fakelocal", "9081", "fakeuser", "fakepass" );
+    testSlave.setObjectId( new LongObjectId( 864 ) );
+    ClusterSchema testSchema = new ClusterSchema( "schema1", Arrays.asList( testSlave ) );
+    testSchema.setObjectId( new LongObjectId( 159 ) );
+    ObjectId result = repo.insertClusterSlave( testSchema, testSlave );
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_CLUSTER_SLAVE, argumentTableName.getValue() );
+    assertEquals( 3, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_CLUSTER_SLAVE_ID_CLUSTER_SLAVE, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 357 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_CLUSTER_SLAVE_ID_CLUSTER, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( Long.valueOf( 159 ), insertRecord.getInteger( 1 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 2 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_CLUSTER_SLAVE_ID_SLAVE, insertRecord.getValueMeta( 2 ).getName() );
+    assertEquals( Long.valueOf( 864 ), insertRecord.getInteger( 2 ) );
+    assertEquals( new LongObjectId( 357 ), result );
+  }
+
+  @Test
+  public void testInsertTransformationCluster() throws KettleException {
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+    doReturn( new LongObjectId( 123 ) ).when( repo.connectionDelegate ).getNextTransformationClusterID();
+
+    ObjectId result = repo.insertTransformationCluster( new LongObjectId( 456 ), new LongObjectId( 789 ) );
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_TRANS_CLUSTER, argumentTableName.getValue() );
+    assertEquals( 3, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_CLUSTER_ID_TRANS_CLUSTER, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 123 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_CLUSTER_ID_TRANSFORMATION, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( Long.valueOf( 456 ), insertRecord.getInteger( 1 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 2 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_CLUSTER_ID_CLUSTER, insertRecord.getValueMeta( 2 ).getName() );
+    assertEquals( Long.valueOf( 789 ), insertRecord.getInteger( 2 ) );
+    assertEquals( new LongObjectId( 123 ), result );
+  }
+
+  @Test
+  public void testInsertTransformationSlave() throws KettleException {
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+    doReturn( new LongObjectId( 789 ) ).when( repo.connectionDelegate ).getNextTransformationSlaveID();
+
+    ObjectId result = repo.insertTransformationSlave( new LongObjectId( 456 ), new LongObjectId( 123 ) );
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_TRANS_SLAVE, argumentTableName.getValue() );
+    assertEquals( 3, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_SLAVE_ID_TRANS_SLAVE, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 789 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_SLAVE_ID_TRANSFORMATION, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( Long.valueOf( 456 ), insertRecord.getInteger( 1 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 2 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_SLAVE_ID_SLAVE, insertRecord.getValueMeta( 2 ).getName() );
+    assertEquals( Long.valueOf( 123 ), insertRecord.getInteger( 2 ) );
+    assertEquals( new LongObjectId( 789 ), result );
+  }
+
+  @Test
+  public void testInsertTransStepCondition() throws KettleException {
+    ArgumentCaptor<String> argumentTableName = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<RowMetaAndData> argumentTableData = ArgumentCaptor.forClass( RowMetaAndData.class );
+    doNothing().when( repo.connectionDelegate ).insertTableRow( argumentTableName.capture(), argumentTableData.capture() );
+
+    repo.insertTransStepCondition( new LongObjectId( 234 ), new LongObjectId( 567 ), new LongObjectId( 468 ) );
+
+    RowMetaAndData insertRecord = argumentTableData.getValue();
+    assertEquals( KettleDatabaseRepository.TABLE_R_TRANS_STEP_CONDITION, argumentTableName.getValue() );
+    assertEquals( 3, insertRecord.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 0 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_STEP_CONDITION_ID_TRANSFORMATION, insertRecord.getValueMeta( 0 ).getName() );
+    assertEquals( Long.valueOf( 234 ), insertRecord.getInteger( 0 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 1 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_STEP_CONDITION_ID_STEP, insertRecord.getValueMeta( 1 ).getName() );
+    assertEquals( Long.valueOf( 567 ), insertRecord.getInteger( 1 ) );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, insertRecord.getValueMeta( 2 ).getType() );
+    assertEquals( KettleDatabaseRepository.FIELD_TRANS_STEP_CONDITION_ID_CONDITION, insertRecord.getValueMeta( 2 ).getName() );
+    assertEquals( Long.valueOf( 468 ), insertRecord.getInteger( 2 ) );
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/DatabaseImpactTest.java
+++ b/engine/test-src/org/pentaho/di/trans/DatabaseImpactTest.java
@@ -1,0 +1,77 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.i18n.BaseMessages;
+
+public class DatabaseImpactTest {
+
+  private static Class<?> PKG = Trans.class;
+
+  @Test
+  public void testGetRow() throws KettleValueException {
+    DatabaseImpact testObject = new DatabaseImpact( DatabaseImpact.TYPE_IMPACT_READ, "myTrans", "aStep", "ProdDB",
+      "DimCustomer", "Customer_Key", "MyValue", "Calculator 2", "SELECT * FROM dimCustomer", "Some remarks" );
+    RowMetaAndData rmd = testObject.getRow();
+
+    assertNotNull( rmd );
+    assertEquals( 10, rmd.size() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 0 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Type" ), rmd.getValueMeta( 0 ).getName() );
+    assertEquals( "Read", rmd.getString( 0, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 1 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Transformation" ), rmd.getValueMeta( 1 ).getName() );
+    assertEquals( "myTrans", rmd.getString( 1, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 2 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Step" ), rmd.getValueMeta( 2 ).getName() );
+    assertEquals( "aStep", rmd.getString( 2, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 3 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Database" ), rmd.getValueMeta( 3 ).getName() );
+    assertEquals( "ProdDB", rmd.getString( 3, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 4 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Table" ), rmd.getValueMeta( 4 ).getName() );
+    assertEquals( "DimCustomer", rmd.getString( 4, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 5 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Field" ), rmd.getValueMeta( 5 ).getName() );
+    assertEquals( "Customer_Key", rmd.getString( 5, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 6 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Value" ), rmd.getValueMeta( 6 ).getName() );
+    assertEquals( "MyValue", rmd.getString( 6, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 7 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.ValueOrigin" ), rmd.getValueMeta( 7 ).getName() );
+    assertEquals( "Calculator 2", rmd.getString( 7, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 8 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.SQL" ), rmd.getValueMeta( 8 ).getName() );
+    assertEquals( "SELECT * FROM dimCustomer", rmd.getString( 8, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rmd.getValueMeta( 9 ).getType() );
+    assertEquals(BaseMessages.getString( PKG, "DatabaseImpact.RowDesc.Label.Remarks" ), rmd.getValueMeta( 9 ).getName() );
+    assertEquals( "Some remarks", rmd.getString( 9, "default" ) );
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/step/BaseStepTest.java
+++ b/engine/test-src/org/pentaho/di/trans/step/BaseStepTest.java
@@ -28,6 +28,8 @@ import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,9 +41,11 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.BlockingRowSet;
 import org.pentaho.di.core.ResultFile;
+import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.SingleRowRowSet;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.fileinput.NonAccessibleFileObject;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
@@ -275,5 +279,37 @@ public class BaseStepTest {
     }
     // whereas instances differ
     assertFalse( meta1 == meta2 );
+  }
+
+  @Test
+  public void testBuildLog() throws KettleValueException {
+    when( mockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+        mockHelper.logChannelInterface );
+    BaseStep testObject = new BaseStep( mockHelper.stepMeta, mockHelper.stepDataInterface, 0, mockHelper.transMeta,
+      mockHelper.trans);
+    Date startDate = new Date( (long) 123 );
+    Date endDate = new Date( (long) 125 );
+    RowMetaAndData result = testObject.buildLog( "myStepName", 13, 123, 234, 345, 456, 567, startDate, endDate );
+
+    assertNotNull( result );
+    assertEquals( 9, result.size() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta( 0 ).getType() );
+    assertEquals( "myStepName", result.getString( 0, "default" ) );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta( 1 ).getType() );
+    assertEquals( new Double( 13.0 ), Double.valueOf( result.getNumber( 1, 0.1 ) ) );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta( 2 ).getType() );
+    assertEquals( new Double( 123 ), Double.valueOf( result.getNumber( 2, 0.1 ) ) );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta( 3 ).getType() );
+    assertEquals( new Double( 234 ), Double.valueOf( result.getNumber( 3, 0.1 ) ) );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta( 4 ).getType() );
+    assertEquals( new Double( 345 ), Double.valueOf( result.getNumber( 4, 0.1 ) ) );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta( 5 ).getType() );
+    assertEquals( new Double( 456 ), Double.valueOf( result.getNumber( 5, 0.1 ) ) );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta( 6 ).getType() );
+    assertEquals( new Double( 567 ), Double.valueOf( result.getNumber( 6, 0.1 ) ) );
+    assertEquals( ValueMetaInterface.TYPE_DATE, result.getValueMeta( 7 ).getType() );
+    assertEquals( startDate, result.getDate( 7, Calendar.getInstance().getTime() ) );
+    assertEquals( ValueMetaInterface.TYPE_DATE, result.getValueMeta( 8 ).getType() );
+    assertEquals( endDate, result.getDate( 8, Calendar.getInstance().getTime() ) );
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/step/StepErrorMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/step/StepErrorMetaTest.java
@@ -1,0 +1,58 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.step;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.variables.Variables;
+
+public class StepErrorMetaTest {
+
+  @Test
+  public void testGetErrorRowMeta() {
+    VariableSpace vars = new Variables();
+    vars.setVariable( "VarNumberErrors", "nbrErrors" );
+    vars.setVariable( "VarErrorDescription", "errorDescription" );
+    vars.setVariable( "VarErrorFields", "errorFields" );
+    vars.setVariable( "VarErrorCodes", "errorCodes" );
+    StepErrorMeta testObject = new StepErrorMeta( vars, new StepMeta(), new StepMeta(),
+      "${VarNumberErrors}", "${VarErrorDescription}", "${VarErrorFields}", "${VarErrorCodes}" );
+    RowMetaInterface result = testObject.getErrorRowMeta( 10, "some data was bad", "factId", "BAD131" );
+
+    assertNotNull( result );
+    assertEquals( 4, result.size() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, result.getValueMeta( 0 ).getType() );
+    assertEquals( "nbrErrors", result.getValueMeta( 0 ).getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta( 1 ).getType() );
+    assertEquals( "errorDescription", result.getValueMeta( 1 ).getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta( 2 ).getType() );
+    assertEquals( "errorFields", result.getValueMeta( 2 ).getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta( 3 ).getType() );
+    assertEquals( "errorCodes", result.getValueMeta( 3 ).getName() );
+  }
+}

--- a/ui/src/org/pentaho/di/ui/core/dialog/EnterStringsDialog.java
+++ b/ui/src/org/pentaho/di/ui/core/dialog/EnterStringsDialog.java
@@ -40,8 +40,8 @@ import org.eclipse.swt.widgets.TableItem;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleValueException;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.PropsUI;
@@ -254,7 +254,7 @@ public class EnterStringsDialog extends Dialog {
         TableItem item = wFields.getNonEmpty( i );
         String name = item.getText( 1 );
         String value = item.getText( 2 );
-        strings.addValue( new ValueMeta( name, ValueMetaInterface.TYPE_STRING ), value );
+        strings.addValue( new ValueMetaString( name ), value );
       }
     }
     dispose();

--- a/ui/src/org/pentaho/di/ui/core/dialog/EnterValueDialog.java
+++ b/ui/src/org/pentaho/di/ui/core/dialog/EnterValueDialog.java
@@ -48,6 +48,7 @@ import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaAndData;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaFactory;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.PropsUI;
 import org.pentaho.di.ui.core.gui.GUIResource;
@@ -430,7 +431,7 @@ public class EnterValueDialog extends Dialog {
       valueMeta.setPrecision( Const.toInt( wPrecision.getText(), -1 ) );
       val.setValueMeta( valueMeta );
 
-      ValueMetaInterface stringValueMeta = new ValueMeta( valuename, ValueMetaInterface.TYPE_STRING );
+      ValueMetaInterface stringValueMeta = new ValueMetaString( valuename );
       stringValueMeta.setConversionMetadata( valueMeta );
 
       Object targetData = stringValueMeta.convertDataUsingConversionMetaData( valueData );

--- a/ui/src/org/pentaho/di/ui/core/dialog/PreviewRowsDialog.java
+++ b/ui/src/org/pentaho/di/ui/core/dialog/PreviewRowsDialog.java
@@ -45,8 +45,8 @@ import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.PropsUI;
@@ -282,7 +282,7 @@ public class PreviewRowsDialog {
 
     if ( dynamic && rowMeta == null ) {
       rowMeta = new RowMeta();
-      rowMeta.addValueMeta( new ValueMeta( "<waiting for rows>", ValueMetaInterface.TYPE_STRING ) );
+      rowMeta.addValueMeta( new ValueMetaString( "<waiting for rows>" ) );
       waitingForRows = true;
     }
     if ( !dynamic ) {

--- a/ui/src/org/pentaho/di/ui/core/widget/ColumnInfo.java
+++ b/ui/src/org/pentaho/di/ui/core/widget/ColumnInfo.java
@@ -26,6 +26,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionListener;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 
 /**
  * Used to define the behaviour and the content of a Table column in a TableView object.
@@ -86,7 +88,7 @@ public class ColumnInfo {
     allignement = SWT.LEFT;
     readonly = false;
     hide_negative = false;
-    valueMeta = new ValueMeta( colname, ValueMetaInterface.TYPE_STRING );
+    valueMeta = new ValueMetaString( colname );
   }
 
   /**
@@ -108,7 +110,7 @@ public class ColumnInfo {
     allignement = SWT.LEFT;
     readonly = false;
     hide_negative = false;
-    valueMeta = new ValueMeta( colname, ValueMetaInterface.TYPE_STRING );
+    valueMeta = new ValueMetaString( colname );
   }
 
   /**
@@ -131,9 +133,9 @@ public class ColumnInfo {
     this.readonly = false;
     this.hide_negative = false;
     if ( numeric ) {
-      valueMeta = new ValueMeta( colname, ValueMetaInterface.TYPE_INTEGER );
+      valueMeta = new ValueMetaInteger( colname );
     } else {
-      valueMeta = new ValueMeta( colname, ValueMetaInterface.TYPE_STRING );
+      valueMeta = new ValueMetaString( colname );
     }
   }
 

--- a/ui/src/org/pentaho/di/ui/core/widget/ConditionEditor.java
+++ b/ui/src/org/pentaho/di/ui/core/widget/ConditionEditor.java
@@ -59,6 +59,7 @@ import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaAndData;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaFactory;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.dialog.EnterSelectionDialog;
@@ -395,7 +396,7 @@ public class ConditionEditor extends Composite {
                       new ErrorDialog( shell, "Error", "Error creating value meta object", exception );
                     }
                   } else {
-                    v = new ValueMetaAndData( new ValueMeta( "constant", ValueMetaInterface.TYPE_STRING ), null );
+                    v = new ValueMetaAndData( new ValueMetaString( "constant" ), null );
                   }
                 }
                 EnterValueDialog evd = new EnterValueDialog( shell, SWT.NONE, v.getValueMeta(), v.getValueData() );

--- a/ui/src/org/pentaho/di/ui/core/widget/TableView.java
+++ b/ui/src/org/pentaho/di/ui/core/widget/TableView.java
@@ -92,6 +92,8 @@ import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.undo.TransAction;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.i18n.BaseMessages;
@@ -215,7 +217,7 @@ public class TableView extends Composite {
     clearUndo();
 
     numberColumn = new ColumnInfo( "#", ColumnInfo.COLUMN_TYPE_TEXT, true, true );
-    ValueMetaInterface numberColumnValueMeta = new ValueMeta( "#", ValueMetaInterface.TYPE_INTEGER );
+    ValueMetaInterface numberColumnValueMeta = new ValueMetaInteger( "#" );
     numberColumnValueMeta.setConversionMask( "####0" );
     numberColumn.setValueMeta( numberColumnValueMeta );
 
@@ -1230,8 +1232,8 @@ public class TableView extends Composite {
       final RowMetaInterface rowMeta = new RowMeta();
 
       // First values are the color name + value!
-      rowMeta.addValueMeta( new ValueMeta( "colorname", ValueMetaInterface.TYPE_STRING ) );
-      rowMeta.addValueMeta( new ValueMeta( "color", ValueMetaInterface.TYPE_INTEGER ) );
+      rowMeta.addValueMeta( new ValueMetaString( "colorname" ) );
+      rowMeta.addValueMeta( new ValueMetaInteger( "color" ) );
       for ( int j = 0; j < table.getColumnCount(); j++ ) {
         ColumnInfo colInfo;
         if ( j > 0 ) {
@@ -2830,9 +2832,9 @@ public class TableView extends Composite {
 
   public RowMetaInterface getRowWithoutValues() {
     RowMetaInterface f = new RowMeta();
-    f.addValueMeta( new ValueMeta( "#", ValueMetaInterface.TYPE_INTEGER ) );
+    f.addValueMeta( new ValueMetaInteger( "#" ) );
     for ( int i = 0; i < columns.length; i++ ) {
-      f.addValueMeta( new ValueMeta( columns[i].getName(), ValueMetaInterface.TYPE_STRING ) );
+      f.addValueMeta( new ValueMetaString( columns[i].getName() ) );
     }
     return f;
   }

--- a/ui/src/org/pentaho/di/ui/spoon/job/JobHistoryDelegate.java
+++ b/ui/src/org/pentaho/di/ui/spoon/job/JobHistoryDelegate.java
@@ -58,6 +58,7 @@ import org.pentaho.di.core.logging.LogTableInterface;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryCopy;
@@ -519,7 +520,7 @@ public class JobHistoryDelegate extends SpoonDelegate implements XulEventHandler
             .append( " WHERE " ).append( logConnection.quoteField( nameField.getFieldName() ) ).append(
               " LIKE ?" );
           params
-            .addValue( new ValueMeta( "transname_literal", ValueMetaInterface.TYPE_STRING ), jobMeta.getName() );
+            .addValue( new ValueMetaString( "transname_literal" ), jobMeta.getName() );
         }
 
         if ( keyField != null && keyField.isEnabled() ) {

--- a/ui/src/org/pentaho/di/ui/spoon/trans/TransHistoryDelegate.java
+++ b/ui/src/org/pentaho/di/ui/spoon/trans/TransHistoryDelegate.java
@@ -57,6 +57,7 @@ import org.pentaho.di.core.logging.LogTableField;
 import org.pentaho.di.core.logging.LogTableInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.TransMeta;
@@ -406,14 +407,14 @@ public class TransHistoryDelegate extends SpoonDelegate implements XulEventHandl
         if ( nameField != null ) {
           if ( transMeta.isUsingAClusterSchema() ) {
             sql.append( " WHERE " ).append( logConnection.quoteField( nameField.getFieldName() ) ).append( " LIKE ?" );
-            params.addValue( new ValueMeta( "transname_literal", ValueMetaInterface.TYPE_STRING ), transMeta.getName() );
+            params.addValue( new ValueMetaString( "transname_literal" ), transMeta.getName() );
 
             sql.append( " OR    " ).append( logConnection.quoteField( nameField.getFieldName() ) ).append( " LIKE ?" );
-            params.addValue( new ValueMeta( "transname_cluster", ValueMetaInterface.TYPE_STRING ), transMeta.getName()
+            params.addValue( new ValueMetaString( "transname_cluster" ), transMeta.getName()
               + " (%" );
           } else {
             sql.append( " WHERE " ).append( logConnection.quoteField( nameField.getFieldName() ) ).append( " = ?" );
-            params.addValue( new ValueMeta( "transname_literal", ValueMetaInterface.TYPE_STRING ), transMeta.getName() );
+            params.addValue( new ValueMetaString( "transname_literal" ), transMeta.getName() );
           }
         }
 

--- a/ui/src/org/pentaho/di/ui/trans/steps/getxmldata/XMLInputFieldsImportProgressDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/getxmldata/XMLInputFieldsImportProgressDialog.java
@@ -43,6 +43,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.pentaho.di.compatibility.Value;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.steps.getxmldata.GetXMLDataField;
@@ -241,7 +242,7 @@ public class XMLInputFieldsImportProgressDialog {
   }
 
   @SuppressWarnings( "unchecked" )
-  private void setNodeField( Node node, IProgressMonitor monitor ) {
+  private void setNodeField( Node node, IProgressMonitor monitor ) throws KettleValueException {
     Element e = (Element) node;
     // get all attributes
     List<Attribute> lista = e.attributes();
@@ -290,7 +291,7 @@ public class XMLInputFieldsImportProgressDialog {
     } // end if
   }
 
-  private void setAttributeField( Attribute attribute, IProgressMonitor monitor ) {
+  private void setAttributeField( Attribute attribute, IProgressMonitor monitor ) throws KettleValueException {
     // Get Attribute Name
     String attributname = attribute.getName();
     String attributnametxt = cleanString( attribute.getPath() );
@@ -370,7 +371,7 @@ public class XMLInputFieldsImportProgressDialog {
     return true;
   }
 
-  private boolean childNode( Node node, IProgressMonitor monitor ) {
+  private boolean childNode( Node node, IProgressMonitor monitor ) throws KettleValueException {
     boolean rc = false; // true: we found child nodes
     Element ce = (Element) node;
     // List child


### PR DESCRIPTION
Mark the ValueMeta class as deprecated, in favor of ValueMetaBase and ValueMetaFactory, allowing pluggable types to be available and used consistently across steps and job entries.