### PR TITLE
[PDI-9585] JobEntryShell Write Script to Temp Dir

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/shell/JobEntryShell.java
+++ b/engine/src/org/pentaho/di/job/entries/shell/JobEntryShell.java
@@ -458,19 +458,19 @@ public class JobEntryShell extends JobEntryBase implements Cloneable, JobEntryIn
         base = new String[] { "command.com", "/C" };
         if ( insertScript ) {
           tempFile =
-            KettleVFS.createTempFile( "kettle", "shell.bat", environmentSubstitute( workDirectory ), this );
+            KettleVFS.createTempFile( "kettle", "shell.bat", System.getProperty( "java.io.tmpdir" ), this );
           fileObject = createTemporaryShellFile( tempFile, realScript );
         }
       } else if ( Const.getOS().startsWith( "Windows" ) ) {
         base = new String[] { "cmd.exe", "/C" };
         if ( insertScript ) {
           tempFile =
-            KettleVFS.createTempFile( "kettle", "shell.bat", environmentSubstitute( workDirectory ), this );
+            KettleVFS.createTempFile( "kettle", "shell.bat", System.getProperty( "java.io.tmpdir" ), this );
           fileObject = createTemporaryShellFile( tempFile, realScript );
         }
       } else {
         if ( insertScript ) {
-          tempFile = KettleVFS.createTempFile( "kettle", "shell", environmentSubstitute( workDirectory ), this );
+          tempFile = KettleVFS.createTempFile( "kettle", "shell", System.getProperty( "java.io.tmpdir" ), this );
           fileObject = createTemporaryShellFile( tempFile, realScript );
         }
         base = new String[] { KettleVFS.getFilename( fileObject ) };


### PR DESCRIPTION
Update the step to use the Java temp directory when the script is embedded in the step.  The working directory is set elsewhere in ProcessBuilder.