### PR TITLE
[PDI-14375] - Incorrect time displayed in Version History after some operations with transformation/jobs in the DI repository

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
@@ -1699,7 +1699,9 @@ public class PurRepository extends AbstractRepository implements Repository, jav
       fullName = file.getName();
     } else {
       // set new title
-      builder.title( RepositoryFile.DEFAULT_LOCALE, newTitle );
+      builder.title( RepositoryFile.DEFAULT_LOCALE, newTitle )
+        // rename operation creates new revision, hence clear old value to be overwritten during saving
+        .createdDate( null );
       fullName = checkAndSanitize( newTitle ) + objectType.getExtension();
     }
 

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_MoveAndRename_IT.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_MoveAndRename_IT.java
@@ -28,9 +28,7 @@ import org.pentaho.platform.api.repository2.unified.VersionSummary;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.junit.matchers.JUnitMatchers.hasItem;
 
 public class PurRepository_MoveAndRename_IT extends PurRepositoryTestBase {
@@ -77,11 +75,18 @@ public class PurRepository_MoveAndRename_IT extends PurRepositoryTestBase {
     AbstractMeta meta = assistant.createNew();
 
     assistant.save( meta, initial, getPublicDir() );
-
     List<VersionSummary> historyBefore = unifiedRepository.getVersionSummaries( meta.getObjectId().getId() );
+
+    long before = System.currentTimeMillis();
     assistant.rename( meta, renamed );
+    long after = System.currentTimeMillis();
+
     List<VersionSummary> historyAfter = unifiedRepository.getVersionSummaries( meta.getObjectId().getId() );
     assertEquals( historyBefore.size() + 1, historyAfter.size() );
+
+    long newRevisionTs = historyAfter.get( historyAfter.size() - 1 ).getDate().getTime();
+    assertTrue( String.format( "%d <= %d <= %d", before, newRevisionTs, after ),
+      ( before <= newRevisionTs ) && ( newRevisionTs <= after ) );
   }
 
 


### PR DESCRIPTION
- clear "createdDate" on renaming to force the repository to inject current time
- update tests to check this condition

@mattyb149, @brosander, review it please  