### PR TITLE
PDI-736: Merge rows takes uncompared fields in identical rows from re…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -770,6 +770,7 @@
             haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.mapping.RunMapping" haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.mapping.MappingTest" haltonerror="false"/>
+      <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.mergerows.MergeRowsTest" haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.metainject.MetaInjectTest"
             haltonerror="false"/>
       <test todir="${testreports.xml.dir}" name="org.pentaho.di.trans.steps.nullif.NullIfTest" haltonerror="false"/>

--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -406,7 +406,7 @@ public class Const {
 
   /** Name of the kettle parameters file */
   public static final String KETTLE_PROPERTIES = "kettle.properties";
-  
+
   /** Name of the kettle shared data file */
   public static final String SHARED_DATA_FILE = "shared.xml";
 
@@ -715,8 +715,10 @@ public class Const {
   public static final String KETTLE_COMPATIBILITY_TEXT_FILE_OUTPUT_APPEND_NO_HEADER =
     "KETTLE_COMPATIBILITY_TEXT_FILE_OUTPUT_APPEND_NO_HEADER";
 
+  public static final String KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL =
+    "KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL";
   /**
-   * You can use this variable to speed up hostname lookup. 
+   * You can use this variable to speed up hostname lookup.
    * Hostname lookup is performed by Kettle so that it is capable of logging the server on which a job or transformation is executed.
    */
   public static final String KETTLE_SYSTEM_HOSTNAME = "KETTLE_SYSTEM_HOSTNAME";
@@ -1014,7 +1016,7 @@ public class Const {
    * A variable to configure jetty option: lowResourcesMaxIdleTime for Carte
    */
   public static final String KETTLE_CARTE_JETTY_RES_MAX_IDLE_TIME = "KETTLE_CARTE_JETTY_RES_MAX_IDLE_TIME";
-  
+
   /**
   * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer
   * overflow while rounding
@@ -1705,8 +1707,8 @@ public class Const {
   public static final String getKettleDirectory() {
     return getUserHomeDirectory() + FILE_SEPARATOR + getUserBaseDir();
   }
-  
-   
+
+
   /**
    * Determines the Kettle directory in the user's home directory.
    *

--- a/engine/src/kettle-variables.xml
+++ b/engine/src/kettle-variables.xml
@@ -357,7 +357,7 @@
     <variable>KETTLE_AGGREGATION_ALL_NULLS_ARE_ZERO</variable>
     <default-value>N</default-value>
   </kettle-variable>
-  
+
   <kettle-variable>
     <description>Set this variable to Y for backward compatibility for the Text File Output step. Setting this to Ywill add no header row at all when the append option is enabled, regardless if the file is existing or not.</description>
     <variable>KETTLE_COMPATIBILITY_TEXT_FILE_OUTPUT_APPEND_NO_HEADER</variable>
@@ -378,35 +378,41 @@
     <default-value>N</default-value>
   </kettle-variable>
 
-	
-	<kettle-variable>
+
+  <kettle-variable>
     <description>You can use this variable to speed up hostname lookup. Hostname lookup is performed by Kettle so that it is capable of logging the server on which a job or transformation is executed.
     </description>
     <variable>KETTLE_SYSTEM_HOSTNAME</variable>
     <default-value></default-value>
   </kettle-variable>
-  
+
   <kettle-variable>
     <description>Set this variable to Y for backward compatibility when importing a reference to a directory with a variable. When set to Y, a directory reference is always prefixed with the root path independently if variables are used or not.
     </description>
     <variable>KETTLE_COMPATIBILITY_IMPORT_PATH_ADDITION_ON_VARIABLES</variable>
     <default-value>N</default-value>
   </kettle-variable>
-  
+
    <kettle-variable>
     <description>A variable to configure jetty option: acceptors for Carte</description>
     <variable>KETTLE_CARTE_JETTY_ACCEPTORS</variable>
   </kettle-variable>
-  
+
   <kettle-variable>
     <description>A variable to configure jetty option: acceptQueueSize for Carte</description>
     <variable>KETTLE_CARTE_JETTY_ACCEPT_QUEUE_SIZE</variable>
   </kettle-variable>
-  
+
   <kettle-variable>
     <description>A variable to configure jetty option: lowResourcesMaxIdleTime for Carte</description>
     <variable>KETTLE_CARTE_JETTY_RES_MAX_IDLE_TIME</variable>
   </kettle-variable>
-  
+
+  <kettle-variable>
+    <description>Set this variable to Y for backward compatibility for the Merge Rows (diff) step. Setting this to Y will use the data from the reference stream (instead of the comparison stream) in case the compared rows are identical.</description>
+    <variable>KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL</variable>
+    <default-value>N</default-value>
+  </kettle-variable>
+
 </kettle-variables>
 

--- a/test/org/pentaho/di/trans/steps/mergerows/MergeRowsTest.java
+++ b/test/org/pentaho/di/trans/steps/mergerows/MergeRowsTest.java
@@ -1,0 +1,273 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.mergerows;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.plugins.StepPluginType;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.trans.RowProducer;
+import org.pentaho.di.core.row.value.ValueMetaFactory;
+import org.pentaho.di.trans.RowStepCollector;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransHopMeta;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepInterface;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.step.errorhandling.StreamInterface;
+import org.pentaho.di.trans.steps.rowgenerator.RowGeneratorMeta;
+
+public class MergeRowsTest {
+
+  String keyField = "key";
+  String compareField = "compareValue";
+  String extraField = "extraValue";
+  String flagField = "flagField";
+
+  // Stuff to set up row generators
+  String[] fieldName = { keyField, compareField, extraField };
+  String[] type = { "String", "String", "String" };
+  String[] fieldFormat = { "", "", "" };
+  String[] group = { "", "", "" };
+  String[] decimal = { "", "", "" };
+  String[] currency = { "", "", "" };
+  int[] intDummies = { -1, -1, -1 };
+  boolean[] setEmptystring = { false, false, false };
+
+  public RowMetaInterface createResultRowMetaInterface() {
+    RowMetaInterface rm = new RowMeta();
+    try {
+      ValueMetaInterface[] valuesMeta = {
+        ValueMetaFactory.createValueMeta( keyField, ValueMetaInterface.TYPE_STRING ),
+        ValueMetaFactory.createValueMeta( compareField, ValueMetaInterface.TYPE_STRING ),
+        ValueMetaFactory.createValueMeta( extraField, ValueMetaInterface.TYPE_STRING ),
+        ValueMetaFactory.createValueMeta( flagField, ValueMetaInterface.TYPE_STRING )
+      };
+      for ( int i = 0; i < valuesMeta.length; i++ ) {
+        rm.addValueMeta( valuesMeta[i] );
+      }
+    } catch ( Exception ex ) {
+      return null;
+    }
+    return rm;
+  }
+
+  public List<RowMetaAndData> createResultData(Object[] values) {
+    List<RowMetaAndData> list = new ArrayList<RowMetaAndData>();
+
+    RowMetaInterface rm = createResultRowMetaInterface();
+
+
+    list.add( new RowMetaAndData( rm, values ) );
+
+    return list;
+  }
+
+  /**
+   *  Check the 2 lists comparing the rows in order.
+   *  If they are not the same fail the test.
+   */
+  public void checkRows( List<RowMetaAndData> rows1, List<RowMetaAndData> rows2 ) {
+    int idx = 1;
+    if ( rows1.size() != rows2.size() ) {
+      fail( "Number of rows is not the same: " + rows1.size() + " and " + rows2.size() );
+    }
+    Iterator<RowMetaAndData> it1 = rows1.iterator();
+    Iterator<RowMetaAndData> it2 = rows2.iterator();
+
+    while ( it1.hasNext() && it2.hasNext() ) {
+      RowMetaAndData rm1 = it1.next();
+      RowMetaAndData rm2 = it2.next();
+
+      Object[] r1 = rm1.getData();
+      Object[] r2 = rm2.getData();
+
+      if ( rm1.size() != rm2.size() ) {
+        fail( "row size of row at " + idx + " is not equal (" + rm1.size() + "," + rm2.size() + ")" );
+      }
+      int[] fields = new int[1];
+      for ( int ydx = 0; ydx < rm1.size(); ydx++ ) {
+        fields[0] = ydx;
+        try {
+          if ( rm1.getRowMeta().compare( r1, r2, fields ) != 0 ) {
+            fail( "row nr " + idx + " is not equal at field nr "
+              + ydx + "(" + rm1.toString() + ";" + rm2.toString() + ")" );
+          }
+        } catch ( KettleValueException e ) {
+          fail( "row nr " + idx + " is not equal at field nr "
+            + ydx + "(" + rm1.toString() + ";" + rm2.toString() + ")" );
+        }
+      }
+
+      idx++;
+    }
+  }
+
+  void createRowGenerator(
+    TransMeta transMeta, PluginRegistry registry,
+    String stepName, String[] values,
+    StepMeta mergeRowsStep, MergeRowsMeta mergeRowsMeta,
+    int index
+  ) {
+    RowGeneratorMeta rowGeneratorMeta = new RowGeneratorMeta();
+    String rowGeneratorPid = registry.getPluginId( StepPluginType.class, rowGeneratorMeta );
+    StepMeta rowGeneratorStep = new StepMeta( rowGeneratorPid, stepName, rowGeneratorMeta );
+    transMeta.addStep( rowGeneratorStep );
+
+    rowGeneratorMeta.setDefault();
+    rowGeneratorMeta.setFieldName( fieldName );
+    rowGeneratorMeta.setFieldType( type );
+    rowGeneratorMeta.setFieldLength( intDummies );
+    rowGeneratorMeta.setFieldPrecision( intDummies );
+    rowGeneratorMeta.setRowLimit( "1" );
+    rowGeneratorMeta.setFieldFormat( fieldFormat );
+    rowGeneratorMeta.setGroup( group );
+    rowGeneratorMeta.setDecimal( decimal );
+    rowGeneratorMeta.setCurrency( currency );
+    rowGeneratorMeta.setEmptyString( setEmptystring );
+
+    rowGeneratorMeta.setValue( values );
+
+    TransHopMeta hi1 = new TransHopMeta( rowGeneratorStep, mergeRowsStep );
+    transMeta.addTransHop( hi1 );
+
+    List<StreamInterface> infoStreams = mergeRowsMeta.getStepIOMeta().getInfoStreams();
+    StreamInterface infoStream = infoStreams.get( index );
+    infoStream.setStepMeta( transMeta.findStep( stepName ) );
+  }
+
+  void testOneRow(String transName, String[] referenceValues, String[] comparisonValues, Object[] goldenImageRowValues) throws Exception {
+    KettleEnvironment.init();
+
+    // Create a new transformation...
+    TransMeta transMeta = new TransMeta();
+    transMeta.setName( transName );
+    PluginRegistry registry = PluginRegistry.getInstance();
+
+    // Create a merge rows step
+    String mergeRowsStepName = "merge rows step";
+    MergeRowsMeta mergeRowsMeta = new MergeRowsMeta();
+
+    String mergeRowsStepPid = registry.getPluginId( StepPluginType.class, mergeRowsMeta );
+    StepMeta mergeRowsStep = new StepMeta( mergeRowsStepPid, mergeRowsStepName, mergeRowsMeta );
+    transMeta.addStep( mergeRowsStep );
+
+    mergeRowsMeta.setKeyFields( new String[]{ keyField } );
+    mergeRowsMeta.setValueFields( new String[]{ compareField } );
+    mergeRowsMeta.setFlagField( flagField );
+
+    List<StreamInterface> infoStreams = mergeRowsMeta.getStepIOMeta().getInfoStreams();
+
+    //
+    // create a reference stream (row generator step)
+    //
+    createRowGenerator(
+      transMeta, registry,
+      "reference row generator", referenceValues,
+      mergeRowsStep, mergeRowsMeta,
+      0
+    );
+
+    //
+    // create a comparison stream (row generator step)
+    //
+    createRowGenerator(
+      transMeta, registry,
+      "comparison row generator", comparisonValues,
+      mergeRowsStep, mergeRowsMeta,
+      1
+    );
+
+    // Now execute the transformation
+    Trans trans = new Trans( transMeta );
+    trans.prepareExecution( null );
+
+    StepInterface si = trans.getStepInterface( mergeRowsStepName, 0 );
+    RowStepCollector endRc = new RowStepCollector();
+    si.addRowListener( endRc );
+
+    trans.startThreads();
+    trans.waitUntilFinished();
+
+    // Now check whether the output is still as we expect.
+    List<RowMetaAndData> goldenImageRows = createResultData( goldenImageRowValues );
+    List<RowMetaAndData> resultRows1 = endRc.getRowsWritten();
+    checkRows( resultRows1, goldenImageRows );
+  }
+
+  @Test
+  public void testMergeRowsIdentical() throws Exception {
+    //if not in backwards compatible mode, use the comparison values when values are "identical"
+    System.setProperty( Const.KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL, "N" );
+    String[] refs = new String[]{ "key", "compareValue1", "extraValue1" };
+    String[] comp = new String[]{ "key", "compareValue1", "extraValue2" };
+    Object[] gold = new Object[]{ "key", "compareValue1", "extraValue2", "identical" };
+    testOneRow("testMergeRowsIdentical", refs, comp, gold);
+  }
+
+  @Test
+  public void testMergeRowsIdenticalPDI736Compatible() throws Exception {
+    //if not in backwards compatible mode, use the reference values when values are "identical"
+    System.setProperty( Const.KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL, "Y" );
+    String[] refs = new String[]{ "key", "compareValue1", "extraValue1" };
+    String[] comp = new String[]{ "key", "compareValue1", "extraValue2" };
+    Object[] gold = new Object[]{ "key", "compareValue1", "extraValue1", "identical" };
+    testOneRow("testMergeRowsIdenticalPDI736Compatible", refs, comp, gold);
+  }
+
+  @Test
+  public void testMergeRowsChanged() throws Exception {
+    //regardless of backwards compatible mode, use the comparison values when values are "changed"
+    System.setProperty( Const.KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL, "N" );
+    String[] refs = new String[]{ "key", "compareValue1", "extraValue1" };
+    String[] comp = new String[]{ "key", "this value changed", "extraValue2" };
+    Object[] gold = new Object[]{ "key", "this value changed", "extraValue2", "changed" };
+    testOneRow("testMergeRowsChanged", refs, comp, gold);
+  }
+
+  @Test
+  public void testMergeRowsChangedPDI736Compatible() throws Exception {
+    //regardless of backwards compatible mode, use the comparison values when values are "changed"
+    System.setProperty( Const.KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL, "Y" );
+    String[] refs = new String[]{ "key", "compareValue1", "extraValue1" };
+    String[] comp = new String[]{ "key", "this value changed", "extraValue2" };
+    Object[] gold = new Object[]{ "key", "this value changed", "extraValue2", "changed" };
+    testOneRow("testMergeRowsChangedPDI736Compatible", refs, comp, gold);
+  }
+
+}
+


### PR DESCRIPTION
…ference rather than comparison

- added a compatibility flag KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL, default 'N'.
- when KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL == 'N', grab values from the comparison stream in case the rows are "identical".
- when KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL == 'Y', grab values from the reference stream in case the rows are "identical".
This is the old, but wrong behavior.
- Added a unit test file, with 4 tests:
These 2 tests verify the actual reported issue.
  * testMergeRowsIdentical - "identical" comparison with KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL == 'N'
  * testMergeRowsIdenticalPDI736Compatible - "identical" comparison with KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL == 'Y'
These 2 tests verify that the behavior in case of "changed" rows are not affected by the setting of the compatibility flag.
(It made sense to add these since the code for "changed" and "identical" was close and in the same conditional branch of the algorithm.
  * testMergeRowsChanged - "changed" comparison with KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL == 'N'
  * testMergeRowsChangedPDI736Compatible - "changed" comparison with KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL == 'Y'
- Added the merge row test to build.xml