### PR TITLE
[SP-2439] - Backport of PDI-14832 - Default values not working in TextFileInput (6.0 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -386,10 +386,9 @@ public class TextFileInputUtils {
           String pol = strings[ fieldnr ];
           try {
             if ( valueMeta.isNull( pol ) || !Const.isEmpty( nullif ) && nullif.equals( pol ) ) {
-              value = null;
-            } else {
-              value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );
+              pol = null;
             }
+            value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );
           } catch ( Exception e ) {
             // OK, give some feedback!
             String message =

--- a/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
@@ -678,10 +678,9 @@ public class TextFileInput extends BaseStep implements StepInterface {
           String pol = strings[ fieldnr ];
           try {
             if ( valueMeta.isNull( pol ) ) {
-              value = null;
-            } else {
-              value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );
+              pol = null;
             }
+            value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );
           } catch ( Exception e ) {
             // OK, give some feedback!
             String message =
@@ -942,8 +941,8 @@ public class TextFileInput extends BaseStep implements StepInterface {
      * If the buffer is empty: open the next file. (if nothing in there, open the next, etc.)
      */
     while ( data.lineBuffer.size() == 0 ) {
-      if ( !openNextFile() ) // Open fails: done processing unless set to skip bad files
-      {
+      if ( !openNextFile() ) {
+        // Open fails: done processing unless set to skip bad files
         if ( failAfterBadFile( null ) ) {
           closeLastFile();
           setOutputDone(); // signal end to receiver(s)
@@ -965,8 +964,8 @@ public class TextFileInput extends BaseStep implements StepInterface {
       /*
        * Different rules apply: on each page: a header a number of data lines a footer
        */
-      if ( !data.doneWithHeader && data.pageLinesRead == 0 ) // We are reading header lines
-      {
+      if ( !data.doneWithHeader && data.pageLinesRead == 0 ) {
+        // We are reading header lines
         if ( log.isRowLevel() ) {
           logRowlevel( "P-HEADER (" + data.headerLinesRead + ") : " + textLine.line );
         }


### PR DESCRIPTION
- in TextFileInput, set input string to null instead of setting result to null
- add test case
- fix Checkstyle violations
(cherry picked from commit 61a5ad9)

@brosander, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/2076 