### PR TITLE
[PDI-11421] - Moving MySQL data via Bulk Loader with DECIMAL Data Type from one MySQL Table to another has precision errors

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
+++ b/engine/src/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
@@ -384,6 +384,16 @@ public class MySQLBulkLoader extends BaseStep implements StepInterface {
               if ( valueMeta.isStorageBinaryString() && data.bulkFormatMeta[i] == null ) {
                 data.fifoStream.write( (byte[]) valueData );
               } else {
+                /**
+                 * If this is the first line, reset default conversion mask for Number type (#.#;-#.#).
+                 * This will make conversion mask to be calculated according to meta data (length, precision).
+                 *
+                 * http://jira.pentaho.com/browse/PDI-11421
+                 */
+                if ( getLinesWritten() == 0 ) {
+                  data.bulkFormatMeta[i].setConversionMask( null );
+                }
+
                 Double d = valueMeta.getNumber( valueData );
                 if ( d != null ) {
                   data.fifoStream.write( data.bulkFormatMeta[i].getString( d ).getBytes() );


### PR DESCRIPTION
- Reset default conversion mask for Number type and make it to be calculated according to field length and precision.
- Additional unit test to verify the behavior...

This is remake of https://github.com/pentaho/pentaho-kettle/pull/2103 which was previously sent to 6.0 branch.