### PR TITLE
[PDI-14015] - Repository import does not populate the transformation reference correctly on the Metadata Injection step

### DIFF
--- a/engine/src/org/pentaho/di/repository/RepositoryExporter.java
+++ b/engine/src/org/pentaho/di/repository/RepositoryExporter.java
@@ -53,6 +53,7 @@ import org.pentaho.di.repository.filerep.KettleFileRepository;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.mapping.MappingMeta;
+import org.pentaho.di.trans.steps.metainject.MetaInjectMeta;
 
 /**
  * <p>This class is used to read repository, load jobs and transformations, and export them into xml file.
@@ -389,6 +390,25 @@ public class RepositoryExporter implements IRepositoryExporterFeedback {
             } catch ( Exception e ) {
               log.logError( BaseMessages.getString( PKG, "Repository.Exporter.Log.UnableToLoadTransInMap", mappingMeta
                   .getName() ), e );
+            }
+          }
+        }
+        if ( stepMeta.isEtlMetaInject() ) {
+          MetaInjectMeta metaInjectMeta = (MetaInjectMeta) stepMeta.getStepMetaInterface();
+          // convert to a named based reference.
+          //
+          if ( metaInjectMeta.getSpecificationMethod() == ObjectLocationSpecificationMethod.FILENAME ) {
+            try {
+              TransMeta meta =
+                  MetaInjectMeta.loadTransformationMeta( metaInjectMeta, fileRep, fileRep.metaStore, transMeta );
+              FileObject fileObject = KettleVFS.getFileObject( meta.getFilename() );
+              metaInjectMeta.setSpecificationMethod( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
+              metaInjectMeta.setFileName( null );
+              metaInjectMeta.setTransName( meta.getName() );
+              metaInjectMeta.setDirectoryPath( Const.NVL( calcRepositoryDirectory( fileRep, fileObject ), "/" ) );
+            } catch ( Exception e ) {
+              log.logError( BaseMessages.getString( PKG, "Repository.Exporter.Log.UnableToLoadTransInMDI",
+                  metaInjectMeta.getName() ), e );
             }
           }
         }

--- a/engine/src/org/pentaho/di/repository/RepositoryImporter.java
+++ b/engine/src/org/pentaho/di/repository/RepositoryImporter.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.xml.parsers.DocumentBuilder;
+
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.cluster.ClusterSchema;
 import org.pentaho.di.cluster.SlaveServer;
@@ -40,9 +42,9 @@ import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.exception.LookupReferencesException;
 import org.pentaho.di.core.exception.KettleMissingPluginsException;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.exception.LookupReferencesException;
 import org.pentaho.di.core.gui.HasOverwritePrompter;
 import org.pentaho.di.core.gui.OverwritePrompter;
 import org.pentaho.di.core.gui.SpoonFactory;
@@ -63,11 +65,10 @@ import org.pentaho.di.shared.SharedObjects;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.mapping.MappingMeta;
+import org.pentaho.di.trans.steps.metainject.MetaInjectMeta;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXParseException;
-
-import javax.xml.parsers.DocumentBuilder;
 
 public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
   public static final String IMPORT_ASK_ABOUT_REPLACE_DB = "IMPORT_ASK_ABOUT_REPLACE_DB";
@@ -570,7 +571,10 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
     replaceSharedObjects( (AbstractMeta) transMeta );
   }
 
-  private void patchMappingSteps( TransMeta transMeta ) {
+  /**
+   * package-local visibility for testing purposes
+   */
+  void patchTransSteps( TransMeta transMeta ) {
     for ( StepMeta stepMeta : transMeta.getSteps() ) {
       if ( stepMeta.isMapping() ) {
         MappingMeta mappingMeta = (MappingMeta) stepMeta.getStepMetaInterface();
@@ -581,6 +585,17 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
           }
           String mappingMetaPath = resolvePath( baseDirectory.getPath(), mappingMeta.getDirectoryPath() );
           mappingMeta.setDirectoryPath( mappingMetaPath );
+        }
+      }
+      if ( stepMeta.isEtlMetaInject() ) {
+        MetaInjectMeta metaInjectMeta = (MetaInjectMeta) stepMeta.getStepMetaInterface();
+        if ( metaInjectMeta.getSpecificationMethod() == ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME ) {
+          if ( transDirOverride != null ) {
+            metaInjectMeta.setDirectoryPath( transDirOverride );
+            continue;
+          }
+          String mappingMetaPath = resolvePath( baseDirectory.getPath(), metaInjectMeta.getDirectoryPath() );
+          metaInjectMeta.setDirectoryPath( mappingMetaPath );
         }
       }
     }
