### PR TITLE
[SP-2346] - Backport of PDI-14358 - Text File Input Interpreting missing values as empty strings instead of null (6.0 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -385,7 +385,7 @@ public class TextFileInputUtils {
         if ( fieldnr < strings.length ) {
           String pol = strings[ fieldnr ];
           try {
-            if ( valueMeta.isNull( pol ) ) {
+            if ( valueMeta.isNull( pol ) || !Const.isEmpty( nullif ) && nullif.equals( pol ) ) {
               value = null;
             } else {
               value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );


### PR DESCRIPTION
- manually check if input sample is equal to "nullif" value
- add a test and refactor TextFileInputTest a bit
(cherry picked from commit 84cd194)

@brosander, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/1997 