### PR TITLE
[PDI-14172] - Text file input Repeat doesn't work

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
@@ -628,7 +628,7 @@ public class TextFileInput extends BaseStep implements StepInterface {
         addRootUri, shortFilename, path, hidden, modificationDateTime, uri, rooturi, extension, size );
   }
 
-  public static final Object[] convertLineToRow( LogChannelInterface log, TextFileLine textFileLine,
+  public static Object[] convertLineToRow( LogChannelInterface log, TextFileLine textFileLine,
       InputFileMetaInterface info, Object[] passThruFields, int nrPassThruFields, RowMetaInterface outputRowMeta,
       RowMetaInterface convertRowMeta, String fname, long rowNr, String delimiter, String enclosure,
       String escapeCharacter, FileErrorHandler errorHandler, boolean addShortFilename, boolean addExtension,
@@ -675,9 +675,13 @@ public class TextFileInput extends BaseStep implements StepInterface {
         int trim_type = fieldnr < nrfields ? f.getTrimType() : ValueMetaInterface.TRIM_TYPE_NONE;
 
         if ( fieldnr < strings.length ) {
-          String pol = strings[fieldnr];
+          String pol = strings[ fieldnr ];
           try {
-            value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );
+            if ( valueMeta.isNull( pol ) ) {
+              value = null;
+            } else {
+              value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );
+            }
           } catch ( Exception e ) {
             // OK, give some feedback!
             String message =

--- a/engine/test-src/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
@@ -44,6 +44,7 @@ import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.trans.step.errorhandling.FileErrorHandler;
 import org.pentaho.di.trans.steps.StepMockUtil;
+import org.pentaho.di.utils.TestUtils;
 
 import static org.junit.Assert.*;
 
@@ -114,28 +115,16 @@ public class TextFileInputTest {
 
   @Test
   public void readWrappedInputWithoutHeaders() throws Exception {
-    final String virtualFile = "ram://pdi-2607.txt";
-    KettleVFS.getFileObject( virtualFile ).createFile();
-
     final String content = new StringBuilder()
       .append( "r1c1" ).append( '\n' ).append( ";r1c2\n" )
       .append( "r2c1" ).append( '\n' ).append( ";r2c2" )
       .toString();
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    bos.write( content.getBytes() );
-
-    OutputStream os = KettleVFS.getFileObject( virtualFile ).getContent().getOutputStream();
-    IOUtils.copy( new ByteArrayInputStream( bos.toByteArray() ), os );
-    os.close();
-
+    final String virtualFile = createVirtualFile( "pdi-2607.txt", content );
 
     TextFileInputMeta meta = new TextFileInputMeta();
     meta.setLineWrapped( true );
     meta.setNrWraps( 1 );
-    meta.setInputFields( new TextFileInputField[] {
-      new TextFileInputField( "col1", -1, -1 ),
-      new TextFileInputField( "col2", -1, -1 )
-    } );
+    meta.setInputFields( new TextFileInputField[] { field( "col1" ), field( "col2" ) } );
     meta.setFileCompression( "None" );
     meta.setFileType( "CSV" );
     meta.setHeader( false );
@@ -159,11 +148,7 @@ public class TextFileInputTest {
 
 
     RowSet output = new BlockingRowSet( 5 );
-    TextFileInput input = StepMockUtil.getStep( TextFileInput.class, TextFileInputMeta.class, "test" );
-    input.setOutputRowSets( Collections.singletonList( output ) );
-    while ( input.processRow( meta, data ) ) {
-      // wait until the step completes executing
-    }
+    executeStep( meta, data, output, 2 );
 
     Object[] row1 = output.getRowImmediate();
     assertRow( row1, "r1c1", "r1c2" );
@@ -172,7 +157,95 @@ public class TextFileInputTest {
     assertRow( row2, "r2c1", "r2c2" );
 
 
-    KettleVFS.getFileObject( virtualFile ).delete();
+    deleteVfsFile( virtualFile );
+  }
+
+  @Test
+  public void readInputWithMissedValues() throws Exception {
+    final String virtualFile = createVirtualFile( "pdi-14172.txt", "1,1,1\n", "2,,2\n" );
+
+    TextFileInputMeta meta = new TextFileInputMeta();
+    TextFileInputField field2 = field( "col2" );
+    field2.setRepeated( true );
+    meta.setInputFields( new TextFileInputField[] {
+      field( "col1" ), field2, field( "col3" )
+    } );
+    meta.setFileCompression( "None" );
+    meta.setFileType( "CSV" );
+    meta.setHeader( false );
+    meta.setNrHeaderLines( -1 );
+    meta.setFooter( false );
+    meta.setNrFooterLines( -1 );
+
+    TextFileInputData data = new TextFileInputData();
+    data.setFiles( new FileInputList() );
+    data.getFiles().addFile( KettleVFS.getFileObject( virtualFile ) );
+
+    data.outputRowMeta = new RowMeta();
+    data.outputRowMeta.addValueMeta( new ValueMetaString( "col1" ) );
+    data.outputRowMeta.addValueMeta( new ValueMetaString( "col2" ) );
+    data.outputRowMeta.addValueMeta( new ValueMetaString( "col3" ) );
+
+    data.dataErrorLineHandler = Mockito.mock( FileErrorHandler.class );
+    data.fileFormatType = TextFileInputMeta.FILE_FORMAT_UNIX;
+    data.separator = ",";
+    data.filterProcessor = new TextFileFilterProcessor( new TextFileFilter[ 0 ] );
+    data.filePlayList = new FilePlayListAll();
+
+
+    RowSet output = new BlockingRowSet( 5 );
+    executeStep( meta, data, output, 2 );
+
+    Object[] row1 = output.getRowImmediate();
+    assertRow( row1, "1", "1", "1" );
+
+    Object[] row2 = output.getRowImmediate();
+    assertRow( row2, "2", "1", "2" );
+
+
+    deleteVfsFile( virtualFile );
+  }
+
+  private void executeStep( TextFileInputMeta meta, TextFileInputData data, RowSet output, int expectedRounds )
+    throws Exception {
+    TextFileInput input = StepMockUtil.getStep( TextFileInput.class, TextFileInputMeta.class, "test" );
+    input.setOutputRowSets( Collections.singletonList( output ) );
+    int i = 0;
+    while ( input.processRow( meta, data ) && i < expectedRounds ) {
+      i++;
+    }
+
+    assertEquals( "The amount of executions should be equal to expected", expectedRounds, i );
+  }
+
+  private static String createVirtualFile( String filename, String... rows ) throws Exception {
+    String virtualFile = TestUtils.createRamFile( filename );
+
+    StringBuilder content = new StringBuilder();
+    if ( rows != null ) {
+      for ( String row : rows ) {
+        content.append( row );
+      }
+    }
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write( content.toString().getBytes() );
+
+    OutputStream os = KettleVFS.getFileObject( virtualFile ).getContent().getOutputStream();
+    try {
+      IOUtils.copy( new ByteArrayInputStream( bos.toByteArray() ), os );
+    } finally {
+      os.close();
+    }
+
+    return virtualFile;
+  }
+
+  private static void deleteVfsFile( String path ) throws Exception {
+    TestUtils.getFileObject( path ).delete();
+  }
+
+  private static TextFileInputField field( String name ) {
+    return new TextFileInputField( name, -1, -1 );
   }
 
   private static void assertRow( Object[] row, Object... values ) {


### PR DESCRIPTION
- set parsing value to null to prevent the regression from PDI-11194
- add test

@mattyb149, @brosander, review it please.
As far as I know, the code freeze was not announced so far, hence I suppose it make sense to include this fix into 6.0 to remove the regression from the brand new release.