### PR TITLE
[SP-2248] - Backport of PDI-14419 - Table Input Step - Insert data from step - writes to other table input steps (6.0 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -113,7 +113,13 @@ public class BaseStepMeta implements Cloneable, StepAttributesInterface {
    */
   public Object clone() {
     try {
-      Object retval = super.clone();
+      BaseStepMeta retval = (BaseStepMeta) super.clone();
+      // PDI-14419: there are several problems with cloning ioMeta
+      //  - we cannot clone all existing streams, as the duplicate should be treated independently
+      //  - we cannot clear ioMeta's stream list, because other classes do not expect the list to be empty
+      // hence, the best solution for now is to assign NULL to the field
+      // meta will re-create properly-configured instance on next attempt to get it
+      retval.ioMeta = null;
       return retval;
     } catch ( CloneNotSupportedException e ) {
       return null;

--- a/engine/test-src/org/pentaho/di/trans/step/BaseStepMetaCloningTest.java
+++ b/engine/test-src/org/pentaho/di/trans/step/BaseStepMetaCloningTest.java
@@ -1,0 +1,63 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.step;
+
+import org.junit.Test;
+import org.pentaho.di.core.database.Database;
+import org.pentaho.di.repository.Repository;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class BaseStepMetaCloningTest {
+
+  @Test
+  public void cloningKeepsAllExceptIoMeta() throws Exception {
+    final Database db1 = mock( Database.class );
+    final Database db2 = mock( Database.class );
+    final Repository repository = mock( Repository.class );
+    final StepMeta stepMeta = mock( StepMeta.class );
+
+    BaseStepMeta meta = new BaseStepMeta();
+    meta.setChanged( true );
+    meta.databases = new Database[] { db1, db2 };
+    meta.ioMeta = new StepIOMeta( true, false, false, false, false, false );
+    meta.repository = repository;
+    meta.parentStepMeta = stepMeta;
+
+    BaseStepMeta clone = (BaseStepMeta) meta.clone();
+    assertTrue( clone.hasChanged() );
+
+    // is it OK ?
+    assertTrue( clone.databases == meta.databases );
+    assertArrayEquals( meta.databases, clone.databases );
+
+    assertEquals( meta.repository, clone.repository );
+    assertEquals( meta.parentStepMeta, clone.parentStepMeta );
+
+    assertNull( clone.ioMeta );
+  }
+}


### PR DESCRIPTION
- set ioMeta = null for clones to prevent sharing its instance among all clones
- add a test
(cherry picked from commit 9dae9ae)

@brosander, @hudak, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/1873  