### PR TITLE
[PDI-14358] - Text File Input Interpreting missing values as empty strings instead of null

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -383,9 +383,9 @@ public class TextFileInputUtils {
         int trim_type = fieldnr < nrfields ? f.getTrimType() : ValueMetaInterface.TRIM_TYPE_NONE;
 
         if ( fieldnr < strings.length ) {
-          String pol = strings[fieldnr];
+          String pol = strings[ fieldnr ];
           try {
-            if ( valueMeta.isNull( pol ) ) {
+            if ( valueMeta.isNull( pol ) || !Const.isEmpty( nullif ) && nullif.equals( pol ) ) {
               value = null;
             } else {
               value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );


### PR DESCRIPTION
- manually check if input sample is equal to "nullif" value
- add a test and refactor TextFileInputTest a bit

@deinspanjer, do you mind reviewing it? That is the case we were discussing a month ago.
@brosander, you are also welcomed, but please look at the ticket's last comment (http://jira.pentaho.com/browse/PDI-14358) before