### PR TITLE
[SP-2440] - Backport of PDI-14832 - Default values not working in TextFileInput (5.4 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
@@ -676,10 +676,9 @@ public class TextFileInput extends BaseStep implements StepInterface {
           String pol = strings[ fieldnr ];
           try {
             if ( valueMeta.isNull( pol ) || !Const.isEmpty( nullif ) && nullif.equals( pol ) ) {
-              value = null;
-            } else {
-              value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );
+              pol = null;
             }
+            value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );
           } catch ( Exception e ) {
             // OK, give some feedback!
             String message =


### PR DESCRIPTION
- in TextFileInput, set input string to null instead of setting result to null
- add a test case

@brosander, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/2076 