### PR TITLE
[PDI-12501] MemoryGroupBy with no input rows

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupBy.java
+++ b/engine/src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupBy.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -81,6 +81,10 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
 
     Object[] r = getRow(); // get row!
     if ( first ) {
+      if ( r == null ) {
+        setOutputDone();
+        return false;
+      }
       String val = getVariable( Const.KETTLE_AGGREGATION_ALL_NULLS_ARE_ZERO, "N" );
       allNullsAreZero = ValueMetaBase.convertStringToBoolean( val );
       val = getVariable( Const.KETTLE_AGGREGATION_MIN_NULL_IS_VALUED, "N" );


### PR DESCRIPTION
Avoid throwing an error when no input rows are available