### PR TITLE
[PDI-14861] Add NULL_AS support to kettle-gpload-plugin

### DIFF
--- a/plugins/kettle-gpload-plugin/ivy.xml
+++ b/plugins/kettle-gpload-plugin/ivy.xml
@@ -21,13 +21,15 @@
     <dependency org="pentaho-kettle" name="kettle-engine" rev="${dependency.kettle.revision}" transitive="true" changing="true"/>
     <dependency org="pentaho-kettle" name="kettle-core" rev="${dependency.kettle.revision}" transitive="true" changing="true"/>
     <dependency org="pentaho-kettle" name="kettle-ui-swt" rev="${dependency.kettle.revision}" transitive="false" changing="true"/>
-      
+
     <dependency org="org.apache.commons" name="commons-vfs2" rev="2.1-20150824" transitive="false"/>
     <!-- SWT it required to compile any version of any architecture will work -->
     <dependency org="org.eclipse.swt" name="swt-linux-x86_64" rev="4.3.2" transitive="false"/>
     <dependency org="org.eclipse" name="jface" rev="3.3.0-I20070606-0010" transitive="false"/>
-    
-    <dependency org="junit" name="junit" rev="4.7" transitive="false" conf="test->default"/>            
-    
+
+    <!-- test dependencies -->
+    <dependency org="junit" name="junit" rev="4.11" conf="test->default"/>
+    <dependency org="pentaho-kettle" name="kettle-engine-test" rev="${dependency.kettle.revision}" changing="true" transitive="false" conf="test->default"/>
+
   </dependencies>
 </ivy-module>

