### PR TITLE
[TEST] - Fix GoogleAnalyticsApiFacadeTest

### DIFF
--- a/plugins/googleanalytics/test-src/org/pentaho/di/trans/steps/googleanalytics/GoogleAnalyticsApiFacadeTest.java
+++ b/plugins/googleanalytics/test-src/org/pentaho/di/trans/steps/googleanalytics/GoogleAnalyticsApiFacadeTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.pentaho.di.core.exception.KettleFileException;
 
 import java.io.FileNotFoundException;
 import java.util.Arrays;
@@ -47,7 +46,8 @@ public class GoogleAnalyticsApiFacadeTest {
       new Object[] { "/key.p12", FileNotFoundException.class },
       new Object[] { "file:///C:/key.p12", FileNotFoundException.class },
       new Object[] { "file:///C:\\key.p12", FileNotFoundException.class },
-      new Object[] { "file:///key.p12", KettleFileException.class }
+      // KettleFileException on Windows, FileNotFoundException on Ubuntu
+      new Object[] { "file:///key.p12", Exception.class }
     );
   }
 


### PR DESCRIPTION
- handle different exceptions thrown on different OSes

@mattyb149, @brosander, merge it please - this is the fix to repair the test broken by https://github.com/pentaho/pentaho-kettle/pull/1837.

I investigated why it happened. Surprisingly, VFS behaves differently on Windows and on Linux, that is why I got no errors when was doing the changes. I checked the test on Ubuntu and could manage to reproduce the problem.