### PR TITLE
[PDI-14606] Salesforce Input default field format (yyyy-MM-dd'T'HH:mm:ss'.000'Z) fails for Date/Time fields

### DIFF
--- a/plugins/salesforce/src/org/pentaho/di/ui/trans/steps/salesforceinput/SalesforceInputDialog.java
+++ b/plugins/salesforce/src/org/pentaho/di/ui/trans/steps/salesforceinput/SalesforceInputDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -98,7 +98,7 @@ public class SalesforceInputDialog extends BaseStepDialog implements StepDialogI
 
   private static Class<?> PKG = SalesforceInputMeta.class; // for i18n purposes, needed by Translator2!!
 
-  private String DEFAULT_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'.000'Z";
+  private String DEFAULT_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'.000'XXX";
   private String DEFAULT_DATE_FORMAT = "yyyy-MM-dd";
 
   private CTabFolder wTabFolder;


### PR DESCRIPTION
SimpleDateFormat class did't support ISO-8601 fully in java-6, but in java 7 new date-patterns were added, and ISO-8601 support became possible.
The purpouse of [this PR](https://github.com/pentaho/pentaho-kettle/commit/0125c88f7f614073986ea8076740117a80cef3ce#diff-21e5912b7c8385e7a9d0f2adef44829eR697) was to provide the ISO-8601 support, and the code for helping SimpleDateFormat (in java 6) to provide ISO-8601 support was to removed.
Since it is removed, we need to change the pattern to java-7 style.

[Here is the test ](https://github.com/pentaho/pentaho-kettle/blob/master/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseTest.java#L497) for parsing this date pattern with SimpleDateFormat.

@akhayrutdinov, @brosander, review it please.