### PR TITLE
[PDI-11864]: As a Salesforce ETL Developer make Salesforce Upsert Ste…

### DIFF
--- a/plugins/salesforce/src/org/pentaho/di/ui/trans/steps/salesforceupsert/SalesforceUpsertDialog.java
+++ b/plugins/salesforce/src/org/pentaho/di/ui/trans/steps/salesforceupsert/SalesforceUpsertDialog.java
@@ -934,7 +934,7 @@ public class SalesforceUpsertDialog extends BaseStepDialog implements StepDialog
       connection.setTimeOut( realTimeOut );
       // connect to Salesforce
       connection.connect();
-      return connection.getFields( connection.getObjectFields( selectedModule, excludeNonUpdatableFields ) );
+      return connection.getFields( selectedModule, excludeNonUpdatableFields );
 
     } catch ( Exception e ) {
       throw new KettleException( "Erreur getting fields from module [" + url + "]!", e );


### PR DESCRIPTION
…p Better by having reference fields handled correctly

This implementation has been done as part of possible changes within the PR https://github.com/pentaho/pentaho-kettle/pull/435.
What was done:
1)For all sales force fields we add field.getName() into targets list;
2)For the reference fields we also scan referenced objects and then uses idLookup fields in them to display target field name in format:
objectReferenceTo:externalIdField/lookupField