### PR TITLE
[SP-2389] Backport of PDI-14448 - Kitchen logging changes for Local and DI server execution (5.4 Suite)

### DIFF
--- a/core/src/org/pentaho/di/core/logging/LoggingRegistry.java
+++ b/core/src/org/pentaho/di/core/logging/LoggingRegistry.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/core/src/org/pentaho/di/core/logging/LoggingRegistry.java
+++ b/core/src/org/pentaho/di/core/logging/LoggingRegistry.java
@@ -70,8 +70,13 @@ public class LoggingRegistry {
         LoggingObjectInterface loggingSourceParent = loggingSource.getParent();
         if ( foundParent != null && loggingSourceParent != null ) {
           String foundParentLogChannelId = foundParent.getLogChannelId();
-          if ( foundParentLogChannelId != null && foundParentLogChannelId.equals( loggingSourceParent.getLogChannelId() ) ) {
-            return foundParentLogChannelId;
+          String sourceParentLogChannelId = loggingSourceParent.getLogChannelId();
+          if ( foundParentLogChannelId != null && sourceParentLogChannelId != null
+            && foundParentLogChannelId.equals( sourceParentLogChannelId ) ) {
+            String foundLogChannelId = found.getLogChannelId();
+            if ( foundLogChannelId != null ) {
+              return foundLogChannelId;
+            }
           }
         }
       }

--- a/core/test-src/org/pentaho/di/core/logging/LoggingRegistryTest.java
+++ b/core/test-src/org/pentaho/di/core/logging/LoggingRegistryTest.java
@@ -1,0 +1,51 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.logging;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class LoggingRegistryTest {
+  public static final String LOG_CHANEL_ID_PARENT = "parent-chanel-id";
+  public static final String LOG_CHANEL_ID_CHILD = "child-chanel-id";
+  public static final String STRING_DEFAULT = "<def>";
+
+  @Test
+  public void correctLogIdReturned_WhenLogObjectRegisteredAlready() {
+    LoggingRegistry loggingRegistry = LoggingRegistry.getInstance();
+
+    LoggingObject parent = new LoggingObject( new SimpleLoggingObject( "parent", LoggingObjectType.TRANS, null ) );
+    parent.setLogChannelId( LOG_CHANEL_ID_PARENT );
+
+    LoggingObject child = new LoggingObject( new SimpleLoggingObject( "child", LoggingObjectType.STEP, parent ) );
+    child.setLogChannelId( LOG_CHANEL_ID_CHILD );
+
+    loggingRegistry.getMap().put( STRING_DEFAULT, child );
+
+    String logChanelId = loggingRegistry.registerLoggingSource( child );
+
+    Assert.assertEquals( logChanelId, LOG_CHANEL_ID_CHILD );
+  }
+
+}


### PR DESCRIPTION
- If loggingSource duplicate found, check that original and found sources have the same parent and return logChanelId of the found source.
- Tests written
- Checkstyle applied

@pamval, @brosander, review it please, This is a backport of #1996