### PR TITLE
[BACKLOG--5675] Add the Ability to remember run options

### DIFF
--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -8492,18 +8492,14 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
 
     TransMeta transMeta = getActiveTransformation();
     if ( transMeta != null ) {
-      if ( show ) {
-        transMeta.setShowTransDialog( show );
-      }
+      transMeta.setShowTransDialog( show || transMeta.isAlwaysShowTransCheckbox() );
       executeTransformation( transMeta, local, remote, cluster, preview, debug, replayDate, safe,
           transExecutionConfiguration.getLogLevel() );
     }
 
     JobMeta jobMeta = getActiveJob();
     if ( jobMeta != null ) {
-      if ( show ) {
-        jobMeta.setShowJobDialog( show );
-      }
+      jobMeta.setShowJobDialog( show || jobMeta.isAlwaysShowJobCheckbox() );
       executeJob( jobMeta, local, remote, replayDate, safe, null, 0 );
     }
 


### PR DESCRIPTION
Fixed: run dialog was opening with F9 even if checkbox was not checked for "always show dialog"

@mdamour1976 