### PR TITLE
[PDI-13952] Return the correct exit code in spoon.sh

### DIFF
--- a/assembly/package-res/spoon.sh
+++ b/assembly/package-res/spoon.sh
@@ -212,6 +212,9 @@ if [ $OS = "linux" ]; then
 else
     "$_PENTAHO_JAVA" $OPT -jar "$STARTUP" -lib $LIBPATH "${1+$@}"
 fi
+EXIT_CODE=$?
 
 # return to the catalog from which spoon.sh has been started
 cd $INITIALDIR
+
+exit $EXIT_CODE


### PR DESCRIPTION
I've adapted the changes made in the pull request #1396 to the current master to fix the issue http://jira.pentaho.com/browse/PDI-13952