### PR TITLE
fixed Japanese garbled page

### DIFF
--- a/engine/src/org/pentaho/di/www/GetStatusServlet.java
+++ b/engine/src/org/pentaho/di/www/GetStatusServlet.java
@@ -24,6 +24,7 @@ package org.pentaho.di.www;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter; 
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
@@ -199,7 +200,7 @@ public class GetStatusServlet extends BaseHttpServlet implements CartePluginInte
       response.setContentType( "text/html;charset=UTF-8" );
     }
 
-    PrintStream out = new PrintStream( response.getOutputStream() );
+    PrintWriter out = response.getWriter();
 
     List<CarteObjectEntry> transEntries = getTransformationMap().getTransformationObjects();
     List<CarteObjectEntry> jobEntries = getJobMap().getJobObjects();

--- a/engine/test-src/org/pentaho/di/www/GetStatusServletTest.java
+++ b/engine/test-src/org/pentaho/di/www/GetStatusServletTest.java
@@ -1,0 +1,99 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www;
+
+import static junit.framework.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.gui.Point;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobMeta;
+
+public class GetStatusServletTest {
+  private TransformationMap mockTransformationMap;
+  private JobMap mockJobMap;
+  private GetStatusServlet getStatusServlet;
+
+  @Before
+  public void setup() {
+    mockTransformationMap = mock( TransformationMap.class );
+    mockJobMap = mock( JobMap.class );
+    getStatusServlet = new GetStatusServlet( mockTransformationMap, mockJobMap );
+  }
+
+  @Test
+  public void testGetStatusServletEscapesHtmlWhenTransNotFound() throws ServletException, IOException {
+    HttpServletRequest mockHttpServletRequest = mock( HttpServletRequest.class );
+    HttpServletResponse mockHttpServletResponse = mock( HttpServletResponse.class );
+
+    StringWriter out = new StringWriter();
+    PrintWriter printWriter = new PrintWriter( out );
+
+    when( mockHttpServletRequest.getContextPath() ).thenReturn( GetStatusServlet.CONTEXT_PATH );
+    when( mockHttpServletRequest.getParameter( anyString() ) ).thenReturn( ServletTestUtils.BAD_STRING );
+    when( mockHttpServletResponse.getWriter() ).thenReturn( printWriter );
+
+    getStatusServlet.doGet( mockHttpServletRequest, mockHttpServletResponse );
+    assertFalse( ServletTestUtils.hasBadText( ServletTestUtils.getInsideOfTag( "H1", out.toString() ) ) );
+  }
+
+  @Test
+  public void testGetStatusServletEscapesHtmlWhenTransFound() throws ServletException, IOException {
+    KettleLogStore.init();
+    HttpServletRequest mockHttpServletRequest = mock( HttpServletRequest.class );
+    HttpServletResponse mockHttpServletResponse = mock( HttpServletResponse.class );
+    Trans mockTrans = mock( Trans.class );
+    TransMeta mockTransMeta = mock( TransMeta.class );
+    LogChannelInterface mockChannelInterface = mock( LogChannelInterface.class );
+    StringWriter out = new StringWriter();
+    PrintWriter printWriter = new PrintWriter( out );
+
+    when( mockHttpServletRequest.getContextPath() ).thenReturn( GetStatusServlet.CONTEXT_PATH );
+    when( mockHttpServletRequest.getParameter( anyString() ) ).thenReturn( ServletTestUtils.BAD_STRING );
+    when( mockHttpServletResponse.getWriter() ).thenReturn( printWriter );
+    when( mockTransformationMap.getTransformation( any( CarteObjectEntry.class ) ) ).thenReturn( mockTrans );
+    when( mockTrans.getLogChannel() ).thenReturn( mockChannelInterface );
+    when( mockTrans.getTransMeta() ).thenReturn( mockTransMeta );
+    when( mockTransMeta.getMaximum() ).thenReturn( new Point( 10, 10 ) );
+
+    getStatusServlet.doGet( mockHttpServletRequest, mockHttpServletResponse );
+    assertFalse( out.toString().contains( ServletTestUtils.BAD_STRING ) );
+  }
+}

--- a/engine/test-src/org/pentaho/di/www/ServletTestUtils.java
+++ b/engine/test-src/org/pentaho/di/www/ServletTestUtils.java
@@ -1,0 +1,41 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www;
+
+public class ServletTestUtils {
+  public static final String BAD_STRING = "!@#$%^&*()<>/";
+
+  public static String getInsideOfTag( String tag, String string ) {
+    String open = "<" + tag + ">";
+    String close = "</" + tag + ">";
+    return string.substring( string.indexOf( open ) + open.length(), string.indexOf( close ) );
+  }
+
+  public static boolean hasBadText( String value ) {
+    return value.indexOf( '!' ) != -1
+      || value.indexOf( '@' ) != -1 || value.indexOf( '$' ) != -1 || value.indexOf( '%' ) != -1
+      || value.indexOf( '^' ) != -1 || value.indexOf( '*' ) != -1 || value.indexOf( '(' ) != -1
+      || value.indexOf( ')' ) != -1 || value.indexOf( '<' ) != -1 || value.indexOf( '>' ) != -1
+      || value.indexOf( '/' ) != -1;
+  }
+}


### PR DESCRIPTION
Japanese strings in DI server:
http://localhost:9080/pentaho-di/kettle/status
are garbled.

normal strings:
![normal](https://cloud.githubusercontent.com/assets/7023720/9092886/ca5c97cc-3be3-11e5-852c-378ae4af760a.PNG)

garbled strings:
![garbled](https://cloud.githubusercontent.com/assets/7023720/9092892/d38758e6-3be3-11e5-940a-a91a8f544c19.PNG)
