### PR TITLE
PDI-14364 In spoon, the Insert/update step’s “Edit mapping” leaves Update Y/N selection in Update/Insert Table empty.

### DIFF
--- a/ui/src/org/pentaho/di/ui/trans/steps/insertupdate/InsertUpdateDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/steps/insertupdate/InsertUpdateDialog.java
@@ -639,6 +639,7 @@ public class InsertUpdateDialog extends BaseStepDialog implements StepDialogInte
         TableItem item = wReturn.table.getItem( i );
         item.setText( 2, sourceFields.getValueMeta( mapping.getSourcePosition() ).getName() );
         item.setText( 1, targetFields.getValueMeta( mapping.getTargetPosition() ).getName() );
+        item.setText( 3, "Y" );
       }
       wReturn.setRowNums();
       wReturn.optWidth( true );


### PR DESCRIPTION
To solve this issue, I added one line of code in 
ui/src/org/pentaho/di/ui/trans/steps/insertupdate/InsertUpdateDialog.java.