--- a/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/GPLoad.java
+++ b/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/GPLoad.java
@@ -281,8 +281,12 @@ public class GPLoad extends BaseStep implements StepInterface {
     contents.append( GPLoad.INDENT ).append( "- FORMAT: TEXT" ).append( Const.CR );
     contents.append( GPLoad.INDENT ).append( "- DELIMITER: " ).append( GPLoad.SINGLE_QUOTE ).append( delimiter )
         .append( GPLoad.SINGLE_QUOTE ).append( Const.CR );
+//  if ( !Const.isEmpty( meta.getNullAs() ) ) {
+    if ( !Const.isEmpty( meta.getNullAs() ) ) {
+      contents.append( GPLoad.INDENT ).append( "- NULL_AS: " ).append( GPLoad.SINGLE_QUOTE ).append( meta.getNullAs() ).append( GPLoad.SINGLE_QUOTE ).append( Const.CR );
+    }
 
-    // TODO: implement escape character, null_as
+    // TODO: implement escape character
     // TODO: test what happens when a single quote is specified- can we specify a single quiote within doubole quotes
     // then?
     String enclosure = meta.getEnclosure();
@@ -389,7 +393,7 @@ public class GPLoad extends BaseStep implements StepInterface {
 
   /**
    * Create a control file.
-   * 
+   *
    * @param filename
    * @param meta
    * @throws KettleException

--- a/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/GPLoadMeta.java
+++ b/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/GPLoadMeta.java
@@ -87,6 +87,9 @@ public class GPLoadMeta extends BaseStepMeta implements StepMetaInterface {
   /** Path to the log file */
   private String logFile;
 
+  /** NULL_AS parameter for gpload - gpload treats values matching this string as null */
+  private String nullAs;
+
   /** database connection */
   private DatabaseMeta databaseMeta;
 
@@ -304,6 +307,7 @@ public class GPLoadMeta extends BaseStepMeta implements StepMetaInterface {
       dataFile = XMLHandler.getTagValue( stepnode, "data_file" );
       delimiter = XMLHandler.getTagValue( stepnode, "delimiter" );
       logFile = XMLHandler.getTagValue( stepnode, "log_file" );
+      nullAs = XMLHandler.getTagValue( stepnode, "null_as" );
       eraseFiles = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, "erase_files" ) );
       encoding = XMLHandler.getTagValue( stepnode, "encoding" );
       updateCondition = XMLHandler.getTagValue( stepnode, "update_condition" );
@@ -316,6 +320,8 @@ public class GPLoadMeta extends BaseStepMeta implements StepMetaInterface {
         localHosts[i] = XMLHandler.getNodeValue( localHostNode );
       }
       localhostPort = XMLHandler.getTagValue( stepnode, "localhost_port" );
+
+      encloseNumbers = XMLHandler.getTagValue( stepnode, "enclose_numbers" ).equalsIgnoreCase( "Y" );
 
       int nrvalues = XMLHandler.countNodes( stepnode, "mapping" );
       allocate( nrvalues );
@@ -365,6 +371,7 @@ public class GPLoadMeta extends BaseStepMeta implements StepMetaInterface {
     controlFile = "control${Internal.Step.CopyNr}.cfg";
     dataFile = "load${Internal.Step.CopyNr}.dat";
     logFile = "";
+    nullAs = "";
     encoding = "";
     delimiter = ",";
     encloseNumbers = false;
@@ -391,6 +398,7 @@ public class GPLoadMeta extends BaseStepMeta implements StepMetaInterface {
     retval.append( "    " ).append( XMLHandler.addTagValue( "data_file", dataFile ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "delimiter", delimiter ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "log_file", logFile ) );
+    retval.append( "    " ).append( XMLHandler.addTagValue( "null_as", nullAs ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "erase_files", eraseFiles ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "encoding", encoding ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "enclose_numbers", ( encloseNumbers ? "Y" : "N" ) ) );
@@ -431,6 +439,7 @@ public class GPLoadMeta extends BaseStepMeta implements StepMetaInterface {
       dataFile = rep.getStepAttributeString( id_step, "data_file" );
       delimiter = rep.getStepAttributeString( id_step, "delimiter" );
       logFile = rep.getStepAttributeString( id_step, "log_file" );
+      nullAs = rep.getStepAttributeString( id_step, "null_as" );
       eraseFiles = rep.getStepAttributeBoolean( id_step, "erase_files" );
       encoding = rep.getStepAttributeString( id_step, "encoding" );
       localhostPort = rep.getStepAttributeString( id_step, "localhost_port" );
@@ -475,6 +484,7 @@ public class GPLoadMeta extends BaseStepMeta implements StepMetaInterface {
       rep.saveStepAttribute( id_transformation, id_step, "data_file", dataFile );
       rep.saveStepAttribute( id_transformation, id_step, "delimiter", delimiter );
       rep.saveStepAttribute( id_transformation, id_step, "log_file", logFile );
+      rep.saveStepAttribute( id_transformation, id_step, "null_as", nullAs );
       rep.saveStepAttribute( id_transformation, id_step, "erase_files", eraseFiles );
       rep.saveStepAttribute( id_transformation, id_step, "encoding", encoding );
       rep.saveStepAttribute( id_transformation, id_step, "enclose_numbers", ( encloseNumbers ? "Y" : "N" ) );
@@ -795,6 +805,14 @@ public class GPLoadMeta extends BaseStepMeta implements StepMetaInterface {
 
   public void setLogFile( String logFile ) {
     this.logFile = logFile;
+  }
+
+  public String getNullAs() {
+    return nullAs;
+  }
+
+  public void setNullAs( String nullAs ) {
+    this.nullAs = nullAs;
   }
 
   public void setLoadAction( String action ) {

--- a/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/messages/messages_en_US.properties
+++ b/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/messages/messages_en_US.properties
@@ -73,6 +73,7 @@ GPLoadDialog.StepMeta.Title=GPLoad
 GPLoadMeta.Exception.UnableToReadStepInfoFromXML=Unable to read step information from XML
 GPLoadMeta.CheckResult.CouldNotReadTableInfo=Couldn''t read the table info, please check the table-name & permissions.
 GPLoadDialog.LogFile.Label=Log file\:
+GPLoadDialog.NullAs.Label=Null as\:
 GPLoadMeta.CheckResult.InvalidConnection=Please select or create a connection\!
 GPLoadMeta.Exception.ConnectionNotDefined=Unable to determine the required fields because the database connection wasn''t defined.
 GPLoadDialog.LoadMethod.Label=Load method

--- a/plugins/kettle-gpload-plugin/src/org/pentaho/di/ui/trans/steps/gpload/GPLoadDialog.java
+++ b/plugins/kettle-gpload-plugin/src/org/pentaho/di/ui/trans/steps/gpload/GPLoadDialog.java
@@ -106,6 +106,7 @@ public class GPLoadDialog extends BaseStepDialog implements StepDialogInterface 
   private TextVar wControlFile;
   private TextVar wDataFile;
   private TextVar wLogFile;
+  private TextVar wNullAs;
   private Combo wEncoding;
   private Button wEraseFiles;
   private GPLoadMeta input;
@@ -380,6 +381,7 @@ public class GPLoadDialog extends BaseStepDialog implements StepDialogInterface 
     wControlFile.addSelectionListener( lsDef );
     wDataFile.addSelectionListener( lsDef );
     wLogFile.addSelectionListener( lsDef );
+    wNullAs.addSelectionListener( lsDef );
 
     // Detect X or ALT-F4 or something that kills this window...
     shell.addShellListener( new ShellAdapter() {
@@ -667,6 +669,9 @@ public class GPLoadDialog extends BaseStepDialog implements StepDialogInterface 
     if ( input.getLogFile() != null ) {
       wLogFile.setText( input.getLogFile() );
     }
+    if ( input.getNullAs() != null ) {
+      wNullAs.setText( input.getNullAs() );
+    }
     if ( input.getEncoding() != null ) {
       wEncoding.setText( input.getEncoding() );
     }
@@ -764,6 +769,7 @@ public class GPLoadDialog extends BaseStepDialog implements StepDialogInterface 
     inf.setControlFile( wControlFile.getText() );
     inf.setDataFile( wDataFile.getText() );
     inf.setLogFile( wLogFile.getText() );
+    inf.setNullAs( wNullAs.getText() );
     inf.setEncoding( wEncoding.getText() );
     inf.setEraseFiles( wEraseFiles.getSelection() );
     inf.setLocalhostPort( wLocalhostPort.getText() );
@@ -1311,6 +1317,24 @@ public class GPLoadDialog extends BaseStepDialog implements StepDialogInterface 
     fdDelimiter.right = new FormAttachment( 100, 0 );
     wDelimiter.setLayoutData( fdDelimiter );
 
+    // NULL_AS parameter
+    Label wlNullAs = new Label( wGPConfigTabComp, SWT.RIGHT );
+    wlNullAs.setText( BaseMessages.getString( PKG, "GPLoadDialog.NullAs.Label" ) );
+    props.setLook( wlNullAs );
+    FormData fdlNullAs = new FormData();
+    fdlNullAs.left = new FormAttachment( 0, 0 );
+    fdlNullAs.top = new FormAttachment( wDataFile, margin );
+    fdlNullAs.right = new FormAttachment( middle, -margin );
+    wlNullAs.setLayoutData( fdlNullAs );
+
+    wNullAs = new TextVar( transMeta, wGPConfigTabComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    props.setLook( wNullAs );
+    wNullAs.addModifyListener( lsMod );
+    FormData fdNullAs = new FormData();
+    fdNullAs.left = new FormAttachment( middle, 0 );
+    fdNullAs.top = new FormAttachment( wDataFile, margin );
+    wNullAs.setLayoutData( fdNullAs );
+
     // Control encoding line
     //
     // The drop down is editable as it may happen an encoding may not be
@@ -1321,7 +1345,7 @@ public class GPLoadDialog extends BaseStepDialog implements StepDialogInterface 
     props.setLook( wlEncoding );
     FormData fdlEncoding = new FormData();
     fdlEncoding.left = new FormAttachment( 0, 0 );
-    fdlEncoding.top = new FormAttachment( wDataFile, margin );
+    fdlEncoding.top = new FormAttachment( wNullAs, margin );
     fdlEncoding.right = new FormAttachment( middle, -margin );
     wlEncoding.setLayoutData( fdlEncoding );
 
@@ -1331,7 +1355,7 @@ public class GPLoadDialog extends BaseStepDialog implements StepDialogInterface 
     props.setLook( wEncoding );
     FormData fdEncoding = new FormData();
     fdEncoding.left = new FormAttachment( middle, 0 );
-    fdEncoding.top = new FormAttachment( wDataFile, margin );
+    fdEncoding.top = new FormAttachment( wNullAs, margin );
     fdEncoding.right = new FormAttachment( 75, 0 );
     wEncoding.setLayoutData( fdEncoding );
     wEncoding.addModifyListener( lsMod );

--- a/plugins/kettle-gpload-plugin/test-src/org/pentaho/di/trans/steps/gpload/GPLoadMetaTest.java
+++ b/plugins/kettle-gpload-plugin/test-src/org/pentaho/di/trans/steps/gpload/GPLoadMetaTest.java
@@ -1,0 +1,107 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.gpload;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
+
+import org.pentaho.di.trans.steps.loadsave.validator.*;
+
+public class GPLoadMetaTest {
+  @Test
+  public void testRoundTrip() throws KettleException {
+    List<String> attributes =
+        Arrays.asList( "localHosts", "localhostPort", "schemaName", "tableName", "errorTableName", "gploadPath", "controlFile", "dataFile",
+            "logFile", "nullAs", "databaseMeta", "fieldTable", "fieldStream", "matchColumn", "updateColumn", "dateMask", "maxErrors",
+            "loadMethod", "loadAction", "encoding", "eraseFiles", "encloseNumbers", "delimiter", "updateCondition" );
+
+    Map<String, String> getterMap = new HashMap<>();
+    Map<String, String> setterMap = new HashMap<>();
+
+    for ( String attribute : attributes ) {
+
+      // Most attributes can be set by convention apart from isEraseFiles (is, not get) and setMatchColumns (pluralised)
+
+      if ( attribute.equals( "eraseFiles" ) ) {
+        getterMap.put( "eraseFiles", "isEraseFiles" );
+      } else {
+        getterMap.put( attribute, "get" + attribute.substring( 0, 1 ).toUpperCase() + attribute.substring( 1 ) );
+      }
+
+      if ( attribute.equals( "matchColumn" ) ) {
+        setterMap.put( "matchColumn", "setMatchColumns" );
+      } else {
+        setterMap.put( attribute, "set" + attribute.substring( 0, 1 ).toUpperCase() + attribute.substring( 1 ) );
+      }
+
+    }
+
+    Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorAttributeMap = new HashMap<>();
+    Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorTypeMap = new HashMap<>();
+
+    fieldLoadSaveValidatorAttributeMap.put( "dateMask", new ArrayLoadSaveValidator<>( new DateMaskLoadSaveValidator(), 10 ) );
+    fieldLoadSaveValidatorTypeMap.put( DatabaseMeta.class.getCanonicalName(), new DatabaseMetaFieldLoadSaveValidator() );
+    fieldLoadSaveValidatorTypeMap.put( String[].class.getCanonicalName(), new ArrayLoadSaveValidator<>( new StringLoadSaveValidator(), 10 ) );
+    fieldLoadSaveValidatorTypeMap.put( boolean[].class.getCanonicalName(), new PrimitiveBooleanArrayLoadSaveValidator( new BooleanLoadSaveValidator(), 10 ) );
+
+    LoadSaveTester loadSaveTester = new LoadSaveTester( GPLoadMeta.class, attributes, getterMap, setterMap,
+        fieldLoadSaveValidatorAttributeMap, fieldLoadSaveValidatorTypeMap );
+
+    loadSaveTester.testRepoRoundTrip();
+    loadSaveTester.testXmlRoundTrip();
+  }
+
+  public class DatabaseMetaFieldLoadSaveValidator implements
+      FieldLoadSaveValidator<DatabaseMeta> {
+    @Override
+    public DatabaseMeta getTestObject() {
+      return null;
+    }
+
+    @Override
+    public boolean validateTestObject( DatabaseMeta testObject, Object actual ) {
+      return testObject == null;
+    }
+  }
+
+  public class DateMaskLoadSaveValidator implements FieldLoadSaveValidator<String> {
+    public DateMaskLoadSaveValidator() {
+    }
+
+    public String getTestObject() {
+      return Math.random() < 0.5 ? GPLoadMeta.DATE_MASK_DATE : GPLoadMeta.DATE_MASK_DATETIME;
+    }
+
+    public boolean validateTestObject( String test, Object actual ) {
+      return test.equals( actual );
+    }
+  }
+
+}


### PR DESCRIPTION
This allows a known value in an import file to be treated as NULL when data is
imported - this has some bearing on http://jira.pentaho.com/browse/PDI-8457 although that may need more work for a full resolution - this PR just adds support for the NULL_AS option, not the ESCAPE option