### PR TITLE
[PDI-13210]Allow multiple call backs per extension point

### DIFF
--- a/core/src/org/pentaho/di/core/extension/ExtensionPointHandler.java
+++ b/core/src/org/pentaho/di/core/extension/ExtensionPointHandler.java
@@ -42,8 +42,7 @@ public class ExtensionPointHandler {
    */
   public static void callExtensionPoint( final LogChannelInterface log, final String id, final Object object )
     throws KettleException {
-    ExtensionPointInterface extensionPoint = ExtensionPointMap.getInstance().get( id );
-    if ( extensionPoint != null ) {
+    for ( ExtensionPointInterface extensionPoint : ExtensionPointMap.getInstance().get( id ).values() ) {
       extensionPoint.callExtensionPoint( log, object );
     }
   }

--- a/core/test-src/org/pentaho/di/core/extension/ExtensionPointIntegrationTest.java
+++ b/core/test-src/org/pentaho/di/core/extension/ExtensionPointIntegrationTest.java
@@ -61,7 +61,7 @@ public class ExtensionPointIntegrationTest {
     // check that all extension points are executed
     final LogChannelInterface log = mock( LogChannelInterface.class );
     for ( KettleExtensionPoint ep : KettleExtensionPoint.values() ) {
-      final ExtensionPointInterface currentEP = ExtensionPointMap.getInstance().get( ep.id );
+      final ExtensionPointInterface currentEP = ExtensionPointMap.getInstance().get( ep.id ).get( "id" + ep.id );
       assertFalse( currentEP.getClass().getField( EXECUTED_FIELD_NAME ).getBoolean( currentEP ) );
       ExtensionPointHandler.callExtensionPoint( log, ep.id, null );
       assertTrue( currentEP.getClass().getField( EXECUTED_FIELD_NAME ).getBoolean( currentEP ) );
@@ -69,7 +69,7 @@ public class ExtensionPointIntegrationTest {
 
     // check modification of extension point
     final KettleExtensionPoint jobAfterOpen = KettleExtensionPoint.JobAfterOpen;
-    final ExtensionPointInterface int1 = ExtensionPointMap.getInstance().get( jobAfterOpen.id );
+    final ExtensionPointInterface int1 = ExtensionPointMap.getInstance().get( jobAfterOpen.id ).get( "id" + jobAfterOpen.id );
     ExtensionPointPluginType.getInstance().registerCustom( createClassRuntime( jobAfterOpen, "Edited" ), "custom", "id"
             + jobAfterOpen.id, jobAfterOpen.id,
         "no description", null );
@@ -79,7 +79,7 @@ public class ExtensionPointIntegrationTest {
     // check removal of extension point
     PluginRegistry.getInstance().removePlugin( ExtensionPointPluginType.class, PluginRegistry.getInstance().getPlugin(
         ExtensionPointPluginType.class, "id" + jobAfterOpen.id ) );
-    assertNull( ExtensionPointMap.getInstance().get( jobAfterOpen.id ) );
+    assertTrue( ExtensionPointMap.getInstance().get( jobAfterOpen.id ).isEmpty() );
     assertEquals( KettleExtensionPoint.values().length - 1, ExtensionPointMap.getInstance().getMap().size() );
   }
 

--- a/core/test-src/org/pentaho/di/core/extension/ExtensionPointMapTest.java
+++ b/core/test-src/org/pentaho/di/core/extension/ExtensionPointMapTest.java
@@ -27,7 +27,10 @@ import org.pentaho.di.core.plugins.PluginRegistry;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ExtensionPointMapTest {
   public static final String TEST_NAME = "testName";
@@ -63,6 +66,6 @@ public class ExtensionPointMapTest {
   @Test
   public void addExtensionPointTest() throws KettlePluginException {
     ExtensionPointMap.getInstance().addExtensionPoint( pluginInterface );
-    assertEquals( ExtensionPointMap.getInstance().get( TEST_NAME ), extensionPoint );
+    assertEquals( ExtensionPointMap.getInstance().get( TEST_NAME ).get( "testID" ), extensionPoint );
   }
 }


### PR DESCRIPTION
Extension points of the same type are overriding each other, allowing only one of each type.

Instead save each extension point to a table by type and id
This allows overwriting old extension points with updated version of the same id and multiple callbacks

@mattyb149 @rmansoor 