### PR TITLE
[PDI-11421] - Moving MySQL data via Bulk Loader with DECIMAL Data Type from one MySQL Table to another has precision errors

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
+++ b/engine/src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
@@ -386,12 +386,12 @@ public class MySQLBulkLoader extends BaseStep implements StepInterface {
               } else {
                 /**
                  * If this is the first line, reset default conversion mask for Number type (#.#;-#.#).
-                 * This will make conversion mask calculated according to meta data (length, precision).
+                 * This will make conversion mask to be calculated according to meta data (length, precision).
                  *
                  * http://jira.pentaho.com/browse/PDI-11421
                  */
-                if(getLinesWritten() == 0){
-                  data.bulkFormatMeta[i].setConversionMask(null);
+                if( getLinesWritten() == 0 ) {
+                  data.bulkFormatMeta[i].setConversionMask( null );
                 }
 
                 Double d = valueMeta.getNumber( valueData );

--- a/engine/src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
+++ b/engine/src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
@@ -384,6 +384,16 @@ public class MySQLBulkLoader extends BaseStep implements StepInterface {
               if ( valueMeta.isStorageBinaryString() && data.bulkFormatMeta[i] == null ) {
                 data.fifoStream.write( (byte[]) valueData );
               } else {
+                /**
+                 * If this is the first line, reset default conversion mask for Number type (#.#;-#.#).
+                 * This will make conversion mask calculated according to meta data (length, precision).
+                 *
+                 * http://jira.pentaho.com/browse/PDI-11421
+                 */
+                if(getLinesWritten() == 0){
+                  data.bulkFormatMeta[i].setConversionMask(null);
+                }
+
                 Double d = valueMeta.getNumber( valueData );
                 if ( d != null ) {
                   data.fifoStream.write( data.bulkFormatMeta[i].getString( d ).getBytes() );

--- a/engine/src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
+++ b/engine/src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
@@ -390,7 +390,7 @@ public class MySQLBulkLoader extends BaseStep implements StepInterface {
                  *
                  * http://jira.pentaho.com/browse/PDI-11421
                  */
-                if( getLinesWritten() == 0 ) {
+                if ( getLinesWritten() == 0 ) {
                   data.bulkFormatMeta[i].setConversionMask( null );
                 }
 

--- a/engine/test-src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoaderTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoaderTest.java
@@ -30,7 +30,6 @@ import java.util.Map;
 
 import junit.framework.Assert;
 import org.junit.Test;
-import org.hibernate.dialect.MySQL5Dialect;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.mockito.Mockito;
@@ -42,6 +41,8 @@ import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.StepPluginType;
 import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
 import org.pentaho.di.core.row.value.ValueMetaPluginType;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -173,5 +174,61 @@ public class MySQLBulkLoaderTest {
     Mockito.when( loader.getRow() ).thenReturn( new String[] { "test\"Escape\\" } );
     loader.processRow( smi, sdi );
     Mockito.verify( sdi.fifoStream, Mockito.times( 1 ) ).write( "test\\\"Escape\\\\".getBytes() );
+  }
+
+  /**
+   * Default conversion mask for Number column type should be calculated according to length and precision.
+   * For example, for type NUMBER(6,3) conversion mask should be: " #000.000;-#000.000"
+   */
+  @Test
+  public void testNumberFormatting() throws KettleException, IOException {
+    PluginRegistry.addPluginType( ValueMetaPluginType.getInstance() );
+    PluginRegistry.init( true );
+
+    MySQLBulkLoader loader;
+    MySQLBulkLoaderData ld = new MySQLBulkLoaderData();
+    MySQLBulkLoaderMeta lm = new MySQLBulkLoaderMeta();
+
+    TransMeta transMeta = new TransMeta();
+    transMeta.setName( "loader" );
+
+    PluginRegistry plugReg = PluginRegistry.getInstance();
+
+    String loaderPid = plugReg.getPluginId( StepPluginType.class, lm );
+    StepMeta stepMeta = new StepMeta( loaderPid, "loader", lm );
+    Trans trans = new Trans( transMeta );
+    transMeta.addStep( stepMeta );
+    trans.setRunning( true );
+
+    loader = Mockito.spy( new MySQLBulkLoader( stepMeta, ld, 1, transMeta, trans ) );
+
+    RowMeta rm = new RowMeta();
+    ValueMetaNumber vm = new ValueMetaNumber( "Test" );
+    rm.addValueMeta( vm );
+    RowMeta spyRowMeta = Mockito.spy( new RowMeta() );
+    Mockito.when( spyRowMeta.getValueMeta( Mockito.anyInt() ) ).thenReturn( vm );
+    loader.setInputRowMeta( spyRowMeta );
+
+    MySQLBulkLoaderMeta smi = new MySQLBulkLoaderMeta();
+    smi.setFieldStream( new String[] { "Test" } );
+    smi.setFieldFormatType( new int[] { MySQLBulkLoaderMeta.FIELD_FORMAT_TYPE_OK } );
+    smi.setDatabaseMeta( Mockito.mock( DatabaseMeta.class ) );
+
+    ValueMetaNumber vmn = new ValueMetaNumber("Test");
+    vmn.setLength(6,3);
+
+    MySQLBulkLoaderData sdi = new MySQLBulkLoaderData();
+    sdi.keynrs = new int[1];
+    sdi.keynrs[0] = 0;
+    sdi.fifoStream = Mockito.mock( OutputStream.class );
+    sdi.bulkFormatMeta = new ValueMetaInterface[] { vmn };
+
+    loader.init( smi, sdi );
+    loader.first = false;
+
+    Mockito.when( loader.getRow() ).thenReturn( new Double[] { 1.023 } );
+    loader.processRow( smi, sdi );
+    Mockito.verify( sdi.fifoStream, Mockito.times( 1 ) ).write( " 001.023".getBytes() );
+    Assert.assertEquals(" #000.000;-#000.000", vmn.getDecimalFormat().toPattern());
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoaderTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoaderTest.java
@@ -60,7 +60,7 @@ public class MySQLBulkLoaderTest {
   MySQLBulkLoaderData ldata;
   MySQLBulkLoader     lder;
   StepMeta smeta;
-  
+
   @BeforeClass
   public static void initEnvironment() throws Exception {
     KettleEnvironment.init();
@@ -93,15 +93,13 @@ public class MySQLBulkLoaderTest {
     ldata = new MySQLBulkLoaderData();
     PluginRegistry plugReg = PluginRegistry.getInstance();
     String mblPid = plugReg.getPluginId( StepPluginType.class, lmeta );
-    smeta = new StepMeta( mblPid, "MySqlBulkLoader", lmeta);
-    Trans trans = new Trans ( transMeta );
+    smeta = new StepMeta( mblPid, "MySqlBulkLoader", lmeta );
+    Trans trans = new Trans( transMeta );
     transMeta.addStep( smeta );
     lder = new MySQLBulkLoader( smeta, ldata, 1, transMeta, trans );
     lder.copyVariablesFrom( transMeta );
-    
   }
-  
-  
+
   @Test
   public void testFieldFormatType() throws KettleXMLException {
     MySQLBulkLoaderMeta lm = new MySQLBulkLoaderMeta();
@@ -214,8 +212,8 @@ public class MySQLBulkLoaderTest {
     smi.setFieldFormatType( new int[] { MySQLBulkLoaderMeta.FIELD_FORMAT_TYPE_OK } );
     smi.setDatabaseMeta( Mockito.mock( DatabaseMeta.class ) );
 
-    ValueMetaNumber vmn = new ValueMetaNumber("Test");
-    vmn.setLength(6,3);
+    ValueMetaNumber vmn = new ValueMetaNumber( "Test" );
+    vmn.setLength( 6, 3 );
 
     MySQLBulkLoaderData sdi = new MySQLBulkLoaderData();
     sdi.keynrs = new int[1];
@@ -229,6 +227,6 @@ public class MySQLBulkLoaderTest {
     Mockito.when( loader.getRow() ).thenReturn( new Double[] { 1.023 } );
     loader.processRow( smi, sdi );
     Mockito.verify( sdi.fifoStream, Mockito.times( 1 ) ).write( " 001.023".getBytes() );
-    Assert.assertEquals(" #000.000;-#000.000", vmn.getDecimalFormat().toPattern());
+    Assert.assertEquals( " #000.000;-#000.000", vmn.getDecimalFormat().toPattern() );
   }
 }


### PR DESCRIPTION
- Reset default conversion mask for Number type and make it to be calculated according to field length and precision.
- Unit test.