### PR TITLE
[PDI-14988] - Add option to disable interactive GSSAPI authentication

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/sftp/SFTPClient.java
+++ b/engine/src/org/pentaho/di/job/entries/sftp/SFTPClient.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.FileUtil;
@@ -128,7 +129,7 @@ public class SFTPClient {
     this.serverPort = serverPort;
     this.userName = userName;
 
-    JSch jsch = new JSch();
+    JSch jsch = createJSch();
     try {
       if ( !Const.isEmpty( privateKeyFilename ) ) {
         // We need to use private key authentication
@@ -144,6 +145,7 @@ public class SFTPClient {
           passphrasebytes ); // byte[] passPhrase          
       }
       s = jsch.getSession( userName, serverIP.getHostAddress(), serverPort );
+      s.setConfig( "PreferredAuthentications", "publickey,keyboard-interactive,password,gssapi-with-mic" );
     } catch ( IOException e ) {
       throw new KettleJobException( e );
     } catch ( KettleFileException e ) {
@@ -425,5 +427,10 @@ public class SFTPClient {
       return null;
     }
     return this.compression;
+  }
+
+  @VisibleForTesting
+  JSch createJSch() {
+    return new JSch();
   }
 }

--- a/engine/test-src/org/pentaho/di/job/entries/sftp/SFTPClientTest.java
+++ b/engine/test-src/org/pentaho/di/job/entries/sftp/SFTPClientTest.java
@@ -1,0 +1,64 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.sftp;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import org.junit.Test;
+
+import java.net.InetAddress;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SFTPClientTest {
+
+  /**
+   * Given SFTP connection configuration.
+   * <br/>
+   * When SFTP Client is instantiated, then default preferred authentications list should be reordered,
+   * particularly, GSS API Authentication should be the last one.
+   */
+  @Test
+  public void shouldReorderDefaultPreferredAuthenticationsList() throws Exception {
+    String serverIp = "serverIp";
+    int serverPort = 1;
+    String userName = "userName";
+    Session session = mock( Session.class );
+    InetAddress server = mock( InetAddress.class );
+    final JSch jSch = mock( JSch.class );
+    when( server.getHostAddress() ).thenReturn( serverIp );
+    when( jSch.getSession( userName, serverIp, serverPort ) ).thenReturn( session );
+
+    new SFTPClient( server, serverPort, userName ) {
+      @Override
+      JSch createJSch() {
+        return jSch;
+      }
+    };
+
+    verify( session )
+      .setConfig( "PreferredAuthentications", "publickey,keyboard-interactive,password,gssapi-with-mic" );
+  }
+}


### PR DESCRIPTION
- reordered default preferred authentications list
- added unit test

The whole fix is reordering of preferred authentications list on the client.
Default order is: `gssapi-with-mic,publickey,keyboard-interactive,password`
Moving GSSAPI to the end: `publickey,keyboard-interactive,password,gssapi-with-mic`
This will make the JSch trying GSSAPI authentication only if other previous have failed.

To reproduce the issue and test the fix a Kerberos authentication server was set up. 
The issue is reproduced when 2 conditions are met:
- GSSAPI Authentication is enabled on the SSH server we want to connect to in SFTP Put step
- Client doesn't have TGT Ticket for that SSH server.

Command line is asking for password and waiting without timeout, no matter how authentication is configured in job entry.


**Note!:** This fix is not removing infinite waiting completely. If user improperly configures SFTP connection, i.e. sets wrong password, and SSH server has GSSAPI Authentication enabled, then the issue will occur. This fix is working when SFTP configuration is valid which means we _pass_ authentication _before_ GSSAPI is tried.
In other words, applying the fix, we adding another one condition to the written above:
- All previous authentications should fail.

---
**Authentication types tested:**
- **gssapi-with-mic**
 - Configured SFTP connection without password or with wrong password. Having TGT Ticket on client the issue doesn't reproduce anyhow. If TGT is absent, then in both cases authentication fails and we freeze, no matter is the fix applied or not.

- **publickey**
 - Before applying the fix we freeze on authentication. After - it works correctly.
**Note:** improper configuration or revoking of public key on server leads to freezing again.

- **password**
 - Before applying the fix we freeze on authentication. After - it works correctly.
**Note:** improper configuration or changing user password on server leads to freezing again.



**Not tested:**
- **keyboard-interactive**
 - Inapplicapable. I believe SFTP job entries are not intended to authenticate this way.