### PR TITLE
[PDI-13240]  Setting for 'Log record timeout' field under Logging - Metrics cannot be saved

### DIFF
--- a/ui/src/org/pentaho/di/ui/trans/dialog/TransDialog.java
+++ b/ui/src/org/pentaho/di/ui/trans/dialog/TransDialog.java
@@ -1434,7 +1434,7 @@ public class TransDialog extends Dialog {
     fdLogTimeout.top = new FormAttachment( wLogTable, margin );
     fdLogTimeout.right = new FormAttachment( 100, 0 );
     wLogTimeout.setLayoutData( fdLogTimeout );
-    wLogTimeout.setText( Const.NVL( channelLogTable.getTimeoutInDays(), "" ) );
+    wLogTimeout.setText( Const.NVL( metricsLogTable.getTimeoutInDays(), "" ) );
 
     // Add the fields grid...
     //


### PR DESCRIPTION
- showing metricsLogTable option instead of channelLogTable value when showMetricsLogTableOptions method is called.

@brosander, @mattcasters review it please