### PR TITLE
[PDI-12814] - Need to prohibit empty names when adding new users or roles

### DIFF
--- a/engine/src/org/pentaho/di/repository/RepositoryCommonValidations.java
+++ b/engine/src/org/pentaho/di/repository/RepositoryCommonValidations.java
@@ -1,0 +1,58 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository;
+
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCommonValidations {
+
+  /**
+   * Validates {@code user}'s data. Common rule for all repositories is: both login and name must contain at least one
+   * meaningful char.
+   *
+   * @param user user
+   * @return {@code true} if user's login and name are not empty
+   * @throws NullPointerException is {@code user} is {@code null}
+   */
+  public static boolean checkUserInfo( IUser user ) {
+    return !isBlank( user.getLogin() ) && !isBlank( user.getName() );
+  }
+
+  /**
+   * Normalizes {@code user}'s data. According to {@linkplain #checkUserInfo(IUser) common rules}, simply trims login
+   * and name.
+   *
+   * @param user user
+   * @return normalized instance
+   * @throws NullPointerException if {@code user} is {@code null} or {@code user}'s login and name
+   */
+  public static IUser normalizeUserInfo( IUser user ) {
+    user.setLogin( user.getLogin().trim() );
+    user.setName( user.getName().trim() );
+    return user;
+  }
+}

--- a/engine/src/org/pentaho/di/repository/RepositorySecurityUserValidator.java
+++ b/engine/src/org/pentaho/di/repository/RepositorySecurityUserValidator.java
@@ -1,0 +1,46 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public interface RepositorySecurityUserValidator extends RepositorySecurityManager {
+
+  /**
+   * Validates {@code user} and returns {@code true} if all its data is valid.<br/>
+   * Note: this method performs fail-fast approach and does not return any details.
+   *
+   * @param user user's info
+   * @return {@code true} or {@code false} depending on whether or not user's info is valid
+   */
+  boolean validateUserInfo( IUser user );
+
+  /**
+   * Performs normalization over {@code user} due to validation rules.</br>
+   * Note: normalized is not guaranteed to pass validation rules
+   *
+   * @param user user's info
+   */
+  void normalizeUserInfo(IUser user);
+}

--- a/engine/src/org/pentaho/di/repository/RepositorySecurityUserValidator.java
+++ b/engine/src/org/pentaho/di/repository/RepositorySecurityUserValidator.java
@@ -42,5 +42,5 @@ public interface RepositorySecurityUserValidator extends RepositorySecurityManag
    *
    * @param user user's info
    */
-  void normalizeUserInfo(IUser user);
+  void normalizeUserInfo( IUser user );
 }

--- a/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepositorySecurityProvider.java
+++ b/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepositorySecurityProvider.java
@@ -31,16 +31,18 @@ import org.pentaho.di.repository.BaseRepositorySecurityProvider;
 import org.pentaho.di.repository.IUser;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.RepositoryCapabilities;
+import org.pentaho.di.repository.RepositoryCommonValidations;
 import org.pentaho.di.repository.RepositoryMeta;
 import org.pentaho.di.repository.RepositoryOperation;
 import org.pentaho.di.repository.RepositorySecurityManager;
 import org.pentaho.di.repository.RepositorySecurityProvider;
+import org.pentaho.di.repository.RepositorySecurityUserValidator;
 import org.pentaho.di.repository.UserInfo;
 import org.pentaho.di.repository.kdr.delegates.KettleDatabaseRepositoryConnectionDelegate;
 import org.pentaho.di.repository.kdr.delegates.KettleDatabaseRepositoryUserDelegate;
 
 public class KettleDatabaseRepositorySecurityProvider extends BaseRepositorySecurityProvider implements
