### PR TITLE
[SP-1979] - Backport of PDI-13961 - Spoon firstly tries to conect via JNDI although connection type is JDBC (5.4 Suite)

### DIFF
--- a/core/src/org/pentaho/di/core/database/ExtendedDSProviderInterface.java
+++ b/core/src/org/pentaho/di/core/database/ExtendedDSProviderInterface.java
@@ -1,0 +1,48 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.database;
+
+import javax.sql.DataSource;
+
+/**
+ * The purpose of this interface is to provide a way to get data sources by unique DS identifier.
+ *
+ * @deprecated This interface exists only for backward compatibility and will be removed in 6.0
+ */
+@Deprecated
+public interface ExtendedDSProviderInterface extends DataSourceProviderInterface {
+
+  /**
+   * Returns the named data source of respecting its <code>type</code>
+   *
+   * @param datasourceName name of the desired data source
+   * @param type           data source's type
+   * @return named data source
+   * @throws DataSourceNamingException
+   */
+  DataSource getNamedDataSource( String datasourceName, DatasourceType type ) throws DataSourceNamingException;
+
+  enum DatasourceType {
+    JNDI, POOLED
+  }
+}

--- a/core/src/org/pentaho/di/core/database/util/DatabaseUtil.java
+++ b/core/src/org/pentaho/di/core/database/util/DatabaseUtil.java
@@ -26,6 +26,7 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DataSourceNamingException;
 import org.pentaho.di.core.database.DataSourceProviderInterface;
 import org.pentaho.di.core.database.Database;
+import org.pentaho.di.core.database.ExtendedDSProviderInterface;
 import org.pentaho.di.i18n.BaseMessages;
 
 import javax.naming.Context;
@@ -42,7 +43,7 @@ import java.util.Map;
  * @author mbatchel
  */
 
-public class DatabaseUtil implements DataSourceProviderInterface {
+public class DatabaseUtil implements DataSourceProviderInterface, ExtendedDSProviderInterface {
   private static Class<?> PKG = Database.class; // for i18n purposes, needed by Translator2!!
   private static Map<String, DataSource> FoundDS = Collections.synchronizedMap( new HashMap<String, DataSource>() );
 
@@ -132,5 +133,21 @@ public class DatabaseUtil implements DataSourceProviderInterface {
     } catch ( NamingException ex ) {
       throw new DataSourceNamingException( ex );
     }
+  }
+
+
+  @Override
+  public DataSource getNamedDataSource( String datasourceName, DatasourceType type )
+    throws DataSourceNamingException {
+    if ( type != null ) {
+      switch( type ) {
+        case JNDI:
+          return getNamedDataSource( datasourceName );
+        case POOLED:
+          throw new UnsupportedOperationException(
+            getClass().getName() + " does not support providing pooled data sources" );
+      }
+    }
+    throw new IllegalArgumentException( "Unsupported data source type: " + type );
   }
 }


### PR DESCRIPTION
- introduce a new interface for distinguishing the source where to look for data sources; the interface is 5.4-only, make it deprecated
- leave the rest of Database.normalConnect()
- add tests

@mattyb149, @brosander, @mattcasters, @deinspanjer, @pentaho-nbaker, @rmansoor, review it please.
**Note! This is not a direct backport of https://github.com/pentaho/pentaho-kettle/pull/1655 !**

/cc @pamval 