### PR TITLE
[BACKLOG-5343]Log deprecation warning when using old ThinDriver

### DIFF
--- a/core/src/org/pentaho/di/core/jdbc/ThinDriver.java
+++ b/core/src/org/pentaho/di/core/jdbc/ThinDriver.java
@@ -22,6 +22,8 @@
 
 package org.pentaho.di.core.jdbc;
 
+import org.pentaho.di.core.KettleClientEnvironment;
+
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -29,12 +31,11 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.pentaho.di.core.KettleClientEnvironment;
-
 /**
- * This class is no longer used
+ * @deprecated As of release 6.0, use org.pentaho.di.trans.dataservice.jdbc.ThinDriver instead
  *
  * Data Service client code is now available in the pdi-dataservice-plugin project
  *
@@ -66,6 +67,11 @@ public class ThinDriver implements Driver {
   public Connection connect( String url, Properties properties ) throws SQLException {
     String username = properties.getProperty( "user" );
     String password = properties.getProperty( "password" );
+
+    Logger.getLogger( getClass().getName() ).log( Level.WARNING,
+      getClass().getName() + " has been deprecated and is scheduled for removal in 6.1. "
+        + "Please use org.pentaho.di.trans.dataservice.jdbc.ThinDriver instead."
+    );
 
     if ( acceptsURL( url ) ) {
       ThinConnection connection = new ThinConnection( url, username, password );


### PR DESCRIPTION
@dkincade 

master: https://github.com/pentaho/pentaho-kettle/pull/1810
CI: http://devci.pentaho.com/job/6.0-snapshot/job/pdi-engine-core/157/