### PR TITLE
[PDI-14089] Fix logDebug error when directory exists

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/getpop/JobEntryGetPOP.java
+++ b/engine/src/org/pentaho/di/job/entries/getpop/JobEntryGetPOP.java
@@ -1348,11 +1348,11 @@ public class JobEntryGetPOP extends JobEntryBase implements Cloneable, JobEntryI
       if ( isDebug() ) {
         switch( folderType ) {
           case JobEntryGetPOP.FOLDER_OUTPUT:
-            throw new KettleException( BaseMessages.getString(
-              PKG, "JobGetMailsFromPOP.Log.OutputFolderExists", folderName ) );
+            logDebug( BaseMessages.getString( PKG, "JobGetMailsFromPOP.Log.OutputFolderExists", folderName ) );
+            break;
           case JobEntryGetPOP.FOLDER_ATTACHMENTS:
-            throw new KettleException( BaseMessages.getString(
-              PKG, "JobGetMailsFromPOP.Log.AttachmentFolderExists", folderName ) );
+            logDebug( BaseMessages.getString( PKG, "JobGetMailsFromPOP.Log.AttachmentFolderExists", folderName ) );
+            break;
         }
       }
     } else {


### PR DESCRIPTION
Replaced "throw exception" with logDebug, as it is informational, and not an issue that a directory already exists.