### PR TITLE
[PDI-13210]Lazy loading extension point interfaces

### DIFF
--- a/core/test-src/org/pentaho/di/core/extension/ExtensionPointMapTest.java
+++ b/core/test-src/org/pentaho/di/core/extension/ExtensionPointMapTest.java
@@ -28,6 +28,7 @@ import org.pentaho.di.core.plugins.PluginRegistry;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,20 +53,24 @@ public class ExtensionPointMapTest {
   public void constructorTest() throws Exception {
     PluginRegistry.getInstance().registerPlugin( ExtensionPointPluginType.class, pluginInterface );
     assertEquals( 1, ExtensionPointMap.getInstance().getMap().size() );
-    verify( pluginInterface, times( 1 ) ).loadClass( any( Class.class ) );
 
     PluginRegistry.getInstance().registerPlugin( ExtensionPointPluginType.class, pluginInterface );
     assertEquals( 1, ExtensionPointMap.getInstance().getMap().size() );
-    verify( pluginInterface, times( 2 ) ).loadClass( any( Class.class ) );
 
     PluginRegistry.getInstance().removePlugin( ExtensionPointPluginType.class, pluginInterface );
     assertEquals( 0, ExtensionPointMap.getInstance().getMap().size() );
-    verify( pluginInterface, times( 2 ) ).loadClass( any( Class.class ) );
+
+    // Verify lazy loading
+    verify( pluginInterface, never() ).loadClass( any( Class.class ) );
   }
 
   @Test
   public void addExtensionPointTest() throws KettlePluginException {
     ExtensionPointMap.getInstance().addExtensionPoint( pluginInterface );
     assertEquals( ExtensionPointMap.getInstance().get( TEST_NAME ).get( "testID" ), extensionPoint );
+
+    // Verify cached instance
+    assertEquals( ExtensionPointMap.getInstance().get( TEST_NAME ).get( "testID" ), extensionPoint );
+    verify( pluginInterface, times( 1 ) ).loadClass( any( Class.class ) );
   }
 }


### PR DESCRIPTION
Use instance caching suppliers in ExtensionPointMap instaed of instances.
Some extension points rely on a Spoon environment and instances were failing in headless enironments.

This change creates a lazy loader for each callback, and the plugin class is instantiated only on first call.

@mattyb149 @rmansoor