### PR TITLE
[SP-2385] Backport of PDI-14632 - When exporting transformations from a repository logging information is being inserted when the logging data does not exist (6.0 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/core/logging/BaseLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/BaseLogTable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-201 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/org/pentaho/di/core/logging/BaseLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/BaseLogTable.java
@@ -528,4 +528,24 @@ public abstract class BaseLogTable {
       && ( tName == null ? blt.getActualTableName() == null : tName.equals( blt.getActualTableName() ) ) );
   }
 
+
+  public void setAllGlobalParametersToNull() {
+    schemaName = isGlobalParameter( schemaName ) ? null : schemaName;
+    connectionName = isGlobalParameter( connectionName ) ? null : connectionName;
+    tableName = isGlobalParameter( tableName ) ? null : tableName;
+    timeoutInDays = isGlobalParameter( timeoutInDays ) ? null : timeoutInDays;
+  }
+
+  protected boolean isGlobalParameter( String parameter ) {
+    if ( parameter == null ) {
+      return false;
+    }
+
+    if ( parameter.startsWith( "${" ) && parameter.endsWith( "}" ) ) {
+      return System.getProperty( parameter.substring( 2, parameter.length() - 1 ) ) != null;
+    }
+
+    return false;
+  }
+
 }

--- a/engine/src/org/pentaho/di/core/logging/JobLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/JobLogTable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/org/pentaho/di/core/logging/JobLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/JobLogTable.java
@@ -447,4 +447,12 @@ public class JobLogTable extends BaseLogTable implements Cloneable, LogTableInte
 
     return indexes;
   }
+
+  @Override
+  public void setAllGlobalParametersToNull() {
+    super.setAllGlobalParametersToNull();
+
+    logInterval = isGlobalParameter( logInterval ) ? null : logInterval;
+    logSizeLimit = isGlobalParameter( logSizeLimit ) ? null : logSizeLimit;
+  }
 }

--- a/engine/src/org/pentaho/di/core/logging/PerformanceLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/PerformanceLogTable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/org/pentaho/di/core/logging/PerformanceLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/PerformanceLogTable.java
@@ -295,4 +295,10 @@ public class PerformanceLogTable extends BaseLogTable implements Cloneable, LogT
     return indexes;
   }
 
+  @Override
+  public void setAllGlobalParametersToNull()  {
+    super.setAllGlobalParametersToNull();
+
+    logInterval = isGlobalParameter( logInterval ) ? null : logInterval;
+  }
 }

--- a/engine/src/org/pentaho/di/core/logging/TransLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/TransLogTable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/org/pentaho/di/core/logging/TransLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/TransLogTable.java
@@ -508,4 +508,12 @@ public class TransLogTable extends BaseLogTable implements Cloneable, LogTableIn
 
     return indexes;
   }
+
+  @Override
+  public void setAllGlobalParametersToNull()  {
+    super.setAllGlobalParametersToNull();
+
+    logInterval = isGlobalParameter( logInterval ) ? null : logInterval;
+    logSizeLimit = isGlobalParameter( logSizeLimit ) ? null : logSizeLimit;
+  }
 }

--- a/engine/test-src/org/pentaho/di/core/logging/LogTableTest.java
+++ b/engine/test-src/org/pentaho/di/core/logging/LogTableTest.java
@@ -1,0 +1,105 @@
+package org.pentaho.di.core.logging;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.trans.HasDatabasesInterface;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class LogTableTest {
+  private static String PARAM_START_SYMBOL = "${";
+  private static String PARAM_END_SYMBOL = "}";
+  private static String GLOBAL_PARAM = PARAM_START_SYMBOL + Const.KETTLE_STEP_LOG_DB + PARAM_END_SYMBOL;
+  private static String USER_PARAM = PARAM_START_SYMBOL + "param-content" + PARAM_END_SYMBOL;
+  private static String HARDCODED_VALUE = "hardcoded";
+  private VariableSpace mockedVariableSpace;
+  private HasDatabasesInterface mockedHasDbInterface;
+
+  @Before
+  public void init() {
+    System.setProperty( Const.KETTLE_STEP_LOG_DB, "KETTLE_STEP_LOG_DB_VALUE" );
+    mockedVariableSpace = mock( VariableSpace.class );
+    mockedHasDbInterface = mock( HasDatabasesInterface.class );
+  }
+  @Test
+  public void hardcodedFieldsNotChanged() {
+    tableFieldsChangedCorrectlyAfterNullingGlobalParams( HARDCODED_VALUE, HARDCODED_VALUE );
+  }
+
+  @Test
+  public void userParamsFieldsNotChanged() {
+    tableFieldsChangedCorrectlyAfterNullingGlobalParams( USER_PARAM, USER_PARAM );
+  }
+
+  @Test
+  public void globalParamsFieldsAreNulled() {
+    tableFieldsChangedCorrectlyAfterNullingGlobalParams( GLOBAL_PARAM, null );
+  }
+
+
+
+  public void tableFieldsChangedCorrectlyAfterNullingGlobalParams( String valueForAllFields,
+                                                                   String expectedAfterNullingGlobalParams ) {
+
+    PerformanceLogTable performanceLogTable = getPerformanceLogTableWithAllEqFields( valueForAllFields );
+    performanceLogTable.setAllGlobalParametersToNull();
+    commonTableFieldsValueChecker( performanceLogTable, expectedAfterNullingGlobalParams );
+    assertEquals( performanceLogTable.getLogInterval(), expectedAfterNullingGlobalParams );
+
+    JobLogTable jobLogTable = getJobLogTableWithAllEqFields( valueForAllFields );
+    jobLogTable.setAllGlobalParametersToNull();
+    commonTableFieldsValueChecker( jobLogTable, expectedAfterNullingGlobalParams );
+    assertEquals( jobLogTable.getLogInterval(), expectedAfterNullingGlobalParams );
+    assertEquals( jobLogTable.getLogSizeLimit(), expectedAfterNullingGlobalParams );
+
+    TransLogTable transLogTable = getTransLogTableWithAllEqFields( valueForAllFields );
+    transLogTable.setAllGlobalParametersToNull();
+    commonTableFieldsValueChecker( transLogTable, expectedAfterNullingGlobalParams );
+    assertEquals( transLogTable.getLogInterval(), expectedAfterNullingGlobalParams );
+    assertEquals( transLogTable.getLogSizeLimit(), expectedAfterNullingGlobalParams );
+  }
+
+  private PerformanceLogTable getPerformanceLogTableWithAllEqFields( String fieldsValue ) {
+    PerformanceLogTable performanceLogTable =
+      PerformanceLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    initCommonTableFields( performanceLogTable, fieldsValue );
+    performanceLogTable.setLogInterval( fieldsValue );
+
+    return performanceLogTable;
+  }
+
+  private JobLogTable getJobLogTableWithAllEqFields( String fieldsValue ) {
+    JobLogTable jobLogTable = JobLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    initCommonTableFields( jobLogTable, fieldsValue  );
+    jobLogTable.setLogSizeLimit( fieldsValue );
+    jobLogTable.setLogInterval( fieldsValue );
+
+    return jobLogTable;
+  }
+
+  private TransLogTable getTransLogTableWithAllEqFields( String fieldsValue ) {
+    TransLogTable transLogTable = TransLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface, null );
+    initCommonTableFields( transLogTable, fieldsValue );
+    transLogTable.setLogInterval( fieldsValue );
+    transLogTable.setLogSizeLimit( fieldsValue );
+
+    return transLogTable;
+  }
+
+  private void initCommonTableFields( BaseLogTable logTable, String value ) {
+    logTable.setTableName( value );
+    logTable.setConnectionName( value );
+    logTable.setSchemaName( value );
+    logTable.setTimeoutInDays( value );
+  }
+
+  private void commonTableFieldsValueChecker( BaseLogTable logTable, String expectedForAllFields ) {
+    assertEquals( logTable.getTableName(), expectedForAllFields );
+    assertEquals( logTable.getConnectionName(), expectedForAllFields );
+    assertEquals( logTable.getSchemaName(), expectedForAllFields );
+    assertEquals( logTable.getTimeoutInDays(), expectedForAllFields );
+  }
+}

