### PR TITLE
[PDI-14253] Text file input: adding 'Minimal width' button to Fields tab

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInputMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInputMeta.java
@@ -920,7 +920,7 @@ public class TextFileInputMeta extends BaseStepMeta implements StepMetaInterface
     } catch ( Exception e ) {
       throw new KettleXMLException( "Unable to load step info from XML", e );
     }
-  } 
+  }
 
   public Object clone() {
     TextFileInputMeta retval = (TextFileInputMeta) super.clone();
@@ -2045,7 +2045,7 @@ public class TextFileInputMeta extends BaseStepMeta implements StepMetaInterface
     allocateFiles( fileName.length );
     setFileName( fileName );
   }
-  
+
   protected String loadSource( Node filenode, Node filenamenode, int i ) {
     return XMLHandler.getNodeValue( filenamenode );
   }
@@ -2057,7 +2057,7 @@ public class TextFileInputMeta extends BaseStepMeta implements StepMetaInterface
   protected String loadSourceRep( Repository rep, ObjectId id_step, int i ) throws KettleException {
     return rep.getStepAttributeString( id_step, i, "file_name" );
   }
-  
+
   protected void saveSourceRep( Repository rep, ObjectId id_transformation, ObjectId id_step, int i, String fileName )
     throws KettleException {
     rep.saveStepAttribute( id_transformation, id_step, i, "file_name", fileName ); //this should be in subclass

--- a/engine/src/org/pentaho/di/trans/steps/textfileinput/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/trans/steps/textfileinput/messages/messages_en_US.properties
@@ -228,6 +228,8 @@ TextFileInputDialog.Delimiter.Button=Insert &TAB
 TextFileInputDialog.Files.ExcludeWildcard.Column=Exclude wildcard
 TextFileInputDialog.Files.ExcludeWildcard.Tooltip=Enter a regular expression to exclude here and a directory in the first column.
 TextFileInputDialog.ExcludeFilemask.Label=Exclude Regular Expression
+TextFileInputDialog.MinWidth.Button=\ &Minimal width
+TextFileInputDialog.MinWidth.Tooltip=Sets the output to non-padded width.
 
 TextFileInputDialog.AdditionalFieldsTab.TabTitle=Additional output fields
 TextFileInputDialog.ShortFileFieldName.Label=Short filename field

--- a/ui/src/org/pentaho/di/ui/trans/steps/textfileinput/TextFileInputDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/textfileinput/TextFileInputDialog.java
@@ -2054,7 +2054,7 @@ public class TextFileInputDialog extends BaseStepDialog implements StepDialogInt
     wMinWidth.setText( BaseMessages.getString( PKG, "TextFileInputDialog.MinWidth.Button" ) );
     wMinWidth.setToolTipText( BaseMessages.getString( PKG, "TextFileInputDialog.MinWidth.Tooltip" ) );
     wMinWidth.addSelectionListener( new SelectionAdapter() {
-      public void widgetSelected ( SelectionEvent e ) {
+      public void widgetSelected( SelectionEvent e ) {
         input.setChanged();
       }
     } );
@@ -3133,6 +3133,15 @@ public class TextFileInputDialog extends BaseStepDialog implements StepDialogInt
     }
 
     wFields.optWidth( true );
+  }
+
+  /**
+   * Overloading setMinimalWidth() in order to test trim functionality
+   * @param wFields mocked TableView to avoid wFields.nrNonEmpty() from throwing NullPointerException
+   */
+  public void setMinimalWidth( TableView wFields ) {
+    this.wFields = wFields;
+    this.setMinimalWidth();
   }
 
   private void addAdditionalFieldsTab() {

--- a/ui/src/org/pentaho/di/ui/trans/steps/textfileinput/TextFileInputDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/textfileinput/TextFileInputDialog.java
@@ -68,6 +68,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.fileinput.FileInputList;
 import org.pentaho.di.core.gui.TextFileInputFieldInterface;
 import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
@@ -360,6 +361,9 @@ public class TextFileInputDialog extends BaseStepDialog implements StepDialogInt
 
   private TextFileInputMeta input;
 
+  private Button wMinWidth;
+  private Listener lsMinWidth;
+
   // Wizard info...
   private Vector<TextFileInputFieldInterface> fields;
 
@@ -533,6 +537,11 @@ public class TextFileInputDialog extends BaseStepDialog implements StepDialogInt
         preview();
       }
     };
