### PR TITLE
[BACKLOG-6496] - Database lookup step with "IS NOT NULL" comparator fails on 6.1

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/databaselookup/readallcache/ReadAllCache.java
+++ b/engine/src/org/pentaho/di/trans/steps/databaselookup/readallcache/ReadAllCache.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -132,7 +132,11 @@ public class ReadAllCache implements DatabaseLookupData.Cache {
 
     for ( Index index : indexes ) {
       int column = index.getColumn();
-      index.applyRestrictionsTo( context, lookupMeta.getValueMeta( column ), lookupRow[ column ] );
+      // IS (NOT) NULL operation does not require second argument
+      // hence, lookupValue can be absent
+      // basically, the index ignores both meta and value, so we can pass everything there
+      Object lookupValue = ( column < lookupRow.length ) ? lookupRow[ column ] : null;
+      index.applyRestrictionsTo( context, lookupMeta.getValueMeta( column ), lookupValue );
       if ( context.isEmpty() ) {
         // if nothing matches, break the search
         return null;

--- a/engine/test-src/org/pentaho/di/trans/steps/databaselookup/readallcache/ReadAllCacheTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/databaselookup/readallcache/ReadAllCacheTest.java
@@ -157,7 +157,6 @@ public class ReadAllCacheTest {
     assertNull( "(1000 <= keys[2] <= 2000) --> none", found );
   }
 
-
   private ReadAllCache buildCache( String conditions ) throws Exception {
     StringTokenizer tokenizer = new StringTokenizer( conditions, "," );
     List<String> operators = Arrays.asList( DatabaseLookupMeta.conditionStrings );
@@ -180,5 +179,23 @@ public class ReadAllCacheTest {
       builder.add( keyTuple, dataTuple );
     }
     return builder.build();
+  }
+
+
+  @Test
+  public void lookup_HandlesAbsenceOfLookupValue() throws Exception {
+    stepData = new DatabaseLookupData();
+    stepData.conditions = new int[] { DatabaseLookupMeta.CONDITION_IS_NOT_NULL };
+
+    ReadAllCache.Builder builder = new ReadAllCache.Builder( stepData, 2 );
+    RowMeta keysMeta = new RowMeta();
+    keysMeta.addValueMeta( new ValueMetaInteger() );
+    builder.setKeysMeta( keysMeta );
+    builder.add( new Object[] { null }, new Object[] { "null" } );
+    builder.add( new Object[] { 1L }, new Object[] { "one" } );
+    ReadAllCache cache = builder.build();
+
+    Object[] found = cache.getRowFromCache( new RowMeta(), new Object[ 0 ] );
+    assertArrayEquals( "(keys[1] == 1L) --> row 2", new Object[] { "one" }, found );
   }
 }


### PR DESCRIPTION
- check if lookup value really exists
- add a test

@brosander, review it please. This PR fixes another problem in the step. 