### PR TITLE
[SP-2032] - Backport of PDI-14095 - Transformation Executor Result Ro…

### DIFF
--- a/engine/test-src/org/pentaho/di/trans/steps/transexecutor/TransExecutorUnitTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/transexecutor/TransExecutorUnitTest.java
@@ -1,0 +1,190 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.transexecutor;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.QueueRowSet;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.RowSet;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.StepMockUtil;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class TransExecutorUnitTest {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  private TransExecutor executor;
+  private TransExecutorMeta meta;
+  private TransExecutorData data;
+  private Trans internalTrans;
+  private Result internalResult;
+
+  @Before
+  public void setUp() throws Exception {
+    executor = StepMockUtil.getStep( TransExecutor.class, TransExecutorMeta.class, "TransExecutorUnitTest" );
+    executor = spy( executor );
+
+    TransMeta internalTransMeta = mock( TransMeta.class );
+    doReturn( internalTransMeta ).when( executor ).loadExecutorTransMeta();
+
+    internalTrans = mock( Trans.class );
+    doReturn( internalTrans ).when( executor ).createInternalTrans();
+    internalResult = new Result();
+    when( internalTrans.getResult() ).thenReturn( internalResult );
+
+    meta = new TransExecutorMeta();
+    data = new TransExecutorData();
+  }
+
+  @After
+  public void tearDown() {
+    executor = null;
+    meta = null;
+    data = null;
+    internalTrans = null;
+    internalResult = null;
+  }
+
+
+  @Test
+  public void collectsResultsFromInternalTransformation() throws Exception {
+    passOneRowToExecutor();
+
+    RowMetaAndData expectedResult = new RowMetaAndData( new RowMeta(), "fake result" );
+    internalResult.getRows().add( expectedResult );
+
+    RowSet rowSet = new QueueRowSet();
+    // any value except null
+    StepMeta stepMeta = mockStepAndMapItToRowSet( "stepMetaMock", rowSet );
+    meta.setOutputRowsSourceStepMeta( stepMeta );
+
+    executor.init( meta, data );
+    executor.setInputRowMeta( new RowMeta() );
+    assertTrue( "Passing one line at first time", executor.processRow( meta, data ) );
+    assertFalse( "Executing the internal trans during the second round", executor.processRow( meta, data ) );
+
+    Object[] resultsRow = rowSet.getRowImmediate();
+    assertNotNull( resultsRow );
+    assertArrayEquals( expectedResult.getData(), resultsRow );
+    assertNull( "Only one row is expected", rowSet.getRowImmediate() );
+  }
+
+
+  @Test
+  public void collectsExecutionResults() throws Exception {
+    passOneRowToExecutor();
+
+    StepMeta parentStepMeta = mock( StepMeta.class );
+    when( parentStepMeta.getName() ).thenReturn( "parentStepMeta" );
+    meta.setParentStepMeta( parentStepMeta );
+
+    internalResult.setResult( true );
+    meta.setExecutionResultField( "executionResultField" );
+
+    internalResult.setNrErrors( 1 );
+    meta.setExecutionNrErrorsField( "executionNrErrorsField" );
+
+    internalResult.setNrLinesRead( 2 );
+    meta.setExecutionLinesReadField( "executionLinesReadField" );
+
+    internalResult.setNrLinesWritten( 3 );
+    meta.setExecutionLinesWrittenField( "executionLinesWrittenField" );
+
+    internalResult.setNrLinesInput( 4 );
+    meta.setExecutionLinesInputField( "executionLinesInputField" );
+
+    internalResult.setNrLinesOutput( 5 );
+    meta.setExecutionLinesOutputField( "executionLinesOutputField" );
+
+    internalResult.setNrLinesRejected( 6 );
+    meta.setExecutionLinesRejectedField( "executionLinesRejectedField" );
+
+    internalResult.setNrLinesUpdated( 7 );
+    meta.setExecutionLinesUpdatedField( "executionLinesUpdatedField" );
+
+    internalResult.setNrLinesDeleted( 8 );
+    meta.setExecutionLinesDeletedField( "executionLinesDeletedField" );
+
+    internalResult.setNrFilesRetrieved( 9 );
+    meta.setExecutionFilesRetrievedField( "executionFilesRetrievedField" );
+
+    internalResult.setExitStatus( 10 );
+    meta.setExecutionExitStatusField( "executionExitStatusField" );
+
+
+    RowSet rowSet = new QueueRowSet();
+    // any value except null
+    StepMeta stepMeta = mockStepAndMapItToRowSet( "stepMetaMock", rowSet );
+    meta.setExecutionResultTargetStepMeta( stepMeta );
+
+    executor.init( meta, data );
+    executor.setInputRowMeta( new RowMeta() );
+    assertTrue( "Passing one line at first time", executor.processRow( meta, data ) );
+    assertFalse( "Executing the internal trans during the second round", executor.processRow( meta, data ) );
+
+    Object[] resultsRow = rowSet.getRowImmediate();
+    assertNotNull( resultsRow );
+    assertNull( "Only one row is expected", rowSet.getRowImmediate() );
+
+    assertEquals( internalResult.getResult(), resultsRow[ 0 ] );
+    assertEquals( internalResult.getNrErrors(), resultsRow[ 1 ] );
+    assertEquals( internalResult.getNrLinesRead(), resultsRow[ 2 ] );
+    assertEquals( internalResult.getNrLinesWritten(), resultsRow[ 3 ] );
+    assertEquals( internalResult.getNrLinesInput(), resultsRow[ 4 ] );
+    assertEquals( internalResult.getNrLinesOutput(), resultsRow[ 5 ] );
+    assertEquals( internalResult.getNrLinesRejected(), resultsRow[ 6 ] );
+    assertEquals( internalResult.getNrLinesUpdated(), resultsRow[ 7 ] );
+    assertEquals( internalResult.getNrLinesDeleted(), resultsRow[ 8 ] );
+    assertEquals( internalResult.getNrFilesRetrieved(), resultsRow[ 9 ] );
+    assertEquals( internalResult.getExitStatus(), ( (Number) resultsRow[ 10 ] ).intValue() );
+  }
+
+
+  private void passOneRowToExecutor() throws Exception {
+    doReturn( new Object[] { "row" } ).doReturn( null ).when( executor ).getRow();
+  }
+
+  private StepMeta mockStepAndMapItToRowSet( String stepName, RowSet rowSet ) throws Exception {
+    StepMeta stepMeta = mock( StepMeta.class );
+    when( stepMeta.getName() ).thenReturn( stepName );
+    doReturn( rowSet ).when( executor ).findOutputRowSet( stepName );
+    return stepMeta;
+  }
+}

