### PR TITLE
[TEST] - Continue splitting PurRepositoryTest

### DIFF
--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
@@ -539,70 +539,6 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
   }
 
   @Test
-  public void testLoadSharedObjects_databases() throws Exception {
-    PurRepository repo = (PurRepository) repository;
-    DatabaseMeta dbMeta = createDatabaseMeta( EXP_DBMETA_NAME );
-    repository.save( dbMeta, VERSION_COMMENT_V1, null );
-
-    Map<RepositoryObjectType, List<? extends SharedObjectInterface>> sharedObjectsByType =
-      new HashMap<RepositoryObjectType, List<? extends SharedObjectInterface>>();
-    repo.readSharedObjects( sharedObjectsByType, RepositoryObjectType.DATABASE );
-    assertNotNull( sharedObjectsByType );
-    @SuppressWarnings( "unchecked" )
-    List<DatabaseMeta> databaseMetas = (List<DatabaseMeta>) sharedObjectsByType.get( RepositoryObjectType.DATABASE );
-    assertNotNull( databaseMetas );
-    assertEquals( 1, databaseMetas.size() );
-    DatabaseMeta dbMetaResult = databaseMetas.get( 0 );
-    assertNotNull( dbMetaResult );
-    assertEquals( dbMeta, dbMetaResult );
-
-    repository.deleteDatabaseMeta( EXP_DBMETA_NAME );
-  }
-
-  @Test
-  public void testLoadSharedObjects_slaves() throws Exception {
-    PurRepository repo = (PurRepository) repository;
-    SlaveServer slave = createSlaveServer( "" ); //$NON-NLS-1$
-    repository.save( slave, VERSION_COMMENT_V1, null );
-
-    Map<RepositoryObjectType, List<? extends SharedObjectInterface>> sharedObjectsByType =
-      new HashMap<RepositoryObjectType, List<? extends SharedObjectInterface>>();
-    repo.readSharedObjects( sharedObjectsByType, RepositoryObjectType.SLAVE_SERVER );
-    assertNotNull( sharedObjectsByType );
-    @SuppressWarnings( "unchecked" )
-    List<SlaveServer> slaveServers = (List<SlaveServer>) sharedObjectsByType.get( RepositoryObjectType.SLAVE_SERVER );
-    assertNotNull( slaveServers );
-    assertEquals( 1, slaveServers.size() );
-    SlaveServer slaveResult = slaveServers.get( 0 );
-    assertNotNull( slaveResult );
-    assertEquals( slave, slaveResult );
-
-    repository.deleteSlave( slave.getObjectId() );
-  }
-
-  @Test
-  public void testLoadSharedObjects_partitions() throws Exception {
-    PurRepository repo = (PurRepository) repository;
-    PartitionSchema partSchema = createPartitionSchema( "" ); //$NON-NLS-1$
-    repository.save( partSchema, VERSION_COMMENT_V1, null );
-
-    Map<RepositoryObjectType, List<? extends SharedObjectInterface>> sharedObjectsByType =
-      new HashMap<RepositoryObjectType, List<? extends SharedObjectInterface>>();
-    repo.readSharedObjects( sharedObjectsByType, RepositoryObjectType.PARTITION_SCHEMA );
-    assertNotNull( sharedObjectsByType );
-    @SuppressWarnings( "unchecked" )
-    List<PartitionSchema> partitionSchemas = (List<PartitionSchema>) sharedObjectsByType
-      .get( RepositoryObjectType.PARTITION_SCHEMA );
-    assertNotNull( partitionSchemas );
-    assertEquals( 1, partitionSchemas.size() );
-    PartitionSchema partitionSchemaResult = partitionSchemas.get( 0 );
-    assertNotNull( partitionSchemaResult );
-    assertEquals( partSchema, partitionSchemaResult );
-
-    repository.deletePartitionSchema( partSchema.getObjectId() );
-  }
-
-  @Test
   public void testNewNonAmbiguousNaming() throws Exception {
     PurRepository repo = (PurRepository) repository;
 
@@ -633,63 +569,6 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
     partitionSchemas = (List<PartitionSchema>) sharedObjectsByType
       .get( RepositoryObjectType.PARTITION_SCHEMA );
     assertEquals( 3, partitionSchemas.size() );
-  }
-
-  @Test
-  public void testLoadSharedObjects_clusters() throws Exception {
-    PurRepository repo = (PurRepository) repository;
-    ClusterSchema clusterSchema = createClusterSchema( EXP_CLUSTER_SCHEMA_NAME );
-    repository.save( clusterSchema, VERSION_COMMENT_V1, null );
-
-    Map<RepositoryObjectType, List<? extends SharedObjectInterface>> sharedObjectsByType =
-      new HashMap<RepositoryObjectType, List<? extends SharedObjectInterface>>();
-    repo.readSharedObjects( sharedObjectsByType, RepositoryObjectType.CLUSTER_SCHEMA );
-    assertNotNull( sharedObjectsByType );
-    @SuppressWarnings( "unchecked" )
-    List<ClusterSchema> clusterSchemas = (List<ClusterSchema>) sharedObjectsByType
-      .get( RepositoryObjectType.CLUSTER_SCHEMA );
-    assertNotNull( clusterSchemas );
-    assertEquals( 1, clusterSchemas.size() );
-    ClusterSchema clusterSchemaResult = clusterSchemas.get( 0 );
-    assertNotNull( clusterSchemaResult );
-    assertEquals( clusterSchema, clusterSchemaResult );
-
-    repository.deleteClusterSchema( clusterSchema.getObjectId() );
-  }
-
-  @Test
-  public void testLoadSharedObjects_databases_and_clusters() throws Exception {
-    PurRepository repo = (PurRepository) repository;
-    DatabaseMeta dbMeta = createDatabaseMeta( EXP_DBMETA_NAME );
-    repository.save( dbMeta, VERSION_COMMENT_V1, null );
-    ClusterSchema clusterSchema = createClusterSchema( EXP_CLUSTER_SCHEMA_NAME );
-    repository.save( clusterSchema, VERSION_COMMENT_V1, null );
-
-    Map<RepositoryObjectType, List<? extends SharedObjectInterface>> sharedObjectsByType =
-      new HashMap<RepositoryObjectType, List<? extends SharedObjectInterface>>();
-    repo.readSharedObjects( sharedObjectsByType, RepositoryObjectType.CLUSTER_SCHEMA, RepositoryObjectType.DATABASE );
-    assertNotNull( sharedObjectsByType );
-    assertEquals( 2, sharedObjectsByType.size() );
-
-    @SuppressWarnings( "unchecked" )
-    List<DatabaseMeta> databaseMetas = (List<DatabaseMeta>) sharedObjectsByType.get( RepositoryObjectType.DATABASE );
-    assertNotNull( databaseMetas );
-    assertEquals( 1, databaseMetas.size() );
-    DatabaseMeta dbMetaResult = databaseMetas.get( 0 );
-    assertNotNull( dbMetaResult );
-    assertEquals( dbMeta, dbMetaResult );
-
-    @SuppressWarnings( "unchecked" )
-    List<ClusterSchema> clusterSchemas = (List<ClusterSchema>) sharedObjectsByType
-      .get( RepositoryObjectType.CLUSTER_SCHEMA );
-    assertNotNull( clusterSchemas );
-    assertEquals( 1, clusterSchemas.size() );
-    ClusterSchema clusterSchemaResult = clusterSchemas.get( 0 );
-    assertNotNull( clusterSchemaResult );
-    assertEquals( clusterSchema, clusterSchemaResult );
-
-    repository.deleteDatabaseMeta( EXP_DBMETA_NAME );
-    repository.deleteClusterSchema( clusterSchema.getObjectId() );
   }
 
   private class MockProgressMonitorListener implements ProgressMonitorListener {

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
@@ -423,6 +423,9 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
     // null out fields to get back memory
     tenantManager = null;
     repo = null;
+
+    mp.stop();
+    mp = null;
   }
 
   @Override

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryTestBase.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryTestBase.java
@@ -111,6 +111,7 @@ public abstract class PurRepositoryTestBase implements ApplicationContextAware {
   private ITenant testingTenant;
 
   // this block stores those values, that should be restored after test's execution
+  private MicroPlatform mp;
   private IRepositoryVersionManager existingVersionManager;
 
 
@@ -150,7 +151,7 @@ public abstract class PurRepositoryTestBase implements ApplicationContextAware {
   }
 
   private void startMicroPlatform() throws Exception {
-    MicroPlatform mp = new MicroPlatform();
+    mp = new MicroPlatform();
     mp.defineInstance( "tenantedUserNameUtils", userNameUtils );
     mp.defineInstance( "tenantedRoleNameUtils", roleNameUtils );
     mp.defineInstance( IAuthorizationPolicy.class, authorizationPolicy );
@@ -254,6 +255,9 @@ public abstract class PurRepositoryTestBase implements ApplicationContextAware {
     repositoryFileDao = null;
     txnTemplate = null;
     systemTenant = testingTenant = null;
+
+    mp.stop();
+    mp = null;
 
     JcrRepositoryFileUtils.setRepositoryVersionManager( existingVersionManager );
     PentahoSessionHolder.setStrategyName( MODE_INHERITABLETHREADLOCAL );

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_SharedObjects_IT.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_SharedObjects_IT.java
@@ -1,0 +1,192 @@
+/*!
+* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+package org.pentaho.di.repository.pur;
+
+import org.junit.Test;
+import org.pentaho.di.cluster.ClusterSchema;
+import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.partition.PartitionSchema;
+import org.pentaho.di.repository.RepositoryElementInterface;
+import org.pentaho.di.repository.RepositoryObjectType;
+import org.pentaho.di.shared.SharedObjectInterface;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.pentaho.di.repository.RepositoryObjectType.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class PurRepository_SharedObjects_IT extends PurRepositoryTestBase {
+
+
+  @Test
+  public void loadClusters() throws Exception {
+    testLoadSharedObjects( cluster() );
+  }
+
+  @Test
+  public void loadDatabases() throws Exception {
+    testLoadSharedObjects( database() );
+  }
+
+  @Test
+  public void loadSlaves() throws Exception {
+    testLoadSharedObjects( slaveServer() );
+  }
+
+  @Test
+  public void loadPartitions() throws Exception {
+    testLoadSharedObjects( partition() );
+  }
+
+  private void testLoadSharedObjects( RepositoryElementInterface sharedObject ) throws Exception {
+    purRepository.save( sharedObject, null, null );
+
+    Map<RepositoryObjectType, List<? extends SharedObjectInterface>> map = map();
+    purRepository.readSharedObjects( map, sharedObject.getRepositoryElementType() );
+
+    List<? extends SharedObjectInterface> objects = map.get( sharedObject.getRepositoryElementType() );
+    assertNotNull( objects );
+    assertEquals( 1, objects.size() );
+
+    SharedObjectInterface object = objects.get( 0 );
+    assertEquals( sharedObject, object );
+  }
+
+
+  @Test
+  public void clusterIsRemovedFromCacheOnDelete() throws Exception {
+    testElementIsRemovedFromCacheOnDelete( cluster(), new Remover() {
+      @Override
+      public void deleteFromRepository( RepositoryElementInterface element ) throws KettleException {
+        purRepository.deleteClusterSchema( element.getObjectId() );
+      }
+    } );
+  }
+
+  @Test
+  public void databaseIsRemovedFromCacheOnDelete() throws Exception {
+    testElementIsRemovedFromCacheOnDelete( database(), new Remover() {
+      @Override
+      public void deleteFromRepository( RepositoryElementInterface element ) throws KettleException {
+        purRepository.deleteDatabaseMeta( element.getName() );
+      }
+    } );
+  }
+
+  @Test
+  public void slaveIsRemovedFromCacheOnDelete() throws Exception {
+    testElementIsRemovedFromCacheOnDelete( slaveServer(), new Remover() {
+      @Override
+      public void deleteFromRepository( RepositoryElementInterface element ) throws KettleException {
+        purRepository.deleteSlave( element.getObjectId() );
+      }
+    } );
+  }
+
+  @Test
+  public void partitionIsRemovedFromCacheOnDelete() throws Exception {
+    testElementIsRemovedFromCacheOnDelete( partition(), new Remover() {
+      @Override
+      public void deleteFromRepository( RepositoryElementInterface element ) throws KettleException {
+        purRepository.deletePartitionSchema( element.getObjectId() );
+      }
+    } );
+  }
+
+  private void testElementIsRemovedFromCacheOnDelete( RepositoryElementInterface element, Remover remover )
+    throws Exception {
+    purRepository.save( element, null, null );
+    assertNotNull( element.getObjectId() );
+
+    List<? extends SharedObjectInterface> before =
+      purRepository.loadAndCacheSharedObjects().get( element.getRepositoryElementType() );
+    assertEquals( 1, before.size() );
+
+    remover.deleteFromRepository( element );
+    List<? extends SharedObjectInterface> after =
+      purRepository.loadAndCacheSharedObjects().get( element.getRepositoryElementType() );
+    assertTrue( after.isEmpty() );
+  }
+
+
+  @Test
+  public void loadAllShared() throws Exception {
+    ClusterSchema cluster = cluster();
+    DatabaseMeta database = database();
+    SlaveServer slaveServer = slaveServer();
+    PartitionSchema partition = partition();
+
+    purRepository.save( cluster, null, null );
+    purRepository.save( database, null, null );
+    purRepository.save( slaveServer, null, null );
+    purRepository.save( partition, null, null );
+
+    Map<RepositoryObjectType, List<? extends SharedObjectInterface>> map = map();
+    purRepository.readSharedObjects( map, CLUSTER_SCHEMA, DATABASE, SLAVE_SERVER, PARTITION_SCHEMA );
+
+    RepositoryElementInterface[] saved = new RepositoryElementInterface[] { cluster, database, slaveServer, partition };
+    assertEquals( saved.length, map.size() );
+    for ( RepositoryElementInterface sharedObject : saved ) {
+      List<? extends SharedObjectInterface> list = map.get( sharedObject.getRepositoryElementType() );
+      assertEquals( 1, list.size() );
+      assertEquals( sharedObject, list.get( 0 ) );
+    }
+  }
+
+
+  private static ClusterSchema cluster() {
+    return new ClusterSchema( "testCluster", Collections.<SlaveServer>emptyList() );
+  }
+
+  private static DatabaseMeta database() {
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( "testDatabase" );
+    return db;
+  }
+
+  private static SlaveServer slaveServer() {
+    SlaveServer server = new SlaveServer();
+    server.setName( "testSlaveServer" );
+    return server;
+  }
+
+  private static PartitionSchema partition() {
+    PartitionSchema schema = new PartitionSchema();
+    schema.setName( "testPartitionSchema" );
+    return schema;
+  }
+
+  private static Map<RepositoryObjectType, List<? extends SharedObjectInterface>> map() {
+    return new EnumMap<RepositoryObjectType, List<? extends SharedObjectInterface>>( RepositoryObjectType.class );
+  }
+
+
+  private interface Remover {
+    void deleteFromRepository( RepositoryElementInterface element ) throws KettleException;
+  }
+}


### PR DESCRIPTION
@mattyb149, @brosander, review it please.
I continue splitting ```PurRepositoryIT``` moving groups of linked tests to separate classes.

The fist commit fixes a lurk flaw -- it properly shutdowns ```PentahoSystem```. Without it, each next attempt to initialise the system causes an thrown exception. It is not reproduced in tests executions, because Ant task forks JVM ```perTest```. However, it fails when I run all tests within IDE as it executes them within one virtual machine.