### PR TITLE
[BACKLOG-5133]Continue to read rows after sampling is done

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/samplerows/SampleRows.java
+++ b/engine/src/org/pentaho/di/trans/steps/samplerows/SampleRows.java
@@ -101,11 +101,6 @@ public class SampleRows extends BaseStep implements StepInterface {
         }
       }
       data.rangeSet = setBuilder.build();
-      // Return now if no rows are to be sampled
-      if ( data.rangeSet.isEmpty() ) {
-        setOutputDone();
-        return false;
-      }
     } // end if first
 
     if ( data.addlineField ) {
@@ -134,11 +129,12 @@ public class SampleRows extends BaseStep implements StepInterface {
     }
 
     // Check if maximum value has been exceeded
-    boolean done = linesRead >= data.rangeSet.span().upperEndpoint();
-    if ( done ) {
+    if ( data.rangeSet.isEmpty() || linesRead >= data.rangeSet.span().upperEndpoint() ) {
       setOutputDone();
     }
-    return !done;
+
+    // Allowed to continue to read in data
+    return true;
   }
 
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {


### PR DESCRIPTION
Sample Rows was hanging up the row set buffers by refusing to read in more rows once it completes.

@mattyb149
/cc @bkemper-pentaho  @dkincade 