### PR TITLE
[TEST] - Repair incorrect test

### DIFF
--- a/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -1162,6 +1162,15 @@ public class ValueMetaBase implements ValueMetaInterface {
    * @throws KettleValueException
    */
   protected String convertBinaryStringToString( byte[] binary ) throws KettleValueException {
+    //noinspection deprecation
+    return convertBinaryStringToString( binary, EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
+  }
+
+  /*
+   * Do not use this method directly! It is for tests!
+   */
+  @Deprecated
+  String convertBinaryStringToString( byte[] binary, boolean emptyStringDiffersFromNull ) throws KettleValueException {
     // OK, so we have an internal representation of the original object, read
     // from file.
     // Before we release it back, we have to see if we don't have to do a
@@ -1172,7 +1181,7 @@ public class ValueMetaBase implements ValueMetaInterface {
     //
     // if (binary==null || binary.length==0) return null;
     if ( binary == null || binary.length == 0 ) {
-      return ( EMPTY_STRING_AND_NULL_ARE_DIFFERENT && binary != null ) ? "" : null;
+      return ( emptyStringDiffersFromNull && binary != null ) ? "" : null;
     }
 
     String encoding;
@@ -3301,11 +3310,20 @@ public class ValueMetaBase implements ValueMetaInterface {
    */
   @Override
   public boolean isNull( Object data ) throws KettleValueException {
+    //noinspection deprecation
+    return isNull( data, EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
+  }
+
+  /*
+   * Do not use this method directly! It is for tests!
+   */
+  @Deprecated
+  boolean isNull( Object data, boolean emptyStringDiffersFromNull ) throws KettleValueException {
     try {
       Object value = data;
 
       if ( isStorageBinaryString() ) {
-        if ( value == null || !EMPTY_STRING_AND_NULL_ARE_DIFFERENT && ( (byte[]) value ).length == 0 ) {
+        if ( value == null || !emptyStringDiffersFromNull && ( (byte[]) value ).length == 0 ) {
           return true; // shortcut
         }
         value = convertBinaryStringToNativeType( (byte[]) data );
@@ -3318,7 +3336,7 @@ public class ValueMetaBase implements ValueMetaInterface {
         return true;
       }
 
-      if ( EMPTY_STRING_AND_NULL_ARE_DIFFERENT ) {
+      if ( emptyStringDiffersFromNull ) {
         return false;
       }
 


### PR DESCRIPTION
- due to `JLS 17.5.3` (http://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.5.3) JVM does not expect final fields to be changed; looks like Java 8 applies some optimisations that utilise that assumption
- change `ValueMetaBase` to be able to get `empty vs null` parameter dynamically and re-implement `ValueMetaStringTest` so, that it becomes stable

@brosander, @deinspanjer, review it please.

While dealing with https://github.com/pentaho/pentaho-kettle/pull/2342, I noticed two failed tests. However, I could manage to reproduce those fails only with Java 8 and that was not stable (~ 1 time from 5 executions). I have only one explanation -- the test is incorrect, because it changes `static final` field with reflection. JVM is allowed to cache `final` values if it needs it for any kind of internal optimisations, and looks like j8 behave in such manner.

I see two possible approaches: the first is to use `ByteBuddy` to redefine classes in runtime thereby removing `final` limitation; the second is to overload some methods to let pass parameter dynamically. Although the first is much more interesting, for the sake of maintainability, I chose the second.