### PR TITLE
Reading properties file without native2ascii in SetVariables JobEntry

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
+++ b/engine/src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
@@ -31,6 +31,9 @@ import static org.pentaho.di.job.entry.validator.JobEntryValidatorUtils.notNullV
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
 
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.CheckResultInterface;
@@ -224,7 +227,11 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
       try {
         if ( !Const.isEmpty( realFilename ) ) {
           Properties properties = new Properties();
-          properties.load( KettleVFS.getInputStream( realFilename ) );
+          InputStream is = KettleVFS.getInputStream( realFilename );
+          // for UTF8 properties files
+          InputStreamReader isr = new InputStreamReader(is, "UTF-8");
+          BufferedReader reader = new BufferedReader(isr);
+          properties.load( reader );
           for ( Object key : properties.keySet() ) {
             variables.add( (String) key );
             variableValues.add( (String) properties.get( key ) );

--- a/engine/test-src/org/pentaho/di/job/entries/setvariables/ASCIIText.properties
+++ b/engine/test-src/org/pentaho/di/job/entries/setvariables/ASCIIText.properties
@@ -1,0 +1,3 @@
+Japanese=\u65e5\u672c\u8a9e
+English=English
+Chinese=\u4e2d\u6587

--- a/engine/test-src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
+++ b/engine/test-src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
@@ -1,0 +1,72 @@
+package org.pentaho.di.job.entries.setvariables;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileAttribute;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entry.JobEntryCopy;
+
+public class JobEntrySetVariablesTest {
+  private Job job;
+  private JobEntrySetVariables entry;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    KettleLogStore.init();
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    job = new Job( null, new JobMeta() );
+    entry = new JobEntrySetVariables();
+    job.getJobMeta().addJobEntry( new JobEntryCopy( entry ) );
+    entry.setParentJob( job );
+    job.setStopped( false );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public void testASCIIText() throws Exception {
+    // properties file with native2ascii
+    entry.setFilename("test-src/org/pentaho/di/job/entries/setvariables/ASCIIText.properties");
+    entry.setVariableName( new String[]{} ); // For absence of null check in execute method
+    entry.setReplaceVars(true);
+    Result result = entry.execute( new Result(), 0 );
+    assertTrue( "Result should be true", result.getResult() );
+    assertEquals( "日本語", entry.getVariable("Japanese") );
+    assertEquals( "English", entry.getVariable("English") );
+    assertEquals( "中文", entry.getVariable("Chinese") );
+  }
+
+  @Test
+  public void testUTF8Text() throws Exception {
+    // properties files without native2ascii
+    entry.setFilename("test-src/org/pentaho/di/job/entries/setvariables/UTF8Text.properties");
+    entry.setVariableName( new String[]{} ); // For absence of null check in execute method
+    entry.setReplaceVars(true);
+    Result result = entry.execute( new Result(), 0 );
+    assertTrue( "Result should be true", result.getResult() );
+    assertEquals( "日本語", entry.getVariable("Japanese") );
+    assertEquals( "English", entry.getVariable("English") );
+    assertEquals( "中文", entry.getVariable("Chinese") );
+  }
+}

--- a/engine/test-src/org/pentaho/di/job/entries/setvariables/UTF8Text.properties
+++ b/engine/test-src/org/pentaho/di/job/entries/setvariables/UTF8Text.properties
@@ -1,0 +1,3 @@
+Japanese=日本語
+English=English
+Chinese=中文


### PR DESCRIPTION
In Setvariables JobEntry,
I want to write a property file with Japanese strings, not in native2ascii-encoded strings.
With multi-byte character languages such as Japanese, Korean and Chinese,
it's too much trouble with native2ascii encoded strings.

Both UTF8 strings and native2ascii-encoded strings are accepted.
