### PR TITLE
[TEST] - abort the test after 10 minutes

### DIFF
--- a/test/org/pentaho/di/cluster/CarteLauncherTest.java
+++ b/test/org/pentaho/di/cluster/CarteLauncherTest.java
@@ -22,11 +22,13 @@
 
 package org.pentaho.di.cluster;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
+import static org.junit.Assert.*;
 import org.pentaho.di.core.KettleEnvironment;
 
-public class CarteLauncherTest extends TestCase {
+public class CarteLauncherTest {
+
+  @Test( timeout = 10 * 60 * 1000 )
   public void testLaunchStopSlaveServer() throws Exception {
     KettleEnvironment.init();
 


### PR DESCRIPTION
@mattyb149, @brosander, review it please.
This is not elegant, but hanging test is not OK either. This approach doesn't lurk the problem (the test fails), but lets the other tests to be executed, so we can see who is failing and who is passing