### PR TITLE
[BACKLOG-5949] - Moving xml step related lineage analyzers out of the…

### DIFF
--- a/plugins/kettle-xml-plugin/ivy.xml
+++ b/plugins/kettle-xml-plugin/ivy.xml
@@ -18,9 +18,10 @@
   </publications>
 
   <dependencies defaultconf="default->default">
-    <dependency org="pentaho-kettle" name="kettle-core"        rev="${dependency.kettle.revision}" conf="dev->default" changing="true"/>
-    <dependency org="pentaho-kettle" name="kettle-engine"      rev="${dependency.kettle.revision}" conf="dev->default" changing="true"/>
-    <dependency org="pentaho-kettle" name="kettle-ui-swt"      rev="${dependency.kettle.revision}" conf="dev->default" changing="true"/>
+    <dependency org="pentaho-kettle" name="kettle-core"           rev="${dependency.kettle.revision}" conf="dev->default" changing="true"/>
+    <dependency org="pentaho-kettle" name="kettle-engine"         rev="${dependency.kettle.revision}" conf="dev->default" changing="true"/>
+    <dependency org="pentaho-kettle" name="kettle-ui-swt"         rev="${dependency.kettle.revision}" conf="dev->default" changing="true"/>
+    <dependency org="pentaho"        name="pentaho-metaverse-api" rev="${dependency.kettle.revision}" conf="dev->default" changing="true"/>
 
 	<!-- runtime dependencies of steps in this project -->
     <dependency org="stax"                name="stax"                rev="1.2.0"                                    conf="dev->default" transitive="false"/>

--- a/plugins/kettle-xml-plugin/src/org/pentaho/di/lifecycle/KettleXmlPluginLifecycleListener.java
+++ b/plugins/kettle-xml-plugin/src/org/pentaho/di/lifecycle/KettleXmlPluginLifecycleListener.java
@@ -1,0 +1,58 @@
+/*
+ * ******************************************************************************
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.lifecycle;
+
+import org.pentaho.di.core.annotations.LifecyclePlugin;
+import org.pentaho.di.core.lifecycle.LifeEventHandler;
+import org.pentaho.di.core.lifecycle.LifecycleException;
+import org.pentaho.di.core.lifecycle.LifecycleListener;
+import org.pentaho.di.trans.steps.getxmldata.GetXMLDataExternalResourceConsumer;
+import org.pentaho.di.trans.steps.getxmldata.GetXMLDataStepAnalyzer;
+import org.pentaho.di.trans.steps.xmloutput.XMLOutputExternalResourceConsumer;
+import org.pentaho.di.trans.steps.xmloutput.XMLOutputStepAnalyzer;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+
+/**
+ * Created by rfellows on 12/31/15.
+ */
+@LifecyclePlugin( id = "KettleXmlPlugin", name = "KettleXmlPlugin" )
+public class KettleXmlPluginLifecycleListener implements LifecycleListener {
+
+  @Override
+  public void onStart( LifeEventHandler handler ) throws LifecycleException {
+    GetXMLDataStepAnalyzer getXMLDataStepAnalyzer = new GetXMLDataStepAnalyzer();
+    GetXMLDataExternalResourceConsumer getXMLDataExternalResourceConsumer = new GetXMLDataExternalResourceConsumer();
+    getXMLDataStepAnalyzer.setExternalResourceConsumer( getXMLDataExternalResourceConsumer );
+
+    XMLOutputStepAnalyzer xmlOutputStepAnalyzer = new XMLOutputStepAnalyzer();
+    XMLOutputExternalResourceConsumer xmlOutputExternalResourceConsumer = new XMLOutputExternalResourceConsumer();
+    xmlOutputStepAnalyzer.setExternalResourceConsumer( xmlOutputExternalResourceConsumer );
+
+    PentahoSystem.registerObject( getXMLDataStepAnalyzer );
+    PentahoSystem.registerObject( getXMLDataExternalResourceConsumer );
+    PentahoSystem.registerObject( xmlOutputStepAnalyzer );
+    PentahoSystem.registerObject( xmlOutputExternalResourceConsumer );
+  }
+
+  @Override public void onExit( LifeEventHandler handler ) throws LifecycleException {
+    // no-op
+  }
+}

