### PR TITLE
[PDI-13271]: External Ids are not handled properly when incoming key is null

### DIFF
--- a/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsert.java
+++ b/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsert.java
@@ -41,7 +41,9 @@ import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.steps.salesforceinput.SalesforceConnection;
+import org.pentaho.di.trans.steps.salesforceutils.SalesforceUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sforce.soap.partner.sobject.SObject;
 
 /**
@@ -115,7 +117,8 @@ public class SalesforceInsert extends BaseStep implements StepInterface {
     return true;
   }
 
-  private void writeToSalesForce( Object[] rowData ) throws KettleException {
+  @VisibleForTesting
+  void writeToSalesForce( Object[] rowData ) throws KettleException {
     try {
 
       if ( log.isDetailed() ) {
@@ -137,7 +140,8 @@ public class SalesforceInsert extends BaseStep implements StepInterface {
           if ( valueMeta.isNull( value ) ) {
             // The value is null
             // We need to keep track of this field
-            fieldsToNull.add( meta.getUpdateLookup()[i] );
+            fieldsToNull.add( SalesforceUtils.getFieldToNullName( log, meta.getUpdateLookup()[i], meta
+                .getUseExternalId()[i] ) );
           } else {
             if ( valueMeta.isDate() ) {
               // Pass date field converted to UTC, see PDI-10836

--- a/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsert.java
+++ b/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsert.java
@@ -23,7 +23,6 @@
 package org.pentaho.di.trans.steps.salesforceupsert;
 
 import java.util.ArrayList;
-
 import org.apache.axis.message.MessageElement;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
@@ -39,7 +38,9 @@ import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.steps.salesforceinput.SalesforceConnection;
+import org.pentaho.di.trans.steps.salesforceutils.SalesforceUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sforce.soap.partner.sobject.SObject;
 
 /**
@@ -112,7 +113,8 @@ public class SalesforceUpsert extends BaseStep implements StepInterface {
     return true;
   }
 
-  private void writeToSalesForce( Object[] rowData ) throws KettleException {
+  @VisibleForTesting
+  void writeToSalesForce( Object[] rowData ) throws KettleException {
     try {
 
       if ( log.isDetailed() ) {
@@ -133,11 +135,12 @@ public class SalesforceUpsert extends BaseStep implements StepInterface {
           if ( valueMeta.isNull( object ) ) {
             // The value is null
             // We need to keep track of this field
-            fieldsToNull.add( meta.getUpdateLookup()[i] );
+            fieldsToNull.add( SalesforceUtils.getFieldToNullName( log, meta.getUpdateLookup()[i], meta
+                .getUseExternalId()[i] ) );
           } else {
             Object normalObject = valueMeta.convertToNormalStorageType( object );
-            upsertfields.add( SalesforceConnection.createMessageElement(
-              meta.getUpdateLookup()[i], normalObject, meta.getUseExternalId()[i] ) );
+            upsertfields.add( SalesforceConnection.createMessageElement( meta.getUpdateLookup()[i], normalObject, meta
+                .getUseExternalId()[i] ) );
           }
         }
 

--- a/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceutils/SalesforceUtils.java
+++ b/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceutils/SalesforceUtils.java
@@ -1,0 +1,94 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.salesforceutils;
+
+import static java.util.regex.Pattern.compile;
+
+import java.util.regex.Pattern;
+
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.i18n.BaseMessages;
+
+/**
+ * Utility class to process salesforce specific features.
+ *
+ * @author Tatsiana_Kasiankova
+ *
+ */
+public class SalesforceUtils {
+  private static Class<?> PKG = SalesforceUtils.class; // for i18n purposes, needed by Translator2!!
+
+  private static final String EXTID_SEPARATOR = "/";
+
+  private static final String CUSTOM_OBJECT_RELATIONSHIP_FIELD_SUFFIX = "_r";
+
+  private static final String CUSTOM_OBJECT_SUFFIX = "_c";
+
+  private static final Pattern FIELD_NAME_WITH_EXTID_PATTERN = compile( "^\\w+\\:\\w+\\/\\w+$" );
+
+  /**
+   * Extract and return the correct name for the field that should be processed as NULL
+   *
+   * @param log
+   *          the logging object
+   * @param field
+   *          the field that should be processed as NULL
+   * @param isUseExtId
+   *          the flag that indicates if the field is external id or not
+   * @return return the correct name for the field that should be processed as NULL
+   */
+  public static String getFieldToNullName( LogChannelInterface log, String field, boolean isUseExtId ) {
+    String fieldToNullName = field;
+    if ( isUseExtId ) {
+      // verify if the field has correct syntax
+      if ( !FIELD_NAME_WITH_EXTID_PATTERN.matcher( field ).matches() ) {
+        if ( log.isDebug() ) {
+          log.logDebug( BaseMessages.getString( PKG, "SalesforceUtils.Warn.IncorrectExternalKeySyntax", field,
+              fieldToNullName ) );
+        }
+        return fieldToNullName;
+      }
+
+      String lookupField = field.substring( field.indexOf( EXTID_SEPARATOR ) + 1 );
+      // working with custom objects and relationship
+      // cut off _r and then add _c in the end of the name
+      if ( lookupField.endsWith( CUSTOM_OBJECT_RELATIONSHIP_FIELD_SUFFIX ) ) {
+        fieldToNullName =
+            lookupField.substring( 0, lookupField.length() - CUSTOM_OBJECT_RELATIONSHIP_FIELD_SUFFIX.length() )
+                + CUSTOM_OBJECT_SUFFIX;
+        if ( log.isDebug() ) {
+          log.logDebug( BaseMessages.getString( PKG, "SalesforceUtils.Debug.NullFieldName", fieldToNullName ) );
+        }
+        return fieldToNullName;
+      }
+
+      fieldToNullName = lookupField + "Id";
+    }
+
+    if ( log.isDebug() ) {
+      log.logDebug( BaseMessages.getString( PKG, "SalesforceUtils.Debug.NullFieldName", fieldToNullName ) );
+    }
+
+    return fieldToNullName;
+  }
+
+}