-  RepositorySecurityProvider, RepositorySecurityManager {
+  RepositorySecurityProvider, RepositorySecurityManager, RepositorySecurityUserValidator {
 
   private RepositoryCapabilities capabilities;
 
@@ -55,7 +57,7 @@ public class KettleDatabaseRepositorySecurityProvider extends BaseRepositorySecu
    * @param userInfo
    */
   public KettleDatabaseRepositorySecurityProvider( KettleDatabaseRepository repository,
-    RepositoryMeta repositoryMeta, IUser userInfo ) {
+                                                   RepositoryMeta repositoryMeta, IUser userInfo ) {
     super( repositoryMeta, userInfo );
     this.repository = repository;
     this.capabilities = repositoryMeta.getRepositoryCapabilities();
@@ -90,6 +92,10 @@ public class KettleDatabaseRepositorySecurityProvider extends BaseRepositorySecu
   }
 
   public void saveUserInfo( IUser userInfo ) throws KettleException {
+    normalizeUserInfo( userInfo );
+    if ( !validateUserInfo( userInfo ) ) {
+      throw new KettleException( "Empty name is not allowed" );
+    }
     userDelegate.saveUserInfo( userInfo );
   }
 
@@ -170,5 +176,16 @@ public class KettleDatabaseRepositorySecurityProvider extends BaseRepositorySecu
   @Override
   public boolean isVersioningEnabled( String fullPath ) {
     return false;
+  }
+
+
+  @Override
+  public boolean validateUserInfo( IUser user ) {
+    return RepositoryCommonValidations.checkUserInfo( user );
+  }
+
+  @Override
+  public void normalizeUserInfo( IUser user ) {
+    RepositoryCommonValidations.normalizeUserInfo( user );
   }
 }

--- a/engine/test-src/org/pentaho/di/repository/RepositoryCommonValidationsTest.java
+++ b/engine/test-src/org/pentaho/di/repository/RepositoryCommonValidationsTest.java
@@ -1,0 +1,87 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.pentaho.di.repository.RepositoryCommonValidations.checkUserInfo;
+import static org.pentaho.di.repository.RepositoryCommonValidations.normalizeUserInfo;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCommonValidationsTest {
+
+  @Test( expected = NullPointerException.class )
+  public void checkUserInfo_Null() {
+    checkUserInfo( null );
+  }
+
+
+  @Test
+  public void checkUserInfo_LoginIsNull() {
+    assertFalse( checkUserInfo( user( null, "name" ) ) );
+  }
+
+  @Test
+  public void checkUserInfo_LoginIsBlank() {
+    assertFalse( checkUserInfo( user( "", "name" ) ) );
+  }
+
+  @Test
+  public void checkUserInfo_LoginContainsSpaces() {
+    assertFalse( checkUserInfo( user( "  \t\n ", "name" ) ) );
+  }
+
+
+  @Test
+  public void checkUserInfo_BothAreMeaningful() {
+    assertTrue( checkUserInfo( user( "login", "name" ) ) );
+  }
+
+
+  @Test( expected = NullPointerException.class )
+  public void normalizeUserInfo_Null() {
+    normalizeUserInfo( null );
+  }
+
+  @Test
+  public void normalizeUserInfo_Valid() {
+    IUser normalized = normalizeUserInfo( user( "login", "name" ) );
+    assertEquals( "login", normalized.getLogin() );
+    assertEquals( "login", normalized.getName() );
+  }
+
+  @Test
+  public void normalizeUserInfo_WithSpaces() {
+    IUser normalized = normalizeUserInfo( user( "  login \t\n ", "name" ) );
+    assertEquals( "login", normalized.getLogin() );
+    assertEquals( "login", normalized.getName() );
+  }
+
+
+  private static IUser user( String login, String name ) {
+    return new UserInfo( login, null, name, name, true );
+  }
+}

--- a/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepositorySecurityProviderTest.java
+++ b/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepositorySecurityProviderTest.java
@@ -1,0 +1,77 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository.kdr;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.UserInfo;
+import org.pentaho.di.repository.kdr.delegates.KettleDatabaseRepositoryUserDelegate;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class KettleDatabaseRepositorySecurityProviderTest {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+
+  private KettleDatabaseRepository repository;
+  private KettleDatabaseRepositorySecurityProvider provider;
+
+  @Before
+  public void setUp() {
+    repository = new KettleDatabaseRepository();
+    repository.userDelegate = mock( KettleDatabaseRepositoryUserDelegate.class );
+    provider =
+      new KettleDatabaseRepositorySecurityProvider( repository, new KettleDatabaseRepositoryMeta(), new UserInfo() );
+  }
+
+  @Test
+  public void saveUserInfo_NormalizesInfo_PassesIfNoViolations() throws Exception {
+    UserInfo info = new UserInfo( "login    " );
+
+    ArgumentCaptor<UserInfo> captor = ArgumentCaptor.forClass( UserInfo.class );
+    provider.saveUserInfo( info );
+    verify( repository.userDelegate ).saveUserInfo( captor.capture() );
+
+    info = captor.getValue();
+    assertEquals( "Spaces should be trimmed", "login", info.getLogin() );
+  }
+
+  @Test( expected = KettleException.class )
+  public void saveUserInfo_NormalizesInfo_FailsIfStillBreaches() throws Exception {
+    UserInfo info = new UserInfo( "    " );
+    provider.saveUserInfo( info );
+  }
+}

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/UserRoleDelegate.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/UserRoleDelegate.java
@@ -46,13 +46,13 @@ public class UserRoleDelegate implements java.io.Serializable {
   private static final long serialVersionUID = 1295309456550391059L; /* EESOURCE: UPDATE SERIALVERUID */
   private UserRoleListChangeListenerCollection userRoleListChangeListeners;
 
+  private final Log logger;
+
   IUserRoleWebService userRoleWebService;
 
   IUserRoleListWebService userDetailsRoleListWebService;
 
   IRoleSupportSecurityManager rsm;
-
-  Log logger;
 
   UserRoleLookupCache lookupCache;
 
@@ -65,19 +65,30 @@ public class UserRoleDelegate implements java.io.Serializable {
 
   public UserRoleDelegate( IRoleSupportSecurityManager rsm, PurRepositoryMeta repositoryMeta, IUser userInfo,
                            Log logger, ServiceManager serviceManager ) {
+    this.logger = logger;
+
+    String login = userInfo.getLogin();
+    String password = userInfo.getPassword();
     try {
-      this.logger = logger;
-      userDetailsRoleListWebService =
-        serviceManager.createService( userInfo.getLogin(), userInfo.getPassword(), IUserRoleListWebService.class );
-      userRoleWebService =
-        serviceManager.createService( userInfo.getLogin(), userInfo.getPassword(), IUserRoleWebService.class );
+      this.userDetailsRoleListWebService =
+        serviceManager.createService( login, password, IUserRoleListWebService.class );
+      this.userRoleWebService =
+        serviceManager.createService( login, password, IUserRoleWebService.class );
       this.rsm = rsm;
       initManaged( repositoryMeta, userInfo );
       updateUserRoleInfo();
     } catch ( Exception e ) {
       this.logger.error( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0001_UNABLE_TO_INITIALIZE_USER_ROLE_WEBSVC" ), e ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0001_UNABLE_TO_INITIALIZE_USER_ROLE_WEBSVC" ), e ); //$NON-NLS-1$
     }
+  }
+
+  // package-local constructor for testing purposes
+  UserRoleDelegate( Log logger, IUserRoleListWebService userDetailsRoleListWebService,
+                    IUserRoleWebService userRoleWebService ) {
+    this.logger = logger;
+    this.userDetailsRoleListWebService = userDetailsRoleListWebService;
+    this.userRoleWebService = userRoleWebService;
   }
 
   private void initManaged( PurRepositoryMeta repositoryMeta, IUser userInfo ) throws JSONException {
@@ -107,69 +118,96 @@ public class UserRoleDelegate implements java.io.Serializable {
     return managed;
   }
 
-  public void createUser( IUser newUser ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        ProxyPentahoUser user = UserRoleHelper.convertToPentahoProxyUser( newUser );
-        userRoleWebService.createUser( user );
-        if ( newUser instanceof IEEUser ) {
-          userRoleWebService
-            .setRoles( user, UserRoleHelper.convertToPentahoProxyRoles( ( (IEEUser) newUser ).getRoles() ) );
-        }
-        lookupCache.insertUserToLookupSet( newUser );
-        fireUserRoleListChange();
-      } catch ( Exception e ) { // it is the only way to determine AlreadyExistsException
-        if ( e.getCause().toString()
-            .contains( "org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException" ) ) {
-          throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-            "UserRoleDelegate.ERROR_0015_USER_NAME_ALREADY_EXISTS" ) );
-        }
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0002_UNABLE_TO_CREATE_USER", newUser.getLogin() ), e ); //$NON-NLS-1$
-      }
-    } else {
+  private void ensureHasPermissions() throws KettleException {
+    if ( !hasNecessaryPermissions ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
         "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
     }
-
   }
 
-  public void deleteUsers( List<IUser> users ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        userRoleWebService.deleteUsers( UserRoleHelper.convertToPentahoProxyUsers( users ) );
-        lookupCache.removeUsersFromLookupSet( users );
-        fireUserRoleListChange();
-      } catch ( Exception e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0003_UNABLE_TO_DELETE_USERS", e.getLocalizedMessage() ), e ); //$NON-NLS-1$
+  public void createUser( IUser newUser ) throws KettleException {
+    ensureHasPermissions();
+
+    ProxyPentahoUser user = UserRoleHelper.convertToPentahoProxyUser( newUser );
+    try {
+      ProxyPentahoUser[] existingUsers = userRoleWebService.getUsers();
+      if ( existsAmong( existingUsers, user ) ) {
+        throw userExistsException();
       }
-    } else {
+    } catch ( UserRoleException e ) {
+      throw cannotCreateUserException( newUser, e );
+    }
+
+    try {
+      userRoleWebService.createUser( user );
+      if ( newUser instanceof IEEUser ) {
+        userRoleWebService
+          .setRoles( user, UserRoleHelper.convertToPentahoProxyRoles( ( (IEEUser) newUser ).getRoles() ) );
+      }
+      lookupCache.insertUserToLookupSet( newUser );
+      fireUserRoleListChange();
+    } catch ( Exception e ) { // it is the only way to determine AlreadyExistsException
+      if ( e.getCause().toString()
+        .contains( "org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException" ) ) {
+        throw userExistsException();
+      }
+      throw cannotCreateUserException( newUser, e );
+    }
+  }
+
+  private boolean existsAmong( ProxyPentahoUser[] existing, ProxyPentahoUser user ) {
+    if ( existing != null ) {
+      String name = user.getName();
+      for ( ProxyPentahoUser pentahoUser : existing ) {
+        if ( name.equalsIgnoreCase( pentahoUser.getName() ) ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private KettleException userExistsException() {
+    return new KettleException( BaseMessages.getString( UserRoleDelegate.class,
+      "UserRoleDelegate.ERROR_0015_USER_NAME_ALREADY_EXISTS" ) );
+  }
+
+  private KettleException cannotCreateUserException( IUser user, Exception e ) {
+    return new KettleException( BaseMessages.getString( UserRoleDelegate.class,
+      "UserRoleDelegate.ERROR_0002_UNABLE_TO_CREATE_USER", user.getName() ), e );
+  }
+
+
+  public void deleteUsers( List<IUser> users ) throws KettleException {
+    ensureHasPermissions();
+
+    try {
+      userRoleWebService.deleteUsers( UserRoleHelper.convertToPentahoProxyUsers( users ) );
+      lookupCache.removeUsersFromLookupSet( users );
+      fireUserRoleListChange();
+    } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0003_UNABLE_TO_DELETE_USERS", e.getLocalizedMessage() ), e ); //$NON-NLS-1$
     }
   }
 
   public void deleteUser( String name ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        ProxyPentahoUser user = userRoleWebService.getUser( name );
-        if ( user != null ) {
-          ProxyPentahoUser[] users = new ProxyPentahoUser[ 1 ];
-          users[ 0 ] = user;
-          userRoleWebService.deleteUsers( users );
-          fireUserRoleListChange();
-        } else {
-          throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-            "UserRoleDelegate.ERROR_0004_UNABLE_TO_DELETE_USER", name ) ); //$NON-NLS-1$       
-        }
-      } catch ( Exception e ) {
+    ensureHasPermissions();
+
+    try {
+      ProxyPentahoUser user = userRoleWebService.getUser( name );
+      if ( user != null ) {
+        ProxyPentahoUser[] users = new ProxyPentahoUser[ 1 ];
+        users[ 0 ] = user;
+        userRoleWebService.deleteUsers( users );
+        fireUserRoleListChange();
+      } else {
         throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0004_UNABLE_TO_DELETE_USER", name ), e ); //$NON-NLS-1$
+          "UserRoleDelegate.ERROR_0004_UNABLE_TO_DELETE_USER", name ) ); //$NON-NLS-1$
       }
-    } else {
+    } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0004_UNABLE_TO_DELETE_USER", name ), e ); //$NON-NLS-1$
     }
   }
 
