### PR TITLE
[BISERVER-11151] - Cannot import csv fields if they are in the format…

### DIFF
--- a/core/src/org/pentaho/di/core/util/StringEvaluator.java
+++ b/core/src/org/pentaho/di/core/util/StringEvaluator.java
@@ -44,7 +44,6 @@ import org.pentaho.di.core.row.ValueMetaInterface;
  * completed.
  *
  * @author matt
- *
  */
 public class StringEvaluator {
 
@@ -63,6 +62,8 @@ public class StringEvaluator {
   private static final String[] DEFAULT_NUMBER_FORMATS = new String[] {
     "#,###,###.#", "#.#", " #.#", "#", "#.0", "#.00", "#.000", "#.0000", "#.00000", "#.000000", " #.0#", };
 
+  protected static final Pattern PRECISION_PATTERN = Pattern.compile( "[^0-9#]" );
+
   public StringEvaluator() {
     this( true );
   }
@@ -72,8 +73,8 @@ public class StringEvaluator {
   }
 
   public StringEvaluator( boolean tryTrimming, List<String> numberFormats, List<String> dateFormats ) {
-    this( tryTrimming, numberFormats.toArray( new String[numberFormats.size()] ), dateFormats
-      .toArray( new String[dateFormats.size()] ) );
+    this( tryTrimming, numberFormats.toArray( new String[ numberFormats.size() ] ), dateFormats
+      .toArray( new String[ dateFormats.size() ] ) );
   }
 
   public StringEvaluator( boolean tryTrimming, String[] numberFormats, String[] dateFormats ) {
@@ -106,6 +107,7 @@ public class StringEvaluator {
 
   private void challengeConversions( String value ) {
     List<StringEvaluationResult> all = new ArrayList<StringEvaluationResult>( evaluationResults );
+    ValueMetaInterface stringMetaClone = null;
     for ( StringEvaluationResult cmm : all ) {
       if ( cmm.getConversionMeta().isBoolean() ) {
         // Boolean conversion never fails.
@@ -119,7 +121,7 @@ public class StringEvaluator {
         }
         if ( !( "Y".equalsIgnoreCase( string )
           || "N".equalsIgnoreCase( string ) || "TRUE".equalsIgnoreCase( string ) || "FALSE"
-            .equalsIgnoreCase( string ) ) ) {
+          .equalsIgnoreCase( string ) ) ) {
           evaluationResults.remove( cmm );
         }
       } else {
@@ -174,10 +176,14 @@ public class StringEvaluator {
             }
 
           }
-          ValueMetaInterface meta = stringMeta.clone();
-          meta.setConversionMetadata( cmm.getConversionMeta() );
-          meta.setTrimType( cmm.getConversionMeta().getTrimType() );
-          Object object = meta.convertDataUsingConversionMetaData( value );
+
+          if ( stringMetaClone == null ) {
+            // avoid cloning each time
+            stringMetaClone = stringMeta.clone();
+          }
+          stringMetaClone.setConversionMetadata( cmm.getConversionMeta() );
+          stringMetaClone.setTrimType( cmm.getConversionMeta().getTrimType() );
+          Object object = stringMetaClone.convertDataUsingConversionMetaData( value );
 
           // Still here? Evaluate the data...
           // Keep track of null values, min, max, etc.
@@ -367,6 +373,11 @@ public class StringEvaluator {
         evaluationResults.add( new StringEvaluationResult( conversionMeta ) );
       }
 
+      EvalResultBuilder numberUsBuilder =
+        new EvalResultBuilder( "number-us", ValueMetaInterface.TYPE_NUMBER, 15, trimType, ".", "," );
+      EvalResultBuilder numberEuBuilder =
+        new EvalResultBuilder( "number-eu", ValueMetaInterface.TYPE_NUMBER, 15, trimType, ",", "." );
+
       for ( String format : getNumberFormats() ) {
 
         if ( format.equals( "#" ) || format.equals( "0" ) ) {
@@ -374,25 +385,9 @@ public class StringEvaluator {
           continue;
         }
 
-        ValueMetaInterface conversionMeta = new ValueMeta( "number-us", ValueMetaInterface.TYPE_NUMBER );
-
         int precision = determinePrecision( format );
-        conversionMeta.setConversionMask( format );
-        conversionMeta.setTrimType( trimType );
-        conversionMeta.setDecimalSymbol( "." );
-        conversionMeta.setGroupingSymbol( "," );
-        conversionMeta.setLength( 15 );
-        conversionMeta.setPrecision( precision );
-        evaluationResults.add( new StringEvaluationResult( conversionMeta ) );
-
-        conversionMeta = new ValueMeta( "number-eu", ValueMetaInterface.TYPE_NUMBER );
-        conversionMeta.setConversionMask( format );
-        conversionMeta.setTrimType( trimType );
-        conversionMeta.setDecimalSymbol( "," );
-        conversionMeta.setGroupingSymbol( "." );
-        conversionMeta.setLength( 15 );
-        conversionMeta.setPrecision( precision );
-        evaluationResults.add( new StringEvaluationResult( conversionMeta ) );
+        evaluationResults.add( numberUsBuilder.format( format, precision ).build() );
+        evaluationResults.add( numberEuBuilder.format( format, precision ).build() );
       }
 
       // Try the locale's Currency
@@ -410,9 +405,16 @@ public class StringEvaluator {
         .getDecimalFormatSymbols().getGroupingSeparator() ) );
       conversionMeta.setCurrencySymbol( currencyFormat.getCurrency().getSymbol() );
       conversionMeta.setLength( 15 );
-      conversionMeta.setPrecision( currencyFormat.getCurrency().getDefaultFractionDigits() );
+      int currencyPrecision = currencyFormat.getCurrency().getDefaultFractionDigits();
+      conversionMeta.setPrecision( currencyPrecision );
 
       evaluationResults.add( new StringEvaluationResult( conversionMeta ) );
+
+      // add same mask w/o currency symbol
+      String currencyMaskAsNumeric =
+        currencyMask.replaceAll( Pattern.quote( currencyFormat.getCurrency().getSymbol() ), "" );
+      evaluationResults.add( numberUsBuilder.format( currencyMaskAsNumeric, currencyPrecision ).build() );
+      evaluationResults.add( numberEuBuilder.format( currencyMaskAsNumeric, currencyPrecision ).build() );
 
       // Integer
       //
@@ -453,14 +455,12 @@ public class StringEvaluator {
   }
 
   protected static int determinePrecision( String numericFormat ) {
-    char decimalSymbol =
-      ( (DecimalFormat) NumberFormat.getInstance() ).getDecimalFormatSymbols().getDecimalSeparator();
-    Pattern p = Pattern.compile( "[^0-9#]" );
-    Matcher m = null;
     if ( numericFormat != null ) {
+      char decimalSymbol =
+        ( (DecimalFormat) NumberFormat.getInstance() ).getDecimalFormatSymbols().getDecimalSeparator();
       int loc = numericFormat.lastIndexOf( decimalSymbol );
       if ( loc >= 0 && loc < numericFormat.length() ) {
-        m = p.matcher( numericFormat.substring( loc + 1 ) );
+        Matcher m = PRECISION_PATTERN.matcher( numericFormat.substring( loc + 1 ) );
         int nonDigitLoc = numericFormat.length();
         if ( m.find() ) {
           nonDigitLoc = loc + 1 + m.start();
@@ -500,5 +500,45 @@ public class StringEvaluator {
    */
   public int getMaxLength() {
     return maxLength;
+  }
+
+
+  private static class EvalResultBuilder {
+    private final String name;
+    private final int type;
+    private final int length;
+    private final int trimType;
+    private final String decimalSymbol;
+    private final String groupingSymbol;
+
+    private String format;
+    private int precision;
+
+    public StringEvaluationResult build() {
+      ValueMetaInterface meta = new ValueMeta( name, type );
+      meta.setConversionMask( format );
+      meta.setTrimType( trimType );
+      meta.setDecimalSymbol( decimalSymbol );
+      meta.setGroupingSymbol( groupingSymbol );
+      meta.setLength( length );
+      meta.setPrecision( precision );
+      return new StringEvaluationResult( meta );
+    }
+
+    public EvalResultBuilder( String name, int type, int length, int trimType, String decimalSymbol,
+                              String groupingSymbol ) {
+      this.name = name;
+      this.type = type;
+      this.length = length;
+      this.trimType = trimType;
+      this.decimalSymbol = decimalSymbol;
+      this.groupingSymbol = groupingSymbol;
+    }
+
+    public EvalResultBuilder format( String format, int precision ) {
+      this.format = format;
+      this.precision = precision;
+      return this;
+    }
   }
 }

--- a/test/org/pentaho/di/AllRegressionTests.java
+++ b/test/org/pentaho/di/AllRegressionTests.java
@@ -73,7 +73,7 @@ public class AllRegressionTests {
     // So adding testcases in the right order is important.
     //
 
-    suite.addTestSuite( StringEvaluatorTest.class );
+    suite.addTest( new JUnit4TestAdapter( StringEvaluatorTest.class ) );
     suite.addTestSuite( ParameterSimpleTransTest.class );
     suite.addTestSuite( ValueDataUtilTest.class );
     suite.addTest( new JUnit4TestAdapter( DatabaseTest.class ) );

--- a/test/org/pentaho/di/core/util/StringEvaluatorTest.java
+++ b/test/org/pentaho/di/core/util/StringEvaluatorTest.java
@@ -26,24 +26,26 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-import junit.framework.TestCase;
-
+import org.junit.*;
 import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.PluginTypeInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.row.value.ValueMetaPluginType;
 
-public class StringEvaluatorTest extends TestCase {
+import static org.junit.Assert.*;
 
-  private String[] series1 = new String[] { "Foo", "Bar", "One", "", "Two", "Three", };
+public class StringEvaluatorTest {
 
+  @Test
   public void testSeries1() throws Exception {
+    String[] series1 = new String[] { "Foo", "Bar", "One", "", "Two", "Three", };
     StringEvaluator evaluator = new StringEvaluator( false );
     for ( String string : series1 ) {
       evaluator.evaluateString( string );
@@ -57,9 +59,9 @@ public class StringEvaluatorTest extends TestCase {
     assertEquals( evaluator.getStringEvaluationResults().size(), 0 );
   }
 
-  private String[] series2 = new String[] { "2009/12/31 12:34:56", "2010/02/14 23:22:01", };
-
+  @Test
   public void testSeries2() throws Exception {
+    String[] series2 = new String[] { "2009/12/31 12:34:56", "2010/02/14 23:22:01", };
     StringEvaluator evaluator = new StringEvaluator( false );
     for ( String string : series2 ) {
       evaluator.evaluateString( string );
@@ -79,9 +81,9 @@ public class StringEvaluatorTest extends TestCase {
     assertEquals( evaluator.getValues().size(), series2.length );
   }
 
-  private String[] series3 = new String[] { "1234,56", "12394,26", "1934,34", "19245,23", "" };
-
+  @Test
   public void testSeries3() throws Exception {
+    String[] series3 = new String[] { "1234,56", "12394,26", "1934,34", "19245,23", "" };
     StringEvaluator evaluator = new StringEvaluator( false );
     for ( String string : series3 ) {
       evaluator.evaluateString( string );
@@ -97,11 +99,11 @@ public class StringEvaluatorTest extends TestCase {
     assertEquals( evaluator.getValues().size(), series3.length );
   }
 
-  private String[] series4 = new String[] {
-    "01234,56     ", "             ", "98765,43     ", "12394,26     ", "01934,34     ", "19245,23     ",
-    "00045,67     ", };
-
+  @Test
   public void testSeries4() throws Exception {
+    String[] series4 = new String[] {
+      "01234,56     ", "             ", "98765,43     ", "12394,26     ", "01934,34     ", "19245,23     ",
+      "00045,67     ", };
     StringEvaluator evaluator = new StringEvaluator( true );
     for ( String string : series4 ) {
       evaluator.evaluateString( string );
@@ -117,6 +119,7 @@ public class StringEvaluatorTest extends TestCase {
     assertEquals( evaluator.getValues().size(), series4.length );
   }
 
+  @Test
   public void testCurrencyData() {
     StringEvaluator eval = new StringEvaluator( true );
     String[] values = new String[] { "$300.00", "$3,400", "$23.00", "($0.50)" };
@@ -131,34 +134,37 @@ public class StringEvaluatorTest extends TestCase {
       .getConversionMeta().getConversionMask() );
   }
 
+  @Test
   public void testCurrencyData_UK() {
     Locale orig = Locale.getDefault();
-    Locale.setDefault( Locale.UK );
-    StringEvaluator eval = new StringEvaluator( true );
-
-    DecimalFormat currencyFormat = ( (DecimalFormat) NumberFormat.getCurrencyInstance() );
     try {
-      currencyFormat.parse( "-£400.059" );
-    } catch ( ParseException e ) {
-      fail();
-    }
-    String[] values = new String[] { "£400.019", "£3,400.029", "£23.00", "-£400.059" };
-    for ( String value : values ) {
-      eval.evaluateString( value );
-    }
-    assertEquals( values.length, eval.getCount() );
-    StringEvaluationResult result = eval.getAdvicedResult();
+      Locale.setDefault( Locale.UK );
+      StringEvaluator eval = new StringEvaluator( true );
 
-    Locale.setDefault( orig );
-
-    assertEquals( "Not a number detected", ValueMetaInterface.TYPE_NUMBER, result.getConversionMeta().getType() );
-    assertEquals( "Precision not correct", 2, result.getConversionMeta().getPrecision() );
-    assertEquals( "Currency format mask is incorrect", "£#,##0.00", result.getConversionMeta().getConversionMask() );
+      DecimalFormat currencyFormat = ( (DecimalFormat) NumberFormat.getCurrencyInstance() );
+      try {
+        currencyFormat.parse( "-£400.059" );
+      } catch ( ParseException e ) {
+        fail();
+      }
+      String[] values = new String[] { "£400.019", "£3,400.029", "£23.00", "-£400.059" };
+      for ( String value : values ) {
+        eval.evaluateString( value );
+      }
+      assertEquals( values.length, eval.getCount() );
+      StringEvaluationResult result = eval.getAdvicedResult();
+      assertEquals( "Not a number detected", ValueMetaInterface.TYPE_NUMBER, result.getConversionMeta().getType() );
+      assertEquals( "Precision not correct", 2, result.getConversionMeta().getPrecision() );
+      assertEquals( "Currency format mask is incorrect", "£#,##0.00", result.getConversionMeta().getConversionMask() );
+    } finally {
+      Locale.setDefault( orig );
+    }
   }
 
+  @Test
   public void testCustomDateFormats() {
-    List<String> dates = Arrays.asList( "MM/dd/yyyy" );
-    List<String> numbers = Arrays.asList( "#,##0.###" );
+    List<String> dates = Collections.singletonList( "MM/dd/yyyy" );
+    List<String> numbers = Collections.singletonList( "#,##0.###" );
 
     StringEvaluator eval = new StringEvaluator( true, numbers, dates );
     String[] goodDateValues = new String[] { "01/01/2000", "02/02/2000", "03/03/2000" };
@@ -180,35 +186,39 @@ public class StringEvaluatorTest extends TestCase {
     assertFalse( "Date detected", result.getConversionMeta().getType() == ValueMetaInterface.TYPE_DATE );
   }
 
+  @Test
   public void testCustomNumberFormats() {
     loadValueMetaPlugins();
 
     // Now get to the real testing
     Locale orig = Locale.getDefault();
-    Locale.setDefault( Locale.US );
+    try {
+      Locale.setDefault( Locale.US );
 
-    StringEvaluator eval = new StringEvaluator();
-    String[] goodValues = new String[] { "200.00", "999.99", "4,309.88" };
-    String[] badValues = new String[] { "9 00", "$30.00", "3.999,00" };
+      StringEvaluator eval = new StringEvaluator();
+      String[] goodValues = new String[] { "200.00", "999.99", "4,309.88" };
+      String[] badValues = new String[] { "9 00", "$30.00", "3.999,00" };
 
-    for ( String value : goodValues ) {
-      eval.evaluateString( value );
+      for ( String value : goodValues ) {
+        eval.evaluateString( value );
+      }
+      assertEquals( goodValues.length, eval.getCount() );
+      StringEvaluationResult result = eval.getAdvicedResult();
+      assertEquals( "Not a number detected", result.getConversionMeta().getTypeDesc(), "Number" );
+
+      eval = new StringEvaluator();
+      for ( String value : badValues ) {
+        eval.evaluateString( value );
+      }
+      assertEquals( badValues.length, eval.getCount() );
+      result = eval.getAdvicedResult();
+      assertFalse( "Number detected", result.getConversionMeta().getType() == ValueMetaInterface.TYPE_NUMBER );
+    } finally {
+      Locale.setDefault( orig );
     }
-    assertEquals( goodValues.length, eval.getCount() );
-    StringEvaluationResult result = eval.getAdvicedResult();
-    assertEquals( "Not a number detected", result.getConversionMeta().getTypeDesc(), "Number" );
-
-    eval = new StringEvaluator();
-    for ( String value : badValues ) {
-      eval.evaluateString( value );
-    }
-    assertEquals( badValues.length, eval.getCount() );
-    result = eval.getAdvicedResult();
-    assertFalse( "Number detected", result.getConversionMeta().getType() == ValueMetaInterface.TYPE_NUMBER );
-
-    Locale.setDefault( orig );
   }
 
+  @Test
   public void testDeterminePrecision() {
     assertEquals( 4, StringEvaluator.determinePrecision( "#.0000" ) );
     assertEquals( 4, StringEvaluator.determinePrecision( "0.#### $" ) );
@@ -217,6 +227,7 @@ public class StringEvaluatorTest extends TestCase {
     assertEquals( 4, StringEvaluator.determinePrecision( "##,##0.#0## $" ) );
   }
 
+  @Test
   public void testLength_IfEvaluationResultIsNumber() {
     loadValueMetaPlugins();
     StringEvaluator eval = new StringEvaluator();
@@ -257,5 +268,48 @@ public class StringEvaluatorTest extends TestCase {
     // ... and have at least 1 ValueMetaPlugin
     List<PluginInterface> valueMetaPlugins = registry.getPlugins( ValueMetaPluginType.class );
     assertTrue( "Size of plugins list expected to be >1", valueMetaPlugins.size() > 1 );
+  }
+
+
+  @Test
+  public void recognisesNumeric_WhenParenthesesMeanNegative_Integer() throws Exception {
+    String[] samples = { "1,234,567,890", "(1,234,567,890)" };
+
+    final Locale environmentLocale = Locale.getDefault();
+    try {
+      Locale.setDefault( Locale.US );
+
+      StringEvaluationResult numericResult = doEvaluation( new StringEvaluator(), samples );
+      ValueMetaInterface meta = numericResult.getConversionMeta();
+      assertTrue( Integer.toString( meta.getType() ), ValueMetaBase.isNumeric( meta.getType() ) );
+      assertEquals( "#,##0.00;(#,##0.00)", meta.getConversionMask() );
+    } finally {
+      Locale.setDefault( environmentLocale );
+    }
+  }
+
+  @Test
+  public void recognisesNumeric_WhenParenthesesMeanNegative_Double() throws Exception {
+    String[] samples = { "1,234,567,890.12", "(1,234,567,890.12)" };
+
+    final Locale environmentLocale = Locale.getDefault();
+    try {
+      Locale.setDefault( Locale.US );
+
+      StringEvaluationResult numericResult = doEvaluation( new StringEvaluator(), samples );
+      ValueMetaInterface meta = numericResult.getConversionMeta();
+      assertTrue( Integer.toString( meta.getType() ), ValueMetaBase.isNumeric( meta.getType() ) );
+      assertEquals( "#,##0.00;(#,##0.00)", meta.getConversionMask() );
+    } finally {
+      Locale.setDefault( environmentLocale );
+    }
+  }
+
+  private StringEvaluationResult doEvaluation( StringEvaluator evaluator, String[] samples ) {
+    for ( String sample : samples ) {
+      evaluator.evaluateString( sample );
+    }
+    assertEquals( evaluator.getCount(), samples.length );
+    return evaluator.getAdvicedResult();
   }
 }


### PR DESCRIPTION
… #,##0;(#,##0) but works if it starts with a dollar sign

- add formatting patterns similar to currency mask, but w/o currency sign
- add tests
- rewrite StringEvaluatorTest to Junit 4 annotations

@mattyb149, @brosander, review it please  