### PR TITLE
[PDI-14343] - Timestamp for jobs in DI repository continuously displays the same value for different versions

### DIFF
--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
@@ -26,14 +26,10 @@ import static org.pentaho.di.repository.pur.PurRepositoryTestingUtils.*;
 
 import java.io.File;
 import java.io.Serializable;
-import java.text.SimpleDateFormat;
 import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -813,53 +809,6 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
   }
 
   @Test
-  public void testVersionDate() throws Exception {
-
-    RepositoryDirectoryInterface rootDir = initRepo();
-    String uniqueTransName = EXP_TRANS_NAME.concat( EXP_DBMETA_NAME );
-    TransMeta transMeta = createTransMeta( EXP_DBMETA_NAME );
-
-    // Create a database association
-    DatabaseMeta dbMeta = createDatabaseMeta( EXP_DBMETA_NAME );
-    repository.save( dbMeta, VERSION_COMMENT_V1, null );
-
-    TableInputMeta tableInputMeta = new TableInputMeta();
-    tableInputMeta.setDatabaseMeta( dbMeta );
-
-    transMeta.addStep( new StepMeta( EXP_TRANS_STEP_1_NAME, tableInputMeta ) );
-
-    RepositoryDirectoryInterface transDir = rootDir.findDirectory( DIR_TRANSFORMATIONS );
-    Calendar cal = Calendar.getInstance( Locale.US );
-
-    SimpleDateFormat df = new SimpleDateFormat( "EEE, d MMM yyyy HH:mm:ss Z", Locale.US );
-    cal.setTime( df.parse( "Wed, 4 Jul 2001 12:08:56 -0700" ) );
-    repository.save( transMeta, VERSION_COMMENT_V1, null, null, true );
-
-    repository.save( transMeta, VERSION_COMMENT_V1 + "2", cal, null, true );
-    deleteStack.push( transMeta ); // So this transformation is cleaned up afterward
-    assertNotNull( transMeta.getObjectId() );
-    ObjectRevision version = transMeta.getObjectRevision();
-    assertNotNull( version );
-    assertTrue( hasVersionWithComment( transMeta, VERSION_COMMENT_V1 ) );
-
-    assertTrue( hasVersionWithCal( transMeta, cal ) );
-
-
-    assertTrue( repository.exists( uniqueTransName, transDir, RepositoryObjectType.TRANSFORMATION ) );
-
-    JobMeta jobMeta = createJobMeta( EXP_JOB_NAME );
-    RepositoryDirectoryInterface jobsDir = rootDir.findDirectory( DIR_JOBS );
-    repository.save( jobMeta, VERSION_COMMENT_V1, null );
-    deleteStack.push( jobMeta );
-    assertNotNull( jobMeta.getObjectId() );
-    version = jobMeta.getObjectRevision();
-    assertNotNull( version );
-    assertTrue( hasVersionWithComment( jobMeta, VERSION_COMMENT_V1 ) );
-    assertTrue( repository.exists( EXP_JOB_NAME, jobsDir, RepositoryObjectType.JOB ) );
-
-  }
-
-  @Test
   public void testMetaStoreBasics() throws MetaStoreException {
     IMetaStore metaStore = repository.getMetaStore();
     assertNotNull( metaStore );
@@ -1117,28 +1066,6 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
     assertEquals( element2, loaded );
   }
 
