### PR TITLE
[BACKLOG-6598]  Data Service SQL fails if field contains a space

### DIFF
--- a/core/src/org/pentaho/di/core/jdbc/ThinUtil.java
+++ b/core/src/org/pentaho/di/core/jdbc/ThinUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -346,9 +346,11 @@ public class ThinUtil {
 
   public static String stripTableAlias( String field, String tableAliasPrefix ) {
     if ( field.toUpperCase().startsWith( ( tableAliasPrefix + "." ).toUpperCase() ) ) {
-      return ThinUtil.stripQuotes( field.substring( tableAliasPrefix.length() + 1 ), '"' );
+      return ThinUtil.stripQuotesIfNoWhitespace(
+        field.substring( tableAliasPrefix.length() + 1 ), '"' );
     } else if ( field.toUpperCase().startsWith( ( "\"" + tableAliasPrefix + "\"." ).toUpperCase() ) ) {
-      return ThinUtil.stripQuotes( field.substring( tableAliasPrefix.length() + 3 ), '"' );
+      return ThinUtil.stripQuotesIfNoWhitespace(
+        field.substring( tableAliasPrefix.length() + 3 ), '"' );
     } else {
       return field;
     }
@@ -473,6 +475,19 @@ public class ThinUtil {
       }
     }
     return builder.toString();
+  }
+
+  /**
+   * Strips leading and trailing quotes if no whitespace present, and no
+   * additional quotes in the string.
+   */
+  public static String stripQuotesIfNoWhitespace(
+    String string, char... quoteChars ) {
+    if ( string.matches( ".*\\s.*" ) ) {
+      // whitespace present
+      return string;
+    }
+    return stripQuotes( string, quoteChars );
   }
 
   private static int countQuotes( String string, char quoteChar ) {
@@ -616,7 +631,7 @@ public class ThinUtil {
     }
 
     // Translate LIKE operators to REGEX
-    pattern = pattern.replace( "_", "." ).replace("%", ".*?" );
+    pattern = pattern.replace( "_", "." ).replace( "%", ".*?" );
 
     return Pattern.compile( pattern, Pattern.CASE_INSENSITIVE | Pattern.DOTALL );
   }

--- a/core/test-src/org/pentaho/di/core/jdbc/ThinUtilTest.java
+++ b/core/test-src/org/pentaho/di/core/jdbc/ThinUtilTest.java
@@ -22,22 +22,19 @@
 
 package org.pentaho.di.core.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.math.BigDecimal;
-import java.sql.SQLException;
-import java.sql.Types;
-
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleSQLException;
 import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.ValueMetaAndData;
 import org.pentaho.di.core.row.ValueMetaInterface;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 public class ThinUtilTest {
   @SuppressWarnings( "deprecation" )
@@ -209,7 +206,7 @@ public class ThinUtilTest {
     ValueMetaAndData result = ThinUtil.attemptNumberValueExtraction( "12345.678" );
     assertNotNull( result );
     assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta().getType() );
-    assertEquals( Double.valueOf( 12345.678 ), result.getValueData() );
+    assertEquals( 12345.678, result.getValueData() );
 
     //assertNull( ThinUtil.attemptNumberValueExtraction( null ) );
     assertNull( ThinUtil.attemptNumberValueExtraction( "" ) );
@@ -263,5 +260,27 @@ public class ThinUtilTest {
     assertNull( ThinUtil.attemptBooleanValueExtraction( null ) );
     assertNull( ThinUtil.attemptBooleanValueExtraction( "" ) );
     assertNull( ThinUtil.attemptBooleanValueExtraction( "abcde" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testStripQuotesIfNoWhitespace() {
+    // map of tests to expected result
+    Map<String, String> testStrings = new ImmutableMap.Builder<String, String>()
+      .put( "\"quotedNospace\"",                   "quotedNospace" )
+      .put( "unquoted",                            "unquoted" )
+      .put( "\"quoted space\"",                    "\"quoted space\"" )
+      .put( "\"field\" \"fieldAlias\"",            "\"field\" \"fieldAlias\"" )
+      .put( "\"field with space\" \"fieldAlias\"", "\"field with space\" \"fieldAlias\"" )
+      .put( "\"field\" AS \"field Alias\"",        "\"field\" AS \"field Alias\"" )
+      .build();
+
+    for ( String test : testStrings.keySet() ) {
+      for ( char quote : new char[] { '\'', '"', '`' } ) {
+        assertEquals(
+          testStrings.get( test ).replace( '"', quote ),
+          ThinUtil.stripQuotesIfNoWhitespace( test.replace( '"', quote ), quote ) );
+      }
+    }
   }
 }

--- a/core/test-src/org/pentaho/di/core/sql/SQLFieldsUnitTest.java
+++ b/core/test-src/org/pentaho/di/core/sql/SQLFieldsUnitTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -51,6 +51,9 @@ public class SQLFieldsUnitTest {
   private static final String WITH_SPACES = "with spaces";
   private static final String SELECT_CLAUSE = String.format( "%s, \"%s\"", NO_SPACE, WITH_SPACES );
   private static final String TABLE = "table";
+  private static final String SELECT_CLAUSE_TABLE_QUALIFIER = String.format(
+    "%s.%s, \"%s\".\"%s\"", TABLE, NO_SPACE, TABLE, WITH_SPACES );
+
   private RowMetaInterface serviceFields;
 
   @Before
@@ -73,10 +76,20 @@ public class SQLFieldsUnitTest {
   @Test
   public void testParseFields() throws KettleSQLException {
     SQLFields sqlFields = new SQLFields( TABLE, serviceFields, SELECT_CLAUSE );
+    checkSqlFields( sqlFields, SELECT_CLAUSE );
+  }
 
+  @Test
+  public void testParseFieldsWithTableQualifier() throws KettleSQLException {
+    SQLFields sqlFields = new SQLFields( TABLE, serviceFields, SELECT_CLAUSE_TABLE_QUALIFIER );
+    // same test as the preceding but with fields referenced like "table"."with space".
+    checkSqlFields( sqlFields, SELECT_CLAUSE_TABLE_QUALIFIER );
+  }
+
+  private void checkSqlFields( SQLFields sqlFields, String selectClause ) {
     assertThat( sqlFields.getTableAlias(), sameInstance( TABLE ) );
     assertThat( sqlFields.getServiceFields(), sameInstance( serviceFields ) );
-    assertThat( sqlFields.getFieldsClause(), equalTo( SELECT_CLAUSE ) );
+    assertThat( sqlFields.getFieldsClause(), equalTo( selectClause ) );
 
     assertThat( sqlFields.getFields(), validSqlFields() );
     assertThat( sqlFields.findByName( NO_SPACE ), sqlField( NO_SPACE ) );


### PR DESCRIPTION
and is referenced with tablename

Modified to avoid stripping quotes when whitespace is present.