### PR TITLE
[BACKLOG-4802] Make Shared Object parsing errors consistent between...

### DIFF
--- a/engine/src/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/org/pentaho/di/job/JobMeta.java
@@ -997,9 +997,9 @@ public class JobMeta extends AbstractMeta implements Cloneable, Comparable<JobMe
           sharedObjects = rep.readJobMetaSharedObjects( this );
         }
       } catch ( Exception e ) {
-        throw new KettleXMLException(
-          BaseMessages.getString( PKG, "JobMeta.ErrorReadingSharedObjects.Message" ), e );
-        // //
+        LogChannel.GENERAL
+          .logError( BaseMessages.getString( PKG, "JobMeta.ErrorReadingSharedObjects.Message", e.toString() ) );
+        LogChannel.GENERAL.logError( Const.getStackTracker( e ) );
       }
 
       // Load the database connections, slave servers, cluster schemas & partition schemas into this object.


### PR DESCRIPTION
JobMeta and TransMeta.

Background: Currently JobMeta will throw an exception when Shared Objects cannot be parsed, where TransMeta will log the exception and continue. It was agreed that they should be consistent and perform the TransMeta's behavior (log and continue).