### PR TITLE
[PDI-13684] - Change in null behavior in 5.x version

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/datagrid/DataGrid.java
+++ b/engine/src/org/pentaho/di/trans/steps/datagrid/DataGrid.java
@@ -59,8 +59,8 @@ public class DataGrid extends BaseStep implements StepInterface {
   }
 
   public boolean processRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
-    if ( data.linesWritten >= meta.getDataLines().size() ) // no more rows to be written
-    {
+    if ( data.linesWritten >= meta.getDataLines().size() ) {
+      // no more rows to be written
       setOutputDone();
       return false;
     }
@@ -84,16 +84,19 @@ public class DataGrid extends BaseStep implements StepInterface {
     List<String> outputLine = meta.getDataLines().get( data.linesWritten );
 
     for ( int i = 0; i < data.outputRowMeta.size(); i++ ) {
-      if ( meta.isSetEmptyString()[i] ) {
+      if ( meta.isSetEmptyString()[ i ] ) {
         // Set empty string
-        outputRowData[i] = StringUtil.EMPTY_STRING;
+        outputRowData[ i ] = StringUtil.EMPTY_STRING;
       } else {
 
         ValueMetaInterface valueMeta = data.outputRowMeta.getValueMeta( i );
         ValueMetaInterface convertMeta = data.convertMeta.getValueMeta( i );
         String valueData = outputLine.get( i );
 
-        outputRowData[i] = valueMeta.convertDataFromString( valueData, convertMeta, null, null, 0 );
+        if ( valueData != null && valueMeta.isNull( valueData ) ) {
+          valueData = null;
+        }
+        outputRowData[ i ] = valueMeta.convertDataFromString( valueData, convertMeta, null, null, 0 );
       }
     }
 

--- a/engine/src/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter.java
+++ b/engine/src/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -51,7 +51,7 @@ public class FieldSplitter extends BaseStep implements StepInterface {
   private FieldSplitterData data;
 
   public FieldSplitter( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
-    Trans trans ) {
+                        Trans trans ) {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
 
@@ -100,8 +100,9 @@ public class FieldSplitter extends BaseStep implements StepInterface {
     //
 
     // Named values info.id[0] not filled in!
-    final boolean selectFieldById =
-      meta.getFieldID().length > 0 && meta.getFieldID()[0] != null && meta.getFieldID()[0].length() > 0;
+    final boolean selectFieldById = ( meta.getFieldID().length > 0 )
+      && ( meta.getFieldID()[ 0 ] != null )
+      && ( meta.getFieldID()[ 0 ].length() > 0 );
 
     if ( log.isDebug() ) {
       if ( selectFieldById ) {
@@ -118,10 +119,10 @@ public class FieldSplitter extends BaseStep implements StepInterface {
       String rawValue = null;
       if ( selectFieldById ) {
         for ( String part : valueParts ) {
-          if ( part.startsWith( meta.getFieldID()[i] ) ) {
+          if ( part.startsWith( meta.getFieldID()[ i ] ) ) {
             // Optionally remove the id
-            if ( meta.getFieldRemoveID()[i] ) {
-              rawValue = part.substring( meta.getFieldID()[i].length() );
+            if ( meta.getFieldRemoveID()[ i ] ) {
+              rawValue = part.substring( meta.getFieldID()[ i ].length() );
             } else {
               rawValue = part;
             }
@@ -134,7 +135,7 @@ public class FieldSplitter extends BaseStep implements StepInterface {
           logDebug( BaseMessages.getString( PKG, "FieldSplitter.Log.SplitInfo" ) + rawValue );
         }
       } else {
-        rawValue = ( valueParts == null || i >= valueParts.length ) ? null : valueParts[i];
+        rawValue = ( valueParts == null || i >= valueParts.length ) ? null : valueParts[ i ];
         prev += ( rawValue == null ? 0 : rawValue.length() ) + data.delimiter.length();
 
         if ( log.isDebug() ) {
@@ -144,18 +145,21 @@ public class FieldSplitter extends BaseStep implements StepInterface {
       }
 
       Object value;
-
       try {
         ValueMetaInterface valueMeta = data.outputMeta.getValueMeta( data.fieldnr + i );
         ValueMetaInterface conversionValueMeta = data.conversionMeta.getValueMeta( data.fieldnr + i );
+
+        if ( rawValue != null && valueMeta.isNull( rawValue ) ) {
+          rawValue = null;
+        }
         value =
-          valueMeta.convertDataFromString( rawValue, conversionValueMeta, meta.getFieldNullIf()[i], meta
-            .getFieldIfNull()[i], meta.getFieldTrimType()[i] );
+          valueMeta.convertDataFromString( rawValue, conversionValueMeta, meta.getFieldNullIf()[ i ],
+            meta.getFieldIfNull()[ i ], meta.getFieldTrimType()[ i ] );
       } catch ( Exception e ) {
         throw new KettleValueException( BaseMessages.getString(
           PKG, "FieldSplitter.Log.ErrorConvertingSplitValue", rawValue, meta.getSplitField() + "]!" ), e );
       }
-      outputRow[data.fieldnr + i] = value;
+      outputRow[ data.fieldnr + i ] = value;
     }
 
     return outputRow;

--- a/engine/test-src/org/pentaho/di/trans/TransTestingUtil.java
+++ b/engine/test-src/org/pentaho/di/trans/TransTestingUtil.java
@@ -1,0 +1,101 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans;
+
+import org.pentaho.di.core.BlockingRowSet;
+import org.pentaho.di.core.RowSet;
+import org.pentaho.di.trans.step.BaseStep;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.step.StepMetaInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class TransTestingUtil {
+
+  public static List<Object[]> execute( BaseStep step,
+                                        StepMetaInterface meta,
+                                        StepDataInterface data,
+                                        int expectedRowsAmount,
+                                        boolean checkIsDone ) throws Exception {
+    RowSet output = new BlockingRowSet( Math.max( 1, expectedRowsAmount ) );
+    step.setOutputRowSets( singletonList( output ) );
+
+    int i = 0;
+    List<Object[]> result = new ArrayList<>( expectedRowsAmount );
+    while ( step.processRow( meta, data ) && i < expectedRowsAmount ) {
+      Object[] row = output.getRowImmediate();
+      assertNotNull( Integer.toString( i ), row );
+      result.add( row );
+
+      i++;
+    }
+    assertEquals( "The amount of executions should be equal to expected", expectedRowsAmount, i );
+    if ( checkIsDone ) {
+      assertTrue( output.isDone() );
+    }
+
+    return result;
+  }
+
+
+  public static void assertResult( Object[] expectedRow, Object[] actualRow ) {
+    assertRow( 0, expectedRow, actualRow );
+  }
+
+  public static void assertResult( List<Object[]> expected, List<Object[]> actual ) {
+    assertEquals( expected.size(), actual.size() );
+    for ( int i = 0; i < expected.size(); i++ ) {
+      Object[] expectedRow = expected.get( i );
+      Object[] actualRow = actual.get( i );
+      assertRow( i, expectedRow, actualRow );
+    }
+  }
+
+  private static void assertRow( int index, Object[] expected, Object[] actual ) {
+    assertNotNull( actual );
+
+    boolean sizeCondition = ( expected.length <= actual.length );
+    if ( !sizeCondition ) {
+      fail(
+        String.format( "Row [%d]: expected.length=[%d]; actual.length=[%d]", index, expected.length, actual.length ) );
+    }
+
+    int i = 0;
+    while ( i < expected.length ) {
+      assertEquals( String.format( "[%d][%d]", index, i ), expected[ i ], actual[ i ] );
+      i++;
+    }
+    while ( i < actual.length ) {
+      assertNull( actual[ i ] );
+      i++;
+    }
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
@@ -1,24 +1,41 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.di.trans.steps.datagrid;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.row.value.ValueMetaFactory;
 import org.pentaho.di.trans.TransTestingUtil;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.steps.StepMockUtil;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
+import org.pentaho.test.util.FieldAccessor;
 
-import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.apache.commons.lang.reflect.FieldUtils.*;
 import static org.mockito.Mockito.when;
 
 /**
@@ -55,30 +72,11 @@ public class DataGrid_EmptyStringVsNull_Test {
 
 
   private void doTestEmptyStringVsNull( boolean diffProperty, List<Object[]> expected ) throws Exception {
-    final String fieldName = "EMPTY_STRING_AND_NULL_ARE_DIFFERENT";
-
-    final Field metaBaseField = getField( ValueMetaBase.class, fieldName );
-    final Object metaBaseValue = readStaticField( metaBaseField );
-
-    final Field metaField = getField( ValueMeta.class, fieldName );
-    final Object metaValue = readStaticField( metaField );
-
-    final Field modifiers = getField( Field.class, "modifiers", true );
-    writeField( modifiers, metaBaseField, metaBaseField.getModifiers() & ~Modifier.FINAL, true );
-    writeField( modifiers, metaField, metaField.getModifiers() & ~Modifier.FINAL, true );
-
-    Field.setAccessible( new AccessibleObject[] { metaBaseField, metaField }, true );
-    writeStaticField( metaBaseField, diffProperty );
-    writeStaticField( metaField, diffProperty );
-
+    FieldAccessor.ensureEmptyStringIsNotNull( diffProperty );
     try {
       executeAndAssertResults( expected );
     } finally {
-      writeStaticField( metaBaseField, metaBaseValue );
-      writeStaticField( metaField, metaValue );
-
-      writeField( modifiers, metaBaseField, metaBaseField.getModifiers() & Modifier.FINAL, true );
-      writeField( modifiers, metaField, metaField.getModifiers() & Modifier.FINAL, true );
+      FieldAccessor.resetEmptyStringIsNotNull();
     }
   }
 

--- a/engine/test-src/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
@@ -1,0 +1,173 @@
+package org.pentaho.di.trans.steps.datagrid;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.BlockingRowSet;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.RowSet;
+import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaFactory;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.steps.StepMockUtil;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.apache.commons.lang.reflect.FieldUtils.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class DataGrid_EmptyStringVsNull_Test {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+
+  @Test
+  public void emptyAndNullsAreNotDifferent() throws Exception {
+    List<Object[]> expected = asList(
+      new Object[] { "", "", null },
+      new Object[] { null, "", null },
+      new Object[] { null, "", null }
+    );
+    doTestEmptyStringVsNull( false, expected );
+  }
+
+
+  @Test
+  public void emptyAndNullsAreDifferent() throws Exception {
+    List<Object[]> expected = asList(
+      new Object[] { "", "", null },
+      new Object[] { "", "", null },
+      new Object[] { null, "", null }
+    );
+    doTestEmptyStringVsNull( true, expected );
+  }
+
+
+  private void doTestEmptyStringVsNull( boolean diffProperty, List<Object[]> expected ) throws Exception {
+    final String fieldName = "EMPTY_STRING_AND_NULL_ARE_DIFFERENT";
+
+    final Field metaBaseField = getField( ValueMetaBase.class, fieldName );
+    final Object metaBaseValue = readStaticField( metaBaseField );
+
+    final Field metaField = getField( ValueMeta.class, fieldName );
+    final Object metaValue = readStaticField( metaField );
+
+    final Field modifiers = getField( Field.class, "modifiers", true );
+    writeField( modifiers, metaBaseField, metaBaseField.getModifiers() & ~Modifier.FINAL, true );
+    writeField( modifiers, metaField, metaField.getModifiers() & ~Modifier.FINAL, true );
+
+    Field.setAccessible( new AccessibleObject[] { metaBaseField, metaField }, true );
+    writeStaticField( metaBaseField, diffProperty );
+    writeStaticField( metaField, diffProperty );
+
+    try {
+      executeAndAssertResults( expected );
+    } finally {
+      writeStaticField( metaBaseField, metaBaseValue );
+      writeStaticField( metaField, metaValue );
+
+      writeField( modifiers, metaBaseField, metaBaseField.getModifiers() & Modifier.FINAL, true );
+      writeField( modifiers, metaField, metaField.getModifiers() & Modifier.FINAL, true );
+    }
+  }
+
+  private void executeAndAssertResults( List<Object[]> expected ) throws Exception {
+    final String stringType = ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_STRING );
+    final String numberType = ValueMetaFactory.getValueMetaName( ValueMetaInterface.TYPE_NUMBER );
+
+    DataGridMeta meta = new DataGridMeta();
+    meta.allocate( 3 );
+    meta.setFieldName( new String[] { "string", "string-setEmpty", "number" } );
+    meta.setFieldType( new String[] { stringType, stringType, numberType } );
+    meta.setEmptyString( new boolean[] { false, true, false } );
+
+    List<List<String>> dataRows = asList(
+      asList( " ", " ", " " ),
+      asList( "", "", "" ),
+      asList( (String) null, null, null )
+    );
+    meta.setDataLines( dataRows );
+
+    DataGridData data = new DataGridData();
+    DataGrid step = createAndInitStep( meta, data );
+
+    List<Object[]> actual = execute( step, meta, data, 3 );
+    assertResult( expected, actual );
+  }
+
+  private DataGrid createAndInitStep( DataGridMeta meta, DataGridData data ) {
+    StepMockHelper<DataGridMeta, StepDataInterface> helper =
+      StepMockUtil.getStepMockHelper( DataGridMeta.class, "DataGrid_EmptyStringVsNull_Test" );
+    when( helper.stepMeta.getStepMetaInterface() ).thenReturn( meta );
+
+    DataGrid step = new DataGrid( helper.stepMeta, data, 0, helper.transMeta, helper.trans );
+    step.init( meta, data );
+    return step;
+  }
+
+  private List<Object[]> execute( DataGrid step,
+                                  DataGridMeta meta,
+                                  DataGridData data,
+                                  int expectedRowsAmount ) throws Exception {
+    RowSet output = new BlockingRowSet( expectedRowsAmount );
+    step.setOutputRowSets( singletonList( output ) );
+
+    int i = 0;
+    List<Object[]> result = new ArrayList<>( expectedRowsAmount );
+    while ( step.processRow( meta, data ) && i < expectedRowsAmount ) {
+      Object[] row = output.getRowImmediate();
+      assertNotNull( Integer.toString( i ), row );
+      result.add( row );
+
+      i++;
+    }
+    assertEquals( "The amount of executions should be equal to expected", expectedRowsAmount, i );
+    assertTrue( output.isDone() );
+
+    return result;
+  }
+
+  private static void assertResult( List<Object[]> expected, List<Object[]> actual ) {
+    assertEquals( expected.size(), actual.size() );
+    for ( int i = 0; i < expected.size(); i++ ) {
+      Object[] expectedRow = expected.get( i );
+      Object[] actualRow = actual.get( i );
+      assertRow( i, expectedRow, actualRow );
+    }
+  }
+
+  private static void assertRow( int index, Object[] expected, Object[] actual ) {
+    assertNotNull( actual );
+
+    boolean sizeCondition = expected.length <= actual.length;
+    if ( !sizeCondition ) {
+      fail(
+        String.format( "Row [%d]: expected.length=[%d]; actual.length=[%d]", index, expected.length, actual.length ) );
+    }
+
+    int i = 0;
+    while ( i < expected.length ) {
+      assertEquals( expected[ i ], actual[ i ] );
+      i++;
+    }
+    while ( i < actual.length ) {
+      assertNull( actual[ i ] );
+      i++;
+    }
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
@@ -2,13 +2,12 @@ package org.pentaho.di.trans.steps.datagrid;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.pentaho.di.core.BlockingRowSet;
 import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.row.value.ValueMetaFactory;
+import org.pentaho.di.trans.TransTestingUtil;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.steps.StepMockUtil;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
@@ -16,13 +15,10 @@ import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.apache.commons.lang.reflect.FieldUtils.*;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 /**
@@ -106,8 +102,8 @@ public class DataGrid_EmptyStringVsNull_Test {
     DataGridData data = new DataGridData();
     DataGrid step = createAndInitStep( meta, data );
 
-    List<Object[]> actual = execute( step, meta, data, 3 );
-    assertResult( expected, actual );
+    List<Object[]> actual = TransTestingUtil.execute( step, meta, data, 3, true );
+    TransTestingUtil.assertResult( expected, actual );
   }
 
   private DataGrid createAndInitStep( DataGridMeta meta, DataGridData data ) {
@@ -118,56 +114,5 @@ public class DataGrid_EmptyStringVsNull_Test {
     DataGrid step = new DataGrid( helper.stepMeta, data, 0, helper.transMeta, helper.trans );
     step.init( meta, data );
     return step;
-  }
-
-  private List<Object[]> execute( DataGrid step,
-                                  DataGridMeta meta,
-                                  DataGridData data,
-                                  int expectedRowsAmount ) throws Exception {
-    RowSet output = new BlockingRowSet( expectedRowsAmount );
-    step.setOutputRowSets( singletonList( output ) );
-
-    int i = 0;
-    List<Object[]> result = new ArrayList<>( expectedRowsAmount );
-    while ( step.processRow( meta, data ) && i < expectedRowsAmount ) {
-      Object[] row = output.getRowImmediate();
-      assertNotNull( Integer.toString( i ), row );
-      result.add( row );
-
-      i++;
-    }
-    assertEquals( "The amount of executions should be equal to expected", expectedRowsAmount, i );
-    assertTrue( output.isDone() );
-
-    return result;
-  }
-
-  private static void assertResult( List<Object[]> expected, List<Object[]> actual ) {
-    assertEquals( expected.size(), actual.size() );
-    for ( int i = 0; i < expected.size(); i++ ) {
-      Object[] expectedRow = expected.get( i );
-      Object[] actualRow = actual.get( i );
-      assertRow( i, expectedRow, actualRow );
-    }
-  }
-
-  private static void assertRow( int index, Object[] expected, Object[] actual ) {
-    assertNotNull( actual );
-
-    boolean sizeCondition = expected.length <= actual.length;
-    if ( !sizeCondition ) {
-      fail(
-        String.format( "Row [%d]: expected.length=[%d]; actual.length=[%d]", index, expected.length, actual.length ) );
-    }
-
-    int i = 0;
-    while ( i < expected.length ) {
-      assertEquals( expected[ i ], actual[ i ] );
-      i++;
-    }
-    while ( i < actual.length ) {
-      assertNull( actual[ i ] );
-      i++;
-    }
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter_EmptyStringVsNull_Test.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter_EmptyStringVsNull_Test.java
@@ -1,0 +1,121 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.fieldsplitter;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.trans.TransTestingUtil;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.steps.StepMockUtil;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+import org.pentaho.test.util.FieldAccessor;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class FieldSplitter_EmptyStringVsNull_Test {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+
+  @Test
+  public void emptyAndNullsAreNotDifferent() throws Exception {
+    List<Object[]> expected = asList(
+      new Object[] { "a", "", "a" },
+      new Object[] { "b", null, "b" },
+      new Object[] { null }
+    );
+    doTestEmptyStringVsNull( false, expected );
+  }
+
+
+  @Test
+  public void emptyAndNullsAreDifferent() throws Exception {
+    List<Object[]> expected = asList(
+      new Object[] { "a", "", "a" },
+      new Object[] { "b", "", "b" },
+      new Object[] { null }
+    );
+    doTestEmptyStringVsNull( true, expected );
+  }
+
+
+  private void doTestEmptyStringVsNull( boolean diffProperty, List<Object[]> expected ) throws Exception {
+    FieldAccessor.ensureEmptyStringIsNotNull( diffProperty );
+    try {
+      executeAndAssertResults( expected );
+    } finally {
+      FieldAccessor.resetEmptyStringIsNotNull();
+    }
+  }
+
+  private void executeAndAssertResults( List<Object[]> expected ) throws Exception {
+    FieldSplitterMeta meta = new FieldSplitterMeta();
+    meta.allocate( 3 );
+    meta.setFieldName( new String[] { "s1", "s2", "s3" } );
+    meta.setFieldType( new int[] { ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_STRING } );
+    meta.setSplitField( "string" );
+    meta.setDelimiter( "," );
+
+    FieldSplitterData data = new FieldSplitterData();
+
+    FieldSplitter step = createAndInitStep( meta, data );
+
+    RowMeta input = new RowMeta();
+    input.addValueMeta( new ValueMetaString( "string" ) );
+    step.setInputRowMeta( input );
+
+    step = spy( step );
+    doReturn( new String[] { "a, ,a" } )
+      .doReturn( new String[] { "b,,b" } )
+      .doReturn( new String[] { null } )
+      .when( step ).getRow();
+
+    List<Object[]> actual = TransTestingUtil.execute( step, meta, data, 3, false );
+    TransTestingUtil.assertResult( expected, actual );
+  }
+
+  private FieldSplitter createAndInitStep( FieldSplitterMeta meta, FieldSplitterData data ) throws Exception {
+    StepMockHelper<FieldSplitterMeta, StepDataInterface> helper =
+      StepMockUtil.getStepMockHelper( FieldSplitterMeta.class, "FieldSplitter_EmptyStringVsNull_Test" );
+    when( helper.stepMeta.getStepMetaInterface() ).thenReturn( meta );
+
+    FieldSplitter step = new FieldSplitter( helper.stepMeta, data, 0, helper.transMeta, helper.trans );
+    step.init( meta, data );
+    return step;
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/regexeval/RegexEval_EmptyStringVsNull_Test.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/regexeval/RegexEval_EmptyStringVsNull_Test.java
@@ -1,0 +1,129 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.regexeval;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.trans.TransTestingUtil;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.steps.StepMockUtil;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+import org.pentaho.test.util.FieldAccessor;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RegexEval_EmptyStringVsNull_Test {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+
+  @Test
+  public void emptyAndNullsAreNotDifferent() throws Exception {
+    List<Object[]> expected = asList(
+      new Object[] { false, "" },
+      new Object[] { false, "" },
+      new Object[] { false, null }
+    );
+    doTestEmptyStringVsNull( false, expected );
+  }
+
+
+  @Test
+  public void emptyAndNullsAreDifferent() throws Exception {
+    List<Object[]> expected = asList(
+      new Object[] { false, "" },
+      new Object[] { false, "" },
+      new Object[] { false, null }
+    );
+    doTestEmptyStringVsNull( true, expected );
+  }
+
+
+  private void doTestEmptyStringVsNull( boolean diffProperty, List<Object[]> expected ) throws Exception {
+    FieldAccessor.ensureEmptyStringIsNotNull( diffProperty );
+    try {
+      executeAndAssertResults( expected );
+    } finally {
+      FieldAccessor.resetEmptyStringIsNotNull();
+    }
+  }
+
+  private void executeAndAssertResults( List<Object[]> expected ) throws Exception {
+    RegexEvalMeta meta = new RegexEvalMeta();
+    meta.allocate( 2 );
+    meta.getFieldName()[ 0 ] = "string";
+    meta.getFieldName()[ 1 ] = "matcher";
+    meta.setFieldType( new int[] { ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_STRING } );
+    meta.setResultFieldName( "string" );
+    meta.setReplacefields( true );
+    meta.setMatcher( "matcher" );
+    meta.setAllowCaptureGroupsFlag( true );
+
+    RegexEvalData data = new RegexEvalData();
+    RegexEval step = createAndInitStep( meta, data );
+
+    RowMeta input = new RowMeta();
+    input.addValueMeta( new ValueMetaString( "string" ) );
+    input.addValueMeta( new ValueMetaString( "matcher" ) );
+    step.setInputRowMeta( input );
+
+    step = spy( step );
+    doReturn( new String[] { " ", " " } )
+      .doReturn( new String[] { "", "" } )
+      .doReturn( new String[] { null, null } )
+      .when( step ).getRow();
+
+    // dummy pattern, just to contain two groups
+    // needed to activate a branch with conversion from string
+    data.pattern = Pattern.compile( "(a)(a)" );
+
+    List<Object[]> actual = TransTestingUtil.execute( step, meta, data, 3, false );
+    TransTestingUtil.assertResult( expected, actual );
+  }
+
+  private RegexEval createAndInitStep( RegexEvalMeta meta, RegexEvalData data ) throws Exception {
+    StepMockHelper<RegexEvalMeta, StepDataInterface> helper =
+      StepMockUtil.getStepMockHelper( RegexEvalMeta.class, "RegexEval_EmptyStringVsNull_Test" );
+    when( helper.stepMeta.getStepMetaInterface() ).thenReturn( meta );
+
+    RegexEval step = new RegexEval( helper.stepMeta, data, 0, helper.transMeta, helper.trans );
+    step.init( meta, data );
+    return step;
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/script/ScriptTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/script/ScriptTest.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.di.trans.steps.script;
 
-import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.when;
 
@@ -30,29 +29,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.pentaho.di.core.BlockingRowSet;
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.trans.TransTestingUtil;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 
 public class ScriptTest {
   private StepMockHelper<ScriptMeta, ScriptData> helper;
 
-  @BeforeClass
-  public static void setUpBeforeClass() throws Exception {
-  }
-
-  @AfterClass
-  public static void tearDownAfterClass() throws Exception {
-  }
-
   @Before
   public void setUp() throws Exception {
-    helper = new StepMockHelper<ScriptMeta, ScriptData>( "test-script", ScriptMeta.class, ScriptData.class );
+    helper = new StepMockHelper<>( "test-script", ScriptMeta.class, ScriptData.class );
     when( helper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
       helper.logChannelInterface );
     when( helper.trans.isRunning() ).thenReturn( true );
@@ -62,6 +51,7 @@ public class ScriptTest {
 
   @After
   public void tearDown() throws Exception {
+    helper = null;
   }
 
   @Test
@@ -74,18 +64,7 @@ public class ScriptTest {
     in.add( rs );
     step.setInputRowSets( in );
 
-    rs = new BlockingRowSet( 5 );
-    List<RowSet> out = new ArrayList<RowSet>();
-    out.add( rs );
-    step.setOutputRowSets( out );
-
-    step.processRow( helper.processRowsStepMetaInterface, helper.processRowsStepDataInterface );
-
-    out = step.getOutputRowSets();
-    rs = out.get( 0 );
-
-    assertTrue( "Script step is supposed to done with output if there is no input", rs.isDone() );
-
+    TransTestingUtil.execute( step, helper.processRowsStepMetaInterface, helper.processRowsStepDataInterface, 0, true );
     rs.getRow();
   }
 

--- a/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesModTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesModTest.java
@@ -24,20 +24,18 @@ package org.pentaho.di.trans.steps.scriptvalues_mod;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.pentaho.di.core.BlockingRowSet;
 import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaBigNumber;
+import org.pentaho.di.trans.TransTestingUtil;
 import org.pentaho.di.trans.steps.StepMockUtil;
 
 import java.math.BigDecimal;
-import java.util.Collections;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.pentaho.di.trans.TransTestingUtil.assertResult;
 
 /**
  * @author Andrey Khayrutdinov
@@ -58,9 +56,6 @@ public class ScriptValuesModTest {
     input.addValueMeta( new ValueMetaBigNumber( "value_double" ) );
     step.setInputRowMeta( input );
 
-    RowSet output = new BlockingRowSet( 5 );
-    step.setOutputRowSets( Collections.singletonList( output ) );
-
     step = spy( step );
     doReturn( new Object[] { BigDecimal.ONE, BigDecimal.ONE } ).when( step ).getRow();
 
@@ -77,15 +72,10 @@ public class ScriptValuesModTest {
     } );
 
     ScriptValuesModData data = new ScriptValuesModData();
-
     step.init( meta, data );
-    step.processRow( meta, data );
 
-    Object[] row = output.getRowImmediate();
-    assertNotNull( row );
-    assertNotNull( row[ 0 ] );
-    assertEquals( BigDecimal.TEN, row[ 0 ] );
-    assertNotNull( row[ 1 ] );
-    assertEquals( new BigDecimal( "10.5" ), row[ 1 ] );
+    Object[] expectedRow = { BigDecimal.TEN, new BigDecimal( "10.5" ) };
+    Object[] row = TransTestingUtil.execute( step, meta, data, 1, false ).get( 0 );
+    assertResult( expectedRow, row );
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
@@ -27,26 +27,26 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.util.Collections;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.pentaho.di.core.BlockingRowSet;
 import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.fileinput.FileInputList;
 import org.pentaho.di.core.playlist.FilePlayListAll;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.trans.TransTestingUtil;
 import org.pentaho.di.trans.step.errorhandling.FileErrorHandler;
 import org.pentaho.di.trans.steps.StepMockUtil;
 import org.pentaho.di.utils.TestUtils;
 
 import static org.junit.Assert.*;
+import static org.pentaho.di.trans.TransTestingUtil.assertResult;
 
 /**
  * @deprecated replaced by implementation in the ...steps.fileinput.text package
@@ -146,16 +146,10 @@ public class TextFileInputTest {
     data.filterProcessor = new TextFileFilterProcessor( new TextFileFilter[ 0 ] );
     data.filePlayList = new FilePlayListAll();
 
-
-    RowSet output = new BlockingRowSet( 5 );
-    executeStep( meta, data, output, 2 );
-
-    Object[] row1 = output.getRowImmediate();
-    assertRow( row1, "r1c1", "r1c2" );
-
-    Object[] row2 = output.getRowImmediate();
-    assertRow( row2, "r2c1", "r2c2" );
-
+    TextFileInput input = StepMockUtil.getStep( TextFileInput.class, TextFileInputMeta.class, "test" );
+    List<Object[]> output = TransTestingUtil.execute( input, meta, data, 2, false );
+    assertResult( new Object[] { "r1c1", "r1c2" }, output.get( 0 ) );
+    assertResult( new Object[] { "r2c1", "r2c2" }, output.get( 1 ) );
 
     deleteVfsFile( virtualFile );
   }
@@ -193,29 +187,12 @@ public class TextFileInputTest {
     data.filePlayList = new FilePlayListAll();
 
 
-    RowSet output = new BlockingRowSet( 5 );
-    executeStep( meta, data, output, 2 );
-
-    Object[] row1 = output.getRowImmediate();
-    assertRow( row1, "1", "1", "1" );
-
-    Object[] row2 = output.getRowImmediate();
-    assertRow( row2, "2", "1", "2" );
-
+    TextFileInput input = StepMockUtil.getStep( TextFileInput.class, TextFileInputMeta.class, "test" );
+    List<Object[]> output = TransTestingUtil.execute( input, meta, data, 2, false );
+    assertResult( new Object[] { "1", "1", "1" }, output.get( 0 ) );
+    assertResult( new Object[] { "2", "1", "2" }, output.get( 1 ) );
 
     deleteVfsFile( virtualFile );
-  }
-
-  private void executeStep( TextFileInputMeta meta, TextFileInputData data, RowSet output, int expectedRounds )
-    throws Exception {
-    TextFileInput input = StepMockUtil.getStep( TextFileInput.class, TextFileInputMeta.class, "test" );
-    input.setOutputRowSets( Collections.singletonList( output ) );
-    int i = 0;
-    while ( input.processRow( meta, data ) && i < expectedRounds ) {
-      i++;
-    }
-
-    assertEquals( "The amount of executions should be equal to expected", expectedRounds, i );
   }
 
   private static String createVirtualFile( String filename, String... rows ) throws Exception {
@@ -246,19 +223,5 @@ public class TextFileInputTest {
 
   private static TextFileInputField field( String name ) {
     return new TextFileInputField( name, -1, -1 );
-  }
-
-  private static void assertRow( Object[] row, Object... values ) {
-    assertNotNull( row );
-    assertTrue( String.format( "%d < %d", row.length, values.length ), row.length >= values.length );
-    int i = 0;
-    while ( i < values.length ) {
-      assertEquals( values[ i ], row[ i ] );
-      i++;
-    }
-    while ( i < row.length ) {
-      assertNull( row[ i ] );
-      i++;
-    }
   }
 }

--- a/engine/test-src/org/pentaho/test/util/FieldAccessor.java
+++ b/engine/test-src/org/pentaho/test/util/FieldAccessor.java
@@ -37,6 +37,8 @@ public class FieldAccessor {
   private static final boolean ValueMeta_EMPTY_STRING_AND_NULL_ARE_DIFFERENT =
       ValueMeta.EMPTY_STRING_AND_NULL_ARE_DIFFERENT;
 
+  private static final String EMPTY_AND_NULL_ARE_DIFF_FIELD = "EMPTY_STRING_AND_NULL_ARE_DIFFERENT";
+
   public static void ensureBooleanStaticFieldVal( Field f, boolean newValue ) throws NoSuchFieldException,
     SecurityException, IllegalArgumentException, IllegalAccessException {
     boolean value = f.getBoolean( null );
@@ -60,38 +62,31 @@ public class FieldAccessor {
       if ( modifiersBak != modifiersNew ) {
         modifiersField.setInt( f, modifiersBak );
         if ( !modifAccessibleBak ) {
-          modifiersField.setAccessible( modifAccessibleBak );
+          modifiersField.setAccessible( false );
         }
       }
       if ( !fieldAccessibleBak ) {
-        Field.setAccessible( new Field[] { f }, fieldAccessibleBak );
+        Field.setAccessible( new Field[] { f }, false );
       }
     }
   }
 
   public static void ensureEmptyStringIsNotNull( boolean newValue ) {
     try {
-      ensureBooleanStaticFieldVal( ValueMetaBase.class.getField( "EMPTY_STRING_AND_NULL_ARE_DIFFERENT" ), newValue );
-      ensureBooleanStaticFieldVal( ValueMeta.class.getField( "EMPTY_STRING_AND_NULL_ARE_DIFFERENT" ), newValue );
-    } catch ( NoSuchFieldException e ) {
-      throw new RuntimeException( e );
-    } catch ( SecurityException e ) {
-      throw new RuntimeException( e );
-    } catch ( IllegalArgumentException e ) {
-      throw new RuntimeException( e );
-    } catch ( IllegalAccessException e ) {
+      ensureBooleanStaticFieldVal( ValueMetaBase.class.getField( EMPTY_AND_NULL_ARE_DIFF_FIELD ), newValue );
+      ensureBooleanStaticFieldVal( ValueMeta.class.getField( EMPTY_AND_NULL_ARE_DIFF_FIELD ), newValue );
+    } catch ( Exception e ) {
       throw new RuntimeException( e );
     }
-    Assert.assertEquals( "ValueMetaBase.EMPTY_STRING_AND_NULL_ARE_DIFFERENT", newValue,
-        ValueMetaBase.EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
-    Assert.assertEquals( "ValueMeta.EMPTY_STRING_AND_NULL_ARE_DIFFERENT", newValue,
-        ValueMeta.EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
+
+    Assert.assertEquals( "ValueMetaBase", newValue, ValueMetaBase.EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
+    Assert.assertEquals( "ValueMeta", newValue, ValueMeta.EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
   }
 
   public static void resetEmptyStringIsNotNull() throws NoSuchFieldException, IllegalAccessException {
-    ensureBooleanStaticFieldVal( ValueMetaBase.class.getField( "EMPTY_STRING_AND_NULL_ARE_DIFFERENT" ),
+    ensureBooleanStaticFieldVal( ValueMetaBase.class.getField( EMPTY_AND_NULL_ARE_DIFF_FIELD ),
         ValueMetaBase_EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
-    ensureBooleanStaticFieldVal( ValueMeta.class.getField( "EMPTY_STRING_AND_NULL_ARE_DIFFERENT" ),
+    ensureBooleanStaticFieldVal( ValueMeta.class.getField( EMPTY_AND_NULL_ARE_DIFF_FIELD ),
         ValueMeta_EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
   }
 }

--- a/test/org/pentaho/di/trans/steps/datagrid/DataGridTest.java
+++ b/test/org/pentaho/di/trans/steps/datagrid/DataGridTest.java
@@ -23,6 +23,7 @@
 package org.pentaho.di.trans.steps.datagrid;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
@@ -32,7 +33,6 @@ import org.junit.Test;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
@@ -43,11 +43,8 @@ import org.pentaho.test.util.FieldAccessorUtl;
 
 public class DataGridTest {
 
-  private static final String FIELD_NAME_STR_1 = "f_str1";
-  private static final String FIELD_NAME_NUM_2 = "f_str2";
   private static final String FIELD_NAME_NUM_1 = "f_num1";
 
-  private static final String FIELD_TYPE_STRING = "String";
   private static final String FIELD_TYPE_NUMBER = "Number";
 
   private static final String STEP_NAME = "testDataGridStep";
@@ -60,188 +57,6 @@ public class DataGridTest {
   @After
   public void after() throws KettleException, NoSuchFieldException, IllegalAccessException {
     FieldAccessorUtl.resetEmptyStringIsNotNull();
-  }
-
-  @Test
-  public void test_emptyStringIsNotNull() throws KettleException {
-    FieldAccessorUtl.ensureEmptyStringIsNotNull( true );
-
-    final DataGridMeta meta = new DataGridMeta();
-
-    String[] fieldNames = new String[] { FIELD_NAME_STR_1, FIELD_NAME_NUM_2, FIELD_NAME_NUM_1 };
-    final String[] fieldTypes = new String[] { FIELD_TYPE_STRING, FIELD_TYPE_STRING, FIELD_TYPE_NUMBER };
-    String[] fieldFormats = new String[] { null, null, null };
-    String[] currencies = new String[] { null, null, null };
-    String[] decimals = new String[] { null, null, null };
-    String[] groups = new String[] { null, null, null };
-    int[] fieldLengths = new int[] { -1, -1, -1 };
-    int[] fieldPrecisions = new int[] { -1, -1, -1 };
-    boolean[] setEmptyStrings = new boolean[] { false, true, false };
-
-    final int fieldsCount = fieldNames.length;
-    Assert.assertEquals( "(test data) fieldTypes.length", fieldsCount, fieldTypes.length );
-    Assert.assertEquals( "(test data) fieldFormats.length", fieldsCount, fieldFormats.length );
-    Assert.assertEquals( "(test data) currencies.length", fieldsCount, currencies.length );
-    Assert.assertEquals( "(test data) decimals.length", fieldsCount, decimals.length );
-    Assert.assertEquals( "(test data) groups.length", fieldsCount, groups.length );
-    Assert.assertEquals( "(test data) fieldLengths.length", fieldsCount, fieldLengths.length );
-    Assert.assertEquals( "(test data) fieldPrecisions.length", fieldsCount, fieldPrecisions.length );
-    Assert.assertEquals( "(test data) setEmptyStrings.length", fieldsCount, setEmptyStrings.length );
-    final String[][] dataRows = new String[][] { //
-        new String[] { "1", "2", "3" }, //
-          new String[] { "a", "b", "34" }, //
-          new String[] { " ", "  ", " " }, //
-          new String[] { "", "", "" }, //
-          new String[] { null, null, null } //
-        };
-    final int rowCount = dataRows.length;
-    assertSize( "(test data) dataRows", rowCount, fieldsCount, dataRows );
-
-    meta.setFieldName( fieldNames );
-    meta.setFieldType( fieldTypes );
-    meta.setFieldFormat( fieldFormats );
-    meta.setCurrency( currencies );
-    meta.setDecimal( decimals );
-    meta.setGroup( groups );
-    meta.setFieldLength( fieldLengths );
-    meta.setFieldPrecision( fieldPrecisions );
-    meta.setEmptyString( setEmptyStrings );
-
-    final String[] expectedFieldNames = fieldNames;
-
-    final int[] expectedFieldTypes =
-        new int[] { ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_NUMBER };
-
-    final int expectedRowCount = rowCount;
-    final int expectedFieldsCount = fieldsCount;
-    Assert.assertEquals( "(test data) expectedFieldNames.length", expectedFieldsCount, expectedFieldNames.length );
-    Assert.assertEquals( "(test data) expectedFieldTypes.length", expectedFieldsCount, expectedFieldTypes.length );
-    Assert.assertEquals( "(test data) expectedFieldTypes.length", expectedFieldsCount, expectedFieldTypes.length );
-    Object[][] expectedRows = new Object[][] { //
-        new Object[] { "1", "", 3.0 }, //
-          new Object[] { "a", "", 34.0 }, //
-          new Object[] { "", "", null }, //
-          new Object[] { "", "", null }, //
-          new Object[] { null, "", null } //
-        };
-    assertSize( "(test data) expectedRows", expectedRowCount, expectedFieldsCount, expectedRows );
-
-    meta.setDataLines( buildListListString( dataRows ) );
-    {
-      final TransMeta transMeta = TransTestFactory.generateTestTransformation( null, meta, STEP_NAME );
-      final List<RowMetaAndData> inputList =
-          java.util.Collections.singletonList( new RowMetaAndData( new RowMeta(), new Object[0] ) );
-
-      List<RowMetaAndData> ret =
-          TransTestFactory.executeTestTransformation( transMeta, TransTestFactory.INJECTOR_STEPNAME, STEP_NAME,
-              TransTestFactory.DUMMY_STEPNAME, inputList );
-
-      assertResultRows( "empty input data", expectedRows, expectedFieldNames, expectedFieldTypes, ret );
-    }
-    {
-      final TransMeta transMeta = TransTestFactory.generateTestTransformation( null, meta, STEP_NAME );
-      final RowMetaInterface inputRowMeta = buildRowMeta( new ValueMetaString( "ff" ) );
-      final Object[] inputRowData = new Object[] { "asdf" };
-      final List<RowMetaAndData> inputList =
-          java.util.Collections.singletonList( new RowMetaAndData( inputRowMeta, inputRowData ) );
-
-      List<RowMetaAndData> ret =
-          TransTestFactory.executeTestTransformation( transMeta, TransTestFactory.INJECTOR_STEPNAME, STEP_NAME,
-              TransTestFactory.DUMMY_STEPNAME, inputList );
-
-      assertResultRows( "not empty input data", expectedRows, expectedFieldNames, expectedFieldTypes, ret );
-    }
-  }
-
-  @Test
-  public void test_emptyStringIsNull() throws KettleException {
-    FieldAccessorUtl.ensureEmptyStringIsNotNull( false );
-
-    final DataGridMeta meta = new DataGridMeta();
-
-    String[] fieldNames = new String[] { FIELD_NAME_STR_1, FIELD_NAME_NUM_2, FIELD_NAME_NUM_1 };
-    final String[] fieldTypes = new String[] { FIELD_TYPE_STRING, FIELD_TYPE_STRING, FIELD_TYPE_NUMBER };
-    String[] fieldFormats = new String[] { null, null, null };
-    String[] currencies = new String[] { null, null, null };
-    String[] decimals = new String[] { null, null, null };
-    String[] groups = new String[] { null, null, null };
-    int[] fieldLengths = new int[] { -1, -1, -1 };
-    int[] fieldPrecisions = new int[] { -1, -1, -1 };
-    boolean[] setEmptyStrings = new boolean[] { false, true, false };
-
-    final int fieldsCount = fieldNames.length;
-    Assert.assertEquals( "(test data) fieldTypes.length", fieldsCount, fieldTypes.length );
-    Assert.assertEquals( "(test data) fieldFormats.length", fieldsCount, fieldFormats.length );
-    Assert.assertEquals( "(test data) currencies.length", fieldsCount, currencies.length );
-    Assert.assertEquals( "(test data) decimals.length", fieldsCount, decimals.length );
-    Assert.assertEquals( "(test data) groups.length", fieldsCount, groups.length );
-    Assert.assertEquals( "(test data) fieldLengths.length", fieldsCount, fieldLengths.length );
-    Assert.assertEquals( "(test data) fieldPrecisions.length", fieldsCount, fieldPrecisions.length );
-    Assert.assertEquals( "(test data) setEmptyStrings.length", fieldsCount, setEmptyStrings.length );
-    final String[][] dataRows = new String[][] { //
-        new String[] { "1", "2", "3" }, //
-          new String[] { "a", "b", "34" }, //
-          new String[] { " ", "  ", " " }, //
-          new String[] { "", "", "" }, //
-          new String[] { null, null, null } //
-        };
-    final int rowCount = dataRows.length;
-    assertSize( "(test data) dataRows", rowCount, fieldsCount, dataRows );
-
-    meta.setFieldName( fieldNames );
-    meta.setFieldType( fieldTypes );
-    meta.setFieldFormat( fieldFormats );
-    meta.setCurrency( currencies );
-    meta.setDecimal( decimals );
-    meta.setGroup( groups );
-    meta.setFieldLength( fieldLengths );
-    meta.setFieldPrecision( fieldPrecisions );
-    meta.setEmptyString( setEmptyStrings );
-
-    final String[] expectedFieldNames = fieldNames;
-
-    final int[] expectedFieldTypes =
-        new int[] { ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_NUMBER };
-
-    final int expectedRowCount = rowCount;
-    final int expectedFieldsCount = fieldsCount;
-    Assert.assertEquals( "(test data) expectedFieldNames.length", expectedFieldsCount, expectedFieldNames.length );
-    Assert.assertEquals( "(test data) expectedFieldTypes.length", expectedFieldsCount, expectedFieldTypes.length );
-    Assert.assertEquals( "(test data) expectedFieldTypes.length", expectedFieldsCount, expectedFieldTypes.length );
-    Object[][] expectedRows = new Object[][] { //
-        new Object[] { "1", "", 3.0 }, //
-          new Object[] { "a", "", 34.0 }, //
-          new Object[] { "", "", null }, //
-          new Object[] { "", "", null }, //
-          new Object[] { null, "", null } //
-        };
-    assertSize( "(test data) expectedRows", expectedRowCount, expectedFieldsCount, expectedRows );
-
-    meta.setDataLines( buildListListString( dataRows ) );
-    {
-      final TransMeta transMeta = TransTestFactory.generateTestTransformation( null, meta, STEP_NAME );
-      final List<RowMetaAndData> inputList =
-          java.util.Collections.singletonList( new RowMetaAndData( new RowMeta(), new Object[0] ) );
-
-      List<RowMetaAndData> ret =
-          TransTestFactory.executeTestTransformation( transMeta, TransTestFactory.INJECTOR_STEPNAME, STEP_NAME,
-              TransTestFactory.DUMMY_STEPNAME, inputList );
-
-      assertResultRows( "empty input data", expectedRows, expectedFieldNames, expectedFieldTypes, ret );
-    }
-    {
-      final TransMeta transMeta = TransTestFactory.generateTestTransformation( null, meta, STEP_NAME );
-      final RowMetaInterface inputRowMeta = buildRowMeta( new ValueMetaString( "ff" ) );
-      final Object[] inputRowData = new Object[] { "asdf" };
-      final List<RowMetaAndData> inputList =
-          java.util.Collections.singletonList( new RowMetaAndData( inputRowMeta, inputRowData ) );
-
-      List<RowMetaAndData> ret =
-          TransTestFactory.executeTestTransformation( transMeta, TransTestFactory.INJECTOR_STEPNAME, STEP_NAME,
-              TransTestFactory.DUMMY_STEPNAME, inputList );
-
-      assertResultRows( "not empty input data", expectedRows, expectedFieldNames, expectedFieldTypes, ret );
-    }
   }
 
   @Test
@@ -270,9 +85,9 @@ public class DataGridTest {
     Assert.assertEquals( "(test data) fieldPrecisions.length", fieldsCount, fieldPrecisions.length );
     Assert.assertEquals( "(test data) setEmptyStrings.length", fieldsCount, setEmptyStrings.length );
     final String[][] dataRows = new String[][] { //
-        new String[] { "a" }, //
-          new String[] { "1" } //
-        };
+      new String[] { "a" }, //
+      new String[] { "1" } //
+    };
     final int rowCount = dataRows.length;
     assertSize( "(test data) dataRows", rowCount, fieldsCount, dataRows );
 
@@ -290,12 +105,11 @@ public class DataGridTest {
     {
       final TransMeta transMeta = TransTestFactory.generateTestTransformation( null, meta, STEP_NAME );
       final List<RowMetaAndData> inputList =
-          java.util.Collections.singletonList( new RowMetaAndData( new RowMeta(), new Object[0] ) );
+        java.util.Collections.singletonList( new RowMetaAndData( new RowMeta(), new Object[ 0 ] ) );
 
       try {
-        List<RowMetaAndData> ret =
-            TransTestFactory.executeTestTransformation( transMeta, TransTestFactory.INJECTOR_STEPNAME, STEP_NAME,
-                TransTestFactory.DUMMY_STEPNAME, inputList );
+        TransTestFactory.executeTestTransformation( transMeta, TransTestFactory.INJECTOR_STEPNAME, STEP_NAME,
+          TransTestFactory.DUMMY_STEPNAME, inputList );
         Assert.fail( "empty input data. KettleException expected" );
       } catch ( KettleException e ) {
         // NOP: Ok
@@ -306,12 +120,11 @@ public class DataGridTest {
       final RowMetaInterface inputRowMeta = buildRowMeta( new ValueMetaString( "ff" ) );
       final Object[] inputRowData = new Object[] { "asdf" };
       final List<RowMetaAndData> inputList =
-          java.util.Collections.singletonList( new RowMetaAndData( inputRowMeta, inputRowData ) );
+        java.util.Collections.singletonList( new RowMetaAndData( inputRowMeta, inputRowData ) );
 
       try {
-        List<RowMetaAndData> ret =
-            TransTestFactory.executeTestTransformation( transMeta, TransTestFactory.INJECTOR_STEPNAME, STEP_NAME,
-                TransTestFactory.DUMMY_STEPNAME, inputList );
+        TransTestFactory.executeTestTransformation( transMeta, TransTestFactory.INJECTOR_STEPNAME, STEP_NAME,
+          TransTestFactory.DUMMY_STEPNAME, inputList );
         Assert.fail( "not empty input data. KettleException expected" );
       } catch ( KettleException e ) {
         // NOP: Ok
@@ -320,84 +133,11 @@ public class DataGridTest {
     }
   }
 
-  /**
-   * 
-   * @param expectedRows
-   * @param expectedFieldNames
-   * @param expectedFieldTypes
-   * @param ret
-   * @throws KettleValueException
-   */
-  private void assertResultRows( final String msg, final Object[][] expectedRows, final String[] expectedFieldNames,
-      final int[] expectedFieldTypes, List<RowMetaAndData> ret ) throws KettleValueException {
-
-    Assert.assertNotNull( msg + ". So we have some results", ret );
-
-    final int expectedRowCount = expectedRows.length;
-    Assert.assertEquals( msg + ". We have one result row", expectedRowCount, ret.size() );
-
-    if ( expectedRowCount > 0 ) {
-      Assert.assertNotNull( msg + ". expectedRows[0]", expectedRows[0] );
-      final int expectedFieldsCount = expectedRows[0].length;
-      for ( int iRow = 0; iRow < expectedRowCount; iRow++ ) {
-        RowMetaAndData rmd = ret.get( iRow );
-
-        Assert.assertEquals( msg + ". Result row includes input plus result columns[" + iRow + "]",
-            expectedFieldsCount, rmd.size() );
-        for ( int iField = 0, nFields = expectedFieldsCount; iField < nFields; iField++ ) {
-
-          final Object expectedResult = expectedRows[iRow][iField];
-          ValueMetaInterface resultValueMeta = rmd.getValueMeta( iField );
-
-          Assert.assertNotNull( resultValueMeta );
-          Assert.assertEquals( msg + ". resultName[" + iRow + "][" + iField + "]", expectedFieldNames[iField],
-              resultValueMeta.getName() );
-          Assert.assertEquals( msg + ". resultType[" + iRow + "][" + iField + "]", expectedFieldTypes[iField],
-              resultValueMeta.getType() );
-
-          switch ( expectedFieldTypes[iField] ) {
-            case ValueMetaInterface.TYPE_STRING:
-              Assert.assertEquals( msg + ". expectedResult[" + iRow + "][" + iField + "].0", expectedResult, rmd
-                  .getString( iField, null ) );
-              Assert.assertEquals( msg + ". expectedResult[" + iRow + "][" + iField + "].1", expectedResult, rmd
-                  .getString( expectedFieldNames[iField], null ) );
-              break;
-            case ValueMetaInterface.TYPE_NUMBER:
-              if ( expectedResult != null ) {
-                final double defaulValue =
-                    ( expectedResult instanceof Number && ( (Number) expectedResult ).doubleValue() == 0.0 ) ? 1.0
-                        : 0.0;
-
-                Assert.assertEquals( msg + ". expectedResult[" + iRow + "][" + iField + "].00", expectedResult, rmd
-                    .getNumber( iField, defaulValue ) );
-                Assert.assertEquals( msg + ". expectedResult[" + iRow + "][" + iField + "].10", expectedResult, rmd
-                    .getNumber( expectedFieldNames[iField], defaulValue ) );
-
-              } else {
-                Assert.assertEquals( msg + ". expectedResult[" + iRow + "][" + iField + "].00", 0.0, rmd.getNumber(
-                    iField, 0.0 ), 0.0 );
-                Assert.assertEquals( msg + ". expectedResult[" + iRow + "][" + iField + "].01", 1.0, rmd.getNumber(
-                    iField, 1.0 ), 0.0 );
-
-                Assert.assertEquals( msg + ". expectedResult[" + iRow + "][" + iField + "].10", 0.0, rmd.getNumber(
-                    expectedFieldNames[iField], 0.0 ), 0.0 );
-                Assert.assertEquals( msg + ". expectedResult[" + iRow + "][" + iField + "].11", 1.0, rmd.getNumber(
-                    expectedFieldNames[iField], 0.1 ), 1.0 );
-              }
-              break;
-            default:
-              Assert.fail( "unpredicted Field type: " + expectedFieldTypes[iField] );
-          }
-        }
-      }
-    }
-  }
-
   private void assertSize( String msg, int expectedRowCount, int expectedFieldsCount, Object[][] rows ) {
     Assert.assertNotNull( msg + ". rows", rows );
     Assert.assertEquals( msg + ". rows.length", expectedRowCount, rows.length );
     for ( int i = 0, n = rows.length; i < n; i++ ) {
-      final Object[] row = rows[i];
+      final Object[] row = rows[ i ];
       Assert.assertNotNull( msg + ". row[" + i + "]", row );
       Assert.assertEquals( msg + ". row[" + i + "].length", expectedFieldsCount, row.length );
     }
@@ -412,25 +152,20 @@ public class DataGridTest {
     for ( String[] rowValues : gridvalues ) {
       final int colCount = rowValues.length;
       List<String> row = new ArrayList<String>( colCount );
-      if ( rowValues != null ) {
-        for ( String colValue : rowValues ) {
-          row.add( colValue );
-        }
-      }
+      Collections.addAll( row, rowValues );
       list.add( row );
     }
     return list;
   }
 
   /**
-   * 
    * @param valueMetaInterfaces
    * @return
    */
   private static RowMetaInterface buildRowMeta( ValueMetaInterface... valueMetaInterfaces ) {
     RowMetaInterface rm = new RowMeta();
     for ( int i = 0; i < valueMetaInterfaces.length; i++ ) {
-      rm.addValueMeta( valueMetaInterfaces[i] );
+      rm.addValueMeta( valueMetaInterfaces[ i ] );
     }
     return rm;
   }

--- a/ui/src/org/pentaho/di/ui/core/dialog/EditRowsDialog.java
+++ b/ui/src/org/pentaho/di/ui/core/dialog/EditRowsDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,6 +25,7 @@ package org.pentaho.di.ui.core.dialog;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ShellAdapter;
 import org.eclipse.swt.events.ShellEvent;
@@ -324,7 +325,8 @@ public class EditRowsDialog {
 
   }
 
-  private Object[] getRowForData( TableItem item, int rowNr ) throws KettleException {
+  @VisibleForTesting
+  Object[] getRowForData( TableItem item, int rowNr ) throws KettleException {
     try {
       Object[] row = RowDataUtil.allocateRowData( rowMeta.size() );
       for ( int i = 0; i < rowMeta.size(); i++ ) {
@@ -332,10 +334,13 @@ public class EditRowsDialog {
         ValueMetaInterface stringValueMeta = stringRowMeta.getValueMeta( i );
 
         int colnr = i + 1;
-        if ( GUIResource.getInstance().getColorBlue().equals( item.getForeground( colnr ) ) ) {
+        if ( isDisplayingNullValue( item, colnr ) ) {
           row[i] = null; // <null> value
         } else {
           String string = item.getText( colnr );
+          if ( stringValueMeta.isNull( string ) ) {
+            string = null;
+          }
           row[i] = valueMeta.convertDataFromString( string, stringValueMeta,
             null, null, ValueMetaInterface.TRIM_TYPE_NONE );
         }
@@ -345,6 +350,11 @@ public class EditRowsDialog {
       throw new KettleException( BaseMessages.getString( PKG, "EditRowsDialog.Error.ErrorGettingRowForData",
         Integer.toString( rowNr ) ), e );
     }
+  }
+
+  @VisibleForTesting
+  boolean isDisplayingNullValue( TableItem item, int column ) throws KettleException {
+    return GUIResource.getInstance().getColorBlue().equals( item.getForeground( column ) );
   }
 
   private void ok() {
@@ -418,5 +428,16 @@ public class EditRowsDialog {
 
   public void setVMax( int m ) {
     vmax = m;
+  }
+
+
+  @VisibleForTesting
+  void setRowMeta( RowMetaInterface rowMeta ) {
+    this.rowMeta = rowMeta;
+  }
+
+  @VisibleForTesting
+  void setStringRowMeta( RowMetaInterface stringRowMeta ) {
+    this.stringRowMeta = stringRowMeta;
   }
 }

--- a/ui/test-src/org/pentaho/di/ui/core/dialog/EditRowsDialog_EmptyStringVsNull_Test.java
+++ b/ui/test-src/org/pentaho/di/ui/core/dialog/EditRowsDialog_EmptyStringVsNull_Test.java
@@ -1,0 +1,97 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.core.dialog;
+
+import org.eclipse.swt.widgets.TableItem;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.trans.TransTestingUtil;
+import org.pentaho.test.util.FieldAccessor;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class EditRowsDialog_EmptyStringVsNull_Test {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+
+  @Test
+  public void emptyAndNullsAreNotDifferent() throws Exception {
+    doTestEmptyStringVsNull( false, "", null, null );
+  }
+
+
+  @Test
+  public void emptyAndNullsAreDifferent() throws Exception {
+    doTestEmptyStringVsNull( true, "", "", null );
+  }
+
+
+  private void doTestEmptyStringVsNull( boolean diffProperty, String... expected ) throws Exception {
+    FieldAccessor.ensureEmptyStringIsNotNull( diffProperty );
+    try {
+      executeAndAssertResults( expected );
+    } finally {
+      FieldAccessor.resetEmptyStringIsNotNull();
+    }
+  }
+
+  private void executeAndAssertResults( String[] expected ) throws Exception {
+    EditRowsDialog dialog = mock( EditRowsDialog.class );
+
+    when( dialog.getRowForData( any( TableItem.class ), anyInt() ) ).thenCallRealMethod();
+    doCallRealMethod().when( dialog ).setRowMeta( any( RowMetaInterface.class ) );
+    doCallRealMethod().when( dialog ).setStringRowMeta( any( RowMetaInterface.class ) );
+
+    when( dialog.isDisplayingNullValue( any( TableItem.class ), anyInt() ) ).thenReturn( false );
+
+    RowMeta meta = new RowMeta();
+    meta.addValueMeta( new ValueMetaString( "s1" ) );
+    meta.addValueMeta( new ValueMetaString( "s2" ) );
+    meta.addValueMeta( new ValueMetaString( "s3" ) );
+    dialog.setRowMeta( meta );
+    dialog.setStringRowMeta( meta );
+
+    TableItem item = mock( TableItem.class );
+    when( item.getText( 1 ) ).thenReturn( " " );
+    when( item.getText( 2 ) ).thenReturn( "" );
+    when( item.getText( 3 ) ).thenReturn( null );
+
+    Object[] data = dialog.getRowForData( item, 0 );
+    TransTestingUtil.assertResult( expected, data );
+  }
+}


### PR DESCRIPTION
@brosander, review it please.

I'll give you a context of the case. With PDI-11194, conversion rules were changed, and this caused regressions. Actually, the fix was correct, and it is legacy code, which does not handle all cases properly. Namely, it is not calling `isNull()` to get whether or not the given value is undefined; meanwhile it is possible to force Kettle not to distinguish empty strings and nulls, that's why we get troubles.

There was a discussion (see it on http://jira.pentaho.com/browse/PDI-14358), and the final resolution was: "we need to somehow improve conversion (see http://jira.pentaho.com/browse/PDI-14693), but for now the changes must be as local as possible -- not to cause any other differences in behaviour".

The list of affected classes is given on http://jira.pentaho.com/browse/PDI-13684?focusedCommentId=235753&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-235753.

So, here is my solution. It is quite clumsy, but it does not affect anything outside the list -- let's just explicitly check if the value is null, and set it to `null` manually. In that case, everything (seems to) works fine.

This PR contains changes for all items from the list except two. For TextFileInput, the same solution has been applied with https://github.com/pentaho/pentaho-kettle/pull/1737. For SwitchCase, it is needless, as the very next action after conversion is `isNull()` call, meaning all properties are handled correctly.

Let me know if you have any questions.