### PR TITLE
[BACKLOG-5247] Agile BI : Fixed save button not opening save dialog f…

### DIFF
--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -4949,8 +4949,8 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   public boolean saveFile() {
     try {
       EngineMetaInterface meta = getActiveMeta();
-      if ( meta != null && AbstractMeta.class.isAssignableFrom( meta.getClass() ) ) {
-        if ( ( (AbstractMeta) meta ).hasMissingPlugins() ) {
+      if ( meta != null ) {
+        if ( AbstractMeta.class.isAssignableFrom( meta.getClass() ) && ( (AbstractMeta) meta ).hasMissingPlugins() ) {
           MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
           mb.setMessage( BaseMessages.getString( PKG, "Spoon.ErrorDialog.MissingPlugin.Error" ) );
           mb.setText( BaseMessages.getString( PKG, "Spoon.ErrorDialog.MissingPlugin.Title" ) );


### PR DESCRIPTION
…or modeler and the save buttons no longer are dithered for analyzer

Only check for missing plugins if object is of type AbstractMeta. For example AnalyzerVisualizationMeta does not extend AbstractMeta.