### PR TITLE
BACKLOG-2941 -- Shared Dimension step should automatically update data

### DIFF
--- a/engine/src/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/org/pentaho/di/trans/TransMeta.java
@@ -771,7 +771,7 @@ public class TransMeta extends AbstractMeta
   public void addOrReplaceStep( StepMeta stepMeta ) {
     int index = steps.indexOf( stepMeta );
     if ( index < 0 ) {
-      steps.add( stepMeta );
+      index = steps.add( stepMeta ) ? 0 : index;
     } else {
       StepMeta previous = getStep( index );
       previous.replaceMeta( stepMeta );
@@ -6209,6 +6209,8 @@ public class TransMeta extends AbstractMeta
       }
       if ( indexListenerRemove >= 0 ) {
         stepChangeListeners.add( indexListenerRemove, list );
+      } else if ( stepChangeListeners.size() == 0 && p == 0 ) {
+        stepChangeListeners.add( list );
       }
     }
   }

--- a/engine/test-src/org/pentaho/di/trans/TransMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/TransMetaTest.java
@@ -145,6 +145,17 @@ public class TransMetaTest {
     assert transMeta.changed_steps;
   }
 
+  @Test
+  public void testStepChangeListener() throws Exception {
+    MetaInjectMeta mim = new MetaInjectMeta();
+    StepMeta sm = new StepMeta( "testStep", mim );
+    try {
+      transMeta.addOrReplaceStep( sm );
+    } catch ( Exception ex ) {
+      fail();
+    }
+  }
+
   private static StepMeta mockStepMeta( String name ) {
     StepMeta meta = mock( StepMeta.class );
     when( meta.getName() ).thenReturn( name );


### PR DESCRIPTION
provider name when the output step name is changed

What was done:
1) During the fix of initial issue the tests using TransMeta.addOrReplace
failed. SO added a unit tetst demonstrating this and created the fix for
the issue.