+    lsMinWidth = new Listener() {
+      public void handleEvent( Event e ) {
+        setMinimalWidth();
+      }
+    };
     lsCancel = new Listener() {
       public void handleEvent( Event e ) {
         cancel();
@@ -543,6 +552,7 @@ public class TextFileInputDialog extends BaseStepDialog implements StepDialogInt
     wFirst.addListener( SWT.Selection, lsFirst );
     wFirstHeader.addListener( SWT.Selection, lsFirstHeader );
     wGet.addListener( SWT.Selection, lsGet );
+    wMinWidth.addListener( SWT.Selection, lsMinWidth );
     wPreview.addListener( SWT.Selection, lsPreview );
     wCancel.addListener( SWT.Selection, lsCancel );
 
@@ -2040,6 +2050,16 @@ public class TextFileInputDialog extends BaseStepDialog implements StepDialogInt
     fdGet.bottom = new FormAttachment( 100, 0 );
     wGet.setLayoutData( fdGet );
 
+    wMinWidth = new Button( wFieldsComp, SWT.PUSH );
+    wMinWidth.setText( BaseMessages.getString( PKG, "TextFileInputDialog.MinWidth.Button" ) );
+    wMinWidth.setToolTipText( BaseMessages.getString( PKG, "TextFileInputDialog.MinWidth.Tooltip" ) );
+    wMinWidth.addSelectionListener( new SelectionAdapter() {
+      public void widgetSelected ( SelectionEvent e ) {
+        input.setChanged();
+      }
+    } );
+    setButtonPositions( new Button[] { wGet, wMinWidth }, margin, null );
+
     final int FieldsRows = input.getInputFields().length;
 
     ColumnInfo[] colinf =
@@ -3075,6 +3095,44 @@ public class TextFileInputDialog extends BaseStepDialog implements StepDialogInt
     Collections.sort( fields );
 
     return fields;
+  }
+
+  /**
+   * Sets the input width to minimal width...
+   *
+   */
+  public void setMinimalWidth() {
+    int nrNonEmptyFields = wFields.nrNonEmpty();
+    for ( int i = 0; i < nrNonEmptyFields; i++ ) {
+      TableItem item = wFields.getNonEmpty( i );
+
+      item.setText( 5, "" );
+      item.setText( 6, "" );
+      item.setText( 12, ValueMeta.getTrimTypeDesc( ValueMetaInterface.TRIM_TYPE_BOTH ) );
+
+      int type = ValueMeta.getType( item.getText( 2 ) );
+      switch ( type ) {
+        case ValueMetaInterface.TYPE_STRING:
+          item.setText( 3, "" );
+          break;
+        case ValueMetaInterface.TYPE_INTEGER:
+          item.setText( 3, "0" );
+          break;
+        case ValueMetaInterface.TYPE_NUMBER:
+          item.setText( 3, "0.#####" );
+          break;
+        case ValueMetaInterface.TYPE_DATE:
+          break;
+        default:
+          break;
+      }
+    }
+
+    for ( int i = 0; i < input.getInputFields().length; i++ ) {
+      input.getInputFields()[i].setTrimType( ValueMetaInterface.TRIM_TYPE_BOTH );
+    }
+
+    wFields.optWidth( true );
   }
 
   private void addAdditionalFieldsTab() {

--- a/ui/test-src/org/pentaho/di/ui/trans/steps/textfileinput/TextFileInputDialogTest.java
+++ b/ui/test-src/org/pentaho/di/ui/trans/steps/textfileinput/TextFileInputDialogTest.java
@@ -1,0 +1,154 @@
+package org.pentaho.di.ui.trans.steps.textfileinput;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.BlockingRowSet;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.Props;
+import org.pentaho.di.core.RowSet;
+import org.pentaho.di.core.fileinput.FileInputList;
+import org.pentaho.di.core.playlist.FilePlayListAll;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.errorhandling.FileErrorHandler;
+import org.pentaho.di.trans.steps.StepMockUtil;
+import org.pentaho.di.trans.steps.textfileinput.*;
+import org.pentaho.di.ui.core.PropsUI;
+import org.pentaho.di.ui.core.widget.TableView;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by jadametz on 9/9/15.
+ */
+public class TextFileInputDialogTest {
+
+  private static boolean changedPropsUi;
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  @BeforeClass
+  public static void hackPropsUi() throws Exception {
+    Field props = getPropsField();
+    if ( props == null ) {
+      throw new IllegalStateException( "Cannot find 'props' field in " + Props.class.getName() );
+    }
+
+    Object value = FieldUtils.readStaticField( props, true );
+    if ( value == null ) {
+      PropsUI mock = mock( PropsUI.class );
+      FieldUtils.writeStaticField( props, mock, true );
+      changedPropsUi = true;
+    } else {
+      changedPropsUi = false;
+    }
+  }
+
+  @AfterClass
+  public static void restoreNullInPropsUi() throws Exception {
+    if ( changedPropsUi ) {
+      Field props = getPropsField();
+      FieldUtils.writeStaticField( props, null, true );
+    }
+  }
+
+  private static Field getPropsField() {
+    return FieldUtils.getDeclaredField( Props.class, "props", true );
+  }
+
+  @Test
+  public void testMinimalWidth_PDI_14253() throws Exception {
+    final String virtualFile = "ram://pdi-14253.txt";
+    KettleVFS.getFileObject( virtualFile ).createFile();
+
+    final String content = "r1c1,  r1c2\nr2c1  ,  r2c2  ";
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write( content.getBytes() );
+
+    OutputStream os = KettleVFS.getFileObject( virtualFile ).getContent().getOutputStream();
+    IOUtils.copy( new ByteArrayInputStream( bos.toByteArray() ), os );
+    os.close();
+
+    TextFileInputMeta meta = new TextFileInputMeta();
+    meta.setLineWrapped( false );
+    meta.setInputFields( new TextFileInputField[]{
+      new TextFileInputField( "col1", -1, -1 ),
+      new TextFileInputField( "col2", -1, -1 )
+    } );
+    meta.setFileCompression( "None" );
+    meta.setFileType( "CSV" );
+    meta.setHeader( false );
+    meta.setNrHeaderLines( -1 );
+    meta.setFooter( false );
+    meta.setNrFooterLines( -1 );
+
+    TextFileInputData data = new TextFileInputData();
+    data.setFiles( new FileInputList() );
+    data.getFiles().addFile( KettleVFS.getFileObject( virtualFile ) );
+
+    data.outputRowMeta = new RowMeta();
+    data.outputRowMeta.addValueMeta( new ValueMetaString( "col1" ) );
+    data.outputRowMeta.addValueMeta( new ValueMetaString( "col2" ) );
+
+    data.dataErrorLineHandler = mock( FileErrorHandler.class );
+    data.fileFormatType = TextFileInputMeta.FILE_FORMAT_UNIX;
+    data.separator = ",";
+    data.filterProcessor = new TextFileFilterProcessor( new TextFileFilter[ 0 ] );
+    data.filePlayList = new FilePlayListAll();
+
+    TextFileInputDialog dialog =
+        new TextFileInputDialog( mock( Shell.class ), meta, mock( TransMeta.class ), "TFIMinimalWidthTest" );
+    TableView tv = mock( TableView.class );
+    when( tv.nrNonEmpty() ).thenReturn( 0 );
+
+    // click the Minimal width button
+    dialog.setMinimalWidth( tv );
+
+    RowSet output = new BlockingRowSet( 5 );
+    TextFileInput input = StepMockUtil.getStep( TextFileInput.class, TextFileInputMeta.class, "test" );
+    input.setOutputRowSets( Collections.singletonList( output ) );
+    while ( input.processRow( meta, data ) ) {
+      // wait until the step completes executing
+    }
+
+    Object[] row1 = output.getRowImmediate();
+    assertRow( row1, "r1c1", "r1c2" );
+
+    Object[] row2 = output.getRowImmediate();
+    assertRow( row2, "r2c1", "r2c2" );
+
+    KettleVFS.getFileObject( virtualFile ).delete();
+
+  }
+
+  private static void assertRow( Object[] row, Object... values ) {
+    assertNotNull( row );
+    assertTrue( String.format( "%d < %d", row.length, values.length ), row.length >= values.length );
+    int i = 0;
+    while ( i < values.length ) {
+      assertEquals( values[ i ], row[ i ] );
+      i++;
+    }
+    while ( i < row.length ) {
+      assertNull( row[ i ] );
+      i++;
+    }
+  }
+}


### PR DESCRIPTION
Implements a Minimal width button on the Fields tab of Text file input. This improvement is meant to save the user time from setting each fields Trim type to "both" when attempting to eliminate padded data.

JIRA Issue: http://jira.pentaho.com/browse/PDI-14253