### PR TITLE
[PDI-13206] - The Kettle5-log4j plugin doesn't work because init never gets called on the plugin

### DIFF
--- a/core/src/org/pentaho/di/core/logging/LoggingPlugin.java
+++ b/core/src/org/pentaho/di/core/logging/LoggingPlugin.java
@@ -46,5 +46,7 @@ public @interface LoggingPlugin {
 
   String classLoaderGroup() default "";
 
+  boolean isSeparateClassLoaderNeeded() default false;
+
   String name() default "";
 }

--- a/core/src/org/pentaho/di/core/logging/LoggingPluginType.java
+++ b/core/src/org/pentaho/di/core/logging/LoggingPluginType.java
@@ -167,7 +167,7 @@ public class LoggingPluginType extends BasePluginType implements PluginTypeInter
 
   @Override
   protected boolean extractSeparateClassLoader( Annotation annotation ) {
-    return false;
+    return ( (LoggingPlugin) annotation ).isSeparateClassLoaderNeeded();
   }
 
   @Override

--- a/plugins/kettle5-log4j-plugin/ivy.xml
+++ b/plugins/kettle5-log4j-plugin/ivy.xml
@@ -23,7 +23,7 @@
     <dependency org="pentaho-kettle" name="kettle-engine" rev="${dependency.kettle.revision}" changing="true"/>
     <dependency org="pentaho-kettle" name="kettle-ui-swt" rev="${dependency.kettle.revision}" changing="true"/>
 
-    <dependency org="log4j" name="log4j" rev="1.2.16" transitive="false"/>
+    <dependency org="log4j" name="log4j" rev="1.2.17" conf="default->default" transitive="false"/>
 
     <dependency org="junit" name="junit" rev="4.7" conf="test->default"/> 
     

--- a/plugins/kettle5-log4j-plugin/res/log4j.xml
+++ b/plugins/kettle5-log4j-plugin/res/log4j.xml
@@ -1,0 +1,21 @@
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j='http://jakarta.apache.org/log4j/'>
+ 
+  <appender name="console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out"/>
+    <layout class="org.apache.log4j.PatternLayout">
+    <param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+    </layout>
+  </appender>
+ 
+   <logger name="org.pentaho.di">
+    <level value="off"/>
+    <appender-ref ref="console" />
+  </logger>
+ 
+  <root>
+    <priority value ="off"></priority>
+    <appender-ref ref="console"></appender-ref>
+  </root>
+ 
+</log4j:configuration>

--- a/plugins/kettle5-log4j-plugin/src/org/pentaho/di/core/logging/CentralLogStore.java
+++ b/plugins/kettle5-log4j-plugin/src/org/pentaho/di/core/logging/CentralLogStore.java
@@ -90,12 +90,7 @@ public class CentralLogStore {
         logWriter.getPentahoLogger(), // Category is deprecated
         event.getTimeStamp(),
         convertKettleLogLevelToLog4jLevel( event.getLevel() ),
-        event.getMessage(),
-        null,
-        null,
-        null,
-        null,
-        null );
+        event.getMessage(), null );
       list.add( loggingEvent );
     }
 

--- a/plugins/kettle5-log4j-plugin/src/org/pentaho/di/core/logging/log4j/Log4jLogging.java
+++ b/plugins/kettle5-log4j-plugin/src/org/pentaho/di/core/logging/log4j/Log4jLogging.java
@@ -22,17 +22,25 @@
 
 package org.pentaho.di.core.logging.log4j;
 
+import java.io.FileNotFoundException;
+
+import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+import org.apache.log4j.helpers.LogLog;
+import org.apache.log4j.xml.DOMConfigurator;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.KettleLoggingEvent;
 import org.pentaho.di.core.logging.LoggingPlugin;
 import org.pentaho.di.core.logging.LoggingPluginInterface;
 
 @LoggingPlugin(
-  id = "Log4jLogging" )
+  id = "Log4jLogging", isSeparateClassLoaderNeeded = true )
 public class Log4jLogging implements LoggingPluginInterface {
-
+  
+  public static final String PLUGIN_PROPERTIES_FILE = "plugins/kettle5-log4j-plugin/log4j.xml";
+  
   public static final String STRING_PENTAHO_DI_LOGGER_NAME = "org.pentaho.di";
 
   public static final String STRING_PENTAHO_DI_CONSOLE_APPENDER = "ConsoleAppender:" + STRING_PENTAHO_DI_LOGGER_NAME;
@@ -40,8 +48,6 @@ public class Log4jLogging implements LoggingPluginInterface {
   private Logger pentahoLogger;
 
   public Log4jLogging() {
-    pentahoLogger = Logger.getLogger( STRING_PENTAHO_DI_LOGGER_NAME );
-    pentahoLogger.setAdditivity( false );
   }
 
   @Override
@@ -62,10 +68,20 @@ public class Log4jLogging implements LoggingPluginInterface {
 
   @Override
   public void init() {
+    applyLog4jConfiguration();
+    pentahoLogger = Logger.getLogger( STRING_PENTAHO_DI_LOGGER_NAME );
+    pentahoLogger.setAdditivity( false );
     KettleLogStore.getAppender().addLoggingEventListener( this );
   }
 
   public void dispose() {
     KettleLogStore.getAppender().removeLoggingEventListener( this );
+  }
+  
+  private static void applyLog4jConfiguration() {
+    LogLog.setQuietMode( true );
+    LogManager.resetConfiguration();
+    LogLog.setQuietMode( false );
+    DOMConfigurator.configure( PLUGIN_PROPERTIES_FILE );
   }
 }


### PR DESCRIPTION
@mdamour1976 please have a look

I added log4j into plugin. This way we will avoid 2 issues: 
1. issues with version changes for other components of kettle.
2. easy way to prevent sharing log4j (its class instances and configuration)  with karaf which also uses log4j

There is no deduplication of kettle5-log4j-plugin-{version}.jar. As I mentioned on our today meeting kettle5-log4j-plugin used in big-data-plugin (big-data-plugin uses some class form it). Thus for deduplication we have to find a reason why we have such strange use case and move this class to kettle or big-data-plugin. 
From my perspective it is better to do this operation after code freeze.

