### PR TITLE
[TEST] - Repair tests for Windows

### DIFF
--- a/core/test-src/org/pentaho/di/core/parameters/DuplicateParamExceptionTest.java
+++ b/core/test-src/org/pentaho/di/core/parameters/DuplicateParamExceptionTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.pentaho.di.core.parameters.NamedParamsExceptionTest.assertMessage;
 
 /**
  * Created by mburgess on 10/13/15.
@@ -44,15 +45,18 @@ public class DuplicateParamExceptionTest {
   public void testConstructors() {
     exception = new DuplicateParamException();
     assertNotNull( exception );
-    assertEquals( "\nnull\n", exception.getMessage() );
+    assertMessage( "null", exception );
+
     exception = new DuplicateParamException( "message" );
-    assertEquals( "\nmessage\n", exception.getMessage() );
+    assertMessage( "message", exception );
+
     Throwable t = mock( Throwable.class );
     when( t.getStackTrace() ).thenReturn( new StackTraceElement[0] );
     exception = new DuplicateParamException( t );
     assertEquals( t, exception.getCause() );
+
     exception = new DuplicateParamException( "message", t );
-    assertEquals( "\nmessage\n", exception.getMessage() );
+    assertMessage( "message", exception );
     assertEquals( t, exception.getCause() );
   }
 }

--- a/core/test-src/org/pentaho/di/core/parameters/NamedParamsExceptionTest.java
+++ b/core/test-src/org/pentaho/di/core/parameters/NamedParamsExceptionTest.java
@@ -40,15 +40,23 @@ public class NamedParamsExceptionTest {
   public void testConstructors() {
     exception = new NamedParamsException();
     assertNotNull( exception );
-    assertEquals( "\nnull\n", exception.getMessage() );
+    assertMessage( "null", exception );
+
     exception = new NamedParamsException( "message" );
-    assertEquals( "\nmessage\n", exception.getMessage() );
+    assertMessage( "message", exception );
+
     Throwable t = mock( Throwable.class );
-    when( t.getStackTrace() ).thenReturn( new StackTraceElement[0] );
+    when( t.getStackTrace() ).thenReturn( new StackTraceElement[ 0 ] );
     exception = new NamedParamsException( t );
     assertEquals( t, exception.getCause() );
+
     exception = new NamedParamsException( "message", t );
-    assertEquals( "\nmessage\n", exception.getMessage() );
+    assertMessage( "message", exception );
     assertEquals( t, exception.getCause() );
+  }
+
+  static void assertMessage( String expected, NamedParamsException exception ) {
+    String surrounded = System.lineSeparator() + expected + System.lineSeparator();
+    assertEquals( surrounded, exception.getMessage() );
   }
 }

--- a/core/test-src/org/pentaho/di/core/parameters/UnknownParamExceptionTest.java
+++ b/core/test-src/org/pentaho/di/core/parameters/UnknownParamExceptionTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.pentaho.di.core.parameters.NamedParamsExceptionTest.assertMessage;
 
 /**
  * Created by mburgess on 10/13/15.
@@ -40,15 +41,18 @@ public class UnknownParamExceptionTest {
   public void testConstructors() {
     exception = new UnknownParamException();
     assertNotNull( exception );
-    assertEquals( "\nnull\n", exception.getMessage() );
+    assertMessage( "null", exception );
+
     exception = new UnknownParamException( "message" );
-    assertEquals( "\nmessage\n", exception.getMessage() );
+    assertMessage( "message", exception );
+
     Throwable t = mock( Throwable.class );
     when( t.getStackTrace() ).thenReturn( new StackTraceElement[0] );
     exception = new UnknownParamException( t );
     assertEquals( t, exception.getCause() );
+
     exception = new UnknownParamException( "message", t );
-    assertEquals( "\nmessage\n", exception.getMessage() );
+    assertMessage( "message", exception );
     assertEquals( t, exception.getCause() );
   }
 }


### PR DESCRIPTION
@mattyb149, @brosander, review it please.
These tests fail on Windows because of different line separators  