### PR TITLE
[BACKLOG-4250] [Google Analytics Step] The field Key File doesn't support the variable ${Internal.Transformation.Filename.Directory}

### DIFF
--- a/plugins/googleanalytics/src/org/pentaho/di/trans/steps/googleanalytics/GoogleAnalyticsApiFacade.java
+++ b/plugins/googleanalytics/src/org/pentaho/di/trans/steps/googleanalytics/GoogleAnalyticsApiFacade.java
@@ -50,27 +50,30 @@ import org.pentaho.di.core.util.Assert;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
 
 public class GoogleAnalyticsApiFacade {
-
   private Analytics analytics;
+  private final HttpTransport httpTransport;
 
   public static GoogleAnalyticsApiFacade createFor(
     String application, String oauthServiceAccount, String oauthKeyFile )
-    throws IOException, GeneralSecurityException {
+      throws IOException, GeneralSecurityException, URISyntaxException {
+
+    URI keyFileURI = new URI( oauthKeyFile );
+    File keyFile = keyFileURI.isAbsolute() ? new File( keyFileURI ) : new File( oauthKeyFile );
 
     return new GoogleAnalyticsApiFacade(
       GoogleNetHttpTransport.newTrustedTransport(),
       JacksonFactory.getDefaultInstance(),
       application,
       oauthServiceAccount,
-      new File( oauthKeyFile )
+      keyFile
     );
   }
-
-  private final HttpTransport httpTransport;
 
   public GoogleAnalyticsApiFacade( HttpTransport httpTransport, JsonFactory jsonFactory, String application,
                                    String oathServiceEmail, File keyFile )


### PR DESCRIPTION
@mattyb149 please review. 
Fix is to detect case when path passed is absolute URI (it is in case of using variables like internal.transformtaion.filename.directory) and call corresponding File constructor, the one with String argument cannot handle absolute URIs.
No test since class affected by the change has only static method and constructor, creating test will involve refactoring it to be testable.