### PR TITLE
[BACKLOG-6700] Changed order of directory removal at

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/LazyUnifiedRepositoryDirectory.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/LazyUnifiedRepositoryDirectory.java
@@ -178,7 +178,7 @@ public class LazyUnifiedRepositoryDirectory extends RepositoryDirectory {
       getChildren();
     }
 
-    if ( i > subdirectories.size() || i < 0 ) {
+    if ( i >= subdirectories.size() || i < 0 ) {
       return null;
     }
     RepositoryDirectoryInterface directoryInterface = subdirectories.get( i );

--- a/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/model/UIRepositoryDirectory.java
+++ b/ui/src/org/pentaho/di/ui/repository/repositoryexplorer/model/UIRepositoryDirectory.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -200,12 +200,12 @@ public class UIRepositoryDirectory extends UIRepositoryObject {
   }
 
   public void delete() throws Exception {
-    uiParent.getChildren().remove( this );
-    if ( uiParent.getRepositoryObjects().contains( this ) ) {
-      uiParent.getRepositoryObjects().remove( this );
-    }
     if ( uiParent.checkDirNameExistsInRepo( getName() ) != null ) {
       rep.deleteRepositoryDirectory( getDirectory() );
+    }
+    uiParent.getChildren().remove( this );    
+    if ( uiParent.getRepositoryObjects().contains( this ) ) {
+      uiParent.getRepositoryObjects().remove( this );
     }
     uiParent.refresh();
   }


### PR DESCRIPTION
UIRepositoryDirectory to first try to delete the directory from the
system and then from UI. Minor fix to LazyUnifiedRepositoryDirectory to
prevent IndexOutOfBoundsException on getSubdirectory( int i ) calls.