--- a/test/org/pentaho/di/trans/steps/transexecutor/TransExecutorTest.java
+++ b/test/org/pentaho/di/trans/steps/transexecutor/TransExecutorTest.java
@@ -51,7 +51,7 @@ public class TransExecutorTest {
   private static final String EXPECTED_SUBTRANS_OUTPUT_PATTERN = "aa";
   private static final int EXPECTED_SUBTRANS_OUTPUT_AMOUNT = 10;
 
-  private static final String SUBTRANS_PATH = TransExecutorTest.class.getResource( "subtrans.ktr" ).toString();
+  private static final String SUBTRANS_PATH = "testfiles/org/pentaho/di/trans/steps/transexecutor/subtrans.ktr";
 
 
   @BeforeClass
@@ -139,13 +139,13 @@ public class TransExecutorTest {
     );
   }
 
-  private static Trans createTrans(TransMeta transMeta) throws Exception {
+  private static Trans createTrans( TransMeta transMeta ) throws Exception {
     Trans trans = new Trans( transMeta );
     trans.prepareExecution( null );
     return trans;
   }
 
-  private RowStepCollector listenExecutor(Trans trans) {
+  private RowStepCollector listenExecutor( Trans trans ) {
     StepInterface transExecutorStep = trans.getStepInterface( transExecutor.getName(), 0 );
     RowStepCollector rc = new RowStepCollector();
     transExecutorStep.addRowListener( rc );
@@ -206,7 +206,7 @@ public class TransExecutorTest {
 
     assertFalse( endRc.getRowsWritten().isEmpty() );
     // execution time field
-    assertNotNull( endRc.getRowsWritten().get( 0 ).getData()[0] );
+    assertNotNull( endRc.getRowsWritten().get( 0 ).getData()[ 0 ] );
   }
 
 }

--- a/testfiles/org/pentaho/di/trans/steps/transexecutor/subtrans.ktr
+++ b/testfiles/org/pentaho/di/trans/steps/transexecutor/subtrans.ktr
@@ -62,7 +62,6 @@
     <partitionschemas>
     </partitionschemas>
     <slaveservers>
-         <slaveserver><name>8081</name><hostname>localhost</hostname><port>8081</port><webAppName/><username>cluster</username><password>Encrypted 2be98afc86aa7f2e4cb1aa265cd86aac8</password><proxy_hostname/><proxy_port/><non_proxy_hosts/><master>Y</master></slaveserver>
     </slaveservers>
     <clusterschemas>
     </clusterschemas>
@@ -74,7 +73,7 @@
   <notepads>
   </notepads>
   <order>
-  <hop> <from>Generate Rows</from><to>Dummy</to><enabled>Y</enabled> </hop>
+  <hop> <from>Generate Rows</from><to>Copy rows to result</to><enabled>Y</enabled> </hop>
   </order>
   <step>
     <name>Generate Rows</name>
@@ -108,15 +107,15 @@
     <last_time_field>FiveSecondsAgo</last_time_field>
      <cluster_schema/>
  <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
-      <xloc>164</xloc>
-      <yloc>134</yloc>
+      <xloc>176</xloc>
+      <yloc>128</yloc>
       <draw>Y</draw>
       </GUI>
     </step>
 
   <step>
-    <name>Dummy</name>
-    <type>Dummy</type>
+    <name>Copy rows to result</name>
+    <type>RowsToResult</type>
     <description/>
     <distribute>Y</distribute>
     <custom_distribution/>
@@ -127,8 +126,8 @@
            </partitioning>
      <cluster_schema/>
  <remotesteps>   <input>   </input>   <output>   </output> </remotesteps>    <GUI>
-      <xloc>314</xloc>
-      <yloc>136</yloc>
+      <xloc>288</xloc>
+      <yloc>128</yloc>
       <draw>Y</draw>
       </GUI>
     </step>


### PR DESCRIPTION
…ws returns data from wrong step (5.4 Suite)

- replace streaming from the last step with obtaining data from Result container
- add tests
- move test transformation to testfiles folder and update it with "Copy rows to result" step
(cherry picked from commit 8361d0f)

@mattyb149, @brosander, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/1580  