### PR TITLE
[SP-2081] - Backport of PDI-13353 - When having duplicate DB Connection names (difference in capitals) PDI defaults to the first (5.4 Suite)

### DIFF
--- a/core/src/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseMeta.java
@@ -2534,6 +2534,21 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     return null;
   }
 
+  public static int indexOfName( String[] databaseNames, String name ) {
+    if ( databaseNames == null || name == null ) {
+      return -1;
+    }
+
+    for ( int i = 0; i < databaseNames.length; i++ ) {
+      String databaseName = databaseNames[ i ];
+      if ( name.equalsIgnoreCase( databaseName ) ) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
   /**
    * Find a database with a certain ID in an arraylist of databases.
    *

--- a/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
@@ -22,10 +22,9 @@
 
 package org.pentaho.di.core.database;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.pentaho.di.core.database.DatabaseMeta.indexOfName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -139,5 +138,26 @@ public class DatabaseMetaTest {
     databaseMeta2.verifyAndModifyDatabaseName( list, null );
 
     assertTrue( !databaseMeta.getDisplayName().equals( databaseMeta2.getDisplayName() ) );
+  }
+
+
+  @Test
+  public void indexOfName_NullArray() {
+    assertEquals( -1, indexOfName( null, "" ) );
+  }
+
+  @Test
+  public void indexOfName_NullName() {
+    assertEquals( -1, indexOfName( new String[] { "1" }, null ) );
+  }
+
+  @Test
+  public void indexOfName_ExactMatch() {
+    assertEquals( 1, indexOfName( new String[] { "a", "b", "c" }, "b" ) );
+  }
+
+  @Test
+  public void indexOfName_NonExactMatch() {
+    assertEquals( 1, indexOfName( new String[] { "a", "b", "c" }, "B" ) );
   }
 }

--- a/engine/src/org/pentaho/di/repository/filerep/KettleFileRepository.java
+++ b/engine/src/org/pentaho/di/repository/filerep/KettleFileRepository.java
@@ -255,7 +255,8 @@ public class KettleFileRepository extends AbstractRepository {
     return calcDirectoryName( null ) + id.toString();
   }
 
-  private FileObject getFileObject( RepositoryElementInterface element ) throws KettleFileException {
+  // package-local visibility for testing purposes
+  FileObject getFileObject( RepositoryElementInterface element ) throws KettleFileException {
     return KettleVFS.getFileObject( calcFilename( element.getRepositoryDirectory(), element.getName(), element
       .getRepositoryElementType().getExtension() ) );
   }
@@ -496,7 +497,18 @@ public class KettleFileRepository extends AbstractRepository {
   }
 
   public ObjectId getDatabaseID( String name ) throws KettleException {
-    return getObjectId( null, name, EXT_DATABASE );
+    ObjectId match = getObjectId( null, name, EXT_DATABASE );
+    if ( match == null ) {
+      // exact match failed, trying to find the DB case-insensitively
+      ObjectId[] existingIds = getDatabaseIDs( false );
+      String[] existingNames = getDatabaseNames( existingIds );
+      int index = DatabaseMeta.indexOfName( existingNames, name );
+      if ( index != -1 ) {
+        return getObjectId( null, existingNames[ index ], EXT_DATABASE );
+      }
+    }
+
+    return match;
   }
 
   public ObjectId[] getTransformationDatabaseIDs( ObjectId id_transformation ) throws KettleException {
@@ -509,6 +521,10 @@ public class KettleFileRepository extends AbstractRepository {
 
   public String[] getDatabaseNames( boolean includeDeleted ) throws KettleException {
     return convertRootIDsToNames( getDatabaseIDs( false ) );
+  }
+
+  private String[] getDatabaseNames( ObjectId[] databaseIds ) throws KettleException {
+    return convertRootIDsToNames( databaseIds );
   }
 
   public String[] getDirectoryNames( ObjectId id_directory ) throws KettleException {

--- a/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepository.java
+++ b/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepository.java
@@ -1747,7 +1747,14 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
   }
 
   public ObjectId getDatabaseID( String name ) throws KettleException {
-    return databaseDelegate.getDatabaseID( name );
+    ObjectId exactMatch = databaseDelegate.getDatabaseID( name );
+    if ( exactMatch == null ) {
+      // look for a database
+      DatabaseMeta database = DatabaseMeta.findDatabase( getDatabases(), name );
+      return ( database == null ) ? null : database.getObjectId();
+    } else {
+      return exactMatch;
+    }
   }
 
   public ObjectId getJobId( String name, RepositoryDirectoryInterface repositoryDirectory ) throws KettleException {

--- a/engine/test-src/org/pentaho/di/repository/filerep/KettleFileRepositoryTestBase.java
+++ b/engine/test-src/org/pentaho/di/repository/filerep/KettleFileRepositoryTestBase.java
@@ -1,0 +1,73 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository.filerep;
+
+import org.junit.After;
+import org.junit.Before;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.repository.RepositoryDirectoryInterface;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public abstract class KettleFileRepositoryTestBase {
+
+  protected KettleFileRepository repository;
+  protected RepositoryDirectoryInterface tree;
+
+  protected String virtualFolder;
+
+  @Before
+  public void setUp() throws Exception {
+    KettleEnvironment.init();
+
+    virtualFolder = "ram://file-repo/" + UUID.randomUUID();
+    KettleVFS.getFileObject( virtualFolder ).createFolder();
+
+    KettleFileRepositoryMeta repositoryMeta =
+      new KettleFileRepositoryMeta( "KettleFileRepository", "FileRep", "File repository", virtualFolder );
+    repository = new KettleFileRepository();
+    repository.init( repositoryMeta );
+
+    // Test connecting... (no security needed)
+    //
+    repository.connect( null, null );
+    assertTrue( repository.isConnected() );
+
+    // Test loading the directory tree
+    //
+    tree = repository.loadRepositoryDirectoryTree();
+    assertNotNull( tree );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    KettleVFS.getFileObject( virtualFolder ).delete();
+  }
+}

--- a/engine/test-src/org/pentaho/di/repository/filerep/KettleFileRepository_DatabaseNames_Test.java
+++ b/engine/test-src/org/pentaho/di/repository/filerep/KettleFileRepository_DatabaseNames_Test.java
@@ -1,0 +1,88 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository.filerep;
+
+import org.apache.commons.vfs.FileObject;
+import org.junit.Test;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.repository.ObjectId;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class KettleFileRepository_DatabaseNames_Test extends KettleFileRepositoryTestBase {
+
+  @Test
+  public void getDatabaseId_ExactMatch() throws Exception {
+    final String name = UUID.randomUUID().toString();
+    DatabaseMeta db = saveDatabase( name );
+
+    ObjectId id = repository.getDatabaseID( name );
+    assertEquals( db.getObjectId(), id );
+  }
+
+  @Test
+  public void getDatabaseId_InsensitiveMatch() throws Exception {
+    final String name = "databaseWithCamelCase";
+    final String lookupName = name.toLowerCase();
+    assertNotSame( lookupName, name );
+
+    DatabaseMeta db = saveDatabase( name );
+
+    ObjectId id = repository.getDatabaseID( lookupName );
+    assertEquals( db.getObjectId(), id );
+  }
+
+  @Test
+  public void getDatabaseId_ReturnsExactMatch_PriorToCaseInsensitiveMatch() throws Exception {
+    final String exact = "databaseExactMatch";
+    final String similar = exact.toLowerCase();
+    assertNotSame( similar, exact );
+
+    DatabaseMeta db = saveDatabase( exact );
+
+    // simulate legacy repository - store a DB with a name different only in case
+    DatabaseMeta another = new DatabaseMeta();
+    another.setName( similar );
+    FileObject fileObject = repository.getFileObject( another );
+    assertFalse( fileObject.exists() );
+    // just create it - enough for this case
+    fileObject.createFile();
+    assertTrue( fileObject.exists() );
+
+    ObjectId id = this.repository.getDatabaseID( exact );
+    assertEquals( db.getObjectId(), id );
+  }
+
+  private DatabaseMeta saveDatabase( String name ) throws Exception {
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( name );
+    repository.save( db, null, null );
+    assertNotNull( db.getObjectId() );
+    return db;
+  }
+}

--- a/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepository_DatabaseNames_Test.java
+++ b/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepository_DatabaseNames_Test.java
@@ -1,0 +1,116 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository.kdr;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.StringObjectId;
+import org.pentaho.di.repository.kdr.delegates.KettleDatabaseRepositoryDatabaseDelegate;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class KettleDatabaseRepository_DatabaseNames_Test {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  private KettleDatabaseRepository repository;
+  private KettleDatabaseRepositoryDatabaseDelegate databaseDelegate;
+
+  @Before
+  public void setUp() throws Exception {
+    repository = spy( new KettleDatabaseRepository() );
+    databaseDelegate = spy( new KettleDatabaseRepositoryDatabaseDelegate( repository ) );
+    repository.databaseDelegate = databaseDelegate;
+  }
+
+
+  @Test
+  public void getDatabaseId_ExactMatch() throws Exception {
+    final String name = UUID.randomUUID().toString();
+    final ObjectId expectedId = new StringObjectId( "expected" );
+    doReturn( expectedId ).when( databaseDelegate ).getDatabaseID( name );
+
+    ObjectId id = repository.getDatabaseID( name );
+    assertEquals( expectedId, id );
+  }
+
+  @Test
+  public void getDatabaseId_InsensitiveMatch() throws Exception {
+    final String name = "databaseWithCamelCase";
+    final String lookupName = name.toLowerCase();
+    assertNotSame( lookupName, name );
+
+    final ObjectId expected = new StringObjectId( "expected" );
+    doReturn( expected ).when( databaseDelegate ).getDatabaseID( name );
+    doReturn( null ).when( databaseDelegate ).getDatabaseID( lookupName );
+
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( name );
+    db.setObjectId( expected );
+    List<DatabaseMeta> dbs = Collections.singletonList( db );
+    doReturn( dbs ).when( repository ).getDatabases();
+
+    ObjectId id = repository.getDatabaseID( lookupName );
+    assertEquals( expected, id );
+  }
+
+  @Test
+  public void getDatabaseId_ReturnsExactMatch_PriorToCaseInsensitiveMatch() throws Exception {
+    final String exact = "databaseExactMatch";
+    final String similar = exact.toLowerCase();
+    assertNotSame( similar, exact );
+
+    final ObjectId exactId = new StringObjectId( "exactId" );
+    doReturn( exactId ).when( databaseDelegate ).getDatabaseID( exact );
+    final ObjectId similarId = new StringObjectId( "similarId" );
+    doReturn( similarId ).when( databaseDelegate ).getDatabaseID( similar );
+
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( exact );
+    DatabaseMeta another = new DatabaseMeta();
+    db.setName( similar );
+    List<DatabaseMeta> dbs = Arrays.asList( another, db );
+    doReturn( dbs ).when( repository ).getDatabases();
+
+    ObjectId id = this.repository.getDatabaseID( exact );
+    assertEquals( exactId, id );
+  }
+
+}

--- a/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepository_GetObjectInformation_Test.java
+++ b/engine/test-src/org/pentaho/di/repository/kdr/KettleDatabaseRepository_GetObjectInformation_Test.java
@@ -54,7 +54,7 @@ import static org.pentaho.di.repository.kdr.KettleDatabaseRepositoryBase.*;
 /**
  * @author Andrey Khayrutdinov
  */
-public class KettleDatabaseRepositoryUnitTest {
+public class KettleDatabaseRepository_GetObjectInformation_Test {
   private static final String ABSENT_ID = "non-existing object";
   private static final String EXISTING_ID = "existing object";
 

--- a/ui/test-src/org/pentaho/di/ui/repository/repositoryexplorer/controllers/ConnectionsControllerTest.java
+++ b/ui/test-src/org/pentaho/di/ui/repository/repositoryexplorer/controllers/ConnectionsControllerTest.java
@@ -1,0 +1,187 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.repository.repositoryexplorer.controllers;
+
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.ProgressMonitorListener;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.StringObjectId;
+import org.pentaho.di.ui.core.database.dialog.DatabaseDialog;
+import org.pentaho.di.ui.repository.repositoryexplorer.model.UIDatabaseConnection;
+import org.pentaho.ui.xul.containers.XulTree;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class ConnectionsControllerTest {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  private ConnectionsController controller;
+  private DatabaseDialog databaseDialog;
+  private Repository repository;
+  private XulTree connectionsTable;
+
+  @Before
+  public void setUp() throws Exception {
+    // a tricky initialisation - first inject private fields
+    controller = new ConnectionsController();
+    connectionsTable = mock( XulTree.class );
+    FieldUtils.writeDeclaredField( controller, "connectionsTable", connectionsTable, true );
+
+    // and then spy the controller
+    controller = spy( controller );
+
+    databaseDialog = mock( DatabaseDialog.class );
+    doReturn( databaseDialog ).when( controller ).getDatabaseDialog();
+    doNothing().when( controller ).refreshConnectionList();
+    doNothing().when( controller ).showAlreadyExistsMessage();
+
+    repository = mock( Repository.class );
+    controller.init( repository );
+  }
+
+
+  @Test
+  public void createConnection_EmptyName() throws Exception {
+    when( databaseDialog.open() ).thenReturn( "" );
+    controller.createConnection();
+
+    // repository was not accessed
+    verify( repository, never() ).getDatabaseID( anyString() );
+    verify( repository, never() ).save( any( DatabaseMeta.class ), anyString(), any( ProgressMonitorListener.class ) );
+  }
+
+  @Test
+  public void createConnection_NameExists() throws Exception {
+    final String dbName = "name";
+
+    when( databaseDialog.open() ).thenReturn( dbName );
+    when( repository.getDatabaseID( dbName ) ).thenReturn( new StringObjectId( "existing" ) );
+
+    controller.createConnection();
+    assertShowedAlreadyExistsMessage();
+  }
+
+  @Test
+  public void createConnection_NewName() throws Exception {
+    final String dbName = "name";
+
+    when( databaseDialog.open() ).thenReturn( dbName );
+    when( databaseDialog.getDatabaseMeta() ).thenReturn( new DatabaseMeta() );
+    when( repository.getDatabaseID( dbName ) ).thenReturn( null );
+
+    controller.createConnection();
+    assertRepositorySavedDb();
+  }
+
+  @Test
+  public void editConnection_EmptyName() throws Exception {
+    final String dbName = "name";
+    List<UIDatabaseConnection> selectedConnection = createSelectedConnectionList( dbName );
+    when( connectionsTable.<UIDatabaseConnection>getSelectedItems() ).thenReturn( selectedConnection );
+
+    when( repository.getDatabaseID( dbName ) ).thenReturn( new StringObjectId( "existing" ) );
+    when( databaseDialog.open() ).thenReturn( "" );
+
+    controller.editConnection();
+
+    // repository.save() was not invoked
+    verify( repository, never() ).save( any( DatabaseMeta.class ), anyString(), any( ProgressMonitorListener.class ) );
+  }
+
+
+  @Test
+  public void editConnection_NameExists_Same() throws Exception {
+    final String dbName = "name";
+    List<UIDatabaseConnection> selectedConnection = createSelectedConnectionList( dbName );
+    when( connectionsTable.<UIDatabaseConnection>getSelectedItems() ).thenReturn( selectedConnection );
+
+    when( repository.getDatabaseID( dbName ) ).thenReturn( new StringObjectId( "existing" ) );
+    when( databaseDialog.open() ).thenReturn( dbName );
+
+    controller.editConnection();
+    assertRepositorySavedDb();
+  }
+
+  @Test
+  public void editConnection_NameDoesNotExist() throws Exception {
+    final String dbName = "name";
+    List<UIDatabaseConnection> selectedConnection = createSelectedConnectionList( dbName );
+    when( connectionsTable.<UIDatabaseConnection>getSelectedItems() ).thenReturn( selectedConnection );
+
+    when( repository.getDatabaseID( dbName ) ).thenReturn( new StringObjectId( "existing" ) );
+    when( databaseDialog.open() ).thenReturn( "non-existing-name" );
+
+    controller.editConnection();
+    assertRepositorySavedDb();
+  }
+
+  @Test
+  public void editConnection_NameExists_Different() throws Exception {
+    final String dbName = "name";
+    List<UIDatabaseConnection> selectedConnection = createSelectedConnectionList( dbName );
+    when( connectionsTable.<UIDatabaseConnection>getSelectedItems() ).thenReturn( selectedConnection );
+
+    final String anotherName = "anotherName";
+    when( repository.getDatabaseID( dbName ) ).thenReturn( new StringObjectId( "existing" ) );
+    when( repository.getDatabaseID( anotherName ) ).thenReturn( new StringObjectId( "another-existing" ) );
+    when( databaseDialog.open() ).thenReturn( anotherName );
+
+    controller.editConnection();
+    assertShowedAlreadyExistsMessage();
+  }
+
+  private List<UIDatabaseConnection> createSelectedConnectionList( String selectedDbName ) {
+    DatabaseMeta meta = new DatabaseMeta();
+    meta.setName( selectedDbName );
+    return singletonList( new UIDatabaseConnection( meta, repository ) );
+  }
+
+
+  private void assertShowedAlreadyExistsMessage() throws KettleException {
+    // repository.save() was not invoked
+    verify( repository, never() ).save( any( DatabaseMeta.class ), anyString(), any( ProgressMonitorListener.class ) );
+    // instead the error dialog was shown
+    verify( controller ).showAlreadyExistsMessage();
+  }
+
+  private void assertRepositorySavedDb() throws KettleException {
+    // repository.save() was invoked
+    verify( repository ).save( any( DatabaseMeta.class ), anyString(), any( ProgressMonitorListener.class ) );
+  }
+}


### PR DESCRIPTION
- prohibit creating connections with similar names different only in case by handling getDatabaseID() method properly
- keep backward-compatibility by letting existing connections to be proceeded (exact match is done firstly)
- add tests for all affected classes
(backported from commits 3003bde1e3ade56b3f64f49266449f2866b97c04 and 99722de042c165b80b755796175526ee89ab9b0a)

@mattyb149, @brosander, review it please.  