### PR TITLE
[PDI-14522] - When sftp server has default user folder, absolute urls don't work

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -1055,6 +1055,12 @@ public class Const {
   public static final String KETTLE_CARTE_JETTY_RES_MAX_IDLE_TIME = "KETTLE_CARTE_JETTY_RES_MAX_IDLE_TIME";
 
   /**
+   * A variable to configure VFS USER_DIR_IS_ROOT option: should be "true" or "false"
+   */
+  public static final String VFS_USER_DIR_IS_ROOT =
+      "vfs.sftp.org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder.USER_DIR_IS_ROOT";
+
+  /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer
    * overflow while rounding
    *

--- a/core/src/org/pentaho/di/core/util/EnvUtil.java
+++ b/core/src/org/pentaho/di/core/util/EnvUtil.java
@@ -109,6 +109,12 @@ public class EnvUtil {
     System.getProperties().put( Const.INTERNAL_VARIABLE_STEP_PARTITION_NR, "0" );
     System.getProperties().put( Const.INTERNAL_VARIABLE_STEP_UNIQUE_COUNT, "1" );
     System.getProperties().put( Const.INTERNAL_VARIABLE_STEP_UNIQUE_NUMBER, "0" );
+
+    // If user didn't set value for USER_DIR_IS_ROOT set it to "false". See PDI-14522
+    if ( !kettleProperties.containsKey( Const.VFS_USER_DIR_IS_ROOT ) ) {
+      System.getProperties().put( Const.VFS_USER_DIR_IS_ROOT, "false" );
+    }
+
   }
 
   public static void applyKettleProperties( Map<?, ?> kettleProperties ) {

--- a/core/test-src/org/pentaho/di/core/util/EnvUtilTest.java
+++ b/core/test-src/org/pentaho/di/core/util/EnvUtilTest.java
@@ -1,0 +1,43 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.util;
+
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Yury_Bakhmutski on 11/4/2015.
+ */
+public class EnvUtilTest {
+
+  @Test
+  public void testEnvironmentInit() throws Exception {
+    EnvUtil.environmentInit();
+    //See PDI-14522
+    boolean expected = false;
+    boolean actual = Boolean.valueOf( System.getProperties().get( Const.VFS_USER_DIR_IS_ROOT ).toString() );
+    assertEquals( expected, actual );
+  }
+}

--- a/engine/src/kettle-variables.xml
+++ b/engine/src/kettle-variables.xml
@@ -414,5 +414,11 @@
     <default-value>N</default-value>
   </kettle-variable>
 
+  <kettle-variable>
+    <description>Set this variable to true if VFS should treat the user directory as the root directory when connecting via ftp. Defaults to false.</description>
+    <variable>vfs.sftp.org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder.USER_DIR_IS_ROOT</variable>
+    <default-value>false</default-value>
+  </kettle-variable>
+
 </kettle-variables>
 

--- a/engine/test-src/org/pentaho/di/core/util/KettleVariablesListTest.java
+++ b/engine/test-src/org/pentaho/di/core/util/KettleVariablesListTest.java
@@ -1,0 +1,50 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.util;
+
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleVariablesList;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Yury_Bakhmutski on 11/4/2015.
+ */
+public class KettleVariablesListTest {
+
+  @Test
+  public void testInit() throws Exception {
+    KettleVariablesList variablesList = KettleVariablesList.getInstance();
+    variablesList.init();
+    //See PDI-14522
+    boolean expected = false;
+    boolean actual = Boolean.valueOf( variablesList.getDefaultValueMap().get( Const.VFS_USER_DIR_IS_ROOT ) );
+    assertEquals( expected, actual );
+
+    String vfsUserDirIsRootDefaultMessage =
+        "Set this variable to true if VFS should treat the user directory"
+            + " as the root directory when connecting via ftp. Defaults to false.";
+    assertEquals( variablesList.getDescriptionMap().get( Const.VFS_USER_DIR_IS_ROOT ), vfsUserDirIsRootDefaultMessage );
+  }
+}


### PR DESCRIPTION
@mattcasters, @brosander, @mattyb149 take a look, please.
What was done: 
1) USER_DIR_IS_ROOT is set to false by default. 
2) Is added corresponding flag to pentaho-variables.xml in order to user has possibility to change USER_DIR_IS_ROOT apache.vfs property
JUnit tests are also provided.

