### PR TITLE
PDI-14178 - Command-line Import Incorrectly Reports Exceptions

### DIFF
--- a/engine/src/org/pentaho/di/imp/Import.java
+++ b/engine/src/org/pentaho/di/imp/Import.java
@@ -179,7 +179,7 @@ public class Import {
         createOption( "filedir", "Import.CmdLine.FileDir", optionFileDir = new StringBuffer() ),
         createOption( "rules", "Import.CmdLine.RulesFile", optionRules = new StringBuffer() ),
         createOption( "norules", "Import.CmdLine.NoRules", optionNoRules = new StringBuffer(), true, false ),
-        createOption( "comment", "Import.CmdLine.Comment", optionComment = new StringBuffer(), true, false ),
+        createOption( "comment", "Import.CmdLine.Comment", optionComment = new StringBuffer(), false, false ),
         createOption( "replace", "Import.CmdLine.Replace", optionReplace = new StringBuffer(), true, false ),
         createOption( "coe", "Import.CmdLine.ContinueOnError", optionContinueOnError = new StringBuffer(), true, false ),
         createOption( "version", "Import.CmdLine.Version", optionVersion = new StringBuffer(), true, false ),


### PR DESCRIPTION
@brosander @e-cuellar @rmansoor 
Please review.

"comment" is not is not a Yes/No flag.
Also i have sent an email to Wes Brown:

Hello Wes,
Could you please find someone to amend this documentation ?
http://infocenter.pentaho.com/help/index.jsp?topic=%2Fpdi_admin_guide%2Freference_import_options.html
http://wiki.pentaho.com/display/EAI/Import+User+Documentation
Because right now only one parameter (“-norules”) is documented(at wiki page) as Yes/No flag, what I see from the source code(https://github.com/pentaho/pentaho-kettle/blob/master/engine/src/org/pentaho/di/imp/Import.java#L183-L184) these parameters were designed to be used in such manner too:

“-replace”, “-coe”

So, for the wiki page this example:
```sh import.sh -rep=PRODUCTION -user=joe -pass=password -dir=/import -rules=prod-rules.xml \
             -file=UAT-export-20110616.xml -coe=false -replace=true \
             -comment="New version upload from UAT"```

I believe should be re-written like this:
```sh import.sh -rep=PRODUCTION -user=joe -pass=password -dir=/import -rules=prod-rules.xml \
             -file=UAT-export-20110616.xml -replace \
             -comment="New version upload from UAT"```

Similar as for infocenter page from:
```sh import.sh -rep=PRODUCTION -user=admin -pass=12345 -dir=/ -file=import-rules.xml -rules=import-rules.xml -coe=false -replace=true -comment="New version upload from UAT"```
to:
```sh import.sh -rep=PRODUCTION -user=admin -pass=12345 -dir=/ -file=import-rules.xml -rules=import-rules.xml -replace -comment="New version upload from UAT"```

Thank you in advance.