### PR TITLE
[BACKLOG-6598]  Data Service SQL fails if field contains a space and

### DIFF
--- a/core/src/org/pentaho/di/core/jdbc/ThinUtil.java
+++ b/core/src/org/pentaho/di/core/jdbc/ThinUtil.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaAndData;
 import org.pentaho.di.core.row.ValueMetaInterface;
@@ -634,5 +635,18 @@ public class ThinUtil {
     pattern = pattern.replace( "_", "." ).replace( "%", ".*?" );
 
     return Pattern.compile( pattern, Pattern.CASE_INSENSITIVE | Pattern.DOTALL );
+  }
+
+  /**
+   * Attempts to resolve the reference to field from the serviceFields value meta list.
+   * Will search with both the quoted and unquoted field.
+   */
+  public static String resolveFieldName( String field, RowMetaInterface serviceFields ) {
+    ValueMetaInterface valueMeta = serviceFields.searchValueMeta( field );
+    if ( valueMeta == null ) {
+      valueMeta = serviceFields.searchValueMeta(
+        ThinUtil.stripQuotes( field, '"' ) );
+    }
+    return valueMeta == null ? field : valueMeta.getName();
   }
 }

--- a/core/src/org/pentaho/di/core/sql/SQLCondition.java
+++ b/core/src/org/pentaho/di/core/sql/SQLCondition.java
@@ -22,20 +22,18 @@
 
 package org.pentaho.di.core.sql;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.pentaho.di.core.Condition;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleSQLException;
 import org.pentaho.di.core.jdbc.ThinUtil;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaAndData;
-import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaString;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SQLCondition {
 
@@ -277,14 +275,15 @@ public class SQLCondition {
 
     // Remove the optional table alias prefix from the left field
     //
-    left = ThinUtil.stripQuoteTableAlias( left, tableAlias );
-
+    left = ThinUtil.resolveFieldName( ThinUtil.stripQuoteTableAlias( left, tableAlias ),
+      getServiceFields() );
     String operatorString = strings.get( 1 );
     String right = strings.get( 2 );
 
     // If it's another column name, remove possible table alias prefix.
     //
-    right = ThinUtil.stripQuoteTableAlias( right, tableAlias );
+    right = ThinUtil.resolveFieldName( ThinUtil.stripQuoteTableAlias( right, tableAlias ),
+      getServiceFields() );
 
     ValueMetaAndData value = null;
 
@@ -353,6 +352,7 @@ public class SQLCondition {
     }
   }
 
+
   /**
    * We need to split conditions on a single operator (for now)
    *
@@ -364,15 +364,15 @@ public class SQLCondition {
     List<String> strings = new ArrayList<String>();
 
     String[]
-        operators =
-        new String[] { "<>", ">=", "=>", "<=", "=<", "<", ">", "=", " REGEX ", " IN ", " IS NOT NULL", " IS NULL",
-            " LIKE", "CONTAINS " };
+      operators =
+      new String[] { "<>", ">=", "=>", "<=", "=<", "<", ">", "=", " REGEX ", " IN ", " IS NOT NULL", " IS NULL",
+        " LIKE", "CONTAINS " };
     int[]
-        functions =
-        new int[] { Condition.FUNC_NOT_EQUAL, Condition.FUNC_LARGER_EQUAL, Condition.FUNC_LARGER_EQUAL,
-            Condition.FUNC_SMALLER_EQUAL, Condition.FUNC_SMALLER_EQUAL, Condition.FUNC_SMALLER, Condition.FUNC_LARGER,
-            Condition.FUNC_EQUAL, Condition.FUNC_REGEXP, Condition.FUNC_IN_LIST, Condition.FUNC_NOT_NULL,
-            Condition.FUNC_NULL, Condition.FUNC_LIKE, Condition.FUNC_CONTAINS, };
+      functions =
+      new int[] { Condition.FUNC_NOT_EQUAL, Condition.FUNC_LARGER_EQUAL, Condition.FUNC_LARGER_EQUAL,
+        Condition.FUNC_SMALLER_EQUAL, Condition.FUNC_SMALLER_EQUAL, Condition.FUNC_SMALLER, Condition.FUNC_LARGER,
+        Condition.FUNC_EQUAL, Condition.FUNC_REGEXP, Condition.FUNC_IN_LIST, Condition.FUNC_NOT_NULL,
+        Condition.FUNC_NULL, Condition.FUNC_LIKE, Condition.FUNC_CONTAINS, };
     int index = 0;
     while ( index < clause.length() ) {
       index = ThinUtil.skipChars( clause, index, '\'', '"' );

--- a/core/src/org/pentaho/di/core/sql/SQLField.java
+++ b/core/src/org/pentaho/di/core/sql/SQLField.java
@@ -228,6 +228,7 @@ public class SQLField {
 
       } else {
         if ( valueMeta == null ) {
+          field = ThinUtil.resolveFieldName( field, serviceFields );
           valueMeta = serviceFields.searchValueMeta( field );
           if ( orderField && selectFields != null ) {
             // See if this isn't an aliased select field that we're ordering on

--- a/core/test-src/org/pentaho/di/core/sql/SQLFieldsUnitTest.java
+++ b/core/test-src/org/pentaho/di/core/sql/SQLFieldsUnitTest.java
@@ -124,6 +124,7 @@ public class SQLFieldsUnitTest {
     }
   }
 
+
   public Matcher<Iterable<? extends SQLField>> validSqlFields() {
     return contains( sqlField( NO_SPACE ), sqlField( WITH_SPACES ) );
   }

--- a/core/test-src/org/pentaho/di/core/sql/SQLTest.java
+++ b/core/test-src/org/pentaho/di/core/sql/SQLTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,6 +32,9 @@ import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
 
 import junit.framework.TestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SQLTest extends TestCase {
 
@@ -533,6 +536,17 @@ public class SQLTest extends TestCase {
     rowMeta.addValueMeta( new ValueMeta( "MONTH_ID", ValueMetaInterface.TYPE_INTEGER, 4 ) );
     rowMeta.addValueMeta( new ValueMeta( "YEAR_ID", ValueMetaInterface.TYPE_INTEGER, 2 ) );
     rowMeta.addValueMeta( new ValueMeta( "STATE", ValueMetaInterface.TYPE_STRING, 30 ) );
+    return rowMeta;
+  }
+
+  public static RowMetaInterface mockRowMeta( String... fieldNames ) {
+    RowMetaInterface rowMeta = mock( RowMetaInterface.class );
+    for ( String field : fieldNames ) {
+      ValueMetaInterface valueMeta = mock( ValueMetaInterface.class );
+      when( valueMeta.getName() ).thenReturn( field );
+      when( rowMeta.searchValueMeta( field ) )
+        .thenReturn( valueMeta );
+    }
     return rowMeta;
   }
 }


### PR DESCRIPTION
is referenced with tablename

The former commit for this issue did not address fields inside of
aggregate functions or conditional expressions.