--- a/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/getxmldata/GetXMLDataExternalResourceConsumer.java
+++ b/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/getxmldata/GetXMLDataExternalResourceConsumer.java
@@ -1,0 +1,118 @@
+/*
+ * ******************************************************************************
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.trans.steps.getxmldata;
+
+import org.apache.commons.vfs2.FileObject;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.metaverse.api.IAnalysisContext;
+import org.pentaho.metaverse.api.analyzer.kettle.step.BaseStepExternalResourceConsumer;
+import org.pentaho.metaverse.api.model.ExternalResourceInfoFactory;
+import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+
+public class GetXMLDataExternalResourceConsumer
+  extends BaseStepExternalResourceConsumer<GetXMLData, GetXMLDataMeta> {
+
+  @Override
+  public boolean isDataDriven( GetXMLDataMeta meta ) {
+    // We can safely assume that the StepMetaInterface object we get back is a GetXMLDataMeta
+    return meta.isInFields();
+  }
+
+  @Override
+  public Collection<IExternalResourceInfo> getResourcesFromMeta( GetXMLDataMeta meta, IAnalysisContext context ) {
+    Collection<IExternalResourceInfo> resources = Collections.emptyList();
+
+    // We only need to collect these resources if we're not data-driven and there are no used variables in the
+    // metadata relating to external files.
+    if ( !isDataDriven( meta ) ) {
+      StepMeta parentStepMeta = meta.getParentStepMeta();
+      if ( parentStepMeta != null ) {
+        TransMeta parentTransMeta = parentStepMeta.getParentTransMeta();
+        if ( parentTransMeta != null ) {
+          String[] paths = parentTransMeta.environmentSubstitute( meta.getFileName() );
+          if ( paths != null ) {
+            resources = new ArrayList<IExternalResourceInfo>( paths.length );
+
+            for ( String path : paths ) {
+              if ( !Const.isEmpty( path ) ) {
+                try {
+
+                  IExternalResourceInfo resource = ExternalResourceInfoFactory
+                    .createFileResource( KettleVFS.getFileObject( path ), true );
+                  if ( resource != null ) {
+                    resources.add( resource );
+                  } else {
+                    throw new KettleFileException( "Error getting file resource!" );
+                  }
+                } catch ( KettleFileException kfe ) {
+                  // TODO throw or ignore?
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return resources;
+  }
+
+  @Override
+  public Collection<IExternalResourceInfo> getResourcesFromRow(
+    GetXMLData textFileInput, RowMetaInterface rowMeta, Object[] row ) {
+    Collection<IExternalResourceInfo> resources = new LinkedList<IExternalResourceInfo>();
+    // For some reason the step doesn't return the StepMetaInterface directly, so go around it
+    GetXMLDataMeta meta = (GetXMLDataMeta) textFileInput.getStepMetaInterface();
+    if ( meta == null ) {
+      meta = (GetXMLDataMeta) textFileInput.getStepMeta().getStepMetaInterface();
+    }
+
+    try {
+      if ( meta.getIsAFile() ) {
+        String filename = ( meta == null ) ? null : rowMeta.getString( row, meta.getXMLField(), null );
+        if ( !Const.isEmpty( filename ) ) {
+          FileObject fileObject = KettleVFS.getFileObject( filename );
+          resources.add( ExternalResourceInfoFactory.createFileResource( fileObject, true ) );
+        }
+      }
+      // TODO URLs?
+    } catch ( KettleException kve ) {
+      // TODO throw exception or ignore?
+    }
+
+    return resources;
+  }
+
+  @Override
+  public Class<GetXMLDataMeta> getMetaClass() {
+    return GetXMLDataMeta.class;
+  }
+}

--- a/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/getxmldata/GetXMLDataStepAnalyzer.java
+++ b/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/getxmldata/GetXMLDataStepAnalyzer.java
@@ -1,0 +1,201 @@
+/*
+ * ******************************************************************************
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.trans.steps.getxmldata;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.dictionary.DictionaryConst;
+import org.pentaho.metaverse.api.IAnalysisContext;
+import org.pentaho.metaverse.api.IMetaverseNode;
+import org.pentaho.metaverse.api.IMetaverseObjectFactory;
+import org.pentaho.metaverse.api.MetaverseAnalyzerException;
+import org.pentaho.metaverse.api.MetaverseException;
+import org.pentaho.metaverse.api.StepField;
+import org.pentaho.metaverse.api.analyzer.kettle.ComponentDerivationRecord;
+import org.pentaho.metaverse.api.analyzer.kettle.step.ExternalResourceStepAnalyzer;
+import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The GetXMLDataStepAnalyzer is responsible for providing nodes and links (i.e. relationships) between itself and
+ * other metaverse entities
+ */
+public class GetXMLDataStepAnalyzer extends ExternalResourceStepAnalyzer<GetXMLDataMeta> {
+  private Logger log = LoggerFactory.getLogger( GetXMLDataStepAnalyzer.class );
+
+  @Override
+  protected Set<StepField> getUsedFields( GetXMLDataMeta meta ) {
+    Set<StepField> usedFields = new HashSet<>();
+    if ( meta.isInFields() ) {
+      Set<StepField> stepFields = createStepFields( meta.getXMLField(), getInputs() );
+      usedFields.addAll( stepFields );
+    }
+    return usedFields;
+  }
+
+  @Override
+  public Set<Class<? extends BaseStepMeta>> getSupportedSteps() {
+    return new HashSet<Class<? extends BaseStepMeta>>() {
+      {
+        add( GetXMLDataMeta.class );
+      }
+    };
+  }
+
+  @Override
+  protected IMetaverseNode createOutputFieldNode( IAnalysisContext context, ValueMetaInterface fieldMeta,
+                                                  String targetStepName, String nodeType ) {
+    IMetaverseNode fieldNode = super.createOutputFieldNode( context, fieldMeta, targetStepName, nodeType );
+    GetXMLDataField[] fields = baseStepMeta.getInputFields();
+    for ( GetXMLDataField field : fields ) {
+      if ( fieldMeta.getName().equals( field.getName() ) ) {
+        fieldNode.setProperty( "xpath", Const.NVL( field.getXPath(), "" ) );
+        fieldNode.setProperty( "element", Const.NVL( field.getElementTypeCode(), "" ) );
+        fieldNode.setProperty( "resultType", Const.NVL( field.getResultTypeCode(), "" ) );
+        fieldNode.setProperty( "repeat", field.isRepeated() );
+        break;
+      }
+    }
+    return fieldNode;
+  }
+
+  @Override
+  protected Map<String, RowMetaInterface> getInputRowMetaInterfaces( GetXMLDataMeta meta ) {
+    Map<String, RowMetaInterface> inputRows = getInputFields( meta );
+    if ( inputRows == null ) {
+      inputRows = new HashMap<>();
+    }
+    // Get some boolean flags from the meta for easier access
+    boolean isInFields = meta.isInFields();
+    boolean isAFile = meta.getIsAFile();
+    boolean isAUrl = meta.isReadUrl();
+
+    // only add resource fields if we are NOT getting the xml or file from a field
+    if ( !isInFields || isAFile || isAUrl ) {
+      RowMetaInterface stepFields = getOutputFields( meta );
+      RowMetaInterface clone = stepFields.clone();
+      // if there are previous steps providing data, we should remove them from the set of "resource" fields
+      for ( RowMetaInterface rowMetaInterface : inputRows.values() ) {
+        for ( ValueMetaInterface valueMetaInterface : rowMetaInterface.getValueMetaList() ) {
+          try {
+            clone.removeValueMeta( valueMetaInterface.getName() );
+          } catch ( KettleValueException e ) {
+            // could not find it in the output, skip it
+          }
+        }
+      }
+      inputRows.put( RESOURCE, clone );
+    }
+    return inputRows;
+  }
+
+  @Override
+  public Set<ComponentDerivationRecord> getChangeRecords( GetXMLDataMeta meta )
+    throws MetaverseAnalyzerException {
+    Set<ComponentDerivationRecord> changes = new HashSet<>();
+
+    boolean isInFields = meta.isInFields();
+    boolean isAFile = meta.getIsAFile();
+    boolean isAUrl = meta.isReadUrl();
+
+    // if we are getting xml from a field, we need to add the "derives" links from the xml to the output fields
+    if ( isInFields && !isAFile && !isAUrl ) {
+      GetXMLDataField[] fields = baseStepMeta.getInputFields();
+      if ( getInputs() != null ) {
+        Set<StepField> inputFields = getInputs().getFieldNames();
+
+        for ( StepField inputField : inputFields ) {
+          if ( inputField.getFieldName().equals( meta.getXMLField() ) ) {
+            // link this to all of the outputs that come from the xml
+            for ( GetXMLDataField field : fields ) {
+              ComponentDerivationRecord change = new ComponentDerivationRecord( meta.getXMLField(), field.getName() );
+              changes.add( change );
+            }
+            break;
+          }
+        }
+      }
+    }
+    return changes;
+  }
+
+  @Override
+  protected void customAnalyze( GetXMLDataMeta meta, IMetaverseNode node ) throws MetaverseAnalyzerException {
+    super.customAnalyze( meta, node );
+    // Add the XPath Loop to the step node
+    node.setProperty( "loopXPath", meta.getLoopXPath() );
+  }
+
+  @Override
+  public IMetaverseNode createResourceNode( IExternalResourceInfo resource ) throws MetaverseException {
+    return createFileNode( resource.getName(), descriptor );
+  }
+
+  @Override
+  public String getResourceInputNodeType() {
+    return DictionaryConst.NODE_TYPE_FILE_FIELD;
+  }
+
+  @Override
+  public String getResourceOutputNodeType() {
+    return null;
+  }
+
+  @Override
+  public boolean isOutput() {
+    return false;
+  }
+
+  @Override
+  public boolean isInput() {
+    return true;
+  }
+
+  ///// used for unit testing
+  protected void setObjectFactory( IMetaverseObjectFactory factory ) {
+    this.metaverseObjectFactory = factory;
+  }
+  protected void setRootNode( IMetaverseNode node ) {
+    rootNode = node;
+  }
+  protected void setBaseStepMeta( GetXMLDataMeta meta ) {
+    baseStepMeta = meta;
+  }
+  protected void setParentTransMeta( TransMeta tm ) {
+    parentTransMeta = tm;
+  }
+  protected void setParentStepMeta( StepMeta sm ) {
+    parentStepMeta = sm;
+  }
+  ///// used for unit testing
+
+}

