### PR TITLE
[SP-2204][PDI-14375] - Incorrect time displayed in Version History af…

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
@@ -1674,7 +1674,9 @@ public class PurRepository extends AbstractRepository implements Repository, jav
       fullName = file.getName();
     } else {
       // set new title
-      builder.title( RepositoryFile.DEFAULT_LOCALE, newTitle );
+      builder.title( RepositoryFile.DEFAULT_LOCALE, newTitle )
+        // rename operation creates new revision, hence clear old value to be overwritten during saving
+        .createdDate( null );
       fullName = checkAndSanitize( newTitle ) + objectType.getExtension();
     }
 

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
@@ -1332,9 +1332,16 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
     saveJob( job, initial, getPublicDir() );
 
     List<VersionSummary> historyBefore = repo.getVersionSummaries( job.getObjectId().getId() );
+
+    long before = System.currentTimeMillis();
     repository.renameTransformation( job.getObjectId(), job.getRepositoryDirectory(), renamed );
+    long after = System.currentTimeMillis();
+
     List<VersionSummary> historyAfter = repo.getVersionSummaries( job.getObjectId().getId() );
     assertEquals( historyBefore.size() + 1, historyAfter.size() );
+    long newRevisionTs = historyAfter.get( historyAfter.size() - 1 ).getDate().getTime();
+    assertTrue( String.format( "%d <= %d <= %d", before, newRevisionTs, after ),
+        ( before <= newRevisionTs ) && ( newRevisionTs <= after ) );
   }
 
   @Test( expected = KettleException.class )
@@ -1472,9 +1479,16 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
     saveTrans( trans, initial, getPublicDir() );
 
     List<VersionSummary> historyBefore = repo.getVersionSummaries( trans.getObjectId().getId() );
+
+    long before = System.currentTimeMillis();
     repository.renameTransformation( trans.getObjectId(), trans.getRepositoryDirectory(), renamed );
+    long after = System.currentTimeMillis();
+
     List<VersionSummary> historyAfter = repo.getVersionSummaries( trans.getObjectId().getId() );
     assertEquals( historyBefore.size() + 1, historyAfter.size() );
+    long newRevisionTs = historyAfter.get( historyAfter.size() - 1 ).getDate().getTime();
+    assertTrue( String.format( "%d <= %d <= %d", before, newRevisionTs, after ),
+        ( before <= newRevisionTs ) && ( newRevisionTs <= after ) );
   }
 
   @Test( expected = KettleException.class )


### PR DESCRIPTION
…ter some operations with transformation/jobs in the DI repository

- clear "createdDate" on renaming to force the repository to inject current time
- update tests to check this condition

Conflicts:
	plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_MoveAndRename_IT.java