@@ -178,41 +216,35 @@ public class UserRoleDelegate implements java.io.Serializable {
   }
 
   public IUser getUser( String name, String password ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      IUser userInfo = null;
-      try {
-        ProxyPentahoUser user = userRoleWebService.getUser( name );
-        if ( user != null && user.getName().equals( name ) && user.getPassword().equals( password ) ) {
-          userInfo = UserRoleHelper.convertToUserInfo( user, userRoleWebService.getRolesForUser( user ), rsm );
-        }
-      } catch ( Exception e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0005_UNABLE_TO_GET_USER", name ), e ); //$NON-NLS-1$
+    ensureHasPermissions();
+
+    IUser userInfo = null;
+    try {
+      ProxyPentahoUser user = userRoleWebService.getUser( name );
+      if ( user != null && user.getName().equals( name ) && user.getPassword().equals( password ) ) {
+        userInfo = UserRoleHelper.convertToUserInfo( user, userRoleWebService.getRolesForUser( user ), rsm );
       }
-      return userInfo;
-    } else {
+    } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0005_UNABLE_TO_GET_USER", name ), e ); //$NON-NLS-1$
     }
+    return userInfo;
   }
 
   public IUser getUser( String name ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      IUser userInfo = null;
-      try {
-        ProxyPentahoUser user = userRoleWebService.getUser( name );
-        if ( user != null && user.getName().equals( name ) ) {
-          userInfo = UserRoleHelper.convertToUserInfo( user, userRoleWebService.getRolesForUser( user ), rsm );
-        }
-      } catch ( Exception e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0005_UNABLE_TO_GET_USER", name ), e ); //$NON-NLS-1$
+    ensureHasPermissions();
+
+    IUser userInfo = null;
+    try {
+      ProxyPentahoUser user = userRoleWebService.getUser( name );
+      if ( user != null && user.getName().equals( name ) ) {
+        userInfo = UserRoleHelper.convertToUserInfo( user, userRoleWebService.getRolesForUser( user ), rsm );
       }
-      return userInfo;
-    } else {
+    } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0005_UNABLE_TO_GET_USER", name ), e ); //$NON-NLS-1$
     }
+    return userInfo;
   }
 
   public List<IUser> getUsers() throws KettleException {
@@ -229,78 +261,95 @@ public class UserRoleDelegate implements java.io.Serializable {
   }
 
   public void updateUser( IUser user ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        ProxyPentahoUser proxyUser = UserRoleHelper.convertToPentahoProxyUser( user );
-        userRoleWebService.updateUser( proxyUser );
-        if ( user instanceof IEEUser ) {
-          userRoleWebService
-            .setRoles( proxyUser, UserRoleHelper.convertToPentahoProxyRoles( ( (IEEUser) user ).getRoles() ) );
-        }
-        lookupCache.updateUserInLookupSet( user );
-        fireUserRoleListChange();
-      } catch ( Exception e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0007_UNABLE_TO_UPDATE_USER", user.getLogin() ), e ); //$NON-NLS-1$
+    ensureHasPermissions();
+
+    try {
+      ProxyPentahoUser proxyUser = UserRoleHelper.convertToPentahoProxyUser( user );
+      userRoleWebService.updateUser( proxyUser );
+      if ( user instanceof IEEUser ) {
+        userRoleWebService
+          .setRoles( proxyUser, UserRoleHelper.convertToPentahoProxyRoles( ( (IEEUser) user ).getRoles() ) );
       }
-    } else {
+      lookupCache.updateUserInLookupSet( user );
+      fireUserRoleListChange();
+    } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0007_UNABLE_TO_UPDATE_USER", user.getLogin() ), e ); //$NON-NLS-1$
     }
   }
 
   public void createRole( IRole newRole ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        ProxyPentahoRole role = UserRoleHelper.convertToPentahoProxyRole( newRole );
-        userRoleWebService.createRole( role );
-        userRoleWebService.setUsers( role, UserRoleHelper.convertToPentahoProxyUsers( newRole.getUsers() ) );
-        lookupCache.insertRoleToLookupSet( newRole );
-        fireUserRoleListChange();
-      } catch ( UserRoleException e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0008_UNABLE_TO_CREATE_ROLE", newRole.getName() ), e ); //$NON-NLS-1$
-      } catch ( Exception e ) { // it is the only way to determine AlreadyExistsException
-        if ( e.getCause().toString()
-            .contains( "org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException" ) ) {
-          throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-            "UserRoleDelegate.ERROR_0016_ROLE_NAME_ALREADY_EXISTS" ) );
-        }
+    ensureHasPermissions();
+
+    ProxyPentahoRole role = UserRoleHelper.convertToPentahoProxyRole( newRole );
+    try {
+      ProxyPentahoRole[] existingRoles = userRoleWebService.getRoles();
+      if ( existsAmong( existingRoles, role ) ) {
+        throw userExistsException();
       }
-    } else {
-      throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+    } catch ( UserRoleException e ) {
+      throw cannotCreateRoleException( newRole, e );
+    }
+
+    try {
+      userRoleWebService.createRole( role );
+      userRoleWebService.setUsers( role, UserRoleHelper.convertToPentahoProxyUsers( newRole.getUsers() ) );
+      lookupCache.insertRoleToLookupSet( newRole );
+      fireUserRoleListChange();
+    } catch ( UserRoleException e ) {
+      throw cannotCreateRoleException( newRole, e );
+    } catch ( Exception e ) { // it is the only way to determine AlreadyExistsException
+      if ( e.getCause().toString()
+        .contains( "org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException" ) ) {
+        throw roleExistsException();
+      }
     }
   }
 