--- a/engine/test-src/org/pentaho/di/core/logging/LogTableTest.java
+++ b/engine/test-src/org/pentaho/di/core/logging/LogTableTest.java
@@ -1,13 +1,35 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.di.core.logging;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.trans.HasDatabasesInterface;
 
-import static junit.framework.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 public class LogTableTest {
   private static String PARAM_START_SYMBOL = "${";
@@ -21,8 +43,8 @@ public class LogTableTest {
   @Before
   public void init() {
     System.setProperty( Const.KETTLE_STEP_LOG_DB, "KETTLE_STEP_LOG_DB_VALUE" );
-    mockedVariableSpace = mock( VariableSpace.class );
-    mockedHasDbInterface = mock( HasDatabasesInterface.class );
+    mockedVariableSpace = Mockito.mock( VariableSpace.class );
+    mockedHasDbInterface = Mockito.mock( HasDatabasesInterface.class );
   }
   @Test
   public void hardcodedFieldsNotChanged() {
@@ -47,19 +69,19 @@ public class LogTableTest {
     PerformanceLogTable performanceLogTable = getPerformanceLogTableWithAllEqFields( valueForAllFields );
     performanceLogTable.setAllGlobalParametersToNull();
     commonTableFieldsValueChecker( performanceLogTable, expectedAfterNullingGlobalParams );
-    assertEquals( performanceLogTable.getLogInterval(), expectedAfterNullingGlobalParams );
+    Assert.assertEquals( performanceLogTable.getLogInterval(), expectedAfterNullingGlobalParams );
 
     JobLogTable jobLogTable = getJobLogTableWithAllEqFields( valueForAllFields );
     jobLogTable.setAllGlobalParametersToNull();
     commonTableFieldsValueChecker( jobLogTable, expectedAfterNullingGlobalParams );
-    assertEquals( jobLogTable.getLogInterval(), expectedAfterNullingGlobalParams );
-    assertEquals( jobLogTable.getLogSizeLimit(), expectedAfterNullingGlobalParams );
+    Assert.assertEquals( jobLogTable.getLogInterval(), expectedAfterNullingGlobalParams );
+    Assert.assertEquals( jobLogTable.getLogSizeLimit(), expectedAfterNullingGlobalParams );
 
     TransLogTable transLogTable = getTransLogTableWithAllEqFields( valueForAllFields );
     transLogTable.setAllGlobalParametersToNull();
     commonTableFieldsValueChecker( transLogTable, expectedAfterNullingGlobalParams );
-    assertEquals( transLogTable.getLogInterval(), expectedAfterNullingGlobalParams );
-    assertEquals( transLogTable.getLogSizeLimit(), expectedAfterNullingGlobalParams );
+    Assert.assertEquals( transLogTable.getLogInterval(), expectedAfterNullingGlobalParams );
+    Assert.assertEquals( transLogTable.getLogSizeLimit(), expectedAfterNullingGlobalParams );
   }
 
   private PerformanceLogTable getPerformanceLogTableWithAllEqFields( String fieldsValue ) {
@@ -97,9 +119,9 @@ public class LogTableTest {
   }
 
   private void commonTableFieldsValueChecker( BaseLogTable logTable, String expectedForAllFields ) {
-    assertEquals( logTable.getTableName(), expectedForAllFields );
-    assertEquals( logTable.getConnectionName(), expectedForAllFields );
-    assertEquals( logTable.getSchemaName(), expectedForAllFields );
-    assertEquals( logTable.getTimeoutInDays(), expectedForAllFields );
+    Assert.assertEquals( logTable.getTableName(), expectedForAllFields );
+    Assert.assertEquals( logTable.getConnectionName(), expectedForAllFields );
+    Assert.assertEquals( logTable.getSchemaName(), expectedForAllFields );
+    Assert.assertEquals( logTable.getTimeoutInDays(), expectedForAllFields );
   }
 }

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryExporter.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryExporter.java
@@ -29,7 +29,9 @@ import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.BaseLogTable;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.logging.LogTableInterface;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -218,6 +220,7 @@ public class PurRepositoryExporter implements IRepositoryExporter, java.io.Seria
       Iterator<RepositoryFile> filesIter = files.iterator();
       while ( ( monitor == null || !monitor.isCanceled() ) && transMetasIter.hasNext() ) {
         TransMeta trans = transMetasIter.next();
+        setGlobalVariablesOfLogTablesNull( trans.getLogTables() );
         RepositoryFile file = filesIter.next();
         try {
           // Validate against the import rules first!
@@ -250,6 +253,14 @@ public class PurRepositoryExporter implements IRepositoryExporter, java.io.Seria
     return shouldExport;
   }
 
+  protected void setGlobalVariablesOfLogTablesNull( List<LogTableInterface> logTables ) {
+    for ( LogTableInterface logTable : logTables ) {
+      if ( logTable instanceof BaseLogTable ) {
+        ( (BaseLogTable) logTable ).setAllGlobalParametersToNull();
+      }
+    }
+  }
+
   private class JobBatchExporter implements RepositoryFileBatchExporter {
     public String getFriendlyTypeName() {
       return "jobs"; //$NON-NLS-1$
@@ -266,6 +277,7 @@ public class PurRepositoryExporter implements IRepositoryExporter, java.io.Seria
       Iterator<RepositoryFile> filesIter = files.iterator();
       while ( ( monitor == null || !monitor.isCanceled() ) && jobsMeta.hasNext() ) {
         JobMeta meta = jobsMeta.next();
+        setGlobalVariablesOfLogTablesNull( meta.getLogTables() );
         RepositoryFile file = filesIter.next();
         try {
           // Validate against the import rules first!

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryExporter.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryExporter.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryUnitTest.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryUnitTest.java
@@ -17,6 +17,7 @@
 
 package org.pentaho.di.repository.pur;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -24,15 +25,35 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.JobEntryLogTable;
+import org.pentaho.di.core.logging.LogTableInterface;
+import org.pentaho.di.core.logging.StepLogTable;
+import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.RepositoryObjectType;
+import org.pentaho.di.trans.HasDatabasesInterface;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileTree;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class PurRepositoryUnitTest {
+  private VariableSpace mockedVariableSpace;
+  private HasDatabasesInterface mockedHasDbInterface;
+
+  @Before
+  public void init() {
+    System.setProperty( Const.KETTLE_TRANS_LOG_TABLE, "KETTLE_STEP_LOG_DB_VALUE" );
+    mockedVariableSpace = mock( VariableSpace.class );
+    mockedHasDbInterface = mock( HasDatabasesInterface.class );
+  }
+
   @Test
   public void testGetObjectInformationGetsAclByFileId() throws KettleException {
     PurRepository purRepository = new PurRepository();
@@ -62,5 +83,37 @@ public class PurRepositoryUnitTest {
     purRepository.connect( "TEST_USER", "TEST_PASSWORD" );
     purRepository.getObjectInformation( objectId, repositoryObjectType );
     verify( mockRepo ).getAcl( testFileId );
+  }
+
+  @Test
+  public void onlyGlobalVariablesOfLogTablesSetToNull() {
+    PurRepositoryExporter purRepoExporter = new PurRepositoryExporter( mock( PurRepository.class ) );
+    String hardcodedString = "hardcoded";
+    String globalParam = "${" + Const.KETTLE_TRANS_LOG_TABLE + "}";
+
+    StepLogTable stepLogTable = StepLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    stepLogTable.setConnectionName( hardcodedString );
+    stepLogTable.setSchemaName( hardcodedString );
+    stepLogTable.setTimeoutInDays( hardcodedString );
+    stepLogTable.setTableName( globalParam );
+
+    JobEntryLogTable jobEntryLogTable = JobEntryLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    jobEntryLogTable.setConnectionName( hardcodedString );
+    jobEntryLogTable.setSchemaName( hardcodedString );
+    jobEntryLogTable.setTimeoutInDays( hardcodedString );
+    jobEntryLogTable.setTableName( globalParam );
+
+    List<LogTableInterface> logTables = new ArrayList<>();
+    logTables.add( jobEntryLogTable );
+    logTables.add( stepLogTable );
+
+    purRepoExporter.setGlobalVariablesOfLogTablesNull( logTables );
+
+    for ( LogTableInterface logTable : logTables ) {
+      assertEquals( logTable.getConnectionName(), hardcodedString );
+      assertEquals( logTable.getSchemaName(), hardcodedString );
+      assertEquals( logTable.getTimeoutInDays(), hardcodedString );
+      assertEquals( logTable.getTableName(), null );
+    }
   }
 }

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryUnitTest.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryUnitTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,16 +17,10 @@
 
 package org.pentaho.di.repository.pur;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.JobEntryLogTable;
@@ -50,44 +44,44 @@ public class PurRepositoryUnitTest {
   @Before
   public void init() {
     System.setProperty( Const.KETTLE_TRANS_LOG_TABLE, "KETTLE_STEP_LOG_DB_VALUE" );
-    mockedVariableSpace = mock( VariableSpace.class );
-    mockedHasDbInterface = mock( HasDatabasesInterface.class );
+    mockedVariableSpace = Mockito.mock( VariableSpace.class );
+    mockedHasDbInterface = Mockito.mock( HasDatabasesInterface.class );
   }
 
   @Test
   public void testGetObjectInformationGetsAclByFileId() throws KettleException {
     PurRepository purRepository = new PurRepository();
-    IUnifiedRepository mockRepo = mock( IUnifiedRepository.class );
-    RepositoryConnectResult result = mock( RepositoryConnectResult.class );
-    when( result.getUnifiedRepository() ).thenReturn( mockRepo );
-    IRepositoryConnector connector = mock( IRepositoryConnector.class );
-    when( connector.connect( anyString(), anyString() ) ).thenReturn( result );
-    PurRepositoryMeta mockMeta = mock( PurRepositoryMeta.class );
+    IUnifiedRepository mockRepo = Mockito.mock( IUnifiedRepository.class );
+    RepositoryConnectResult result = Mockito.mock( RepositoryConnectResult.class );
+    Mockito.when( result.getUnifiedRepository() ).thenReturn( mockRepo );
+    IRepositoryConnector connector = Mockito.mock( IRepositoryConnector.class );
+    Mockito.when( connector.connect( Mockito.anyString(), Mockito.anyString() ) ).thenReturn( result );
+    PurRepositoryMeta mockMeta = Mockito.mock( PurRepositoryMeta.class );
     purRepository.init( mockMeta );
     purRepository.setPurRepositoryConnector( connector );
     // purRepository.setTest( mockRepo );
-    ObjectId objectId = mock( ObjectId.class );
-    RepositoryFile mockFile = mock( RepositoryFile.class );
-    RepositoryFile mockRootFolder = mock( RepositoryFile.class );
+    ObjectId objectId = Mockito.mock( ObjectId.class );
+    RepositoryFile mockFile = Mockito.mock( RepositoryFile.class );
+    RepositoryFile mockRootFolder = Mockito.mock( RepositoryFile.class );
     RepositoryObjectType repositoryObjectType = RepositoryObjectType.TRANSFORMATION;
-    RepositoryFileTree mockRepositoryTree = mock( RepositoryFileTree.class );
+    RepositoryFileTree mockRepositoryTree = Mockito.mock( RepositoryFileTree.class );
     String testId = "TEST_ID";
     String testFileId = "TEST_FILE_ID";
-    when( objectId.getId() ).thenReturn( testId );
-    when( mockRepo.getFileById( testId ) ).thenReturn( mockFile );
-    when( mockFile.getPath() ).thenReturn( "/home/testuser/path.ktr" );
-    when( mockFile.getId() ).thenReturn( testFileId );
-    when( mockRepo.getTree( anyString(), anyInt(), anyString(), anyBoolean() ) ).thenReturn( mockRepositoryTree );
-    when( mockRepositoryTree.getFile() ).thenReturn( mockRootFolder );
-    when( mockRootFolder.getId() ).thenReturn( "/" );
+    Mockito.when( objectId.getId() ).thenReturn( testId );
+    Mockito.when( mockRepo.getFileById( testId ) ).thenReturn( mockFile );
+    Mockito.when( mockFile.getPath() ).thenReturn( "/home/testuser/path.ktr" );
+    Mockito.when( mockFile.getId() ).thenReturn( testFileId );
+    Mockito.when( mockRepo.getTree( Mockito.anyString(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean() ) ).thenReturn( mockRepositoryTree );
+    Mockito.when( mockRepositoryTree.getFile() ).thenReturn( mockRootFolder );
+    Mockito.when( mockRootFolder.getId() ).thenReturn( "/" );
     purRepository.connect( "TEST_USER", "TEST_PASSWORD" );
     purRepository.getObjectInformation( objectId, repositoryObjectType );
-    verify( mockRepo ).getAcl( testFileId );
+    Mockito.verify( mockRepo ).getAcl( testFileId );
   }
 
   @Test
   public void onlyGlobalVariablesOfLogTablesSetToNull() {
-    PurRepositoryExporter purRepoExporter = new PurRepositoryExporter( mock( PurRepository.class ) );
+    PurRepositoryExporter purRepoExporter = new PurRepositoryExporter( Mockito.mock( PurRepository.class ) );
     String hardcodedString = "hardcoded";
     String globalParam = "${" + Const.KETTLE_TRANS_LOG_TABLE + "}";
 
@@ -110,10 +104,10 @@ public class PurRepositoryUnitTest {
     purRepoExporter.setGlobalVariablesOfLogTablesNull( logTables );
 
     for ( LogTableInterface logTable : logTables ) {
-      assertEquals( logTable.getConnectionName(), hardcodedString );
-      assertEquals( logTable.getSchemaName(), hardcodedString );
-      assertEquals( logTable.getTimeoutInDays(), hardcodedString );
-      assertEquals( logTable.getTableName(), null );
+      Assert.assertEquals( logTable.getConnectionName(), hardcodedString );
+      Assert.assertEquals( logTable.getSchemaName(), hardcodedString );
+      Assert.assertEquals( logTable.getTimeoutInDays(), hardcodedString );
+      Assert.assertEquals( logTable.getTableName(), null );
     }
   }
 }

--- a/ui/src/org/pentaho/di/core/XmlExportHelper.java
+++ b/ui/src/org/pentaho/di/core/XmlExportHelper.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/ui/src/org/pentaho/di/core/XmlExportHelper.java
+++ b/ui/src/org/pentaho/di/core/XmlExportHelper.java
@@ -1,0 +1,133 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core;
+
+import org.pentaho.di.core.logging.BaseLogTable;
+import org.pentaho.di.core.logging.ChannelLogTable;
+import org.pentaho.di.core.logging.JobEntryLogTable;
+import org.pentaho.di.core.logging.JobLogTable;
+import org.pentaho.di.core.logging.LogTableInterface;
+import org.pentaho.di.core.logging.MetricsLogTable;
+import org.pentaho.di.core.logging.PerformanceLogTable;
+import org.pentaho.di.core.logging.StepLogTable;
+import org.pentaho.di.core.logging.TransLogTable;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.trans.TransMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class that filterers information, before export of meta.
+ *
+ * @author IvanNikolaychuk
+ */
+public class XmlExportHelper {
+
+  /**
+   * When exporting meta we should not export user global parameters.
+   * Method makes clone for each table and deletes all global parameters.
+   * We have to make clones of each table, because we don't want to change real tables content.
+   *
+   * @param transMeta
+   *              meta, that contains log tables to be refactored before export
+   */
+  public static void swapTables( TransMeta transMeta ) {
+    TransLogTable transLogTable = transMeta.getTransLogTable();
+    if ( transLogTable != null ) {
+      TransLogTable cloneTransLogTable = (TransLogTable) transLogTable.clone();
+      cloneTransLogTable.setAllGlobalParametersToNull();
+      transMeta.setTransLogTable( cloneTransLogTable );
+    }
+
+    StepLogTable stepLogTable = transMeta.getStepLogTable();
+    if ( stepLogTable != null ) {
+      StepLogTable cloneStepLogTable = (StepLogTable) stepLogTable.clone();
+      cloneStepLogTable.setAllGlobalParametersToNull();
+      transMeta.setStepLogTable( cloneStepLogTable );
+    }
+
+    PerformanceLogTable performanceLogTable = transMeta.getPerformanceLogTable();
+    if ( performanceLogTable != null ) {
+      PerformanceLogTable clonePerformanceLogTable = (PerformanceLogTable) performanceLogTable.clone();
+      clonePerformanceLogTable.setAllGlobalParametersToNull();
+      transMeta.setPerformanceLogTable( clonePerformanceLogTable );
+    }
+
+    ChannelLogTable channelLogTable = transMeta.getChannelLogTable();
+    if ( channelLogTable != null ) {
+      ChannelLogTable cloneChannelLogTable = (ChannelLogTable) channelLogTable.clone();
+      cloneChannelLogTable.setAllGlobalParametersToNull();
+      transMeta.setChannelLogTable( cloneChannelLogTable );
+    }
+
+    MetricsLogTable metricsLogTable = transMeta.getMetricsLogTable();
+    if ( metricsLogTable != null ) {
+      MetricsLogTable cloneMetricsLogTable = (MetricsLogTable) metricsLogTable.clone();
+      cloneMetricsLogTable.setAllGlobalParametersToNull();
+      transMeta.setMetricsLogTable( cloneMetricsLogTable );
+    }
+  }
+
+  /**
+   * @param jobMeta
+   *            contains log tables to be refactored before export
+   */
+  public static void swapTables( JobMeta jobMeta ) {
+    JobLogTable jobLogTable = jobMeta.getJobLogTable();
+    if ( jobLogTable != null ) {
+      JobLogTable cloneJobLogTable = (JobLogTable) jobLogTable.clone();
+      cloneJobLogTable.setAllGlobalParametersToNull();
+      jobMeta.setJobLogTable( cloneJobLogTable );
+    }
+
+    JobEntryLogTable jobEntryLogTable = jobMeta.getJobEntryLogTable();
+    if ( jobEntryLogTable != null ) {
+      JobEntryLogTable cloneEntryLogTable = (JobEntryLogTable) jobEntryLogTable.clone();
+      cloneEntryLogTable.setAllGlobalParametersToNull();
+      jobMeta.setJobEntryLogTable( cloneEntryLogTable );
+    }
+
+    ChannelLogTable channelLogTable = jobMeta.getChannelLogTable();
+    if ( channelLogTable != null ) {
+      ChannelLogTable cloneChannelLogTable = (ChannelLogTable) channelLogTable.clone();
+      cloneChannelLogTable.setAllGlobalParametersToNull();
+      jobMeta.setChannelLogTable( cloneChannelLogTable );
+    }
+
+    List<LogTableInterface> extraLogTables = jobMeta.getExtraLogTables();
+    if ( extraLogTables != null ) {
+      List<LogTableInterface> cloneExtraLogTables = new ArrayList<>();
+      for ( LogTableInterface logTable : extraLogTables ) {
+        if ( logTable instanceof BaseLogTable ) {
+          if ( logTable instanceof Cloneable ) {
+            BaseLogTable cloneExtraLogTable = (BaseLogTable) logTable.clone();
+            cloneExtraLogTable.setAllGlobalParametersToNull();
+            cloneExtraLogTables.add( (LogTableInterface) cloneExtraLogTable );
+          }
+        }
+      }
+      jobMeta.setExtraLogTables( cloneExtraLogTables );
+    }
+  }
+}

--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -436,7 +436,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
 
   // THE HANDLERS
   public SpoonDelegates delegates = new SpoonDelegates( this );
-  
+
   private SharedObjectSyncUtil sharedObjectSyncUtil = new SharedObjectSyncUtil( delegates );
 
   public RowMetaAndData variables = new RowMetaAndData( new RowMeta() );
@@ -702,7 +702,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       }
     }
   }
-  
+
   public Spoon() {
     this( null );
   }
@@ -1026,16 +1026,15 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       String beforeCloseId = null;
       String afterCloseId = null;
 
-      if( meta instanceof TransMeta ) {
+      if ( meta instanceof TransMeta ) {
         beforeCloseId = KettleExtensionPoint.TransBeforeClose.id;
         afterCloseId = KettleExtensionPoint.TransAfterClose.id;
-      }
-      else if( meta instanceof JobMeta ) {
+      } else if ( meta instanceof JobMeta ) {
         beforeCloseId = KettleExtensionPoint.JobBeforeClose.id;
         afterCloseId = KettleExtensionPoint.JobAfterClose.id;
       }
 
-      if( beforeCloseId != null ) {
+      if ( beforeCloseId != null ) {
         try {
           ExtensionPointHandler.callExtensionPoint( log, beforeCloseId, meta );
         } catch ( KettleException e ) {
@@ -1046,7 +1045,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       // If a transformation or job is the current active tab, close it
       closed = tabCloseSelected();
 
-      if( closed && ( afterCloseId != null ) ) {
+      if ( closed && ( afterCloseId != null ) ) {
         try {
           ExtensionPointHandler.callExtensionPoint( log, afterCloseId, meta );
         } catch ( KettleException e ) {
@@ -2316,14 +2315,14 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         } );
         for ( PluginInterface p : sortedCat ) {
           final Image stepImage =
-              GUIResource.getInstance().getImagesStepsSmall().get( p.getIds()[ 0 ] );
-            String pluginName = p.getName();
-            String pluginDescription = p.getDescription();
-            if ( !filterMatch( pluginName ) && !filterMatch( pluginDescription ) ) {
-              continue;
-            }
-            createTreeItem( item, pluginName, stepImage );
-            coreStepToolTipMap.put( pluginName, pluginDescription );
+            GUIResource.getInstance().getImagesStepsSmall().get( p.getIds()[ 0 ] );
+          String pluginName = p.getName();
+          String pluginDescription = p.getDescription();
+          if ( !filterMatch( pluginName ) && !filterMatch( pluginDescription ) ) {
+            continue;
+          }
+          createTreeItem( item, pluginName, stepImage );
+          coreStepToolTipMap.put( pluginName, pluginDescription );
         }
       }
 
@@ -3138,7 +3137,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       sharedObjectSyncUtil.synchronizeSlaveServers( slaveServer );
     }
   }
-  
+
   private AbstractMeta getActiveAbstractMeta() {
     AbstractMeta abstractMeta = getActiveTransformation();
     if ( abstractMeta == null ) {
@@ -4258,7 +4257,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
           if ( RepositoryObjectType.TRANSFORMATION.equals( type ) ) {
             TransLoadProgressDialog tlpd = null;
             // prioritize loading file by id
-            if( objId != null && !Const.isEmpty( objId.getId() ) ) {
+            if ( objId != null && !Const.isEmpty( objId.getId() ) ) {
               tlpd = new TransLoadProgressDialog( shell, rep, objId, null ); // Load by id
             } else {
               tlpd = new TransLoadProgressDialog( shell, rep, name, repDir, null ); // Load by name/path
@@ -4287,7 +4286,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
             // Load a job
             JobLoadProgressDialog jlpd = null;
             // prioritize loading file by id
-            if( objId != null && !Const.isEmpty( objId.getId() ) ) {
+            if ( objId != null && !Const.isEmpty( objId.getId() ) ) {
               jlpd = new JobLoadProgressDialog( shell, rep, objId, null ); // Loads
             } else {
               jlpd = new JobLoadProgressDialog( shell, rep, name, repDir, null ); // Loads
@@ -4945,7 +4944,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       // on windows [...].swt.ole.win32.OleClientSite.OnInPlaceDeactivate can
       // cause the focus to move to an already disposed tab, resulting in a NPE
       // so we first move the focus to somewhere else
-      if(this.selectionLabel != null && !this.selectionLabel.isDisposed()) {
+      if ( this.selectionLabel != null && !this.selectionLabel.isDisposed() ) {
         this.selectionLabel.forceFocus();
       }
 
@@ -5170,9 +5169,10 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
 
             boolean versioningEnabled = true;
             boolean versionCommentsEnabled = true;
-            String fullPath = meta.getRepositoryDirectory() + "/" + meta.getName() + meta.getRepositoryElementType().getExtension(); 
+            String fullPath =
+              meta.getRepositoryDirectory() + "/" + meta.getName() + meta.getRepositoryElementType().getExtension();
             RepositorySecurityProvider repositorySecurityProvider =
-                rep != null && rep.getSecurityProvider() != null ? rep.getSecurityProvider() : null;
+              rep != null && rep.getSecurityProvider() != null ? rep.getSecurityProvider() : null;
             if ( repositorySecurityProvider != null ) {
               versioningEnabled = repositorySecurityProvider.isVersioningEnabled( fullPath );
               versionCommentsEnabled = repositorySecurityProvider.allowsVersionComments( fullPath );
@@ -5616,7 +5616,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
 
     // Finally before importing, ask for a version comment (if applicable)
     //
-    String fullPath = baseDirectory.getPath() + "/foo.ktr"; 
+    String fullPath = baseDirectory.getPath() + "/foo.ktr";
     String versionComment = null;
     boolean versionOk = false;
     while ( !versionOk ) {
@@ -6952,18 +6952,17 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       }
 
       boolean changed = entry.getObject().hasContentChanged();
-      if( changed ) {
+      if ( changed ) {
         // Call extension point to alert plugins that a transformation or job has changed
         Object tabObject = entry.getObject().getManagedObject();
         String changedId = null;
-        if( tabObject instanceof TransMeta ) {
+        if ( tabObject instanceof TransMeta ) {
           changedId = KettleExtensionPoint.TransChanged.id;
-        }
-        else if( tabObject instanceof JobMeta ) {
+        } else if ( tabObject instanceof JobMeta ) {
           changedId = KettleExtensionPoint.JobChanged.id;
         }
 
-        if( changedId != null ) {
+        if ( changedId != null ) {
           try {
             ExtensionPointHandler.callExtensionPoint( log, changedId, tabObject );
           } catch ( KettleException e ) {
@@ -7201,7 +7200,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         filename = rep != null ? jobMeta.getName() : jobMeta.getFilename();
         directory = jobMeta.getRepositoryDirectory().toString();
         openType = LastUsedFile.OPENED_ITEM_TYPE_MASK_GRAPH;
-        entry.setObjectName( jobMeta.getName() );        
+        entry.setObjectName( jobMeta.getName() );
       }
 
       if ( fileType != null ) {
@@ -7297,7 +7296,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       if ( ta.getType() == TransAction.TYPE_ACTION_DELETE_HOP ) {
         setUndoMenu( undoInterface ); // something changed: change the menu
         ta = undoInterface.viewNextUndo();
-        if ( ta != null && ta.getType() == TransAction.TYPE_ACTION_DELETE_STEP) {
+        if ( ta != null && ta.getType() == TransAction.TYPE_ACTION_DELETE_STEP ) {
           ta = undoInterface.nextUndo();
           delegates.trans.redoTransformationAction( (TransMeta) undoInterface, ta );
         }
@@ -7309,13 +7308,13 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       if ( ta.getType() == TransAction.TYPE_ACTION_DELETE_JOB_HOP ) {
         setUndoMenu( undoInterface ); // something changed: change the menu
         ta = undoInterface.viewNextUndo();
-        if ( ta != null && ta.getType() == TransAction.TYPE_ACTION_DELETE_JOB_ENTRY) {
+        if ( ta != null && ta.getType() == TransAction.TYPE_ACTION_DELETE_JOB_ENTRY ) {
           ta = undoInterface.nextUndo();
           delegates.jobs.redoJobAction( (JobMeta) undoInterface, ta );
         }
       }
-    }    
-    
+    }
+
 
     // Put what we redo in focus
     if ( undoInterface instanceof TransMeta ) {
@@ -8613,7 +8612,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   public void deleteJobEntryCopies( JobMeta jobMeta, JobEntryCopy[] jobEntry ) {
     delegates.jobs.deleteJobEntryCopies( jobMeta, jobEntry );
   }
-  
+
   public void deleteJobEntryCopies( JobMeta jobMeta, JobEntryCopy jobEntry ) {
     delegates.jobs.deleteJobEntryCopies( jobMeta, jobEntry );
   }

--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -137,6 +137,7 @@ import org.pentaho.di.core.ObjectUsageCount;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.SourceToTargetMapping;
+import org.pentaho.di.core.XmlExportHelper;
 import org.pentaho.di.core.changed.ChangedFlagInterface;
 import org.pentaho.di.core.changed.PDIObserver;
 import org.pentaho.di.core.database.DatabaseMeta;
@@ -159,15 +160,23 @@ import org.pentaho.di.core.lifecycle.LifeEventHandler;
 import org.pentaho.di.core.lifecycle.LifeEventInfo;
 import org.pentaho.di.core.lifecycle.LifecycleException;
 import org.pentaho.di.core.lifecycle.LifecycleSupport;
+import org.pentaho.di.core.logging.ChannelLogTable;
 import org.pentaho.di.core.logging.DefaultLogLevel;
 import org.pentaho.di.core.logging.FileLoggingEventListener;
+import org.pentaho.di.core.logging.JobEntryLogTable;
+import org.pentaho.di.core.logging.JobLogTable;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.logging.LogTableInterface;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
 import org.pentaho.di.core.logging.LoggingObjectType;
+import org.pentaho.di.core.logging.MetricsLogTable;
+import org.pentaho.di.core.logging.PerformanceLogTable;
 import org.pentaho.di.core.logging.SimpleLoggingObject;
+import org.pentaho.di.core.logging.StepLogTable;
+import org.pentaho.di.core.logging.TransLogTable;
 import org.pentaho.di.core.parameters.NamedParams;
 import org.pentaho.di.core.plugins.JobEntryPluginType;
 import org.pentaho.di.core.plugins.LifecyclePluginType;
@@ -5642,15 +5651,52 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   public boolean saveXMLFile( boolean export ) {
     TransMeta transMeta = getActiveTransformation();
     if ( transMeta != null ) {
-      return saveXMLFile( transMeta, export );
+      return saveTransAsXmlFile( transMeta, export );
     }
 
     JobMeta jobMeta = getActiveJob();
     if ( jobMeta != null ) {
-      return saveXMLFile( jobMeta, export );
+      return saveJobAsXmlFile( jobMeta, export );
     }
 
     return false;
+  }
+
+  private boolean saveTransAsXmlFile( TransMeta transMeta, boolean export ) {
+    TransLogTable origTransLogTable = transMeta.getTransLogTable();
+    StepLogTable origStepLogTable = transMeta.getStepLogTable();
+    PerformanceLogTable origPerformanceLogTable = transMeta.getPerformanceLogTable();
+    ChannelLogTable origChannelLogTable = transMeta.getChannelLogTable();
+    MetricsLogTable origMetricsLogTable = transMeta.getMetricsLogTable();
+
+    try {
+      XmlExportHelper.swapTables( transMeta );
+      return saveXMLFile( transMeta, export );
+    } finally {
+      transMeta.setTransLogTable( origTransLogTable );
+      transMeta.setStepLogTable( origStepLogTable );
+      transMeta.setPerformanceLogTable( origPerformanceLogTable );
+      transMeta.setChannelLogTable( origChannelLogTable );
+      transMeta.setMetricsLogTable( origMetricsLogTable );
+    }
+  }
+
+
+  private boolean saveJobAsXmlFile( JobMeta jobMeta, boolean export ) {
+    JobLogTable origJobLogTable = jobMeta.getJobLogTable();
+    JobEntryLogTable originEntryLogTable = jobMeta.getJobEntryLogTable();
+    ChannelLogTable originChannelLogTable = jobMeta.getChannelLogTable();
+    List<LogTableInterface> originExtraLogTables = jobMeta.getExtraLogTables();
+
+    try {
+      XmlExportHelper.swapTables( jobMeta );
+      return saveXMLFile( jobMeta, export );
+    } finally {
+      jobMeta.setJobLogTable( origJobLogTable );
+      jobMeta.setJobEntryLogTable( originEntryLogTable );
+      jobMeta.setChannelLogTable( originChannelLogTable );
+      jobMeta.setExtraLogTables( originExtraLogTables );
+    }
   }
 
   public boolean saveXMLFile( EngineMetaInterface meta, boolean export ) {

--- a/ui/test-src/org/pentaho/di/ui/spoon/SpoonExportXmlTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/SpoonExportXmlTest.java
@@ -1,0 +1,159 @@
+package org.pentaho.di.ui.spoon;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.BaseLogTable;
+import org.pentaho.di.core.logging.ChannelLogTable;
+import org.pentaho.di.core.logging.JobEntryLogTable;
+import org.pentaho.di.core.logging.JobLogTable;
+import org.pentaho.di.core.logging.MetricsLogTable;
+import org.pentaho.di.core.logging.PerformanceLogTable;
+import org.pentaho.di.core.logging.StepLogTable;
+import org.pentaho.di.core.logging.TransLogTable;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.trans.HasDatabasesInterface;
+import org.pentaho.di.trans.TransMeta;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SpoonExportXmlTest {
+  private VariableSpace mockedVariableSpace;
+  private HasDatabasesInterface mockedHasDbInterface;
+  private static String PARAM_START_SYMBOL = "${";
+  private static String PARAM_END_SYMBOL = "}";
+  private static String GLOBAL_PARAM = PARAM_START_SYMBOL + Const.KETTLE_STEP_LOG_SCHEMA + PARAM_END_SYMBOL;
+  private static String USER_PARAM = PARAM_START_SYMBOL + "param-content" + PARAM_END_SYMBOL;
+  private static String HARDCODED_VALUE = "hardcoded";
+
+  private final Spoon spoon = mock( Spoon.class );
+
+  @Before
+  public void setUp() throws KettleException {
+    System.setProperty( Const.KETTLE_STEP_LOG_SCHEMA, "KETTLE_STEP_LOG_DB_VALUE" );
+    mockedVariableSpace = mock( VariableSpace.class );
+    mockedHasDbInterface = mock( HasDatabasesInterface.class );
+  }
+
+  @Test
+  public void savingTransToXmlNotChangesLogTables() {
+    TransMeta transMeta = new TransMeta();
+    initTables( transMeta );
+
+    TransLogTable originTransLogTable = transMeta.getTransLogTable();
+    StepLogTable originStepLogTable = transMeta.getStepLogTable();
+    PerformanceLogTable originPerformanceLogTable = transMeta.getPerformanceLogTable();
+    ChannelLogTable originChannelLogTable = transMeta.getChannelLogTable();
+    MetricsLogTable originMetricsLogTable = transMeta.getMetricsLogTable();
+
+    when( spoon.getActiveTransformation() ).thenReturn( transMeta );
+    when( spoon.saveXMLFile( any( TransMeta.class ), anyBoolean() ) ).thenReturn( true );
+    when( spoon.saveXMLFile( anyBoolean() ) ).thenCallRealMethod();
+
+    spoon.saveXMLFile( true );
+
+    tablesCommonValuesEqual( originTransLogTable, transMeta.getTransLogTable() );
+    assertEquals( originTransLogTable.getLogInterval(), transMeta.getTransLogTable().getLogInterval() );
+    assertEquals( originTransLogTable.getLogSizeLimit(), transMeta.getTransLogTable().getLogSizeLimit() );
+
+    tablesCommonValuesEqual( originStepLogTable, transMeta.getStepLogTable() );
+
+    tablesCommonValuesEqual( originPerformanceLogTable, transMeta.getPerformanceLogTable() );
+    assertEquals( originPerformanceLogTable.getLogInterval(), transMeta.getPerformanceLogTable().getLogInterval() );
+
+    tablesCommonValuesEqual( originChannelLogTable, transMeta.getChannelLogTable() );
+
+    tablesCommonValuesEqual( originMetricsLogTable, transMeta.getMetricsLogTable() );
+  }
+
+  @Test
+  public void savingJobToXmlNotChangesLogTables() {
+    JobMeta jobMeta = new JobMeta();
+    initTables( jobMeta );
+
+    JobLogTable originJobLogTable = jobMeta.getJobLogTable();
+    JobEntryLogTable originJobEntryLogTable = jobMeta.getJobEntryLogTable();
+    ChannelLogTable originChannelLogTable = jobMeta.getChannelLogTable();
+
+    when( spoon.getActiveTransformation() ).thenReturn( null );
+    when( spoon.getActiveJob() ).thenReturn( jobMeta );
+    when( spoon.saveXMLFile( any( JobMeta.class ), anyBoolean() ) ).thenReturn( true );
+    when( spoon.saveXMLFile( anyBoolean() ) ).thenCallRealMethod();
+    spoon.saveXMLFile( true );
+
+    tablesCommonValuesEqual( originJobLogTable, jobMeta.getJobLogTable() );
+    assertEquals( originJobLogTable.getLogInterval(), jobMeta.getJobLogTable().getLogInterval() );
+    assertEquals( originJobLogTable.getLogSizeLimit(), jobMeta.getJobLogTable().getLogSizeLimit() );
+
+    tablesCommonValuesEqual( originJobEntryLogTable, jobMeta.getJobEntryLogTable() );
+
+    tablesCommonValuesEqual( originChannelLogTable, jobMeta.getChannelLogTable() );
+  }
+
+
+  public void tablesCommonValuesEqual( BaseLogTable table1, BaseLogTable table2 ) {
+    assertEquals( table1.getConnectionName(), table2.getConnectionName() );
+    assertEquals( table1.getSchemaName(), table2.getSchemaName() );
+    assertEquals( table1.getTableName(), table2.getTableName() );
+    assertEquals( table1.getTimeoutInDays(), table2.getTimeoutInDays() );
+  }
+
+  private void initTables( TransMeta transMeta ) {
+    TransLogTable transLogTable = TransLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface, null );
+    initTableWithSampleParams( transLogTable );
+    transLogTable.setLogInterval( GLOBAL_PARAM );
+    transLogTable.setLogSizeLimit( GLOBAL_PARAM );
+    transMeta.setTransLogTable( transLogTable );
+
+    StepLogTable stepLogTable = StepLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    initTableWithSampleParams( stepLogTable );
+    transMeta.setStepLogTable( stepLogTable );
+
+    PerformanceLogTable performanceLogTable =
+      PerformanceLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    initTableWithSampleParams( performanceLogTable );
+    performanceLogTable.setLogInterval( GLOBAL_PARAM );
+    transMeta.setPerformanceLogTable( performanceLogTable );
+
+    ChannelLogTable channelLogTable = ChannelLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    initTableWithSampleParams( channelLogTable );
+    transMeta.setChannelLogTable( channelLogTable );
+
+    MetricsLogTable metricsLogTable = MetricsLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    initTableWithSampleParams( metricsLogTable );
+    transMeta.setMetricsLogTable( metricsLogTable );
+
+  }
+
+  private void initTables( JobMeta jobMeta ) {
+    JobLogTable jobLogTable = JobLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    initTableWithSampleParams( jobLogTable );
+    jobLogTable.setLogInterval( GLOBAL_PARAM );
+    jobLogTable.setLogSizeLimit( GLOBAL_PARAM );
+    jobMeta.setJobLogTable( jobLogTable );
+
+    JobEntryLogTable jobEntryLogTable = JobEntryLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    initTableWithSampleParams( jobEntryLogTable );
+    jobMeta.setJobEntryLogTable( jobEntryLogTable );
+
+    ChannelLogTable channelLogTable = ChannelLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+    initTableWithSampleParams( channelLogTable );
+    jobMeta.setChannelLogTable( channelLogTable );
+
+    jobMeta.setExtraLogTables( null );
+  }
+
+  private void initTableWithSampleParams( BaseLogTable table ) {
+    table.setTableName( GLOBAL_PARAM );
+    table.setSchemaName( HARDCODED_VALUE );
+    table.setConnectionName( HARDCODED_VALUE );
+    table.setTimeoutInDays( USER_PARAM );
+  }
+
+}

--- a/ui/test-src/org/pentaho/di/ui/spoon/SpoonExportXmlTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/SpoonExportXmlTest.java
@@ -1,7 +1,32 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.di.ui.spoon;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.BaseLogTable;
@@ -17,12 +42,6 @@ import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.trans.HasDatabasesInterface;
 import org.pentaho.di.trans.TransMeta;
 
-import static junit.framework.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public class SpoonExportXmlTest {
   private VariableSpace mockedVariableSpace;
   private HasDatabasesInterface mockedHasDbInterface;
@@ -32,13 +51,13 @@ public class SpoonExportXmlTest {
   private static String USER_PARAM = PARAM_START_SYMBOL + "param-content" + PARAM_END_SYMBOL;
   private static String HARDCODED_VALUE = "hardcoded";
 
-  private final Spoon spoon = mock( Spoon.class );
+  private final Spoon spoon = Mockito.mock( Spoon.class );
 
   @Before
   public void setUp() throws KettleException {
     System.setProperty( Const.KETTLE_STEP_LOG_SCHEMA, "KETTLE_STEP_LOG_DB_VALUE" );
-    mockedVariableSpace = mock( VariableSpace.class );
-    mockedHasDbInterface = mock( HasDatabasesInterface.class );
+    mockedVariableSpace = Mockito.mock( VariableSpace.class );
+    mockedHasDbInterface = Mockito.mock( HasDatabasesInterface.class );
   }
 
   @Test
@@ -52,20 +71,21 @@ public class SpoonExportXmlTest {
     ChannelLogTable originChannelLogTable = transMeta.getChannelLogTable();
     MetricsLogTable originMetricsLogTable = transMeta.getMetricsLogTable();
 
-    when( spoon.getActiveTransformation() ).thenReturn( transMeta );
-    when( spoon.saveXMLFile( any( TransMeta.class ), anyBoolean() ) ).thenReturn( true );
-    when( spoon.saveXMLFile( anyBoolean() ) ).thenCallRealMethod();
+    Mockito.when( spoon.getActiveTransformation() ).thenReturn( transMeta );
+    Mockito.when( spoon.saveXMLFile( Matchers.any( TransMeta.class ), Matchers.anyBoolean() ) ).thenReturn( true );
+    Mockito.when( spoon.saveXMLFile( Matchers.anyBoolean() ) ).thenCallRealMethod();
 
     spoon.saveXMLFile( true );
 
     tablesCommonValuesEqual( originTransLogTable, transMeta.getTransLogTable() );
-    assertEquals( originTransLogTable.getLogInterval(), transMeta.getTransLogTable().getLogInterval() );
-    assertEquals( originTransLogTable.getLogSizeLimit(), transMeta.getTransLogTable().getLogSizeLimit() );
+    Assert.assertEquals( originTransLogTable.getLogInterval(), transMeta.getTransLogTable().getLogInterval() );
+    Assert.assertEquals( originTransLogTable.getLogSizeLimit(), transMeta.getTransLogTable().getLogSizeLimit() );
 
     tablesCommonValuesEqual( originStepLogTable, transMeta.getStepLogTable() );
 
     tablesCommonValuesEqual( originPerformanceLogTable, transMeta.getPerformanceLogTable() );
-    assertEquals( originPerformanceLogTable.getLogInterval(), transMeta.getPerformanceLogTable().getLogInterval() );
+    Assert.assertEquals( originPerformanceLogTable.getLogInterval(),
+      transMeta.getPerformanceLogTable().getLogInterval() );
 
     tablesCommonValuesEqual( originChannelLogTable, transMeta.getChannelLogTable() );
 
@@ -81,15 +101,15 @@ public class SpoonExportXmlTest {
     JobEntryLogTable originJobEntryLogTable = jobMeta.getJobEntryLogTable();
     ChannelLogTable originChannelLogTable = jobMeta.getChannelLogTable();
 
-    when( spoon.getActiveTransformation() ).thenReturn( null );
-    when( spoon.getActiveJob() ).thenReturn( jobMeta );
-    when( spoon.saveXMLFile( any( JobMeta.class ), anyBoolean() ) ).thenReturn( true );
-    when( spoon.saveXMLFile( anyBoolean() ) ).thenCallRealMethod();
+    Mockito.when( spoon.getActiveTransformation() ).thenReturn( null );
+    Mockito.when( spoon.getActiveJob() ).thenReturn( jobMeta );
+    Mockito.when( spoon.saveXMLFile( Matchers.any( JobMeta.class ), Matchers.anyBoolean() ) ).thenReturn( true );
+    Mockito.when( spoon.saveXMLFile( Matchers.anyBoolean() ) ).thenCallRealMethod();
     spoon.saveXMLFile( true );
 
     tablesCommonValuesEqual( originJobLogTable, jobMeta.getJobLogTable() );
-    assertEquals( originJobLogTable.getLogInterval(), jobMeta.getJobLogTable().getLogInterval() );
-    assertEquals( originJobLogTable.getLogSizeLimit(), jobMeta.getJobLogTable().getLogSizeLimit() );
+    Assert.assertEquals( originJobLogTable.getLogInterval(), jobMeta.getJobLogTable().getLogInterval() );
+    Assert.assertEquals( originJobLogTable.getLogSizeLimit(), jobMeta.getJobLogTable().getLogSizeLimit() );
 
     tablesCommonValuesEqual( originJobEntryLogTable, jobMeta.getJobEntryLogTable() );
 
@@ -98,10 +118,10 @@ public class SpoonExportXmlTest {
 
 
   public void tablesCommonValuesEqual( BaseLogTable table1, BaseLogTable table2 ) {
-    assertEquals( table1.getConnectionName(), table2.getConnectionName() );
-    assertEquals( table1.getSchemaName(), table2.getSchemaName() );
-    assertEquals( table1.getTableName(), table2.getTableName() );
-    assertEquals( table1.getTimeoutInDays(), table2.getTimeoutInDays() );
+    Assert.assertEquals( table1.getConnectionName(), table2.getConnectionName() );
+    Assert.assertEquals( table1.getSchemaName(), table2.getSchemaName() );
+    Assert.assertEquals( table1.getTableName(), table2.getTableName() );
+    Assert.assertEquals( table1.getTimeoutInDays(), table2.getTimeoutInDays() );
   }
 
   private void initTables( TransMeta transMeta ) {


### PR DESCRIPTION
- Before exporting meta, setting to null all global variables in every field of meta log tables
- In case of exporting single meta (not a hole repository) storing tables, and setting their original values back after export
- Tests written
- Checkstyle applied


@pamval, @brosander, review it please, This is a backport of https://github.com/pentaho/pentaho-kettle/pull/1969