### PR TITLE
[MARKET-314] Allow close and disposal of SpoonBrowser tabs other than the Welcome tab

### DIFF
--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -1114,14 +1114,6 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     }
   }
 
-  public void closeSpoonBrowser() {
-    TabMapEntry browserTab = delegates.tabs.findTabMapEntry( STRING_WELCOME_TAB_NAME, ObjectType.BROWSER );
-
-    if ( browserTab != null ) {
-      delegates.tabs.removeTab( browserTab );
-    }
-  }
-
   /**
    * Search the transformation meta-data.
    *

--- a/ui/src/org/pentaho/di/ui/spoon/delegates/SpoonTabsDelegate.java
+++ b/ui/src/org/pentaho/di/ui/spoon/delegates/SpoonTabsDelegate.java
@@ -121,7 +121,7 @@ public class SpoonTabsDelegate extends SpoonDelegate {
             spoon.refreshTree();
             // spoon.refreshCoreObjects();
           } else if ( entry.getObject() instanceof SpoonBrowser ) {
-            spoon.closeSpoonBrowser();
+            this.removeTab( entry );
             spoon.refreshTree();
           } else if ( entry.getObject() instanceof Composite ) {
             Composite comp = (Composite) entry.getObject();


### PR DESCRIPTION
It was assumed the Welcome tab was the only SpoonBrowser. The closing of other
SpoonBrowser tab caused the closing of Welcome tab, and probably the deficient
disposal of the intended tab.

@graimundo