### PR TITLE
[SP-2516] Backport of BISERVER-12601 - MS SQL repository: csv data source can't be created if any of column has non zero precision (6.0 Suite)

### DIFF
--- a/core/src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/core/src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta.java
@@ -264,9 +264,9 @@ public class MSSQLServerDatabaseMeta extends BaseDatabaseMeta implements Databas
             if ( precision > 0 ) {
               if ( length > 0 ) {
                 retval += "DECIMAL(" + length + "," + precision + ")";
+              } else {
+                retval += "FLOAT(53)";
               }
-            } else {
-              retval += "FLOAT(53)";
             }
           }
         }

--- a/core/test-src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta_FieldDefinitionTest.java
+++ b/core/test-src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta_FieldDefinitionTest.java
@@ -31,7 +31,6 @@ import org.pentaho.di.core.row.value.ValueMetaString;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
-import static org.pentaho.di.core.row.ValueMetaInterface.*;
 
 public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
   private MSSQLServerDatabaseMeta dbMeta;
@@ -55,7 +54,7 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
   @Test
   public void numberType_ZeroLength_ZeroPrecision() {
     ValueMetaInterface valueMeta =
-      new MetaInterfaceBuilder( TYPE_NUMBER )
+      new MetaInterfaceBuilder( ValueMetaInterface.TYPE_NUMBER )
         .length( 0 )
         .precision( 0 )
         .build();
@@ -66,7 +65,7 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
   @Test
   public void numberType_LessThanNineLength_ZeroPrecision() {
     ValueMetaInterface valueMeta =
-      new MetaInterfaceBuilder( TYPE_NUMBER )
+      new MetaInterfaceBuilder( ValueMetaInterface.TYPE_NUMBER )
         .length( 5 )
         .precision( 0 )
         .build();
@@ -78,7 +77,7 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
   @Test
   public void numberType_MoreThanNineLessThanEighteenLength_ZeroPrecision() {
     ValueMetaInterface valueMeta =
-      new MetaInterfaceBuilder( TYPE_NUMBER )
+      new MetaInterfaceBuilder( ValueMetaInterface.TYPE_NUMBER )
         .length( 17 )
         .precision( 0 )
         .build();
@@ -89,7 +88,7 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
   @Test
   public void numberType_MoreThanEighteenLength_ZeroPrecision() {
     ValueMetaInterface valueMeta =
-      new MetaInterfaceBuilder( TYPE_NUMBER )
+      new MetaInterfaceBuilder( ValueMetaInterface.TYPE_NUMBER )
         .length( 19 )
         .precision( 0 )
         .build();
@@ -103,7 +102,7 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
   @Test
   public void numberType_NonZeroLength_NonZeroPrecision() {
     ValueMetaInterface valueMeta =
-      new MetaInterfaceBuilder( TYPE_NUMBER )
+      new MetaInterfaceBuilder( ValueMetaInterface.TYPE_NUMBER )
         .length( 5 )
         .precision( 5 )
         .build();
@@ -115,7 +114,7 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
 
   @Test
   public void numberType_ZeroLength_NonZeroPrecision() {
-    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( TYPE_NUMBER )
+    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( ValueMetaInterface.TYPE_NUMBER )
       .length( 0 )
       .precision( 5 )
       .build();
@@ -129,7 +128,7 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
 
   @Test
   public void stringType_ZeroLength() {
-    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( TYPE_STRING )
+    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( ValueMetaInterface.TYPE_STRING )
       .length( 0 )
       .build();
 
@@ -142,7 +141,7 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
 
   @Test
   public void stringType_NonZeroLength() {
-    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( TYPE_STRING )
+    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( ValueMetaInterface.TYPE_STRING )
       .length( 50 )
       .build();
 
@@ -154,7 +153,7 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
 
   @Test
   public void stringType_TenThousandLength() {
-    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( TYPE_STRING )
+    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( ValueMetaInterface.TYPE_STRING )
       .length( 10_000 )
       .build();
 
@@ -171,11 +170,11 @@ public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
     }
 
     public MetaInterfaceBuilder( Integer type, String name ) {
-      switch( type ) {
-        case TYPE_NUMBER:
+      switch ( type ) {
+        case ValueMetaInterface.TYPE_NUMBER:
           meta = new ValueMetaNumber( name );
           break;
-        case TYPE_STRING:
+        case ValueMetaInterface.TYPE_STRING:
           meta = new ValueMetaString( name );
           break;
         default:

--- a/core/test-src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta_FieldDefinitionTest.java
+++ b/core/test-src/org/pentaho/di/core/database/MSSQLServerDatabaseMeta_FieldDefinitionTest.java
@@ -1,0 +1,200 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.database;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaNone;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.pentaho.di.core.row.ValueMetaInterface.*;
+
+public class MSSQLServerDatabaseMeta_FieldDefinitionTest {
+  private MSSQLServerDatabaseMeta dbMeta;
+
+  private static final String DEFAULT_TABLE_NAME = "table";
+
+  private static final String STRING_INT = "INT";
+  private static final String STRING_BIGINT = "BIGINT";
+  private static final String STRING_DECIMAL = "DECIMAL";
+  private static final String STRING_FLOAT = "FLOAT";
+  private static final String STRING_VARCHAR = "VARCHAR";
+  private static final String STRING_TEXT = "TEXT";
+
+
+  @Before
+  public void init() {
+    dbMeta = new MSSQLServerDatabaseMeta();
+  }
+
+
+  @Test
+  public void numberType_ZeroLength_ZeroPrecision() {
+    ValueMetaInterface valueMeta =
+      new MetaInterfaceBuilder( TYPE_NUMBER )
+        .length( 0 )
+        .precision( 0 )
+        .build();
+
+    assertEquals( STRING_INT, dbMeta.getFieldDefinition( valueMeta, null, null, false, false, false ) );
+  }
+
+  @Test
+  public void numberType_LessThanNineLength_ZeroPrecision() {
+    ValueMetaInterface valueMeta =
+      new MetaInterfaceBuilder( TYPE_NUMBER )
+        .length( 5 )
+        .precision( 0 )
+        .build();
+
+    assertEquals( STRING_INT, dbMeta.getFieldDefinition( valueMeta, null, null, false, false, false ) );
+  }
+
+
+  @Test
+  public void numberType_MoreThanNineLessThanEighteenLength_ZeroPrecision() {
+    ValueMetaInterface valueMeta =
+      new MetaInterfaceBuilder( TYPE_NUMBER )
+        .length( 17 )
+        .precision( 0 )
+        .build();
+
+    assertEquals( STRING_BIGINT, dbMeta.getFieldDefinition( valueMeta, null, null, false, false, false ) );
+  }
+
+  @Test
+  public void numberType_MoreThanEighteenLength_ZeroPrecision() {
+    ValueMetaInterface valueMeta =
+      new MetaInterfaceBuilder( TYPE_NUMBER )
+        .length( 19 )
+        .precision( 0 )
+        .build();
+
+    final String expected =
+      STRING_DECIMAL + "(" + valueMeta.getLength() + "," + valueMeta.getPrecision() + ")";
+
+    assertEquals( expected, dbMeta.getFieldDefinition( valueMeta, null, null, false, false, false ) );
+  }
+
+  @Test
+  public void numberType_NonZeroLength_NonZeroPrecision() {
+    ValueMetaInterface valueMeta =
+      new MetaInterfaceBuilder( TYPE_NUMBER )
+        .length( 5 )
+        .precision( 5 )
+        .build();
+
+    final String expected = STRING_DECIMAL + "(" + valueMeta.getLength() + "," + valueMeta.getPrecision() + ")";
+
+    assertEquals( expected, dbMeta.getFieldDefinition( valueMeta, null, null, false, false, false ) );
+  }
+
+  @Test
+  public void numberType_ZeroLength_NonZeroPrecision() {
+    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( TYPE_NUMBER )
+      .length( 0 )
+      .precision( 5 )
+      .build();
+
+    final String definition = dbMeta.getFieldDefinition( valueMeta, null, null, false, false, false );
+
+    // There is actually returned FLOAT(53), where 53 is hardcoded string,
+    // but we don't wanna tie to it, so checking type only.
+    assertTrue( definition.contains( STRING_FLOAT ) );
+  }
+
+  @Test
+  public void stringType_ZeroLength() {
+    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( TYPE_STRING )
+      .length( 0 )
+      .build();
+
+    final String definition = dbMeta.getFieldDefinition( valueMeta, null, null, false, false, false );
+
+    // There is actually returned VARCHAR(100), where 100 is hardcoded string,
+    // but we don't wanna tie to it, so checking type only.
+    assertTrue( definition.contains( STRING_VARCHAR ) );
+  }
+
+  @Test
+  public void stringType_NonZeroLength() {
+    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( TYPE_STRING )
+      .length( 50 )
+      .build();
+
+    final String expected = STRING_VARCHAR + "(" + valueMeta.getLength() + ")";
+
+    assertEquals( expected, dbMeta.getFieldDefinition( valueMeta, null, null, false, false, false ) );
+
+  }
+
+  @Test
+  public void stringType_TenThousandLength() {
+    ValueMetaInterface valueMeta = new MetaInterfaceBuilder( TYPE_STRING )
+      .length( 10_000 )
+      .build();
+
+
+    assertEquals( STRING_TEXT, dbMeta.getFieldDefinition( valueMeta, null, null, false, false, false ) );
+
+  }
+
+  private static class MetaInterfaceBuilder {
+    private final ValueMetaInterface meta;
+
+    public MetaInterfaceBuilder( Integer type ) {
+      this( type, DEFAULT_TABLE_NAME );
+    }
+
+    public MetaInterfaceBuilder( Integer type, String name ) {
+      switch( type ) {
+        case TYPE_NUMBER:
+          meta = new ValueMetaNumber( name );
+          break;
+        case TYPE_STRING:
+          meta = new ValueMetaString( name );
+          break;
+        default:
+          meta = new ValueMetaNone( name );
+      }
+    }
+
+    public MetaInterfaceBuilder length( int length ) {
+      meta.setLength( length );
+      return this;
+    }
+
+    public MetaInterfaceBuilder precision( int precision ) {
+      meta.setPrecision( precision );
+      return this;
+    }
+
+    public ValueMetaInterface build() {
+      return meta;
+    }
+  }
+}


### PR DESCRIPTION
- In case of non zero precision and zero length choosing float as a type for a column.
- Tests wirtten.
- Checkstyle applied.


@akhayrutdinov, review it please. It is a backport of https://github.com/pentaho/pentaho-kettle/pull/2207