### PR TITLE
Fixed invalid error message for Mail step

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/mail/Mail.java
+++ b/engine/src/org/pentaho/di/trans/steps/mail/Mail.java
@@ -311,7 +311,7 @@ public class Mail extends BaseStep implements StepInterface {
           throw new KettleException( BaseMessages.getString( PKG, "Mail.Exception.AttachedContentFieldEmpty" ) );
         }
         data.indexOfAttachedContent = data.previousRowMeta.indexOfValue( attachedContentField );
-        if ( data.indexOfComment < 0 ) {
+        if ( data.indexOfAttachedContent < 0 ) {
           throw new KettleException( BaseMessages.getString(
             PKG, "Mail.Exception.CouldnotFindAttachedContentField", attachedContentField ) );
         }
@@ -323,7 +323,7 @@ public class Mail extends BaseStep implements StepInterface {
             PKG, "Mail.Exception.AttachedContentFileNameFieldEmpty" ) );
         }
         data.IndexOfAttachedFilename = data.previousRowMeta.indexOfValue( attachedContentFileNameField );
-        if ( data.indexOfComment < 0 ) {
+        if ( data.IndexOfAttachedFilename < 0 ) {
           throw new KettleException( BaseMessages.getString(
             PKG, "Mail.Exception.CouldnotFindAttachedContentFileNameField", attachedContentFileNameField ) );
         }


### PR DESCRIPTION
If a "Comment" field was not specified and files were to be attached, an erroneous error message would be presented saying that content files could not be found when in fact it is the "Comment" field that was not specified.