--- a/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceutils/messages/messages_en_US.properties
+++ b/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceutils/messages/messages_en_US.properties
@@ -1,0 +1,2 @@
+SalesforceUtils.Warn.IncorrectExternalKeySyntax=The field has incorrect external key syntax: {0}. Syntax for external key should be : object:externalId/lookupField. Trying to use fieldToNullName={1}.
+SalesforceUtils.Debug.NullFieldName=fieldToNullName={0}

--- a/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsertTest.java
+++ b/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsertTest.java
@@ -1,0 +1,179 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.salesforceinsert;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.axis.message.MessageElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+import org.pentaho.di.trans.steps.salesforceinput.SalesforceConnection;
+
+import com.sforce.soap.partner.sobject.SObject;
+
+public class SalesforceInsertTest {
+
+  private static final String ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT = "Account:ExtID_AccountId__c/Account";
+  private static final String ACCOUNT_ID = "AccountId";
+  private StepMockHelper<SalesforceInsertMeta, SalesforceInsertData> smh;
+
+  @Before
+  public void setUp() throws Exception {
+    smh =
+        new StepMockHelper<SalesforceInsertMeta, SalesforceInsertData>( "SalesforceInsert", SalesforceInsertMeta.class,
+            SalesforceInsertData.class );
+    when( smh.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+        smh.logChannelInterface );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNullExtIdField_WithExtIdNO() throws Exception {
+    SalesforceInsert sfInputStep =
+        new SalesforceInsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceInsertMeta meta = generateSalesforceInsertMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceInsertData data = generateSalesforceInsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccNoExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { null } );
+    assertEquals( 1, data.sfBuffer[0].getFieldsToNull().length );
+    assertEquals( ACCOUNT_ID, data.sfBuffer[0].getFieldsToNull()[0] );
+    assertNull( data.sfBuffer[0].get_any() );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNullExtIdField_WithExtIdYES() throws Exception {
+    SalesforceInsert sfInputStep =
+        new SalesforceInsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceInsertMeta meta =
+        generateSalesforceInsertMeta( new String[] { ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT }, new Boolean[] { true } );
+    SalesforceInsertData data = generateSalesforceInsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { null } );
+    assertEquals( 1, data.sfBuffer[0].getFieldsToNull().length );
+    assertEquals( ACCOUNT_ID, data.sfBuffer[0].getFieldsToNull()[0] );
+    assertNull( data.sfBuffer[0].get_any() );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNotNullExtIdField_WithExtIdNO() throws Exception {
+    SalesforceInsert sfInputStep =
+        new SalesforceInsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceInsertMeta meta = generateSalesforceInsertMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceInsertData data = generateSalesforceInsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccNoExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { "001i000001c5Nv9AAE" } );
+    assertNull( data.sfBuffer[0].getFieldsToNull() );
+    assertEquals( 1, data.sfBuffer[0].get_any().length );
+    assertEquals( getExpectedMessageElement( ACCOUNT_ID, "001i000001c5Nv9AAE", false ), data.sfBuffer[0].get_any()[0] );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNotNullExtIdField_WithExtIdYES() throws Exception {
+    SalesforceInsert sfInputStep =
+        new SalesforceInsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceInsertMeta meta =
+        generateSalesforceInsertMeta( new String[] { ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT }, new Boolean[] { true } );
+    SalesforceInsertData data = generateSalesforceInsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { "tkas88" } );
+    assertNull( data.sfBuffer[0].getFieldsToNull() );
+    assertEquals( 1, data.sfBuffer[0].get_any().length );
+    assertEquals( getExpectedMessageElement( ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT, "tkas88", true ), data.sfBuffer[0]
+        .get_any()[0] );
+  }
+
+  @Test
+  public void testLogMessageInDetailedModeFotWriteToSalesForce() throws KettleException {
+    SalesforceInsert sfInputStep =
+        new SalesforceInsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceInsertMeta meta = generateSalesforceInsertMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceInsertData data = generateSalesforceInsertData();
+    sfInputStep.init( meta, data );
+    when( sfInputStep.getLogChannel().isDetailed() ).thenReturn( true );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccNoExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    verify( sfInputStep.getLogChannel(), never() ).logDetailed( anyString() );
+    sfInputStep.writeToSalesForce( new Object[] { "001i000001c5Nv9AAE" } );
+    verify( sfInputStep.getLogChannel() ).logDetailed( "Called writeToSalesForce with 0 out of 2" );
+  }
+
+  private SalesforceInsertData generateSalesforceInsertData() {
+    SalesforceInsertData data = smh.initStepDataInterface;
+    data.nrfields = 1;
+    data.fieldnrs = new int[] { 0 };
+    data.sfBuffer = new SObject[] { null };
+    data.outputBuffer = new Object[][] { null };
+    return data;
+  }
+
+  private SalesforceInsertMeta generateSalesforceInsertMeta( String[] updateLookup, Boolean[] useExternalId ) {
+    SalesforceInsertMeta meta = smh.initStepMetaInterface;
+    doReturn( 2 ).when( meta ).getBatchSizeInt();
+    doReturn( updateLookup ).when( meta ).getUpdateLookup();
+    doReturn( useExternalId ).when( meta ).getUseExternalId();
+    return meta;
+  }
+
+  private MessageElement getExpectedMessageElement( String name, String value, boolean isExternalId ) throws Exception {
+    return SalesforceConnection.createMessageElement( name, value, isExternalId );
+  }
+}