-  public void deleteRoles( List<IRole> roles ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        userRoleWebService.deleteRoles( UserRoleHelper.convertToPentahoProxyRoles( roles ) );
-        lookupCache.removeRolesFromLookupSet( roles );
-        fireUserRoleListChange();
-      } catch ( Exception e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0009_UNABLE_TO_DELETE_ROLES" ), e ); //$NON-NLS-1$
+  private boolean existsAmong( ProxyPentahoRole[] existing, ProxyPentahoRole role ) {
+    if ( existing != null ) {
+      String name = role.getName();
+      for ( ProxyPentahoRole pentahoRole : existing ) {
+        if ( name.equalsIgnoreCase( pentahoRole.getName() ) ) {
+          return true;
+        }
       }
-    } else {
+    }
+    return false;
+  }
+
+  private KettleException roleExistsException() {
+    return new KettleException( BaseMessages.getString( UserRoleDelegate.class,
+      "UserRoleDelegate.ERROR_0016_ROLE_NAME_ALREADY_EXISTS" ) );
+  }
+
+  private KettleException cannotCreateRoleException( IRole role, Exception e ) {
+    return new KettleException( BaseMessages.getString( UserRoleDelegate.class,
+      "UserRoleDelegate.ERROR_0008_UNABLE_TO_CREATE_ROLE", role.getName() ), e );
+  }
+
+  public void deleteRoles( List<IRole> roles ) throws KettleException {
+    ensureHasPermissions();
+
+    try {
+      userRoleWebService.deleteRoles( UserRoleHelper.convertToPentahoProxyRoles( roles ) );
+      lookupCache.removeRolesFromLookupSet( roles );
+      fireUserRoleListChange();
+    } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0009_UNABLE_TO_DELETE_ROLES" ), e ); //$NON-NLS-1$
     }
   }
 
   public IRole getRole( String name ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        return UserRoleHelper.convertFromProxyPentahoRole( userRoleWebService, UserRoleHelper.getProxyPentahoRole(
-          userRoleWebService, name ), lookupCache, rsm );
-      } catch ( Exception e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0010_UNABLE_TO_GET_ROLE", name ), e ); //$NON-NLS-1$
-      }
-    } else {
+    ensureHasPermissions();
+
+    try {
+      return UserRoleHelper.convertFromProxyPentahoRole( userRoleWebService, UserRoleHelper.getProxyPentahoRole(
+        userRoleWebService, name ), lookupCache, rsm );
+    } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0010_UNABLE_TO_GET_ROLE", name ), e ); //$NON-NLS-1$
     }
   }
 
