### PR TITLE
[BACKLOG-6565] Renamed kettle-variable from

### DIFF
--- a/engine/src/kettle-variables.xml
+++ b/engine/src/kettle-variables.xml
@@ -422,7 +422,7 @@
 
   <kettle-variable>
     <description>Set this variable to restore the directory loading behavior of the repository as it was before 6.1. Changing this to false will make repository loading more expensive</description>
-    <variable>org.pentaho.di.repository.Repository.LAZY_REPOSITORY</variable>
+    <variable>KETTLE_LAZY_REPOSITORY</variable>
     <default-value>true</default-value>
   </kettle-variable>
 

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
@@ -119,7 +119,7 @@ public class PurRepository extends AbstractRepository implements Repository, jav
   private static final long serialVersionUID = 7460109109707189479L; /* EESOURCE: UPDATE SERIALVERUID */
 
   // Kettle property that when set to false disabled the lazy repository access
-  public static final String LAZY_REPOSITORY = "org.pentaho.di.repository.Repository.LAZY_REPOSITORY";
+  public static final String LAZY_REPOSITORY = "KETTLE_LAZY_REPOSITORY";
 
   private static Class<?> PKG = PurRepository.class;
 


### PR DESCRIPTION
org.pentaho.di.repository.Repository.LAZY_REPOSITORY to
KETTLE_LAZY_REPOSITORY in order to be consistent with the remaining
kettle variables names