### PR TITLE
[SP-2405] - Backport of PDI-14823 - Using week in year date format with "Select values" step (5.4 Suite)

### DIFF
--- a/core/src/org/pentaho/di/core/util/EnvUtil.java
+++ b/core/src/org/pentaho/di/core/util/EnvUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -281,7 +281,7 @@ public class EnvUtil {
    */
   public static Locale createLocale( String localeCode ) {
     Locale resultLocale = null;
-    if ( localeCode != null ) {
+    if ( !Const.isEmpty( localeCode ) ) {
       StringTokenizer parser = new StringTokenizer( localeCode, "_" );
       if ( parser.countTokens() == 2 ) {
         resultLocale = new Locale( parser.nextToken(), parser.nextToken() );

--- a/core/test-src/org/pentaho/di/core/util/EnvUtilTest.java
+++ b/core/test-src/org/pentaho/di/core/util/EnvUtilTest.java
@@ -1,0 +1,56 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.util;
+
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Created by Yury_Bakhmutski on 11/4/2015.
+ */
+public class EnvUtilTest {
+
+  @Test
+  public void createLocale_Null() throws Exception {
+    assertNull( EnvUtil.createLocale( null ) );
+  }
+
+  @Test
+  public void createLocale_Empty() throws Exception {
+    assertNull( EnvUtil.createLocale( "" ) );
+  }
+
+  @Test
+  public void createLocale_SingleCode() throws Exception {
+    assertEquals( Locale.ENGLISH, EnvUtil.createLocale( "en" ) );
+  }
+
+  @Test
+  public void createLocale_DoubleCode() throws Exception {
+    assertEquals( Locale.US, EnvUtil.createLocale( "en_US" ) );
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/selectvalues/SelectValues_LocaleHandling_Test.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/selectvalues/SelectValues_LocaleHandling_Test.java
@@ -1,0 +1,131 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.selectvalues;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.trans.TransTestingUtil;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.steps.StepMockUtil;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Locale;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Note: In Europe (e.g. in UK), week starts on Monday. In USA, it starts on Sunday.
+ *
+ * @author Andrey Khayrutdinov
+ */
+public class SelectValues_LocaleHandling_Test {
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  private SelectValues step;
+  private Locale current;
+
+  @Before
+  public void setUp() throws Exception {
+    current = Locale.getDefault();
+    Locale.setDefault( Locale.UK );
+
+    StepMockHelper<SelectValuesMeta, StepDataInterface> helper =
+      StepMockUtil.getStepMockHelper( SelectValuesMeta.class, "SelectValues_LocaleHandling_Test" );
+    when( helper.stepMeta.isDoingErrorHandling() ).thenReturn( true );
+
+    step = new SelectValues( helper.stepMeta, helper.stepDataInterface, 1, helper.transMeta, helper.trans );
+    step = spy( step );
+
+    // Dec 28, 2015
+    Calendar calendar = Calendar.getInstance();
+    calendar.set( 2015, Calendar.DECEMBER, 28, 0, 0, 0 );
+    doReturn( new Object[] { calendar.getTime() } ).doReturn( null )
+      .when( step ).getRow();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    step = null;
+
+    Locale.setDefault( current );
+    current = null;
+  }
+
+
+  @Test
+  public void returns53_ForNull() throws Exception {
+    executeAndCheck( null, "53" );
+  }
+
+  @Test
+  public void returns53_ForEmpty() throws Exception {
+    executeAndCheck( "", "53" );
+  }
+
+  @Test
+  public void returns53_ForEn_GB() throws Exception {
+    executeAndCheck( "en_GB", "53" );
+  }
+
+  @Test
+  public void returns01_ForEn_US() throws Exception {
+    executeAndCheck( "en_US", "01" );
+  }
+
+  private void executeAndCheck( String locale, String expectedWeekNumber ) throws Exception {
+    RowMeta inputRowMeta = new RowMeta();
+    inputRowMeta.addValueMeta( new ValueMetaDate( "field" ) );
+    step.setInputRowMeta( inputRowMeta );
+
+    SelectValuesMeta stepMeta = new SelectValuesMeta();
+    stepMeta.allocate( 1, 0, 1 );
+    stepMeta.getSelectName()[ 0 ] = "field";
+    stepMeta.getMeta()[ 0 ] =
+      new SelectMetadataChange( stepMeta, "field", null, ValueMetaInterface.TYPE_STRING, -2, -2,
+        ValueMetaInterface.STORAGE_TYPE_NORMAL, "ww", false, locale, null, false, null, null, null );
+
+    SelectValuesData stepData = new SelectValuesData();
+    stepData.select = true;
+    stepData.metadata = true;
+    stepData.firstselect = true;
+    stepData.firstmetadata = true;
+
+    List<Object[]> execute = TransTestingUtil.execute( step, stepMeta, stepData, 1, true );
+    TransTestingUtil.assertResult( execute, singletonList( new Object[] { expectedWeekNumber } ) );
+  }
+}


### PR DESCRIPTION
- do not create locale instances for empty strings

(adopted from commit 6a7e129)

@brosander, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/2063 