### PR TITLE
[PDI-14950] Spoon does not pass instanceName parameter to MSSQL Server JDBC connection string

### DIFF
--- a/core/src/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseMeta.java
@@ -1134,9 +1134,10 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
             String parameter = typedParameter.substring( dotIndex + 1 );
             String value = map.get( typedParameter );
 
-            // Only add to the URL if it's the same database type code...
-            //
-            if ( databaseInterface.getPluginId().equals( typeCode ) ) {
+            // Only add to the URL if it's the same database type code,
+            // or underlying database is the same for both id's, and any subset of
+            // connection settings for one database is valid for another
+            if ( databaseForBothConnTypesIsTheSame( typeCode, databaseInterface.getPluginId() ) ) {
               if ( first && url.indexOf( valueSeparator ) == -1 ) {
                 url.append( optionIndicator );
               } else {
@@ -1159,6 +1160,32 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     // }
 
     return url.toString();
+  }
+
+  /**
+   *  This method is designed to identify whether the actual database for two database connection types is the same.
+   *  This situation can occur in two cases:
+   *
+   *  1. {@code secondaryDbConnType} represents a connection to a database, that is the same as {@code primaryDbConnType}
+   *  2. {@code secondaryDbConnType} represents a connection to a database, that is a subset of {@code primaryDbConnType}
+   *  and <b> all connection settings specified to one connection is valid to another </b>. In this case
+   *  we treat {@code secondaryDbConnType} as {@code primaryDbConnType}
+   *
+   *  Example of case 2 is the following:
+   *  MSSQLNATIVE connection type is a subset of MSSQL connection type and all valid MSSQLNATIVE connection settings are valid to MSSQL also.
+   *  In this case we can safely treat MSSQLNATIVE connection type as MSSQL connection type.
+   *
+   */
+  protected boolean databaseForBothConnTypesIsTheSame( String primaryDbConnType, String secondaryDbConnType ) {
+    if ( primaryDbConnType.equals( secondaryDbConnType ) ) {
+      return true;
+    }
+
+    if ( primaryDbConnType.equals( "MSSQL" ) && secondaryDbConnType.equals( "MSSQLNATIVE" ) ) {
+      return true;
+    }
+
+    return false;
   }
 
   public Properties getConnectionProperties() {

--- a/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
@@ -51,6 +51,10 @@ public class DatabaseMetaTest {
   private static final String DROP_STATEMENT = "dropStatement";
   private static final String DROP_STATEMENT_FALLBACK = "DROP TABLE IF EXISTS " + TABLE_NAME;
 
+  private static final String CONNECTION_TYPE_ID_MSSQL = "MSSQL";
+  private static final String CONNECTION_TYPE_ID_MSSQL_NATIVE = "MSSQLNATIVE";
+  private static final String CONNECTION_TYPE_ID_ORACLE = "ORACLE";
+
   private DatabaseMeta databaseMeta;
   private DatabaseInterface databaseInterface;
 
@@ -253,4 +257,21 @@ public class DatabaseMetaTest {
 
     assertEquals( DROP_STATEMENT_FALLBACK, statement );
   }
+
+  @Test
+  public void databases_WithSameDbConnTypes_AreTheSame() {
+    assertTrue( databaseMeta.databaseForBothConnTypesIsTheSame( CONNECTION_TYPE_ID_ORACLE, CONNECTION_TYPE_ID_ORACLE ) );
+  }
+
+  @Test
+  public void databases_WithDifferentDbConnTypes_AreDifferent_IfNonOfThemIsSubsetOfAnother() {
+    assertFalse( databaseMeta.databaseForBothConnTypesIsTheSame( CONNECTION_TYPE_ID_MSSQL, CONNECTION_TYPE_ID_ORACLE ) );
+  }
+
+  @Test
+  public void databases_WithDifferentDbConnTypes_AreTheSame_IfOneConnTypeIsSubsetOfAnother() {
+    assertTrue( databaseMeta.databaseForBothConnTypesIsTheSame( CONNECTION_TYPE_ID_MSSQL, CONNECTION_TYPE_ID_MSSQL_NATIVE ) );
+  }
+
+
 }


### PR DESCRIPTION
The reason why this bug occures is [this line] (https://github.com/pentaho/pentaho-kettle/blob/master/core/src/org/pentaho/di/core/database/DatabaseMeta.java#L2717).
We set extra option, specifying MSSQL (that is a hardcoded string) as databaseTypeCode in all cases, though it can be of type MSSQLNATIVE also. 
My first approach was to treat this plugins as seperate databaseTypeCode, but it's not such an easy task as it seemed to be. In short: I could not do it, because when edditing/creating a database we can't pull an up-to-date databasePluginId *before* clicking on "OK" button. I can provide a more detailed description for the problems of this approach, if necessary.

My second approach is described bellow in a short form and more explisit in java docs.

When generating connection URL, treat the one connection type B as connection type A if:
 1. A is B
 2. B is subset of A, where every connection setting, that is valid to B is valid to A also.

 See javaDocks for databaseForBothConnTypesIsTheSame method for more details.


@akhayrutdinov, could you please review it?