### PR TITLE
[SP-2495] - Backport of PDI-4837 - CSV File Input - fails to populate rownum, filenameField, input row count (6.0 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
@@ -22,13 +22,6 @@
 
 package org.pentaho.di.trans.steps.csvinput;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.provider.local.LocalFile;
 import org.pentaho.di.core.Const;
@@ -51,6 +44,13 @@ import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.steps.textfileinput.EncodingType;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Read a simple CSV file Just output Strings found in the file...
@@ -425,6 +425,21 @@ public class CsvInput extends BaseStep implements StepInterface {
             // Make certain that at least one record exists before
             // filling the rest of them with null
             if ( outputIndex > 0 ) {
+              // Optionally add the current filename to the mix as well...
+              //
+              if ( meta.isIncludingFilename() && !Const.isEmpty( meta.getFilenameField() ) ) {
+                if ( meta.isLazyConversionActive() ) {
+                  outputRowData[data.filenameFieldIndex] = data.binaryFilename;
+                } else {
+                  outputRowData[data.filenameFieldIndex] = data.filenames[data.filenr - 1];
+                }
+              }
+
+              if ( data.isAddingRowNumber ) {
+                outputRowData[data.rownumFieldIndex] = data.rowNumber++;
+              }
+
+              incrementLinesInput();
               return outputRowData;
             }
           }
@@ -727,7 +742,7 @@ public class CsvInput extends BaseStep implements StepInterface {
         }
       }
 
-      switch( data.encodingType ) {
+      switch ( data.encodingType ) {
         case DOUBLE_BIG_ENDIAN:
           data.crLfMatcher = new MultiByteBigCrLfMatcher();
           break;

--- a/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputRowNumberTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputRowNumberTest.java
@@ -1,0 +1,93 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.csvinput;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.trans.TransTestingUtil;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.steps.StepMockUtil;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+import org.pentaho.di.trans.steps.textfileinput.TextFileInputField;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class CsvInputRowNumberTest extends CsvInputUnitTestBase {
+
+  private CsvInput csvInput;
+
+  @Before
+  public void setUp() throws Exception {
+    StepMockHelper<CsvInputMeta, StepDataInterface> stepMockHelper =
+      StepMockUtil.getStepMockHelper( CsvInputMeta.class, "CsvInputRowNumberTest" );
+    csvInput = new CsvInput(
+      stepMockHelper.stepMeta, stepMockHelper.stepDataInterface, 0, stepMockHelper.transMeta,
+      stepMockHelper.trans );
+  }
+
+
+  @Test
+  public void hasNotEnclosures_HasNotNewLine() throws Exception {
+    File tmp = createTestFile( "utf-8", "a,b\na," );
+    try {
+      doTest( tmp );
+    } finally {
+      tmp.delete();
+    }
+  }
+
+  public void doTest( File file ) throws Exception {
+    CsvInputData data = new CsvInputData();
+    CsvInputMeta meta = createMeta( file, createInputFileFields( "a", "b" ) );
+    List<Object[]> actual;
+    try {
+      csvInput.init( meta, data );
+      actual = TransTestingUtil.execute( csvInput, meta, data, 2, false );
+    } finally {
+      csvInput.dispose( meta, data );
+    }
+
+    List<Object[]> expected = Arrays.asList(
+      new Object[] { "a", "b", 1L },
+      new Object[] { "a", null, 2L }
+    );
+    TransTestingUtil.assertResult( expected, actual );
+  }
+
+  private CsvInputMeta createMeta( File file, TextFileInputField[] fields ) {
+    CsvInputMeta meta = new CsvInputMeta();
+    meta.setFilename( file.getAbsolutePath() );
+    meta.setDelimiter( "," );
+    meta.setEncoding( "utf-8" );
+    meta.setBufferSize( "1024" );
+    meta.setInputFields( fields );
+    meta.setHeaderPresent( false );
+    meta.setRowNumField( "rownum" );
+    return meta;
+  }
+}


### PR DESCRIPTION
- set meta data columns on last, incomplete CSV row
- add a test
(adopted from commits 6e436e0, 268c314)

@brosander, @hudak, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/2185