### PR TITLE
[PDI-10210] - min nr of rows before % evaluation issue

### DIFF
--- a/engine/src/org/pentaho/di/trans/step/BaseStep.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStep.java
@@ -1665,7 +1665,7 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
     if ( maxPercentErrors > 0
       && getLinesRejected() > 0
       && ( minRowsForMaxErrorPercent <= 0 || getLinesRead() >= minRowsForMaxErrorPercent ) ) {
-      int pct = (int) ( 100 * getLinesRejected() / getLinesRead() );
+      int pct = (int) Math.ceil(100 * (double)getLinesRejected() / getLinesRead()); // additional conversion for PDI-10210
       if ( pct > maxPercentErrors ) {
         logError( BaseMessages.getString(
           PKG, "BaseStep.Log.MaxPercentageRejectedReached", Integer.toString( pct ), Long


### PR DESCRIPTION
Issue with 'Error Handling settings' when the value of 'min nr of rows to read before doing % evaluation' is greater than 100