--- a/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xmloutput/XMLOutputExternalResourceConsumer.java
+++ b/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xmloutput/XMLOutputExternalResourceConsumer.java
@@ -1,0 +1,88 @@
+/*
+ * ******************************************************************************
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.trans.steps.xmloutput;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.metaverse.api.IAnalysisContext;
+import org.pentaho.metaverse.api.analyzer.kettle.step.BaseStepExternalResourceConsumer;
+import org.pentaho.metaverse.api.model.ExternalResourceInfoFactory;
+import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+public class XMLOutputExternalResourceConsumer
+  extends BaseStepExternalResourceConsumer<XMLOutput, XMLOutputMeta> {
+
+  @Override
+  public boolean isDataDriven( XMLOutputMeta meta ) {
+    // We can safely assume that the StepMetaInterface object we get back is a XMLOutputMeta
+    return false;
+  }
+
+  @Override
+  public Collection<IExternalResourceInfo> getResourcesFromMeta( XMLOutputMeta meta, IAnalysisContext context ) {
+    Collection<IExternalResourceInfo> resources = Collections.emptyList();
+
+    // We only need to collect these resources if we're not data-driven and there are no used variables in the
+    // metadata relating to external files.
+    if ( !isDataDriven( meta ) /* TODO */ ) {
+      StepMeta parentStepMeta = meta.getParentStepMeta();
+      if ( parentStepMeta != null ) {
+        TransMeta parentTransMeta = parentStepMeta.getParentTransMeta();
+        if ( parentTransMeta != null ) {
+          String[] paths = meta.getFiles( parentTransMeta );
+          if ( paths != null ) {
+            resources = new ArrayList<IExternalResourceInfo>( paths.length );
+
+            for ( String path : paths ) {
+              if ( !Const.isEmpty( path ) ) {
+                try {
+
+                  IExternalResourceInfo resource = ExternalResourceInfoFactory
+                    .createFileResource( KettleVFS.getFileObject( path ), false );
+                  if ( resource != null ) {
+                    resources.add( resource );
+                  } else {
+                    throw new KettleFileException( "Error getting file resource!" );
+                  }
+                } catch ( KettleFileException kfe ) {
+                  // TODO throw or ignore?
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return resources;
+  }
+
+  @Override
+  public Class<XMLOutputMeta> getMetaClass() {
+    return XMLOutputMeta.class;
+  }
+}

--- a/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xmloutput/XMLOutputStepAnalyzer.java
+++ b/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xmloutput/XMLOutputStepAnalyzer.java
@@ -1,0 +1,120 @@
+/*
+ * ******************************************************************************
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.trans.steps.xmloutput;
+
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.dictionary.DictionaryConst;
+import org.pentaho.metaverse.api.IMetaverseNode;
+import org.pentaho.metaverse.api.IMetaverseObjectFactory;
+import org.pentaho.metaverse.api.MetaverseAnalyzerException;
+import org.pentaho.metaverse.api.MetaverseException;
+import org.pentaho.metaverse.api.StepField;
+import org.pentaho.metaverse.api.analyzer.kettle.step.ExternalResourceStepAnalyzer;
+import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The XMLOutputStepAnalyzer is responsible for providing nodes and links (i.e. relationships) between for the
+ * fields operated on by XML Output steps.
+ */
+public class XMLOutputStepAnalyzer extends ExternalResourceStepAnalyzer<XMLOutputMeta> {
+
+  private Logger log = LoggerFactory.getLogger( XMLOutputStepAnalyzer.class );
+
+  @Override
+  protected Set<StepField> getUsedFields( XMLOutputMeta meta ) {
+    return null;
+  }
+
+  @Override protected void customAnalyze( XMLOutputMeta meta, IMetaverseNode node ) throws MetaverseAnalyzerException {
+    super.customAnalyze( meta, node );
+    node.setProperty( "parentnode", meta.getMainElement() );
+    node.setProperty( "rownode", meta.getRepeatElement() );
+  }
+
+  @Override
+  public Set<Class<? extends BaseStepMeta>> getSupportedSteps() {
+    return new HashSet<Class<? extends BaseStepMeta>>() {
+      {
+        add( XMLOutputMeta.class );
+      }
+    };
+  }
+
+  @Override
+  public IMetaverseNode createResourceNode( IExternalResourceInfo resource ) throws MetaverseException {
+    return createFileNode( resource.getName(), getDescriptor() );
+  }
+
+  @Override
+  public String getResourceInputNodeType() {
+    return null;
+  }
+
+  @Override
+  public String getResourceOutputNodeType() {
+    return DictionaryConst.NODE_TYPE_FILE_FIELD;
+  }
+
+  @Override
+  public boolean isOutput() {
+    return true;
+  }
+
+  @Override
+  public boolean isInput() {
+    return false;
+  }
+
+  @Override
+  public Set<String> getOutputResourceFields( XMLOutputMeta meta ) {
+    Set<String> fields = new HashSet<>();
+    XMLField[] outputFields = meta.getOutputFields();
+    for ( int i = 0; i < outputFields.length; i++ ) {
+      XMLField outputField = outputFields[ i ];
+      fields.add( outputField.getFieldName() );
+    }
+    return fields;
+  }
+
+  ///////////// for unit testing
+  protected void setBaseStepMeta( XMLOutputMeta meta ) {
+    baseStepMeta = meta;
+  }
+  protected void setRootNode( IMetaverseNode node ) {
+    rootNode = node;
+  }
+  protected void setParentTransMeta( TransMeta tm ) {
+    parentTransMeta = tm;
+  }
+  protected void setParentStepMeta( StepMeta sm ) {
+    parentStepMeta = sm;
+  }
+  protected void setObjectFactory( IMetaverseObjectFactory objectFactory ) {
+    this.metaverseObjectFactory = objectFactory;
+  }
+}

--- a/plugins/kettle-xml-plugin/test-src/org/pentaho/di/trans/steps/getxmldata/GetXMLDataStepAnalyzerTest.java
+++ b/plugins/kettle-xml-plugin/test-src/org/pentaho/di/trans/steps/getxmldata/GetXMLDataStepAnalyzerTest.java
@@ -1,0 +1,322 @@
+/*
+ * ******************************************************************************
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.trans.steps.getxmldata;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.dictionary.DictionaryConst;
+import org.pentaho.metaverse.api.IAnalysisContext;
+import org.pentaho.metaverse.api.IComponentDescriptor;
+import org.pentaho.metaverse.api.IMetaverseBuilder;
+import org.pentaho.metaverse.api.IMetaverseNode;
+import org.pentaho.metaverse.api.INamespace;
+import org.pentaho.metaverse.api.MetaverseComponentDescriptor;
+import org.pentaho.metaverse.api.MetaverseObjectFactory;
+import org.pentaho.metaverse.api.StepField;
+import org.pentaho.metaverse.api.analyzer.kettle.ComponentDerivationRecord;
+import org.pentaho.metaverse.api.analyzer.kettle.step.ExternalResourceStepAnalyzer;
+import org.pentaho.metaverse.api.analyzer.kettle.step.StepNodes;
+import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by mburgess on 4/24/15.
+ */
+@RunWith( MockitoJUnitRunner.class )
+public class GetXMLDataStepAnalyzerTest {
+
+  GetXMLDataStepAnalyzer analyzer;
+
+  @Mock GetXMLDataMeta meta;
+  @Mock INamespace mockNamespace;
+  @Mock IMetaverseNode node;
+  @Mock IMetaverseBuilder builder;
+  @Mock TransMeta parentTransMeta;
+  @Mock StepMeta parentStepMeta;
+  @Mock RowMetaInterface rmi;
+  @Mock GetXMLData data;
+
+  IComponentDescriptor descriptor;
+
+  static MetaverseObjectFactory metaverseObjectFactory = new MetaverseObjectFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    when( mockNamespace.getParentNamespace() ).thenReturn( mockNamespace );
+    descriptor = new MetaverseComponentDescriptor( "test", DictionaryConst.NODE_TYPE_TRANS_STEP, mockNamespace );
+    analyzer = spy( new GetXMLDataStepAnalyzer() );
+    analyzer.setDescriptor( descriptor );
+    analyzer.setObjectFactory( metaverseObjectFactory );
+    analyzer.setRootNode( node );
+    analyzer.setParentTransMeta( parentTransMeta );
+    analyzer.setParentStepMeta( parentStepMeta );
+  }
+
+  @Test
+  public void testGetResourceInputNodeType() throws Exception {
+    assertEquals( DictionaryConst.NODE_TYPE_FILE_FIELD, analyzer.getResourceInputNodeType() );
+  }
+
+  @Test
+  public void testGetResourceOutputNodeType() throws Exception {
+    assertNull( analyzer.getResourceOutputNodeType() );
+  }
+
+  @Test
+  public void testIsOutput() throws Exception {
+    assertFalse( analyzer.isOutput() );
+  }
+
+  @Test
+  public void testIsInput() throws Exception {
+    assertTrue( analyzer.isInput() );
+  }
+
+  @Test
+  public void testGetSupportedSteps() {
+    GetXMLDataStepAnalyzer analyzer = new GetXMLDataStepAnalyzer();
+    Set<Class<? extends BaseStepMeta>> types = analyzer.getSupportedSteps();
+    assertNotNull( types );
+    assertEquals( types.size(), 1 );
+    assertTrue( types.contains( GetXMLDataMeta.class ) );
+  }
+
+  @Test
+  public void testGetUsedFields_xmlNotInField() throws Exception {
+    when( meta.isInFields() ).thenReturn( false );
+    Set<StepField> usedFields = analyzer.getUsedFields( meta );
+    assertEquals( 0, usedFields.size() );
+  }
+
+  @Test
+  public void testGetUsedFields() throws Exception {
+    when( meta.isInFields() ).thenReturn( true );
+    when( meta.getXMLField() ).thenReturn( "xml" );
+
+    StepNodes inputs = new StepNodes();
+    inputs.addNode( "previousStep", "xml", node );
+    inputs.addNode( "previousStep", "otherField", node );
+    doReturn( inputs ).when( analyzer ).getInputs();
+
+    Set<StepField> usedFields = analyzer.getUsedFields( meta );
+    assertEquals( 1, usedFields.size() );
+    assertEquals( "xml", usedFields.iterator().next().getFieldName() );
+  }
+
+  @Test
+  public void testCreateResourceNode() throws Exception {
+    IExternalResourceInfo res = mock( IExternalResourceInfo.class );
+    when( res.getName() ).thenReturn( "file:///Users/home/tmp/xyz.xml" );
+    IMetaverseNode resourceNode = analyzer.createResourceNode( res );
+    assertNotNull( resourceNode );
+    assertEquals( DictionaryConst.NODE_TYPE_FILE, resourceNode.getType() );
+  }
+
+  @Test
+  public void testCreateOutputFieldNode() throws Exception {
+    doReturn( builder ).when( analyzer ).getMetaverseBuilder();
+    analyzer.setBaseStepMeta( meta );
+
+    GetXMLDataField[] fields = new GetXMLDataField[2];
+    GetXMLDataField field1 = new GetXMLDataField( "name" );
+    GetXMLDataField field2 = new GetXMLDataField( "age" );
+    field1.setXPath( "field1/xpath" );
+    field2.setElementType( 1 );
+    field1.setResultType( 1 );
+    field2.setRepeated( true );
+
+    fields[0] = field1;
+    fields[1] = field2;
+    when( meta.getInputFields() ).thenReturn( fields );
+
+    IAnalysisContext context = mock( IAnalysisContext.class );
+    doReturn( "thisStepName" ).when( analyzer ).getStepName();
+    when( node.getLogicalId() ).thenReturn( "logical id" );
+    ValueMetaInterface vmi = new ValueMeta( "name", 1 );
+
+    IMetaverseNode outputFieldNode = analyzer.createOutputFieldNode(
+      context,
+      vmi,
+      ExternalResourceStepAnalyzer.RESOURCE,
+      DictionaryConst.NODE_TYPE_TRANS_FIELD );
+
+    assertNotNull( outputFieldNode );
+
+    assertNotNull( outputFieldNode.getProperty( DictionaryConst.PROPERTY_KETTLE_TYPE ) );
+    assertEquals( ExternalResourceStepAnalyzer.RESOURCE,
+      outputFieldNode.getProperty( DictionaryConst.PROPERTY_TARGET_STEP ) );
+    assertEquals( "field1/xpath", outputFieldNode.getProperty( "xpath" ) );
+    assertNotNull( outputFieldNode.getProperty( "resultType" ) );
+    assertNotNull( outputFieldNode.getProperty( "element" ) );
+    assertEquals( false, outputFieldNode.getProperty( "repeat" ) );
+
+    // the input node should be added by this step
+    verify( builder ).addNode( outputFieldNode );
+
+  }
+
+  @Test
+  public void testGetInputRowMetaInterfaces_isInFields() throws Exception {
+    when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
+
+    RowMetaInterface rowMetaInterface = mock( RowMetaInterface.class );
+    doReturn( rowMetaInterface ).when( analyzer ).getOutputFields( meta );
+    when( meta.isInFields() ).thenReturn( true );
+    when( meta.getIsAFile() ).thenReturn( false );
+    when( meta.isReadUrl() ).thenReturn( false );
+
+    Map<String, RowMetaInterface> rowMetaInterfaces = analyzer.getInputRowMetaInterfaces( meta );
+    assertNotNull( rowMetaInterfaces );
+    assertEquals( 0, rowMetaInterfaces.size() );
+  }
+
+  @Test
+  public void testGetInputRowMetaInterfaces_isNotInField() throws Exception {
+    Map<String, RowMetaInterface> inputs = new HashMap<>();
+    RowMetaInterface inputRmi = mock( RowMetaInterface.class );
+
+    List<ValueMetaInterface> vmis = new ArrayList<>();
+    ValueMetaInterface vmi = new ValueMeta( "filename" );
+    vmis.add( vmi );
+
+    when( inputRmi.getValueMetaList() ).thenReturn( vmis );
+    inputs.put( "test", inputRmi );
+    doReturn( inputs ).when( analyzer ).getInputFields( meta );
+    when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
+
+    RowMetaInterface rowMetaInterface = new RowMeta();
+    rowMetaInterface.addValueMeta( vmi );
+    ValueMetaInterface vmi2 = new ValueMeta( "otherField" );
+    rowMetaInterface.addValueMeta( vmi2 );
+
+    doReturn( rowMetaInterface ).when( analyzer ).getOutputFields( meta );
+    when( meta.isInFields() ).thenReturn( false );
+    when( meta.getIsAFile() ).thenReturn( false );
+    when( meta.isReadUrl() ).thenReturn( false );
+
+    Map<String, RowMetaInterface> rowMetaInterfaces = analyzer.getInputRowMetaInterfaces( meta );
+    assertNotNull( rowMetaInterfaces );
+    assertEquals( 2, rowMetaInterfaces.size() );
+    RowMetaInterface metaInterface = rowMetaInterfaces.get( ExternalResourceStepAnalyzer.RESOURCE );
+    // the row meta interface should only have 1 value meta in it, and it should NOT be filename
+    assertEquals( 1, metaInterface.size() );
+    assertEquals( "otherField", metaInterface.getFieldNames()[0] );
+  }
+
+  @Test
+  public void testGetChangeRecords() throws Exception {
+
+    when( meta.isInFields() ).thenReturn( true );
+    when( meta.getIsAFile() ).thenReturn( false );
+    when( meta.isReadUrl() ).thenReturn( false );
+    when( meta.getXMLField() ).thenReturn( "xml" );
+    analyzer.setBaseStepMeta( meta );
+
+    GetXMLDataField[] fields = new GetXMLDataField[2];
+    GetXMLDataField field1 = new GetXMLDataField( "name" );
+    GetXMLDataField field2 = new GetXMLDataField( "age" );
+    field1.setXPath( "field1/xpath" );
+    field2.setElementType( 1 );
+    field1.setResultType( 1 );
+    field2.setRepeated( true );
+
+    fields[0] = field1;
+    fields[1] = field2;
+    when( meta.getInputFields() ).thenReturn( fields );
+
+    StepNodes inputs = new StepNodes();
+    inputs.addNode( "previousStep", "xml", node );
+    doReturn( inputs ).when( analyzer ).getInputs();
+
+    Set<ComponentDerivationRecord> changeRecords = analyzer.getChangeRecords( meta );
+    assertNotNull( changeRecords );
+    assertEquals( 2, changeRecords.size() );
+  }
+
+  @Test
+  public void testCustomAnalyze() throws Exception {
+    when( meta.getLoopXPath() ).thenReturn( "file/xpath/name" );
+    analyzer.customAnalyze( meta, node );
+    verify( node ).setProperty( "loopXPath", "file/xpath/name" );
+  }
+
+
+  @Test
+  public void testGetXMLDataExternalResourceConsumer() throws Exception {
+    GetXMLDataExternalResourceConsumer consumer = new GetXMLDataExternalResourceConsumer();
+
+    StepMeta spyMeta = spy( new StepMeta( "test", meta ) );
+
+    when( meta.getParentStepMeta() ).thenReturn( spyMeta );
+    when( spyMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
+    when( data.getStepMetaInterface() ).thenReturn( meta );
+
+    when( meta.isInFields() ).thenReturn( false );
+    String[] filePaths = { "/path/to/file1", "/another/path/to/file2" };
+    when( meta.getFileName() ).thenReturn( filePaths );
+    when( parentTransMeta.environmentSubstitute( any( String[].class ) ) ).thenReturn( filePaths );
+
+    assertFalse( consumer.isDataDriven( meta ) );
+    Collection<IExternalResourceInfo> resources = consumer.getResourcesFromMeta( meta );
+    assertFalse( resources.isEmpty() );
+    assertEquals( 2, resources.size() );
+
+
+    when( meta.isInFields() ).thenReturn( true );
+    when( meta.getIsAFile() ).thenReturn( true );
+    assertTrue( consumer.isDataDriven( meta ) );
+    assertTrue( consumer.getResourcesFromMeta( meta ).isEmpty() );
+    when( rmi.getString( Mockito.any( Object[].class ), anyString(), anyString() ) )
+      .thenReturn( "/path/to/row/file" );
+    resources = consumer.getResourcesFromRow( data, rmi, new String[]{ "id", "name" } );
+    assertFalse( resources.isEmpty() );
+    assertEquals( 1, resources.size() );
+
+    when( rmi.getString( Mockito.any( Object[].class ), anyString(), anyString() ) )
+      .thenThrow( new KettleValueException() );
+    resources = consumer.getResourcesFromRow( data, rmi, new String[]{ "id", "name" } );
+    assertTrue( resources.isEmpty() );
+
+    assertEquals( GetXMLDataMeta.class, consumer.getMetaClass() );
+  }
+
+}

--- a/plugins/kettle-xml-plugin/test-src/org/pentaho/di/trans/steps/xmloutput/XMLOutputStepAnalyzerTest.java
+++ b/plugins/kettle-xml-plugin/test-src/org/pentaho/di/trans/steps/xmloutput/XMLOutputStepAnalyzerTest.java
@@ -1,0 +1,197 @@
+/*
+ * ******************************************************************************
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.trans.steps.xmloutput;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.dictionary.DictionaryConst;
+import org.pentaho.metaverse.api.IComponentDescriptor;
+import org.pentaho.metaverse.api.IMetaverseBuilder;
+import org.pentaho.metaverse.api.IMetaverseNode;
+import org.pentaho.metaverse.api.INamespace;
+import org.pentaho.metaverse.api.MetaverseComponentDescriptor;
+import org.pentaho.metaverse.api.MetaverseObjectFactory;
+import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class XMLOutputStepAnalyzerTest {
+
+  private XMLOutputStepAnalyzer analyzer;
+
+  @Mock
+  private XMLOutput mockXMLOutput;
+
+  @Mock
+  private XMLOutputMeta meta;
+
+  @Mock
+  private XMLOutputData data;
+
+  @Mock
+  IMetaverseNode node;
+  @Mock
+  IMetaverseBuilder mockBuilder;
+  @Mock
+  private INamespace mockNamespace;
+  @Mock
+  private StepMeta parentStepMeta;
+  @Mock
+  private TransMeta mockTransMeta;
+
+  IComponentDescriptor descriptor;
+
+  static MetaverseObjectFactory metaverseObjectFactory = new MetaverseObjectFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    analyzer = spy( new XMLOutputStepAnalyzer() );
+    analyzer.setMetaverseBuilder( mockBuilder );
+    analyzer.setBaseStepMeta( meta );
+    analyzer.setRootNode( node );
+    analyzer.setParentTransMeta( mockTransMeta );
+    analyzer.setParentStepMeta( parentStepMeta );
+
+    descriptor = new MetaverseComponentDescriptor( "test", DictionaryConst.NODE_TYPE_TRANS_STEP, mockNamespace );
+    analyzer.setDescriptor( descriptor );
+    analyzer.setObjectFactory( metaverseObjectFactory );
+
+    when( mockXMLOutput.getStepDataInterface() ).thenReturn( data );
+    when( mockXMLOutput.getStepMeta() ).thenReturn( parentStepMeta );
+
+    when( meta.getParentStepMeta() ).thenReturn( parentStepMeta );
+    when( parentStepMeta.getStepMetaInterface() ).thenReturn( meta );
+    when( parentStepMeta.getParentTransMeta() ).thenReturn( mockTransMeta );
+    when( parentStepMeta.getName() ).thenReturn( "test" );
+    when( parentStepMeta.getStepID() ).thenReturn( "XmlOutputStep" );
+  }
+
+  @Test
+  public void testCustomAnalyze() throws Exception {
+    when( meta.getMainElement() ).thenReturn( "main" );
+    when( meta.getRepeatElement() ).thenReturn( "repeat" );
+    analyzer.customAnalyze( meta, node );
+
+    verify( node ).setProperty( "parentnode", "main" );
+    verify( node ).setProperty( "rownode", "repeat" );
+
+  }
+
+  @Test
+  public void testGetSupportedSteps() {
+    XMLOutputStepAnalyzer analyzer = new XMLOutputStepAnalyzer();
+    Set<Class<? extends BaseStepMeta>> types = analyzer.getSupportedSteps();
+    assertNotNull( types );
+    assertEquals( types.size(), 1 );
+    assertTrue( types.contains( XMLOutputMeta.class ) );
+  }
+
+  @Test
+  public void testGetOutputResourceFields() throws Exception {
+    XMLField[] outputFields = new XMLField[2];
+    XMLField field1 = mock( XMLField.class );
+    XMLField field2 = mock( XMLField.class );
+    outputFields[0] = field1;
+    outputFields[1] = field2;
+
+    when( field1.getFieldName() ).thenReturn( "field1" );
+    when( field2.getFieldName() ).thenReturn( "field2" );
+
+    when( meta.getOutputFields() ).thenReturn( outputFields );
+
+    Set<String> outputResourceFields = analyzer.getOutputResourceFields( meta );
+
+    assertEquals( outputFields.length, outputResourceFields.size() );
+    for ( XMLField outputField : outputFields ) {
+      assertTrue( outputResourceFields.contains( outputField.getFieldName() ) );
+    }
+  }
+
+  @Test
+  public void testXMLOutputExternalResourceConsumer() throws Exception {
+    XMLOutputExternalResourceConsumer consumer = new XMLOutputExternalResourceConsumer();
+
+    StepMeta meta = new StepMeta( "test", this.meta );
+    StepMeta spyMeta = spy( meta );
+
+    when( this.meta.getParentStepMeta() ).thenReturn( spyMeta );
+    when( spyMeta.getParentTransMeta() ).thenReturn( mockTransMeta );
+    when( this.meta.getFileName() ).thenReturn( null );
+    String[] filePaths = { "/path/to/file1", "/another/path/to/file2" };
+    when( this.meta.getFiles( Mockito.any( VariableSpace.class ) ) ).thenReturn( filePaths );
+
+    assertFalse( consumer.isDataDriven( this.meta ) );
+    Collection<IExternalResourceInfo> resources = consumer.getResourcesFromMeta( this.meta );
+    assertFalse( resources.isEmpty() );
+    assertEquals( 2, resources.size() );
+
+    when( this.meta.getExtension() ).thenReturn( "txt" );
+
+    assertEquals( XMLOutputMeta.class, consumer.getMetaClass() );
+  }
+
+  @Test
+  public void testCreateResourceNode() throws Exception {
+    IExternalResourceInfo res = mock( IExternalResourceInfo.class );
+    when( res.getName() ).thenReturn( "file:///Users/home/tmp/xyz.xml" );
+    IMetaverseNode resourceNode = analyzer.createResourceNode( res );
+    assertNotNull( resourceNode );
+    assertEquals( DictionaryConst.NODE_TYPE_FILE, resourceNode.getType() );
+  }
+  @Test
+  public void testGetResourceInputNodeType() throws Exception {
+    assertNull( analyzer.getResourceInputNodeType() );
+  }
+
+  @Test
+  public void testGetResourceOutputNodeType() throws Exception {
+    assertEquals( DictionaryConst.NODE_TYPE_FILE_FIELD, analyzer.getResourceOutputNodeType() );
+  }
+
+  @Test
+  public void testIsOutput() throws Exception {
+    assertTrue( analyzer.isOutput() );
+  }
+
+  @Test
+  public void testIsInput() throws Exception {
+    assertFalse( analyzer.isInput() );
+  }
+
+  @Test
+  public void testGetUsedFields() throws Exception {
+    assertNull( analyzer.getUsedFields( meta ) );
+  }
+}
+


### PR DESCRIPTION
… metaverse and into the kettle-xml-plugin

More to come, the analyzer isn't firing currently. There is a problem somewhere that isn't obviously apparent. It will take more research to fix properly. This will at least get the plugins loading properly again.

commit that goes along with this one:
https://github.com/pentaho/pentaho-metaverse/pull/403