@@ -318,61 +367,51 @@ public class UserRoleDelegate implements java.io.Serializable {
   }
 
   public List<IRole> getDefaultRoles() throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        return UserRoleHelper.convertToListFromProxyPentahoDefaultRoles( userRoleSecurityInfo, rsm );
-      } catch ( Exception e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0011_UNABLE_TO_GET_ROLES" ), e ); //$NON-NLS-1$
-      }
-    } else {
+    ensureHasPermissions();
+
+    try {
+      return UserRoleHelper.convertToListFromProxyPentahoDefaultRoles( userRoleSecurityInfo, rsm );
+    } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0011_UNABLE_TO_GET_ROLES" ), e ); //$NON-NLS-1$
     }
   }
 
   public void updateRole( IRole role ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        List<String> users = new ArrayList<String>();
-        for ( IUser user : role.getUsers() ) {
-          users.add( user.getLogin() );
-        }
-        userRoleWebService.updateRole( role.getName(), role.getDescription(), users );
-        lookupCache.updateRoleInLookupSet( role );
-        fireUserRoleListChange();
-      } catch ( Exception e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0012_UNABLE_TO_UPDATE_ROLE", role.getName() ), e ); //$NON-NLS-1$
+    ensureHasPermissions();
+
+    try {
+      List<String> users = new ArrayList<String>();
+      for ( IUser user : role.getUsers() ) {
+        users.add( user.getLogin() );
       }
-    } else {
+      userRoleWebService.updateRole( role.getName(), role.getDescription(), users );
+      lookupCache.updateRoleInLookupSet( role );
+      fireUserRoleListChange();
+    } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
+        "UserRoleDelegate.ERROR_0012_UNABLE_TO_UPDATE_ROLE", role.getName() ), e ); //$NON-NLS-1$
     }
   }
 
   public void deleteRole( String name ) throws KettleException {
-    if ( hasNecessaryPermissions ) {
-      try {
-        ProxyPentahoRole roleToDelete = UserRoleHelper.getProxyPentahoRole( userRoleWebService, name );
-        if ( roleToDelete != null ) {
-          ProxyPentahoRole[] roleArray = new ProxyPentahoRole[ 1 ];
-          roleArray[ 0 ] = roleToDelete;
-          userRoleWebService.deleteRoles( roleArray );
-          fireUserRoleListChange();
-        } else {
-          throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-            "UserRoleDelegate.ERROR_0013_UNABLE_TO_DELETE_ROLE", name ) ); //$NON-NLS-1$
-        }
-      } catch ( Exception e ) {
-        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-          "UserRoleDelegate.ERROR_0013_UNABLE_TO_DELETE_ROLE", name ), e ); //$NON-NLS-1$
-      }
-    } else {
-      throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
-        "UserRoleDelegate.ERROR_0014_INSUFFICIENT_PRIVILEGES" ) ); //$NON-NLS-1$
-    }
+    ensureHasPermissions();
 
