### PR TITLE
[TEST] - replace a stream from Ant with array-based (caused by eb2906…

### DIFF
--- a/engine/test-src/org/pentaho/di/trans/TransTest.java
+++ b/engine/test-src/org/pentaho/di/trans/TransTest.java
@@ -28,7 +28,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -38,7 +40,6 @@ import java.util.concurrent.CountDownLatch;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs.FileObject;
-import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -182,9 +183,12 @@ public class TransTest {
     when( mockTransMeta.getParameterValue( testParam ) ).thenReturn( testParamValue );
     FileObject ktr = KettleVFS.createTempFile( "parameters", ".ktr", "ram://" );
     OutputStream outputStream = ktr.getContent().getOutputStream( true );
-    StringInputStream stringInputStream = new StringInputStream( "<transformation></transformation>" );
-    IOUtils.copy( stringInputStream, outputStream );
-    outputStream.close();
+    try {
+      InputStream inputStream = new ByteArrayInputStream( "<transformation></transformation>".getBytes() );
+      IOUtils.copy( inputStream, outputStream );
+    } finally {
+      outputStream.close();
+    }
     Trans trans = new Trans( mockTransMeta, null, null, null, ktr.getURL().toURI().toString() );
     assertEquals( testParamValue, trans.getParameterValue( testParam ) );
   }


### PR DESCRIPTION
…1f34263816cf35781cf2d689be6c0bd5ad (Mondrian))

@mattyb149, @brosander, take a look at this please.
Today I faced with a problem when tried to upgrade local codebase to the last. ```TransTest``` failed to compile and claimed ```org.apache.tools.ant.filters.StringInputStream``` had not been found.

I am using IntelliJ with IvyIDEA plugin. Surprisingly, running ```ant resolve compile-tests``` completed successfully. I made an investigation and found out, that recently @lucboudreau made this commit in Mondrian: https://github.com/pentaho/mondrian/commit/eb29061f34263816cf35781cf2d689be6c0bd5ad. Apart from others, he prohibited pulling ```ant-1.7.1``` transitively and this removed the jar from ```lib``` folder. 

So, IvyIDEA cannot resolve the jar now and IntelliJ indicates the compilation error.

I have no robust explanation why the test is compiling within console and hasn't failed on the CI yet. My only conjecture: ```ant``` adds itself to the classpath implicitly, so ```StringInputStream``` is actually included there.

My commit replaces ```StringInputStream``` with ```ByteArrayInputStream```. I checked that test is passing.