### PR TITLE
[SP-2204][PDI-14375] - Incorrect time displayed in Version History af…

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
@@ -1695,7 +1695,9 @@ public class PurRepository extends AbstractRepository implements Repository, jav
       fullName = file.getName();
     } else {
       // set new title
-      builder.title( RepositoryFile.DEFAULT_LOCALE, newTitle );
+      builder.title( RepositoryFile.DEFAULT_LOCALE, newTitle )
+        // rename operation creates new revision, hence clear old value to be overwritten during saving
+        .createdDate( null );
       fullName = checkAndSanitize( newTitle ) + objectType.getExtension();
     }
 

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_MoveAndRename_Test.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_MoveAndRename_Test.java
@@ -31,6 +31,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.matchers.JUnitMatchers.hasItem;
 
 public class PurRepository_MoveAndRename_Test extends PurRepositoryTestBase {
@@ -79,9 +80,15 @@ public class PurRepository_MoveAndRename_Test extends PurRepositoryTestBase {
     assistant.save( meta, initial, getPublicDir() );
 
     List<VersionSummary> historyBefore = unifiedRepository.getVersionSummaries( meta.getObjectId().getId() );
+
+    long before = System.currentTimeMillis();
     assistant.rename( meta, renamed );
+    long after = System.currentTimeMillis();
+
     List<VersionSummary> historyAfter = unifiedRepository.getVersionSummaries( meta.getObjectId().getId() );
     assertEquals( historyBefore.size() + 1, historyAfter.size() );
+    long newRevisionTs = historyAfter.get( historyAfter.size() - 1 ).getDate().getTime();
+    assertTrue( String.format( "%d <= %d <= %d", before, newRevisionTs, after ), ( before <= newRevisionTs ) && ( newRevisionTs <= after ) );
   }
 
 


### PR DESCRIPTION
…ter some operations with transformation/jobs in the DI repository

- clear "createdDate" on renaming to force the repository to inject current time
- update tests to check this condition

Conflicts:
	plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepository_MoveAndRename_IT.java