### PR TITLE
PDI-11863: As a Salesforce ETL Developer Make Upsert Mapping exclude non-updatable fields

### DIFF
--- a/plugins/salesforce/src/org/pentaho/di/ui/trans/steps/salesforceupsert/SalesforceUpsertDialog.java
+++ b/plugins/salesforce/src/org/pentaho/di/ui/trans/steps/salesforceupsert/SalesforceUpsertDialog.java
@@ -174,6 +174,8 @@ public class SalesforceUpsertDialog extends BaseStepDialog implements StepDialog
   private static List<ColumnInfo> tableFieldColumns = new ArrayList<ColumnInfo>();
   private boolean gotFields = false;
 
+  private boolean excludeNonUpdatableFields = true;
+
   public SalesforceUpsertDialog( Shell parent, Object in, TransMeta transMeta, String sname ) {
     super( parent, (BaseStepMeta) in, transMeta, sname );
     input = (SalesforceUpsertMeta) in;
@@ -932,8 +934,8 @@ public class SalesforceUpsertDialog extends BaseStepDialog implements StepDialog
       connection.setTimeOut( realTimeOut );
       // connect to Salesforce
       connection.connect();
-      // return fieldsname for the module
-      return connection.getFields( selectedModule );
+      return connection.getFields( connection.getObjectFields( selectedModule, excludeNonUpdatableFields ) );
+
     } catch ( Exception e ) {
       throw new KettleException( "Erreur getting fields from module [" + url + "]!", e );
     } finally {
@@ -944,6 +946,7 @@ public class SalesforceUpsertDialog extends BaseStepDialog implements StepDialog
         }
       }
     }
+
   }
 
   /**


### PR DESCRIPTION
What was done:
1)It's moved to org.pentaho.di.trans.steps.salesforceinput.SalesforceConnection
2)The fields with type="id" should not be excluded - we need mapped this fied when Upset Comparison Field=Id.
3)Deleted the code that belongs to PDI-11864. It should be in the separate PR.