### PR TITLE
[PDI-13487] Excel Output field formats are ignored when "Split Every ... Rows" is used

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
@@ -578,6 +578,13 @@ public class ExcelOutput extends BaseStep implements StepInterface {
         data.sheet.setRowView( data.positionY, data.Headerrowheight );
       }
 
+      try {
+          setFonts();
+      } catch ( Exception we ) {
+          logError( "Error preparing fonts, colors for header and rows: " + we.toString() );
+          return retval;
+      }
+      
       data.headerWrote = false;
       data.splitnr++;
       data.oneFileOpened = true;
@@ -672,13 +679,6 @@ public class ExcelOutput extends BaseStep implements StepInterface {
       data.realHeaderImage = environmentSubstitute( meta.getHeaderImage() );
       if ( !Const.isEmpty( meta.getEncoding() ) ) {
         data.ws.setEncoding( meta.getEncoding() );
-      }
-
-      try {
-        setFonts();
-      } catch ( Exception we ) {
-        logError( "Error preparing fonts, colors for header and rows: " + we.toString() );
-        return false;
       }
 
       if ( !meta.isDoNotOpenNewFileInit() ) {


### PR DESCRIPTION
Set font formatting with each new file