### PR TITLE
[BACKLOG-4238] - Incorrect synchronization in Database class

### DIFF
--- a/core/src/org/pentaho/di/core/database/Database.java
+++ b/core/src/org/pentaho/di/core/database/Database.java
@@ -164,7 +164,7 @@ public class Database implements VariableSpace, LoggingObjectInterface {
   private int nrExecutedCommits;
 
   private static List<ValueMetaInterface> valueMetaPluginClasses;
-  
+
   static {
     try {
       valueMetaPluginClasses = ValueMetaFactory.getValueMetaPluginClasses();
@@ -179,7 +179,7 @@ public class Database implements VariableSpace, LoggingObjectInterface {
       throw new RuntimeException( "Unable to get list of instantiated value meta plugin classes", e );
     }
   }
-  
+
   /**
    * Construct a new Database Connection
    *
@@ -352,9 +352,7 @@ public class Database implements VariableSpace, LoggingObjectInterface {
           // There was no mapped value before
           lookup = this;
         }
-        this.connection = lookup.getOrCreateSharedConnection( partitionId );
-        // opened in volatile, thus we can access it directly
-        this.copy = lookup.opened;
+        lookup.shareConnectionWith( partitionId, this );
       } else {
         // Proceed with a normal connect
         normalConnect( partitionId );
@@ -372,7 +370,7 @@ public class Database implements VariableSpace, LoggingObjectInterface {
     }
   }
 
-  private synchronized Connection getOrCreateSharedConnection( String partitionId ) throws KettleDatabaseException {
+  private synchronized void shareConnectionWith( String partitionId, Database anotherDb ) throws KettleDatabaseException {
     // inside synchronized block we can increment 'opened' directly
     this.opened++;
 
@@ -384,7 +382,9 @@ public class Database implements VariableSpace, LoggingObjectInterface {
       //
       setAutoCommit( false );
     }
-    return this.connection;
+
+    anotherDb.connection = this.connection;
+    anotherDb.copy = this.opened;
   }
 
   /**

--- a/core/test-src/org/pentaho/di/core/database/DatabaseConnectingTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseConnectingTest.java
@@ -102,19 +102,20 @@ public class DatabaseConnectingTest {
   @Test
   public void connect_GroupIsEqual_InParallel() throws Exception {
     final Connection shared = mock( Connection.class );
-    final int threadsAmount = 30;
+    final int dbsAmount = 300;
+    final int threadsAmount = 50;
 
-    List<DatabaseStub> dbs = new ArrayList<DatabaseStub>( threadsAmount );
-    Set<Integer> copies = new HashSet<Integer>( threadsAmount );
+    List<DatabaseStub> dbs = new ArrayList<DatabaseStub>( dbsAmount );
+    Set<Integer> copies = new HashSet<Integer>( dbsAmount );
     ExecutorService pool = Executors.newFixedThreadPool( threadsAmount );
     try {
       CompletionService<DatabaseStub> service = new ExecutorCompletionService<DatabaseStub>( pool );
-      for ( int i = 0; i < threadsAmount; i++ ) {
+      for ( int i = 0; i < dbsAmount; i++ ) {
         service.submit( createStubDatabase( shared ) );
         copies.add( i + 1 );
       }
 
-      for ( int i = 0; i < threadsAmount; i++ ) {
+      for ( int i = 0; i < dbsAmount; i++ ) {
         DatabaseStub db = service.take().get();
         assertEquals( shared, db.getConnection() );
         dbs.add( db );
@@ -125,9 +126,9 @@ public class DatabaseConnectingTest {
 
     for ( DatabaseStub db : dbs ) {
       String message =
-        String.format( "There should be %d shares of the connection, but found %d", threadsAmount, db.getOpened() );
+        String.format( "There should be %d shares of the connection, but found %d", dbsAmount, db.getOpened() );
       // 0 is for those instances that use the shared connection
-      assertTrue( message, db.getOpened() == 0 || db.getOpened() == threadsAmount );
+      assertTrue( message, db.getOpened() == 0 || db.getOpened() == dbsAmount );
 
       assertTrue( "Each instance should have a unique 'copy' value", copies.remove( db.getCopy() ) );
     }


### PR DESCRIPTION
- fix the problem by moving fields' initialisation inside critical section

@mattyb149, @brosander, have you noticed ```DatabaseConnectingTest``` fails from time to time? I found out the reason and this fix is aimed to resolve it. Review it please.