### PR TITLE
[PDI-13353] - When having duplicate DB Connection names (difference in capitals) PDI defaults to the first

### DIFF
--- a/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/controllers/ConnectionsController.java
+++ b/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/controllers/ConnectionsController.java
@@ -222,16 +222,19 @@ public class ConnectionsController extends LazilyInitializedController implement
       getDatabaseDialog().setDatabaseMeta( databaseMeta );
 
       String dbName = getDatabaseDialog().open();
-      if ( !"".equals( dbName ) ) {
-        // See if this user connection exists...
-        ObjectId idDatabase = repository.getDatabaseID( dbName );
-        if ( idDatabase == null ) {
-          repository.insertLogEntry( BaseMessages.getString(
-            PKG, "ConnectionsController.Message.CreatingDatabase", getDatabaseDialog()
-              .getDatabaseMeta().getName() ) );
-          repository.save( getDatabaseDialog().getDatabaseMeta(), Const.VERSION_COMMENT_INITIAL_VERSION, null );
-        } else {
-          showAlreadyExistsMessage();
+      if ( dbName != null ) {
+        dbName = dbName.trim();
+        if ( !dbName.isEmpty() ) {
+          // See if this user connection exists...
+          ObjectId idDatabase = repository.getDatabaseID( dbName );
+          if ( idDatabase == null ) {
+            repository.insertLogEntry( BaseMessages.getString(
+              PKG, "ConnectionsController.Message.CreatingDatabase", getDatabaseDialog()
+                .getDatabaseMeta().getName() ) );
+            repository.save( getDatabaseDialog().getDatabaseMeta(), Const.VERSION_COMMENT_INITIAL_VERSION, null );
+          } else {
+            showAlreadyExistsMessage();
+          }
         }
       }
       // We should be able to tell the difference between a cancel and an empty database name
@@ -337,16 +340,19 @@ public class ConnectionsController extends LazilyInitializedController implement
         } else {
           getDatabaseDialog().setDatabaseMeta( databaseMeta );
           String dbName = getDatabaseDialog().open();
-          if ( !"".equals( dbName ) ) {
-            ObjectId idRenamed = repository.getDatabaseID( dbName );
-            if ( idRenamed == null || idRenamed.equals( idDatabase ) ) {
-              // renaming to non-existing name or updating the current
-              repository.insertLogEntry( BaseMessages.getString(
-                PKG, "ConnectionsController.Message.UpdatingDatabase", databaseMeta.getName() ) );
-              repository.save( databaseMeta, Const.VERSION_COMMENT_EDIT_VERSION, null );
-            } else {
-              // trying to rename to an existing name - show error dialog
-              showAlreadyExistsMessage();
+          if ( dbName != null ) {
+            dbName = dbName.trim();
+            if ( !dbName.isEmpty() ) {
+              ObjectId idRenamed = repository.getDatabaseID( dbName );
+              if ( idRenamed == null || idRenamed.equals( idDatabase ) ) {
+                // renaming to non-existing name or updating the current
+                repository.insertLogEntry( BaseMessages.getString(
+                  PKG, "ConnectionsController.Message.UpdatingDatabase", databaseMeta.getName() ) );
+                repository.save( databaseMeta, Const.VERSION_COMMENT_EDIT_VERSION, null );
+              } else {
+                // trying to rename to an existing name - show error dialog
+                showAlreadyExistsMessage();
+              }
             }
           }
           // We should be able to tell the difference between a cancel and an empty database name

--- a/ui/test-src/org/pentaho/di/ui/repository/repositoryexplorer/controllers/ConnectionsControllerTest.java
+++ b/ui/test-src/org/pentaho/di/ui/repository/repositoryexplorer/controllers/ConnectionsControllerTest.java
@@ -77,14 +77,31 @@ public class ConnectionsControllerTest {
 
 
   @Test
-  public void createConnection_EmptyName() throws Exception {
-    when( databaseDialog.open() ).thenReturn( "" );
-    controller.createConnection();
-
-    // repository was not accessed
-    verify( repository, never() ).getDatabaseID( anyString() );
-    verify( repository, never() ).save( any( DatabaseMeta.class ), anyString(), any( ProgressMonitorListener.class ) );
+  public void createConnection_NullName() throws Exception {
+    testEditConnectionGetsWrongName( null );
   }
+
+  @Test
+  public void createConnection_EmptyName() throws Exception {
+    testEditConnectionGetsWrongName( "" );
+  }
+
+  @Test
+  public void createConnection_BlankName() throws Exception {
+    testCreateConnectionGetsWrongName( "  " );
+  }
+
+  private void testCreateConnectionGetsWrongName( String wrongName ) throws Exception {
+    when( databaseDialog.open() ).thenReturn( wrongName );
+    controller.createConnection();
+    assertRepositoryWasNotAccessed();
+  }
+
+  private void assertRepositoryWasNotAccessed() throws KettleException {
+    verify( repository, never() ).getDatabaseID( anyString() );
+    assertSaveWasNotInvoked();
+  }
+
 
   @Test
   public void createConnection_NameExists() throws Exception {
@@ -109,19 +126,33 @@ public class ConnectionsControllerTest {
     assertRepositorySavedDb();
   }
 
+
+  @Test
+  public void editConnection_NullName() throws Exception {
+    testEditConnectionGetsWrongName( null );
+  }
+
   @Test
   public void editConnection_EmptyName() throws Exception {
+    testEditConnectionGetsWrongName( "" );
+  }
+
+  @Test
+  public void editConnection_BlankName() throws Exception {
+    testEditConnectionGetsWrongName( "  " );
+  }
+
+  private void testEditConnectionGetsWrongName( String wrongName ) throws Exception {
     final String dbName = "name";
     List<UIDatabaseConnection> selectedConnection = createSelectedConnectionList( dbName );
     when( connectionsTable.<UIDatabaseConnection>getSelectedItems() ).thenReturn( selectedConnection );
 
     when( repository.getDatabaseID( dbName ) ).thenReturn( new StringObjectId( "existing" ) );
-    when( databaseDialog.open() ).thenReturn( "" );
+    when( databaseDialog.open() ).thenReturn( wrongName );
 
     controller.editConnection();
 
-    // repository.save() was not invoked
-    verify( repository, never() ).save( any( DatabaseMeta.class ), anyString(), any( ProgressMonitorListener.class ) );
+    assertSaveWasNotInvoked();
   }
 
 
@@ -172,10 +203,12 @@ public class ConnectionsControllerTest {
     return singletonList( new UIDatabaseConnection( meta, repository ) );
   }
 
+  private void assertSaveWasNotInvoked() throws KettleException {
+    verify( repository, never() ).save( any( DatabaseMeta.class ), anyString(), any( ProgressMonitorListener.class ) );
+  }
 
   private void assertShowedAlreadyExistsMessage() throws KettleException {
-    // repository.save() was not invoked
-    verify( repository, never() ).save( any( DatabaseMeta.class ), anyString(), any( ProgressMonitorListener.class ) );
+    assertSaveWasNotInvoked();
     // instead the error dialog was shown
     verify( controller ).showAlreadyExistsMessage();
   }


### PR DESCRIPTION
- handle NULL returned from the dialog
- trim connection's names
- add tests

@mattyb149, @brosander, review it please  