### PR TITLE
[PDI-14608] Added case for DASH so AutoDoc step no longer fails

### DIFF
--- a/engine/src/org/pentaho/di/core/gui/SwingGC.java
+++ b/engine/src/org/pentaho/di/core/gui/SwingGC.java
@@ -648,6 +648,9 @@ public class SwingGC implements GCInterface {
       case PARALLEL:
         dash = new float[] { 10, 5, 10, 5, };
         break;
+	  case DASH:
+        dash = new float[] { 6, 2, };
+        break;
       default:
         throw new RuntimeException( "Unhandled line style!" );
     }


### PR DESCRIPTION
I reviewed the other relevant code and couldn't for the life of me decide if DASH from JobPainter/TransPainter should have been something else, so I'm recommending another case be added to SwingGC.  Feel free to change the values for the dash variable.