--- a/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceupdate/SalesforceUpdateTest.java
+++ b/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceupdate/SalesforceUpdateTest.java
@@ -1,0 +1,180 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.salesforceupdate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.axis.message.MessageElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+import org.pentaho.di.trans.steps.salesforceinput.SalesforceConnection;
+
+import com.sforce.soap.partner.sobject.SObject;
+
+public class SalesforceUpdateTest {
+
+  private static final String ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT = "Account:ExtID_AccountId__c/Account";
+  private static final String ACCOUNT_ID = "AccountId";
+  private StepMockHelper<SalesforceUpdateMeta, SalesforceUpdateData> smh;
+
+  @Before
+  public void setUp() throws Exception {
+    smh =
+        new StepMockHelper<SalesforceUpdateMeta, SalesforceUpdateData>( "SalesforceUpsert", SalesforceUpdateMeta.class,
+            SalesforceUpdateData.class );
+    when( smh.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+        smh.logChannelInterface );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNullExtIdField_WithExtIdNO() throws Exception {
+    SalesforceUpdate sfInputStep =
+        new SalesforceUpdate( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpdateMeta meta = generateSalesforceUpdateMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceUpdateData data = generateSalesforceUpdateData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccNoExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { null } );
+    assertEquals( 1, data.sfBuffer[0].getFieldsToNull().length );
+    assertEquals( ACCOUNT_ID, data.sfBuffer[0].getFieldsToNull()[0] );
+    assertNull( data.sfBuffer[0].get_any() );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNullExtIdField_WithExtIdYES() throws Exception {
+    SalesforceUpdate sfInputStep =
+        new SalesforceUpdate( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpdateMeta meta =
+        generateSalesforceUpdateMeta( new String[] { ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT }, new Boolean[] { true } );
+    SalesforceUpdateData data = generateSalesforceUpdateData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { null } );
+    assertEquals( 1, data.sfBuffer[0].getFieldsToNull().length );
+    assertEquals( ACCOUNT_ID, data.sfBuffer[0].getFieldsToNull()[0] );
+    assertNull( data.sfBuffer[0].get_any() );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNotNullExtIdField_WithExtIdNO() throws Exception {
+    SalesforceUpdate sfInputStep =
+        new SalesforceUpdate( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpdateMeta meta = generateSalesforceUpdateMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceUpdateData data = generateSalesforceUpdateData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccNoExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { "001i000001c5Nv9AAE" } );
+    assertNull( data.sfBuffer[0].getFieldsToNull() );
+    assertEquals( 1, data.sfBuffer[0].get_any().length );
+    assertEquals( getExpectedMessageElement( ACCOUNT_ID, "001i000001c5Nv9AAE", false ), data.sfBuffer[0].get_any()[0] );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNotNullExtIdField_WithExtIdYES() throws Exception {
+    SalesforceUpdate sfInputStep =
+        new SalesforceUpdate( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpdateMeta meta =
+        generateSalesforceUpdateMeta( new String[] { ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT }, new Boolean[] { true } );
+    SalesforceUpdateData data = generateSalesforceUpdateData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { "tkas88" } );
+    assertNull( data.sfBuffer[0].getFieldsToNull() );
+    assertEquals( 1, data.sfBuffer[0].get_any().length );
+    assertEquals( getExpectedMessageElement( ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT, "tkas88", true ), data.sfBuffer[0]
+        .get_any()[0] );
+  }
+
+  @Test
+  public void testLogMessageInDetailedModeFotWriteToSalesForce() throws KettleException {
+    SalesforceUpdate sfInputStep =
+        new SalesforceUpdate( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpdateMeta meta = generateSalesforceUpdateMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceUpdateData data = generateSalesforceUpdateData();
+    sfInputStep.init( meta, data );
+    when( sfInputStep.getLogChannel().isDetailed() ).thenReturn( true );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccNoExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    verify( sfInputStep.getLogChannel(), never() ).logDetailed( anyString() );
+    sfInputStep.writeToSalesForce( new Object[] { "001i000001c5Nv9AAE" } );
+    verify( sfInputStep.getLogChannel() ).logDetailed( "Called writeToSalesForce with 0 out of 2" );
+  }
+
+  private SalesforceUpdateData generateSalesforceUpdateData() {
+    SalesforceUpdateData data = smh.initStepDataInterface;
+    data.nrfields = 1;
+    data.fieldnrs = new int[] { 0 };
+    data.sfBuffer = new SObject[] { null };
+    data.outputBuffer = new Object[][] { null };
+    return data;
+  }
+
+  private SalesforceUpdateMeta generateSalesforceUpdateMeta( String[] updateLookup, Boolean[] useExternalId ) {
+    SalesforceUpdateMeta meta = smh.initStepMetaInterface;
+    doReturn( 2 ).when( meta ).getBatchSizeInt();
+    doReturn( updateLookup ).when( meta ).getUpdateLookup();
+    doReturn( useExternalId ).when( meta ).getUseExternalId();
+    return meta;
+  }
+
+  private MessageElement getExpectedMessageElement( String name, String value, boolean isExternalId ) throws Exception {
+    return SalesforceConnection.createMessageElement( name, value, isExternalId );
+  }
+
+}

--- a/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsertTest.java
+++ b/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsertTest.java
@@ -1,0 +1,180 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.salesforceupsert;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.axis.message.MessageElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+import org.pentaho.di.trans.steps.salesforceinput.SalesforceConnection;
+
+import com.sforce.soap.partner.sobject.SObject;
+
+public class SalesforceUpsertTest {
+
+  private static final String ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT = "Account:ExtID_AccountId__c/Account";
+  private static final String ACCOUNT_ID = "AccountId";
+  private StepMockHelper<SalesforceUpsertMeta, SalesforceUpsertData> smh;
+
+  @Before
+  public void setUp() throws Exception {
+    smh =
+        new StepMockHelper<SalesforceUpsertMeta, SalesforceUpsertData>( "SalesforceUpsert", SalesforceUpsertMeta.class,
+            SalesforceUpsertData.class );
+    when( smh.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+        smh.logChannelInterface );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNullExtIdField_WithExtIdNO() throws Exception {
+    SalesforceUpsert sfInputStep =
+        new SalesforceUpsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpsertMeta meta = generateSalesforceUpsertMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceUpsertData data = generateSalesforceUpsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccNoExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { null } );
+    assertEquals( 1, data.sfBuffer[0].getFieldsToNull().length );
+    assertEquals( ACCOUNT_ID, data.sfBuffer[0].getFieldsToNull()[0] );
+    assertNull( data.sfBuffer[0].get_any() );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNullExtIdField_WithExtIdYES() throws Exception {
+    SalesforceUpsert sfInputStep =
+        new SalesforceUpsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpsertMeta meta =
+        generateSalesforceUpsertMeta( new String[] { ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT }, new Boolean[] { true } );
+    SalesforceUpsertData data = generateSalesforceUpsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { null } );
+    assertEquals( 1, data.sfBuffer[0].getFieldsToNull().length );
+    assertEquals( ACCOUNT_ID, data.sfBuffer[0].getFieldsToNull()[0] );
+    assertNull( data.sfBuffer[0].get_any() );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNotNullExtIdField_WithExtIdNO() throws Exception {
+    SalesforceUpsert sfInputStep =
+        new SalesforceUpsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpsertMeta meta = generateSalesforceUpsertMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceUpsertData data = generateSalesforceUpsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccNoExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { "001i000001c5Nv9AAE" } );
+    assertNull( data.sfBuffer[0].getFieldsToNull() );
+    assertEquals( 1, data.sfBuffer[0].get_any().length );
+    assertEquals( getExpectedMessageElement( ACCOUNT_ID, "001i000001c5Nv9AAE", false ), data.sfBuffer[0].get_any()[0] );
+  }
+
+  @Test
+  public void testWriteToSalesForceForNotNullExtIdField_WithExtIdYES() throws Exception {
+    SalesforceUpsert sfInputStep =
+        new SalesforceUpsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpsertMeta meta =
+        generateSalesforceUpsertMeta( new String[] { ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT }, new Boolean[] { true } );
+    SalesforceUpsertData data = generateSalesforceUpsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { "tkas88" } );
+    assertNull( data.sfBuffer[0].getFieldsToNull() );
+    assertEquals( 1, data.sfBuffer[0].get_any().length );
+    assertEquals( getExpectedMessageElement( ACCOUNT_EXT_ID_ACCOUNT_ID_C_ACCOUNT, "tkas88", true ), data.sfBuffer[0]
+        .get_any()[0] );
+  }
+
+  @Test
+  public void testLogMessageInDetailedModeFotWriteToSalesForce() throws KettleException {
+    SalesforceUpsert sfInputStep =
+        new SalesforceUpsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpsertMeta meta = generateSalesforceUpsertMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceUpsertData data = generateSalesforceUpsertData();
+    sfInputStep.init( meta, data );
+    when( sfInputStep.getLogChannel().isDetailed() ).thenReturn( true );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaString( "AccNoExtId" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    verify( sfInputStep.getLogChannel(), never() ).logDetailed( anyString() );
+    sfInputStep.writeToSalesForce( new Object[] { "001i000001c5Nv9AAE" } );
+    verify( sfInputStep.getLogChannel() ).logDetailed( "Called writeToSalesForce with 0 out of 2" );
+  }
+
+  private SalesforceUpsertData generateSalesforceUpsertData() {
+    SalesforceUpsertData data = smh.initStepDataInterface;
+    data.nrfields = 1;
+    data.fieldnrs = new int[] { 0 };
+    data.sfBuffer = new SObject[] { null };
+    data.outputBuffer = new Object[][] { null };
+    return data;
+  }
+
+  private SalesforceUpsertMeta generateSalesforceUpsertMeta( String[] updateLookup, Boolean[] useExternalId ) {
+    SalesforceUpsertMeta meta = smh.initStepMetaInterface;
+    doReturn( 2 ).when( meta ).getBatchSizeInt();
+    doReturn( updateLookup ).when( meta ).getUpdateLookup();
+    doReturn( useExternalId ).when( meta ).getUseExternalId();
+    return meta;
+  }
+
+  private MessageElement getExpectedMessageElement( String name, String value, boolean isExternalId ) throws Exception {
+    return SalesforceConnection.createMessageElement( name, value, isExternalId );
+  }
+
+}

--- a/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceutils/SalesforceUtilsTest.java
+++ b/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceutils/SalesforceUtilsTest.java
@@ -1,0 +1,131 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.salesforceutils;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.logging.LogChannelInterface;
+
+/**
+ * @author Tatsiana_Kasiankova
+ *
+ */
+public class SalesforceUtilsTest {
+
+  private static LogChannelInterface logMock;
+
+  private String inputFieldName;
+
+  private String expectedFieldName;
+
+  @Before
+  public void setUp() {
+    logMock = mock( LogChannelInterface.class );
+  }
+
+  @Test
+  public void testFieldWithExtIdYes_StandartObject() {
+    inputFieldName = "Account:ExtID_AccountId__c/Account";
+    expectedFieldName = "AccountId";
+    String fieldToNullName = SalesforceUtils.getFieldToNullName( logMock, inputFieldName, true );
+    assertEquals( expectedFieldName, fieldToNullName );
+  }
+
+  @Test
+  public void testFieldWithExtIdNo_StandartObject() {
+    inputFieldName = "AccountId";
+    expectedFieldName = "AccountId";
+    String fieldToNullName = SalesforceUtils.getFieldToNullName( logMock, inputFieldName, false );
+    assertEquals( expectedFieldName, fieldToNullName );
+  }
+
+  @Test
+  public void testFieldWithExtIdYes_CustomObject() {
+    inputFieldName = "ParentObject__c:Name/ParentObjectId__r";
+    expectedFieldName = "ParentObjectId__c";
+    String fieldToNullName = SalesforceUtils.getFieldToNullName( logMock, inputFieldName, true );
+    assertEquals( expectedFieldName, fieldToNullName );
+  }
+
+  @Test
+  public void testFieldWithExtIdNo_CustomObject() {
+    inputFieldName = "ParentObjectId__c";
+    expectedFieldName = "ParentObjectId__c";
+    String fieldToNullName = SalesforceUtils.getFieldToNullName( logMock, inputFieldName, false );
+    assertEquals( expectedFieldName, fieldToNullName );
+  }
+
+  @Test
+  public void testFieldWithExtIdYesButNameInIncorrectSyntax_StandartObject() {
+    when( logMock.isDebug() ).thenReturn( true );
+    inputFieldName = "Account";
+    expectedFieldName = inputFieldName;
+    String fieldToNullName = SalesforceUtils.getFieldToNullName( logMock, inputFieldName, true );
+    assertEquals( expectedFieldName, fieldToNullName );
+  }
+
+  @Test
+  public void testIncorrectExternalKeySyntaxWarnIsLoggedInDebugMode() {
+    when( logMock.isDebug() ).thenReturn( true );
+    inputFieldName = "AccountId";
+    verify( logMock, never() ).logDebug( anyString() );
+    SalesforceUtils.getFieldToNullName( logMock, inputFieldName, true );
+    verify( logMock ).logDebug(
+        "The field has incorrect external key syntax: AccountId. Syntax for external key should be : object:externalId/lookupField. Trying to use fieldToNullName=AccountId." );
+  }
+
+  @Test
+  public void testIncorrectExternalKeySyntaxWarnIsNotLoggedInNotDebugMode() {
+    when( logMock.isDebug() ).thenReturn( false );
+    inputFieldName = "AccountId";
+    verify( logMock, never() ).logDebug( anyString() );
+    SalesforceUtils.getFieldToNullName( logMock, inputFieldName, true );
+    verify( logMock, never() ).logDebug(
+        "The field has incorrect external key syntax: AccountId. Syntax for external key should be : object:externalId/lookupField. Trying to use fieldToNullName=AccountId." );
+  }
+
+  @Test
+  public void testFinalNullFieldNameIsLoggedInDebugMode_StandartObject() {
+    when( logMock.isDebug() ).thenReturn( true );
+    inputFieldName = "Account:ExtID_AccountId__c/Account";
+    verify( logMock, never() ).logDebug( anyString() );
+    SalesforceUtils.getFieldToNullName( logMock, inputFieldName, true );
+    verify( logMock ).logDebug( "fieldToNullName=AccountId" );
+  }
+
+  @Test
+  public void testFinalNullFieldNameIsLoggedInDebugMode_CustomObject() {
+    when( logMock.isDebug() ).thenReturn( true );
+    inputFieldName = "ParentObject__c:Name/ParentObjectId__r";
+    verify( logMock, never() ).logDebug( anyString() );
+    SalesforceUtils.getFieldToNullName( logMock, inputFieldName, true );
+    verify( logMock ).logDebug( "fieldToNullName=ParentObjectId__c" );
+  }
+
+}


### PR DESCRIPTION
The problem was:
when isUseExtId=Y for the field, we add incorrect field name in FieldsToNull.
What was done:
1)Added utility method to get valid names for null fields candidates.
2)Added calls this method in the steps: SalesforceUpsert, SalesforceInput, SalesforceUpdate.
3)Added a couple of unit tests.