### PR TITLE
[BACKLOG-3431]Fire content listeners on set/clear

### DIFF
--- a/engine/test-src/org/pentaho/di/job/JobMetaTest.java
+++ b/engine/test-src/org/pentaho/di/job/JobMetaTest.java
@@ -22,18 +22,22 @@
 
 package org.pentaho.di.job;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.listeners.ContentChangedListener;
 import org.pentaho.di.job.entries.empty.JobEntryEmpty;
 import org.pentaho.di.job.entry.JobEntryCopy;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class JobMetaTest {
   private JobMeta jm;
@@ -78,5 +82,27 @@ public class JobMetaTest {
   @Test
   public void testPathNotExist() throws KettleXMLException, IOException, URISyntaxException {
     Assert.assertFalse( jm.isPathExist( je2, je4 ) );
+  }
+
+  @Test
+  public void testContentChangeListener() throws Exception {
+    ContentChangedListener listener = mock( ContentChangedListener.class );
+    jm.addContentChangedListener( listener );
+
+    jm.setChanged();
+    jm.setChanged( true );
+
+    verify( listener, times( 2 ) ).contentChanged( same( jm ) );
+
+    jm.clearChanged();
+    jm.setChanged( false );
+
+    verify( listener, times( 2 ) ).contentSafe( same( jm ) );
+
+    jm.removeContentChangedListener( listener );
+    jm.setChanged();
+    jm.setChanged( true );
+
+    verifyNoMoreInteractions( listener );
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/TransMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/TransMetaTest.java
@@ -21,9 +21,6 @@
  ******************************************************************************/
 package org.pentaho.di.trans;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,6 +29,7 @@ import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.gui.Point;
+import org.pentaho.di.core.listeners.ContentChangedListener;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaString;
@@ -44,6 +42,19 @@ import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.steps.metainject.MetaInjectMeta;
 import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.stores.memory.MemoryMetaStore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class TransMetaTest {
 
@@ -154,6 +165,28 @@ public class TransMetaTest {
     } catch ( Exception ex ) {
       fail();
     }
+  }
+
+  @Test
+  public void testContentChangeListener() throws Exception {
+    ContentChangedListener listener = mock( ContentChangedListener.class );
+    transMeta.addContentChangedListener( listener );
+
+    transMeta.setChanged();
+    transMeta.setChanged( true );
+
+    verify( listener, times( 2 ) ).contentChanged( same( transMeta ) );
+
+    transMeta.clearChanged();
+    transMeta.setChanged( false );
+
+    verify( listener, times( 2 ) ).contentSafe( same( transMeta ) );
+
+    transMeta.removeContentChangedListener( listener );
+    transMeta.setChanged();
+    transMeta.setChanged( true );
+
+    verifyNoMoreInteractions( listener );
   }
 
   private static StepMeta mockStepMeta( String name ) {


### PR DESCRIPTION
Replaced AbstractMeta inheritance of ChangeFlag with delegation to prevent circular override.