### PR TITLE
[BACKLOG-6041] Reducing log message from basic to debug

### DIFF
--- a/ui/src/org/pentaho/di/ui/core/PropsUI.java
+++ b/ui/src/org/pentaho/di/ui/core/PropsUI.java
@@ -200,7 +200,7 @@ public class PropsUI extends Props {
         }
       } catch ( ClassCastException cce ) {
         // Not all Lifecycle plugins implement GUIOption, keep calm and carry on
-        LogChannel.GENERAL.logBasic( "Plugin " + plugin.getIds()[0]
+        LogChannel.GENERAL.logDebug( "Plugin " + plugin.getIds()[0]
             + " does not implement GUIOption, it will not be editable" );
       } catch ( Exception e ) {
         LogChannel.GENERAL.logError( "Unexpected error loading class for plugin " + plugin.getName(), e );


### PR DESCRIPTION
This message is now showing up in the logs since the KettleXmlPluginLifecycleListener exists without implementing GUIOption (nor do we want it to).