-
-  @Test
-  public void testJobRevisionDate() {
-    final Long createdTime = 1441961024857L;
-    RepositoryElementInterface job = new JobMeta();
-    job.setName( "Job" );
-    try {
-      RepositoryDirectoryInterface directory = repository.findDirectory( "public" );
-      job.setRepositoryDirectory( directory );
-
-      Calendar cal = Calendar.getInstance( Locale.US );
-      cal.setTime( new Date( createdTime ) );
-
-      repository.save( job, VERSION_COMMENT_V1, cal, null, true );
-
-      assertEquals( "Revision date is incorrect", job.getObjectRevision().getCreationDate().getTime(),
-          (long) createdTime );
-    } catch ( Exception e ) {
-      e.printStackTrace();
-      fail( "Unexpected error" );
-    }
-  }
 
   @Test
   public void testExportWithRules() throws Exception {

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_Revisions_IT.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_Revisions_IT.java
@@ -1,0 +1,158 @@
+/*!
+* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+package org.pentaho.di.repository.pur;
+
+import org.junit.Test;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.ObjectRevision;
+import org.pentaho.di.repository.RepositoryElementInterface;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.VersionSummary;
+
+import java.util.Calendar;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class PurRepository_Revisions_IT extends PurRepositoryTestBase {
+
+  @Test
+  public void onlyRevision_DataAndCommentAreSaved_Trans() throws Exception {
+    testOnlyRevision_DateAndCommentAreSaved( new TransMeta() );
+  }
+
+  @Test
+  public void onlyRevision_DataAndCommentAreSaved_Job() throws Exception {
+    testOnlyRevision_DateAndCommentAreSaved( new JobMeta() );
+  }
+
+  private void testOnlyRevision_DateAndCommentAreSaved( RepositoryElementInterface transOrJob ) throws Exception {
+    final String elementName = "onlyRevision_" + transOrJob.getRepositoryElementType();
+    final String comment = "onlyRevision";
+    final Calendar date = Calendar.getInstance();
+    date.setTimeInMillis( 0 );
+
+    transOrJob.setName( elementName );
+    transOrJob.setRepositoryDirectory( purRepository.getDefaultSaveDirectory( transOrJob ) );
+    purRepository.save( transOrJob, comment, date, null, false );
+
+    assertCommentAndDate( transOrJob.getObjectRevision(), date, comment );
+
+    List<VersionSummary> versions = assertExistsAndGetRevisions( transOrJob );
+    assertEquals( 1, versions.size() );
+    assertCommentAndDate( versions.get( 0 ), date, comment );
+  }
+
+
+  @Test
+  public void onlyRevision_DataAndCommentAreNull_Trans() throws Exception {
+    testOnlyRevision_DateAndCommentAreNull( new TransMeta() );
+  }
+
+  @Test
+  public void onlyRevision_DataAndCommentAreNull_Job() throws Exception {
+    testOnlyRevision_DateAndCommentAreNull( new JobMeta() );
+  }
+
+  private void testOnlyRevision_DateAndCommentAreNull( RepositoryElementInterface transOrJob ) throws Exception {
+    final String elementName = "revisionWithOutComment_" + transOrJob.getRepositoryElementType();
+
+    transOrJob.setName( elementName );
+    transOrJob.setRepositoryDirectory( purRepository.getDefaultSaveDirectory( transOrJob ) );
+
+    final long before = System.currentTimeMillis();
+    purRepository.save( transOrJob, null, null, null, false );
+    final long after = System.currentTimeMillis();
+
+    assertNull( transOrJob.getObjectRevision().getComment() );
+
+    final long revisionDate = transOrJob.getObjectRevision().getCreationDate().getTime();
+    assertTrue( "Revision date should be inside 'before' and 'after' measurements",
+      before <= revisionDate && revisionDate <= after );
+
+    List<VersionSummary> versions = assertExistsAndGetRevisions( transOrJob );
+    assertEquals( 1, versions.size() );
+    assertNull( versions.get( 0 ).getMessage() );
+
+    final long versionSummaryDate = versions.get( 0 ).getDate().getTime();
+    assertTrue( "Revision date should be inside 'before' and 'after' measurements",
+      before <= versionSummaryDate && versionSummaryDate <= after );
+  }
+
+
+  @Test
+  public void twoRevisions_DataAndCommentAreSaved_Trans() throws Exception {
+    testTwoRevisions_DateAndCommentAreSaved( new TransMeta() );
+  }
+
+  @Test
+  public void twoRevisions_DataAndCommentAreSaved_Job() throws Exception {
+    testTwoRevisions_DateAndCommentAreSaved( new JobMeta() );
+  }
+
+  private void testTwoRevisions_DateAndCommentAreSaved( RepositoryElementInterface transOrJob ) throws Exception {
+    final String elementName = "twoRevisions_" + transOrJob.getRepositoryElementType();
+
+    final String comment1 = "first";
+    final Calendar date1 = Calendar.getInstance();
+    date1.setTimeInMillis( 0 );
+
+    final String comment2 = "second";
+    final Calendar date2 = Calendar.getInstance();
+    date2.setTimeInMillis( 100 );
+
+    transOrJob.setName( elementName );
+    transOrJob.setRepositoryDirectory( purRepository.getDefaultSaveDirectory( transOrJob ) );
+
+    purRepository.save( transOrJob, comment1, date1, null, false );
+    assertCommentAndDate( transOrJob.getObjectRevision(), date1, comment1 );
+
+    purRepository.save( transOrJob, comment2, date2, null, false );
+    assertCommentAndDate( transOrJob.getObjectRevision(), date2, comment2 );
+
+    List<VersionSummary> versions = assertExistsAndGetRevisions( transOrJob );
+    assertEquals( 2, versions.size() );
+    assertCommentAndDate( versions.get( 0 ), date1, comment1 );
+    assertCommentAndDate( versions.get( 1 ), date2, comment2 );
+  }
+
+
+  private List<VersionSummary> assertExistsAndGetRevisions( RepositoryElementInterface transOrJob ) {
+    ObjectId id = transOrJob.getObjectId();
+    assertNotNull( id );
+
+    RepositoryFile file = unifiedRepository.getFileById( id.toString() );
+    assertNotNull( file );
+    return unifiedRepository.getVersionSummaries( id.toString() );
+  }
+
+  private void assertCommentAndDate( VersionSummary summary, Calendar expectedDate, String expectedComment ) {
+    assertEquals( expectedDate.getTimeInMillis(), summary.getDate().getTime() );
+    assertEquals( expectedComment, summary.getMessage() );
+  }
+
+  private void assertCommentAndDate( ObjectRevision revision, Calendar expectedDate, String expectedComment ) {
+    assertEquals( expectedDate.getTimeInMillis(), revision.getCreationDate().getTime() );
+    assertEquals( expectedComment, revision.getComment() );
+  }
+}


### PR DESCRIPTION
- improve PurRepository
  - remove code duplication in ```saveTrans0()``` and ```saveJob0()```
  - add java docs for ```saveKettleEntity()```
  - fix checkstyle violations
- re-organize tests
  - delete revision-related tests from ```PurRepositoryIT```
  - introduce ```PurRepository_Revisions_I```T and implement revision-related test cases there

@mattyb149, @brosander, review it please. The problem described in the ticket has been already fixed. This PR eliminates code duplication and brushes up tests