### PR TITLE
PDI-13867: Able to save job/transformation in the root folder

### DIFF
--- a/ui/src/org/pentaho/di/ui/job/dialog/JobDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/dialog/JobDialog.java
@@ -74,7 +74,6 @@ import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.repository.KettleRepositoryLostException;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
-import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.ui.core.ConstUI;
 import org.pentaho.di.ui.core.PropsUI;
@@ -88,7 +87,7 @@ import org.pentaho.di.ui.core.widget.ComboVar;
 import org.pentaho.di.ui.core.widget.FieldDisabledListener;
 import org.pentaho.di.ui.core.widget.TableView;
 import org.pentaho.di.ui.core.widget.TextVar;
-import org.pentaho.di.ui.repository.dialog.SelectDirectoryDialog;
+import org.pentaho.di.ui.repository.RepositoryDirectoryUI;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 import org.pentaho.di.ui.util.HelpUtils;
 
@@ -549,22 +548,14 @@ public class JobDialog extends Dialog {
     wbDirectory.addSelectionListener( new SelectionAdapter() {
       public void widgetSelected( SelectionEvent arg0 ) {
         RepositoryDirectoryInterface directoryFrom = jobMeta.getRepositoryDirectory();
-        if ( directoryFrom == null ) {
-          directoryFrom = new RepositoryDirectory();
+        RepositoryDirectoryInterface rd = RepositoryDirectoryUI.chooseDirectory( shell, rep, directoryFrom );
+        if ( rd == null ) {
+          return;
         }
-        ObjectId idDirectoryFrom = directoryFrom.getObjectId();
-
-        SelectDirectoryDialog sdd = new SelectDirectoryDialog( shell, SWT.NONE, rep );
-        RepositoryDirectoryInterface rd = sdd.open();
-        if ( rd != null ) {
-          if ( idDirectoryFrom != rd.getObjectId() ) {
-            // We need to change this in the repository as well!!
-            // We do this when the user pressed OK
-            newDirectory = rd;
-            wDirectory.setText( rd.getPath() );
-          }
-          // Else same directory!
-        }
+        // We need to change this in the repository as well!!
+        // We do this when the user pressed OK
+        newDirectory = rd;
+        wDirectory.setText( rd.getPath() );
       }
     } );
 
@@ -1658,7 +1649,7 @@ public class JobDialog extends Dialog {
   public static PluginInterface getPlugin( JobEntryInterface jobEntryInterface ) {
     return PluginRegistry.getInstance().getPlugin( JobEntryPluginType.class, jobEntryInterface );
   }
-  
+
   public static Image getImage( Shell shell, PluginInterface plugin ) {
     String id = plugin.getIds()[0];
     if ( id != null ) {
@@ -1667,7 +1658,7 @@ public class JobDialog extends Dialog {
     }
     return null;
   }
-  
+
   public void setDirectoryChangeAllowed( boolean directoryChangeAllowed ) {
     this.directoryChangeAllowed = directoryChangeAllowed;
   }

--- a/ui/src/org/pentaho/di/ui/job/entries/job/JobEntryJobDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/job/JobEntryJobDialog.java
@@ -1140,7 +1140,8 @@ public class JobEntryJobDialog extends JobEntryDialog implements JobEntryDialogI
   protected void newJob() {
     JobMeta newJobMeta = new JobMeta();
     newJobMeta.getDatabases().addAll( jobMeta.getDatabases() );
-    newJobMeta.setRepository( rep );
+    newJobMeta.setRepository( jobMeta.getRepository() );
+    newJobMeta.setRepositoryDirectory( jobMeta.getRepositoryDirectory() );
     newJobMeta.setMetaStore( metaStore );
 
     JobDialog jobDialog = new JobDialog( shell, SWT.NONE, newJobMeta, rep );

--- a/ui/src/org/pentaho/di/ui/job/entries/trans/JobEntryTransDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/trans/JobEntryTransDialog.java
@@ -1160,6 +1160,7 @@ public class JobEntryTransDialog extends JobEntryDialog implements JobEntryDialo
 
     newTransMeta.getDatabases().addAll( jobMeta.getDatabases() );
     newTransMeta.setRepository( rep );
+    newTransMeta.setRepositoryDirectory( jobMeta.getRepositoryDirectory() );
     newTransMeta.setMetaStore( metaStore );
 
     TransDialog transDialog = new TransDialog( shell, SWT.NONE, newTransMeta, rep );

--- a/ui/src/org/pentaho/di/ui/repository/RepositoryDirectoryUI.java
+++ b/ui/src/org/pentaho/di/ui/repository/RepositoryDirectoryUI.java
@@ -24,16 +24,20 @@ package org.pentaho.di.ui.repository;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TreeItem;
+
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
@@ -41,6 +45,8 @@ import org.pentaho.di.repository.RepositoryElementMetaInterface;
 import org.pentaho.di.repository.RepositoryObject;
 import org.pentaho.di.repository.RepositoryObjectType;
 import org.pentaho.di.ui.core.gui.GUIResource;
+import org.pentaho.di.ui.repository.dialog.SelectDirectoryDialog;
+
 
 public class RepositoryDirectoryUI {
 
@@ -225,6 +231,36 @@ public class RepositoryDirectoryUI {
       subti.setImage( GUIResource.getInstance().getImageArrow() );
       getDirectoryTree( subti, dircolor, subdir );
     }
+  }
+
+  public static RepositoryDirectoryInterface chooseDirectory( Shell shell, Repository rep, RepositoryDirectoryInterface directoryFrom ) {
+    if ( rep == null ) {
+      return null;
+    }
+
+    if ( directoryFrom == null ) {
+      try {
+        directoryFrom = rep.getUserHomeDirectory();
+      } catch ( KettleException ex ) {
+        directoryFrom = new RepositoryDirectory();
+      }
+    }
+    ObjectId idDirectoryFrom = directoryFrom.getObjectId();
+
+    SelectDirectoryDialog sdd = new SelectDirectoryDialog( shell, SWT.NONE, rep );
+
+    //PDI-13867: root dir is restricted.
+    HashSet<String> restrictedPaths = new HashSet<String>();
+    restrictedPaths.add( directoryFrom.findRoot().getPath() );
+    sdd.setRestrictedPaths( restrictedPaths );
+
+    //TODO: expand and select directoryFrom in the dialog.
+
+    RepositoryDirectoryInterface rd = sdd.open();
+    if ( rd == null || idDirectoryFrom == rd.getObjectId() ) {
+      return null;
+    }
+    return rd;
   }
 
 }

--- a/ui/src/org/pentaho/di/ui/repository/dialog/SelectDirectoryDialog.java
+++ b/ui/src/org/pentaho/di/ui/repository/dialog/SelectDirectoryDialog.java
@@ -22,6 +22,9 @@
 
 package org.pentaho.di.ui.repository.dialog;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MenuDetectEvent;
 import org.eclipse.swt.events.MenuDetectListener;
@@ -83,6 +86,16 @@ public class SelectDirectoryDialog extends Dialog {
   private RepositoryDirectoryInterface repositoryTree;
 
   private boolean readOnly;
+
+  private Set<String> restrictedPaths = Collections.<String>emptySet();
+
+  public void setRestrictedPaths( Set<String> restrictedPaths ) {
+    this.restrictedPaths = restrictedPaths;
+  }
+
+  private boolean isRestrictedPath( String path ) {
+    return restrictedPaths.contains( path );
+  }
 
   public SelectDirectoryDialog( Shell parent, int style, Repository rep ) {
     super( parent, style );
@@ -176,8 +189,33 @@ public class SelectDirectoryDialog extends Dialog {
     } );
 
     wTree.addSelectionListener( new SelectionAdapter() {
-      public void widgetDefaultSelected( SelectionEvent arg0 ) {
+      private String getSelectedPath( SelectionEvent selectionEvent ) {
+        TreeItem treeItem = (TreeItem) selectionEvent.item;
+        String path;
+        if ( treeItem.getParentItem() == null ) {
+          path = treeItem.getText();
+        } else {
+          path = ConstUI.getTreePath( treeItem, 0 );
+        }
+        return path;
+      }
+
+      private boolean isSelectedPathRestricted( SelectionEvent selectionEvent ) {
+        String path = getSelectedPath( selectionEvent );
+        boolean isRestricted = isRestrictedPath( path );
+        return isRestricted;
+      }
+
+      public void widgetDefaultSelected( SelectionEvent selectionEvent ) {
+        if ( isSelectedPathRestricted( selectionEvent ) ) {
+          return;
+        }
         handleOK();
+      }
+
+      public void widgetSelected( SelectionEvent selectionEvent ) {
+        boolean restricted = isSelectedPathRestricted( selectionEvent );
+        wOK.setEnabled( !restricted );
       }
     } );
 

--- a/ui/src/org/pentaho/di/ui/trans/dialog/TransDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/dialog/TransDialog.java
@@ -73,7 +73,6 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.KettleRepositoryLostException;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
-import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.trans.TransDependency;
 import org.pentaho.di.trans.TransMeta;
@@ -93,7 +92,7 @@ import org.pentaho.di.ui.core.widget.ComboVar;
 import org.pentaho.di.ui.core.widget.FieldDisabledListener;
 import org.pentaho.di.ui.core.widget.TableView;
 import org.pentaho.di.ui.core.widget.TextVar;
-import org.pentaho.di.ui.repository.dialog.SelectDirectoryDialog;
+import org.pentaho.di.ui.repository.RepositoryDirectoryUI;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 
 
@@ -565,26 +564,15 @@ public class TransDialog extends Dialog {
     wbDirectory.setLayoutData( fdbDirectory );
     wbDirectory.addSelectionListener( new SelectionAdapter() {
       public void widgetSelected( SelectionEvent arg0 ) {
-        if ( rep != null ) {
-          RepositoryDirectoryInterface directoryFrom = transMeta.getRepositoryDirectory();
-          if ( directoryFrom == null ) {
-            directoryFrom = new RepositoryDirectory();
-          }
-          ObjectId idDirectoryFrom = directoryFrom.getObjectId();
-
-          SelectDirectoryDialog sdd = new SelectDirectoryDialog( shell, SWT.NONE, rep );
-          RepositoryDirectoryInterface rd = sdd.open();
-          if ( rd != null ) {
-            if ( idDirectoryFrom != rd.getObjectId() ) {
-              // We need to change this in the repository as well!!
-              // We do this when the user pressed OK
-              newDirectory = rd;
-              wDirectory.setText( rd.getPath() );
-            }
-            // else: Same directory!
-
-          }
+        RepositoryDirectoryInterface directoryFrom = transMeta.getRepositoryDirectory();
+        RepositoryDirectoryInterface rd = RepositoryDirectoryUI.chooseDirectory( shell, rep, directoryFrom );
+        if ( rd == null ) {
+          return;
         }
+        // We need to change this in the repository as well!!
+        // We do this when the user pressed OK
+        newDirectory = rd;
+        wDirectory.setText( rd.getPath() );
       }
     } );
 

--- a/ui/src/org/pentaho/di/ui/trans/steps/jobexecutor/JobExecutorDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/jobexecutor/JobExecutorDialog.java
@@ -1682,6 +1682,8 @@ public class JobExecutorDialog extends BaseStepDialog implements StepDialogInter
   protected void newJob() {
     JobMeta newJobMeta = new JobMeta();
     newJobMeta.getDatabases().addAll( transMeta.getDatabases() );
+    newJobMeta.setRepository( transMeta.getRepository() );
+    newJobMeta.setRepositoryDirectory( transMeta.getRepositoryDirectory() );
     JobDialog jobDialog = new JobDialog( shell, SWT.NONE, newJobMeta, repository );
     if ( jobDialog.open() != null ) {
       Spoon spoon = Spoon.getInstance();

--- a/ui/src/org/pentaho/di/ui/trans/steps/mapping/MappingDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/mapping/MappingDialog.java
@@ -841,6 +841,8 @@ public class MappingDialog extends BaseStepDialog implements StepDialogInterface
     TransMeta newTransMeta = new TransMeta();
 
     newTransMeta.getDatabases().addAll( transMeta.getDatabases() );
+    newTransMeta.setRepository( transMeta.getRepository() );
+    newTransMeta.setRepositoryDirectory( transMeta.getRepositoryDirectory() );
 
     // Pass some interesting settings from the parent transformations...
     //

--- a/ui/src/org/pentaho/di/ui/trans/steps/metainject/MetaInjectDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/metainject/MetaInjectDialog.java
@@ -1351,6 +1351,8 @@ public class MetaInjectDialog extends BaseStepDialog implements StepDialogInterf
     TransMeta newTransMeta = new TransMeta();
 
     newTransMeta.getDatabases().addAll( transMeta.getDatabases() );
+    newTransMeta.setRepository( transMeta.getRepository() );
+    newTransMeta.setRepositoryDirectory( transMeta.getRepositoryDirectory() );
 
     // Pass some interesting settings from the parent transformations...
     //

--- a/ui/src/org/pentaho/di/ui/trans/steps/simplemapping/SimpleMappingDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/simplemapping/SimpleMappingDialog.java
@@ -732,6 +732,8 @@ public class SimpleMappingDialog extends BaseStepDialog implements StepDialogInt
     TransMeta newTransMeta = new TransMeta();
 
     newTransMeta.getDatabases().addAll( transMeta.getDatabases() );
+    newTransMeta.setRepository( transMeta.getRepository() );
+    newTransMeta.setRepositoryDirectory( transMeta.getRepositoryDirectory() );
 
     // Pass some interesting settings from the parent transformations...
     //

--- a/ui/src/org/pentaho/di/ui/trans/steps/singlethreader/SingleThreaderDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/singlethreader/SingleThreaderDialog.java
@@ -1022,6 +1022,8 @@ public class SingleThreaderDialog extends BaseStepDialog implements StepDialogIn
     TransMeta newTransMeta = new TransMeta();
 
     newTransMeta.getDatabases().addAll( transMeta.getDatabases() );
+    newTransMeta.setRepository( transMeta.getRepository() );
+    newTransMeta.setRepositoryDirectory( transMeta.getRepositoryDirectory() );
 
     // Pass some interesting settings from the parent transformations...
     //

--- a/ui/src/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
@@ -1660,6 +1660,12 @@ public class TransExecutorDialog extends BaseStepDialog implements StepDialogInt
     TransMeta newTransMeta = new TransMeta();
 
     newTransMeta.getDatabases().addAll( transMeta.getDatabases() );
+    newTransMeta.setRepository( transMeta.getRepository() );
+    newTransMeta.setRepositoryDirectory( transMeta.getRepositoryDirectory() );
+
+    // Pass some interesting settings from the parent transformations...
+    //
+    newTransMeta.setUsingUniqueConnections( transMeta.isUsingUniqueConnections() );
 
     TransDialog transDialog = new TransDialog( shell, SWT.NONE, newTransMeta, repository );
     if ( transDialog.open() != null ) {


### PR DESCRIPTION
- Add a list of restricted directories to the SelectDirectoryDialog dialog (Disable Ok button if the selection is in the restricted paths list)
- Move the code in TransDialog and JobDialog that sets up the SelectDirectoryDialog into RepositoryDirectoryUI so it can be setup consistently
- Restrict selection of the root when creating the SelectDirectoryDialog so people cant save their transformation or job there.
- Instead of defaulting the repository to a new directory (which points to the root), use the user home directory
- Use current repository directory as default when creating a new Transformation with the mapping step
- Use current repository directory as default when creating a new Transformation with the etl metadata injection step
- Use current repository directory as default when creating a new Transformation with the simple mapping step
- Use current repository directory as default when creating a new Transformation with the single threader step
- Use current repository directory as default when creating a new Transformation with the transformation executor step
- Use current repository directory as default when creating a new Transformation with the transformation job entry
- Use current repository directory as default when creating a new Job with the Job executor step
- Use current repository directory as default when creating a new Job with the job job entry.