### PR TITLE
[SP-2592] Backport of PDI-14606 - Salesforce Input default field format (yyyy-MM-dd'T'HH:mm:ss'.000'Z) fails for Date/Time fields (6.1 Suite)

### DIFF
--- a/plugins/salesforce/src/org/pentaho/di/ui/trans/steps/salesforceinput/SalesforceInputDialog.java
+++ b/plugins/salesforce/src/org/pentaho/di/ui/trans/steps/salesforceinput/SalesforceInputDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -98,7 +98,7 @@ public class SalesforceInputDialog extends BaseStepDialog implements StepDialogI
 
   private static Class<?> PKG = SalesforceInputMeta.class; // for i18n purposes, needed by Translator2!!
 
-  private String DEFAULT_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'.000'Z";
+  private String DEFAULT_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'.000'XXX";
   private String DEFAULT_DATE_FORMAT = "yyyy-MM-dd";
 
   private CTabFolder wTabFolder;


### PR DESCRIPTION
- Changing date time format to java 7 style (it would be parsed with SimpleDateFormat class, that supports ISO - 8601 from java 7)

@akhayrutdinov , could you please review it? It's a backport of  https://github.com/pentaho/pentaho-kettle/pull/2272


@pamval , @pedrofvteixeira , could you please run WM?