### PR TITLE
[BACKLOG-5231] Fix for transformation not opening in file system repo

### DIFF
--- a/engine/src/org/pentaho/di/repository/filerep/KettleFileRepository.java
+++ b/engine/src/org/pentaho/di/repository/filerep/KettleFileRepository.java
@@ -1020,6 +1020,8 @@ public class KettleFileRepository extends AbstractRepository {
     //
     String filename = calcDirectoryName( repdir ) + transname + ".ktr";
     TransMeta transMeta = new TransMeta( filename, this, setInternalVariables );
+    transMeta.setRepository( this );
+    transMeta.setMetaStore( getMetaStore() );
     transMeta.setFilename( null );
     transMeta.setName( transname );
     transMeta.setObjectId( new StringObjectId( calcObjectId( repdir, transname, EXT_TRANSFORMATION ) ) );


### PR DESCRIPTION
@dkincade 

BACKLOG-5231 - Importing repository to File System repos saved Transformation doesn't open
http://jira.pentaho.com/browse/BACKLOG-5231

Master Commit:
https://github.com/pentaho/pentaho-kettle/pull/1785

DevCI:
http://devci.pentaho.com/job/6.0-snapshot/job/pdi-engine-core/147/