+    try {
+      ProxyPentahoRole roleToDelete = UserRoleHelper.getProxyPentahoRole( userRoleWebService, name );
+      if ( roleToDelete != null ) {
+        ProxyPentahoRole[] roleArray = new ProxyPentahoRole[ 1 ];
+        roleArray[ 0 ] = roleToDelete;
+        userRoleWebService.deleteRoles( roleArray );
+        fireUserRoleListChange();
+      } else {
+        throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
+          "UserRoleDelegate.ERROR_0013_UNABLE_TO_DELETE_ROLE", name ) ); //$NON-NLS-1$
+      }
+    } catch ( Exception e ) {
+      throw new KettleException( BaseMessages.getString( UserRoleDelegate.class,
+        "UserRoleDelegate.ERROR_0013_UNABLE_TO_DELETE_ROLE", name ), e ); //$NON-NLS-1$
+    }
   }
 
   public void setRoles( List<IRole> roles ) throws KettleException {

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/pur/services/RepositorySecurityRoleValidator.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/pur/services/RepositorySecurityRoleValidator.java
@@ -1,0 +1,48 @@
+package org.pentaho.di.ui.repository.pur.services;
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+
+import org.pentaho.di.repository.pur.model.IRole;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public interface RepositorySecurityRoleValidator extends IRoleSupportSecurityManager {
+
+  /**
+   * Validates {@code role} and returns {@code true} if all its data is valid.<br/>
+   * Note: this method performs fail-fast approach and does not return any details.
+   *
+   * @param role role's info
+   * @return {@code true} or {@code false} depending on whether or not role's info is valid
+   */
+  boolean validateRoleInfo( IRole role );
+
+  /**
+   * Performs normalization over {@code user} due to validation rules.</br>
+   * Note: normalized is not guaranteed to pass validation rules
+   *
+   * @param role role's info
+   */
+  void normalizeRoleInfo( IRole role );
+}

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositorySecurityManagerTest.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositorySecurityManagerTest.java
@@ -1,0 +1,95 @@
+/*!
+* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+package org.pentaho.di.repository.pur;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.IUser;
+import org.pentaho.di.repository.UserInfo;
+import org.pentaho.di.repository.pur.model.EERoleInfo;
+import org.pentaho.di.repository.pur.model.IRole;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class PurRepositorySecurityManagerTest {
+
+  private PurRepositorySecurityManager manager;
+  private UserRoleDelegate roleDelegate;
+
+  @Before
+  public void setUp() throws Exception {
+    manager = mock( PurRepositorySecurityManager.class );
+    doCallRealMethod().when( manager ).saveUserInfo( any( IUser.class ) );
+    doCallRealMethod().when( manager ).validateUserInfo( any( IUser.class ) );
+    doCallRealMethod().when( manager ).normalizeUserInfo( any( IUser.class ) );
+
+    doCallRealMethod().when( manager ).createRole( any( IRole.class ) );
+    doCallRealMethod().when( manager ).validateRoleInfo( any( IRole.class ) );
+    doCallRealMethod().when( manager ).normalizeRoleInfo( any( IRole.class ) );
+
+    roleDelegate = mock( UserRoleDelegate.class );
+    doCallRealMethod().when( manager ).setUserRoleDelegate( any( UserRoleDelegate.class ) );
+    manager.setUserRoleDelegate( roleDelegate );
+  }
+
+  @Test
+  public void createRole_NormalizesInfo_PassesIfNoViolations() throws Exception {
+    IRole info = new EERoleInfo( "role  ", "" );
+
+    ArgumentCaptor<IRole> captor = ArgumentCaptor.forClass( IRole.class );
+    manager.createRole( info );
+    verify( roleDelegate ).createRole( captor.capture() );
+
+    info = captor.getValue();
+    assertEquals( "Spaces should be trimmed", "role", info.getName() );
+  }
+
+  @Test( expected = KettleException.class )
+  public void createRole_NormalizesInfo_FailsIfStillBreaches() throws Exception {
+    IRole info = new EERoleInfo( "    ", "" );
+    manager.createRole( info );
+  }
+
+
+  @Test
+  public void saveUserInfo_NormalizesInfo_PassesIfNoViolations() throws Exception {
+    IUser info = new UserInfo( "login    " );
+
+    ArgumentCaptor<IUser> captor = ArgumentCaptor.forClass( IUser.class );
+    manager.saveUserInfo( info );
+    verify( roleDelegate ).createUser( captor.capture() );
+
+    info = captor.getValue();
+    assertEquals( "Spaces should be trimmed", "login", info.getLogin() );
+  }
+
+  @Test( expected = KettleException.class )
+  public void saveUserInfo_NormalizesInfo_FailsIfStillBreaches() throws Exception {
+    UserInfo info = new UserInfo( "    " );
+    manager.saveUserInfo( info );
+  }
+}

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/UserRoleDelegateTest.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/UserRoleDelegateTest.java
@@ -1,0 +1,114 @@
+/*!
+* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+package org.pentaho.di.repository.pur;
+
+import org.apache.commons.logging.Log;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.IUser;
+import org.pentaho.di.repository.UserInfo;
+import org.pentaho.di.repository.pur.model.EERoleInfo;
+import org.pentaho.di.repository.pur.model.IRole;
+import org.pentaho.platform.security.userrole.ws.IUserRoleListWebService;
+import org.pentaho.platform.security.userroledao.ws.IUserRoleWebService;
+import org.pentaho.platform.security.userroledao.ws.ProxyPentahoRole;
+import org.pentaho.platform.security.userroledao.ws.ProxyPentahoUser;
+import org.pentaho.platform.security.userroledao.ws.UserRoleSecurityInfo;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.pentaho.di.repository.pur.UserRoleHelper.convertToPentahoProxyRole;
+import static org.pentaho.di.repository.pur.UserRoleHelper.convertToPentahoProxyUser;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class UserRoleDelegateTest {
+
+  @Mock
+  private Log log;
+  @Mock
+  private IUserRoleListWebService roleListWebService;
+  @Mock
+  private IUserRoleWebService roleWebService;
+
+  private UserRoleDelegate delegate;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks( this );
+
+    when( roleWebService.getUserRoleSecurityInfo() ).thenReturn( new UserRoleSecurityInfo() );
+
+    delegate = new UserRoleDelegate( log, roleListWebService, roleWebService );
+    delegate.managed = true;
+    delegate.updateUserRoleInfo();
+  }
+
+  @After
+  public void tearDown() {
+    delegate = null;
+    log = null;
+    roleListWebService = null;
+    roleListWebService = null;
+  }
+
+  @Test( expected = KettleException.class )
+  public void createUser_ProhibitsToCreate_WhenNameCollides() throws Exception {
+    final String name = "user";
+    final String similar = "User";
+    assertTrue( name.equalsIgnoreCase( similar ) );
+
+    IUser existing = new UserInfo( similar );
+    when( roleWebService.getUsers() ).thenReturn( new ProxyPentahoUser[] { convertToPentahoProxyUser( existing ) } );
+
+    delegate.createUser( new UserInfo( name ) );
+  }
+
+  @Test
+  public void createUser_CreatesSuccessfully_WhenNameIsUnique() throws Exception {
+    final String name = "user";
+    delegate.createUser( new UserInfo( name ) );
+    verify( roleWebService ).createUser( any( ProxyPentahoUser.class ) );
+  }
+
+  @Test( expected = KettleException.class )
+  public void createRole_ProhibitsToCreate_WhenNameCollides() throws Exception {
+    final String name = "role";
+    final String similar = "Role";
+    assertTrue( name.equalsIgnoreCase( similar ) );
+
+    IRole existing = new EERoleInfo( name );
+    when( roleWebService.getRoles() ).thenReturn( new ProxyPentahoRole[]{ convertToPentahoProxyRole( existing ) } );
+
+    delegate.createRole( new EERoleInfo( name ) );
+  }
+
+  @Test
+  public void createRole_CreatesSuccessfully_WhenNameIsUnique() throws Exception {
+    final String name = "role";
+    delegate.createRole( new EERoleInfo( name ) );
+    verify( roleWebService ).createRole( any( ProxyPentahoRole.class ) );
+  }
+}


### PR DESCRIPTION
@mattyb149, @brosander, @deinspanjer, review it please.
Since the ticket is included in October SP, do not ignore it please.

These commits do not contain UI changes, that were refused previously. This PR solves two problems:

1. it makes EE repo and DB repo behave similarly (the previous changes related to this ticket treated only EE)
2. it prohibits not only creating empty names, but also "similar", e.g. "user" and "USER"

/cc @pamval 