### PR TITLE
[MARKET-315] Prevent NPE when quitting with open SpoonBrowser tabs on Windows

### DIFF
--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -4932,6 +4932,13 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     }
 
     if ( exit ) {
+      // on windows [...].swt.ole.win32.OleClientSite.OnInPlaceDeactivate can
+      // cause the focus to move to an already disposed tab, resulting in a NPE
+      // so we first move the focus to somewhere else
+      if(this.selectionLabel != null && !this.selectionLabel.isDisposed()) {
+        this.selectionLabel.forceFocus();
+      }
+
       close();
     }
 


### PR DESCRIPTION
On Windows, browser tabs are instances of `org.eclipse.swt.ole.win32.OleClientSite`
that manages embedded ActiveX controls.

When disposed (at least in SWT 4.3.2) `OnInPlaceDeactivate` is called and if the
tab has focus forces its move to the next focusable control (the next open tab).
Great when closing a tab!

Unfortunately when quiting the app it seems it can end up on an already disposed tab,
throwing a NullPointerException.

Moving in advance the focus to other non-embedded control prevents it.

@graimundo