### PR TITLE
[BACKLOG-4257] [Google Analytics Step] NPE - Clicking Get Fields button

### DIFF
--- a/plugins/googleanalytics/src/org/pentaho/di/ui/trans/steps/googleanalytics/GaInputStepDialog.java
+++ b/plugins/googleanalytics/src/org/pentaho/di/ui/trans/steps/googleanalytics/GaInputStepDialog.java
@@ -868,16 +868,6 @@ public class GaInputStepDialog extends BaseStepDialog implements StepDialogInter
           try {
             GaData dataFeed = query.execute();
 
-            if ( dataFeed.getRows().size() < 1 ) {
-
-              MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
-              mb.setText( "Query yields empty feed" );
-              mb.setMessage( "The feed did not give any results. Please specify a query that returns data." );
-              mb.open();
-
-              return;
-            }
-
             int i = 0;
             List<GaData.ColumnHeaders> colHeaders = dataFeed.getColumnHeaders();
             wFields.table.setItemCount( colHeaders.size() + dataFeed.getProfileInfo().size() );


### PR DESCRIPTION
@mattyb149 please review. Previous version of GA api returned list of entries and column info needed to be fetched from it. New API returns null in case of no rows matched however column headers info is available.

See https://developers.google.com/gdata/javadoc/com/google/gdata/data/BaseFeed.html#getEntries()
https://developers.google.com/resources/api-libraries/documentation/analytics/v3/java/latest/com/google/api/services/analytics/model/GaData.html