@@ -613,7 +628,10 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
     }
   }
 
-  private String resolvePath( String rootPath, String entryPath ) {
+  /**
+   * package-local visibility for testing purposes
+   */
+  String resolvePath( String rootPath, String entryPath ) {
     String extraPath = Const.NVL( entryPath, "/" );
     if ( needToCheckPathForVariables() ) {
       if ( containsVariables( entryPath ) ) {
@@ -701,7 +719,7 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
       replaceSharedObjects( transMeta );
       transMeta.setObjectId( existingId );
       transMeta.setRepositoryDirectory( targetDirectory );
-      patchMappingSteps( transMeta );
+      patchTransSteps( transMeta );
 
       try {
         // Keep info on who & when this transformation was created...

--- a/engine/src/org/pentaho/di/repository/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/repository/messages/messages_en_US.properties
@@ -102,6 +102,7 @@ Repository.Exporter.Log.TransRuleViolation=Transformation [{0}] from directory [
 Repository.Exporter.Log.UnableToLoadJobTrans=Unable to load transformation specified in job entry ''{0}''
 Repository.Exporter.Log.UnableToLoadJobJob=Unable to load job specified in job entry ''{0}''
 Repository.Exporter.Log.UnableToLoadTransInMap=Unable to load transformation specified in map ''{0}''
+Repository.Exporter.Log.UnableToLoadTransInMDI=Unable to load transformation specified in meta inject ''{0}''
 Repository.Exporter.Monitor.StartTransExport=Exporting the transformations...
 Repository.Exporter.Log.FindTrans=Found {0} transformations in directory {1}
 Repository.Exporter.Monitor.ExportTransformation=Exporting transformation [{0}]

--- a/engine/test-src/org/pentaho/di/repository/RepositoryImporterTest.java
+++ b/engine/test-src/org/pentaho/di/repository/RepositoryImporterTest.java
@@ -22,7 +22,10 @@
 
 package org.pentaho.di.repository;
 
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +47,7 @@ import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.mapping.MappingMeta;
+import org.pentaho.di.trans.steps.metainject.MetaInjectMeta;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -190,6 +194,26 @@ public class RepositoryImporterTest {
 
     importerWithCompatibilityImportPath.importTransformation( entityNode, feedback );
     verify( mappingMeta2 ).setDirectoryPath( ROOT_PATH + "/myDir/${USER_VARIABLE}" );
+  }
+
+  @Test
+  public void testPatchTransSteps_with_meta_inject_step() {
+    Repository repository = mock( Repository.class );
+    LogChannelInterface log = mock( LogChannelInterface.class );
+    RepositoryImporter importer = spy( new RepositoryImporter( repository, log ) );
+    importer.setBaseDirectory( mock( RepositoryDirectoryInterface.class ) );
+    doReturn( "TEST_PATH" ).when( importer ).resolvePath( anyString(), anyString() );
+
+    MetaInjectMeta metaInjectMeta = mock( MetaInjectMeta.class );
+    doReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME ).when( metaInjectMeta ).getSpecificationMethod();
+    StepMeta stepMeta = mock( StepMeta.class );
+    doReturn( metaInjectMeta ).when( stepMeta ).getStepMetaInterface();
+    doReturn( true ).when( stepMeta ).isEtlMetaInject();
+    TransMeta transMeta = mock( TransMeta.class );
+    doReturn( Collections.singletonList( stepMeta ) ).when( transMeta ).getSteps();
+
+    importer.patchTransSteps( transMeta );
+    verify( metaInjectMeta ).setDirectoryPath( "TEST_PATH" );
   }
 
   private static JobEntryTrans createJobEntryTrans() {


### PR DESCRIPTION
@mdamour1976 please review.

p.s.: it is a "cheap & dirty" solution. if it is too dirty - let me know i'll present the other one - we can add a new interface which specifies method to recalculate path for current location. Then this interface should be added to all steps/job entries which need path correction on import/export. 