### PR TITLE
[BACKLOG-6777] Fixed getDirectory( String path ) method of

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/LazyUnifiedRepositoryDirectory.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/LazyUnifiedRepositoryDirectory.java
@@ -67,6 +67,18 @@ public class LazyUnifiedRepositoryDirectory extends RepositoryDirectory {
     this.registry = registry;
   }
 
+  private String getParentPath( String absolutePath ) {
+    int parentEndIndex;
+    if ( absolutePath.endsWith( RepositoryDirectory.DIRECTORY_SEPARATOR ) ) {
+      parentEndIndex = absolutePath.lastIndexOf( RepositoryDirectory.DIRECTORY_SEPARATOR, absolutePath.length() - 2 );
+    } else {
+      parentEndIndex = absolutePath.lastIndexOf( RepositoryDirectory.DIRECTORY_SEPARATOR );
+    }
+    if ( parentEndIndex < 0 ) {
+      return null;
+    }
+    return absolutePath.substring( 0, parentEndIndex );
+  }
 
   @Override public RepositoryDirectory findDirectory( String path ) {
     if ( StringUtils.isEmpty( path ) ) {
@@ -94,7 +106,20 @@ public class LazyUnifiedRepositoryDirectory extends RepositoryDirectory {
     if ( isRoot() && RepositoryDirectory.DIRECTORY_SEPARATOR.equals( absolutePath ) ) {
       return this;
     }
-    return new LazyUnifiedRepositoryDirectory( file, this, repository, registry );
+
+    // Verifies if this is the parent directory of file and if so passes this as parent argument
+    String parentPath = getParentPath( absolutePath );
+    if ( self.getPath().endsWith( RepositoryDirectory.DIRECTORY_SEPARATOR ) ) {
+      if ( parentPath.equals( self.getPath().substring( 0, self.getPath().length() - 1 ) ) ) {
+        return new LazyUnifiedRepositoryDirectory( file, this, repository, registry );
+      }
+    } else {
+      if ( parentPath.equals( self.getPath() ) ) {
+        return new LazyUnifiedRepositoryDirectory( file, this, repository, registry );
+      }
+    }
+
+    return new LazyUnifiedRepositoryDirectory( file, findDirectory( parentPath ), repository, registry );
 
   }
 

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java
@@ -1050,6 +1050,23 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
     repository.createRepositoryDirectory( treeLazy, "/home/admin2L/new1" );
   }
 
+  @Test
+  public void testFindDirectory() throws Exception {
+    System.setProperty( PurRepository.LAZY_REPOSITORY, "false" );
+    RepositoryDirectoryInterface tree = repository.loadRepositoryDirectoryTree();
+    RepositoryDirectoryInterface dir = repository.createRepositoryDirectory( tree, "/home/admin3/n" );
+    RepositoryDirectoryInterface sameDir = repository.findDirectory( "/home/admin3/n/" );
+    assertEquals( dir.getPath(), sameDir.getPath() );
+    assertEquals( dir.getParent().getPath(), sameDir.getParent().getPath() );
+
+    System.setProperty( PurRepository.LAZY_REPOSITORY, "true" );
+    tree = repository.loadRepositoryDirectoryTree();
+    dir = repository.createRepositoryDirectory( tree, "/home/admin3L/n" );
+    sameDir = repository.findDirectory( "/home/admin3L/n/" );
+    assertEquals( dir.getPath(), sameDir.getPath() );
+    assertEquals( dir.getParent().getPath(), sameDir.getParent().getPath() );
+  }
+
   protected static class LogListener implements KettleLoggingEventListener {
     private List<KettleLoggingEvent> events = new ArrayList<>();
     private LogLevel logThreshold;


### PR DESCRIPTION
LazyUnifiedRepositoryDirectory when creating a new
LazyUnifiedRepositoryDirectory, now it will have the right parent
directory as argument