### PR TITLE
[PDI-14821] - Spoon message : "cfgbuilder - Warning: The configuration parameter [org] is not supported by the default configuration builder for scheme: sftp" when open ktr from Open Referenced Object

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1056,9 +1056,9 @@ public class Const {
 
   /**
    * A variable to configure VFS USER_DIR_IS_ROOT option: should be "true" or "false"
+   * {@linkplain org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder#USER_DIR_IS_ROOT}
    */
-  public static final String VFS_USER_DIR_IS_ROOT =
-      "vfs.sftp.org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder.USER_DIR_IS_ROOT";
+  public static final String VFS_USER_DIR_IS_ROOT = "vfs.sftp.userDirIsRoot";
 
   /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer

--- a/core/src/org/pentaho/di/core/util/EnvUtil.java
+++ b/core/src/org/pentaho/di/core/util/EnvUtil.java
@@ -93,7 +93,8 @@ public class EnvUtil {
       Thread.currentThread().setContextClassLoader( ClassLoader.getSystemClassLoader() );
     }
 
-    Map<?, ?> kettleProperties = EnvUtil.readProperties( Const.KETTLE_PROPERTIES );
+    Map<Object, Object> kettleProperties = EnvUtil.readProperties( Const.KETTLE_PROPERTIES );
+    insertDefaultValues( kettleProperties );
     applyKettleProperties( kettleProperties );
 
     // Also put some default values for obscure environment variables in there...
@@ -109,12 +110,14 @@ public class EnvUtil {
     System.getProperties().put( Const.INTERNAL_VARIABLE_STEP_PARTITION_NR, "0" );
     System.getProperties().put( Const.INTERNAL_VARIABLE_STEP_UNIQUE_COUNT, "1" );
     System.getProperties().put( Const.INTERNAL_VARIABLE_STEP_UNIQUE_NUMBER, "0" );
+  }
 
-    // If user didn't set value for USER_DIR_IS_ROOT set it to "false". See PDI-14522
+  private static void insertDefaultValues( Map<Object, Object> kettleProperties ) {
+    // If user didn't set value for USER_DIR_IS_ROOT set it to "false".
+    // See PDI-14522, PDI-14821
     if ( !kettleProperties.containsKey( Const.VFS_USER_DIR_IS_ROOT ) ) {
-      System.getProperties().put( Const.VFS_USER_DIR_IS_ROOT, "false" );
+      kettleProperties.put( Const.VFS_USER_DIR_IS_ROOT, "false" );
     }
-
   }
 
   public static void applyKettleProperties( Map<?, ?> kettleProperties ) {

--- a/core/src/org/pentaho/di/core/vfs/configuration/KettleSftpFileSystemConfigBuilder.java
+++ b/core/src/org/pentaho/di/core/vfs/configuration/KettleSftpFileSystemConfigBuilder.java
@@ -114,7 +114,7 @@ public class KettleSftpFileSystemConfigBuilder extends KettleGenericFileSystemCo
             }
             setParam( opts, "identities", identities );
           } else {
-            setParam( opts, name, value );
+            super.setParameter( opts, name, value, fullParameterName, vfsUrl );
           }
         } else {
           // No host match found

--- a/core/test-src/org/pentaho/di/core/util/EnvUtilTest.java
+++ b/core/test-src/org/pentaho/di/core/util/EnvUtilTest.java
@@ -24,10 +24,12 @@ package org.pentaho.di.core.util;
 
 import org.junit.Test;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.variables.Variables;
 
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
@@ -36,12 +38,13 @@ import static org.junit.Assert.assertNull;
 public class EnvUtilTest {
 
   @Test
-  public void testEnvironmentInit() throws Exception {
+  public void vfsUserDirIsRoot_IsPublishedOnInitialisation() throws Exception {
     EnvUtil.environmentInit();
-    //See PDI-14522
-    boolean expected = false;
-    boolean actual = Boolean.valueOf( System.getProperties().get( Const.VFS_USER_DIR_IS_ROOT ).toString() );
-    assertEquals( expected, actual );
+    //See PDI-14522, PDI-14821
+    // don't check the exact value, because the initialisation depends on local settings
+    // instead, simply check the value exists
+    assertNotNull( Variables.getADefaultVariableSpace().getVariable( Const.VFS_USER_DIR_IS_ROOT ) );
+    assertNotNull( System.getProperty( Const.VFS_USER_DIR_IS_ROOT ) );
   }
 
   @Test

--- a/core/test-src/org/pentaho/di/core/vfs/configuration/KettleSftpFileSystemConfigBuilderTest.java
+++ b/core/test-src/org/pentaho/di/core/vfs/configuration/KettleSftpFileSystemConfigBuilderTest.java
@@ -1,0 +1,56 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.vfs.configuration;
+
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class KettleSftpFileSystemConfigBuilderTest {
+
+  @Test
+  public void recognizesAndSetsUserHomeDirProperty() throws Exception {
+    final String fullName = Const.VFS_USER_DIR_IS_ROOT;
+    final String name = fullName.substring( "vfs.sftp.".length() );
+    final String vfsInternalName = SftpFileSystemConfigBuilder.class.getName() + ".USER_DIR_IS_ROOT";
+
+    final FileSystemOptions opts = new FileSystemOptions();
+    KettleSftpFileSystemConfigBuilder builder = KettleSftpFileSystemConfigBuilder.getInstance();
+    builder.setParameter( opts, name, "true", fullName, "sftp://fake-url:22" );
+
+    Method getOption = ReflectionUtils.findMethod( opts.getClass(), "getOption", Class.class, String.class );
+    getOption.setAccessible( true );
+    Object value = ReflectionUtils.invokeMethod( getOption, opts, builder.getConfigClass(), vfsInternalName );
+    assertEquals( true, value );
+  }
+
+}

--- a/engine/src/kettle-variables.xml
+++ b/engine/src/kettle-variables.xml
@@ -416,7 +416,7 @@
 
   <kettle-variable>
     <description>Set this variable to true if VFS should treat the user directory as the root directory when connecting via ftp. Defaults to false.</description>
-    <variable>vfs.sftp.org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder.USER_DIR_IS_ROOT</variable>
+    <variable>vfs.sftp.userDirIsRoot</variable>
     <default-value>false</default-value>
   </kettle-variable>
 

--- a/ui/src/org/pentaho/di/core/vfs/KettleVfsDelegatingResolver.java
+++ b/ui/src/org/pentaho/di/core/vfs/KettleVfsDelegatingResolver.java
@@ -1,0 +1,52 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.vfs;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.vfs.ui.VfsResolver;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class KettleVfsDelegatingResolver implements VfsResolver {
+
+  @Override
+  public FileObject resolveFile( String vfsUrl ) {
+    try {
+      return KettleVFS.getFileObject( vfsUrl );
+    } catch ( KettleFileException e ) {
+      throw new RuntimeException( e );
+    }
+  }
+
+  @Override
+  public FileObject resolveFile( String vfsUrl, FileSystemOptions fsOptions ) {
+    try {
+      return KettleVFS.getFileObject( vfsUrl, fsOptions );
+    } catch ( KettleFileException e ) {
+      throw new RuntimeException( e );
+    }
+  }
+}

--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -199,6 +199,7 @@ import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.core.vfs.KettleVfsDelegatingResolver;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.imp.ImportRules;
@@ -1010,8 +1011,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
 
   public VfsFileChooserDialog getVfsFileChooserDialog( FileObject rootFile, FileObject initialFile ) {
     if ( vfsFileChooserDialog == null ) {
-      vfsFileChooserDialog = new VfsFileChooserDialog( shell, KettleVFS.getInstance().getFileSystemManager(), rootFile,
-          initialFile );
+      vfsFileChooserDialog = new VfsFileChooserDialog( shell, new KettleVfsDelegatingResolver(), rootFile, initialFile );
     }
     vfsFileChooserDialog.setRootFile( rootFile );
     vfsFileChooserDialog.setInitialFile( initialFile );


### PR DESCRIPTION
- change the fix from PDI-14522: rename the parameter and do not pass via system environment, instead pass KettleVFS into Open File dialog
- add tests

@deinspanjer, @brosander, review it please. This PR must be merged strictly after https://github.com/pentaho/apache-vfs-browser/pull/20