### PR TITLE
[PDI-14950] Spoon does not pass instanceName parameter to MSSQL Server JDBC connection string

### DIFF
--- a/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
@@ -260,18 +260,54 @@ public class DatabaseMetaTest {
 
   @Test
   public void databases_WithSameDbConnTypes_AreTheSame() {
-    assertTrue( databaseMeta.databaseForBothConnTypesIsTheSame( CONNECTION_TYPE_ID_ORACLE, CONNECTION_TYPE_ID_ORACLE ) );
+    DatabaseInterface mssqlServerDatabaseMeta =  new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( "MSSQL" );
+    assertTrue( databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta, mssqlServerDatabaseMeta ) );
+  }
+
+  @Test
+  public void databases_WithSameDbConnTypes_AreNotSame_IfPluginIdIsNull() {
+    DatabaseInterface mssqlServerDatabaseMeta =  new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( null );
+    assertFalse( databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta, mssqlServerDatabaseMeta ) );
   }
 
   @Test
   public void databases_WithDifferentDbConnTypes_AreDifferent_IfNonOfThemIsSubsetOfAnother() {
-    assertFalse( databaseMeta.databaseForBothConnTypesIsTheSame( CONNECTION_TYPE_ID_MSSQL, CONNECTION_TYPE_ID_ORACLE ) );
+    DatabaseInterface mssqlServerDatabaseMeta =  new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( "MSSQL" );
+    DatabaseInterface oracleDatabaseMeta = new OracleDatabaseMeta();
+    oracleDatabaseMeta.setPluginId( "ORACLE" );
+
+    assertFalse( databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta, oracleDatabaseMeta ) );
   }
 
   @Test
-  public void databases_WithDifferentDbConnTypes_AreTheSame_IfOneConnTypeIsSubsetOfAnother() {
-    assertTrue( databaseMeta.databaseForBothConnTypesIsTheSame( CONNECTION_TYPE_ID_MSSQL, CONNECTION_TYPE_ID_MSSQL_NATIVE ) );
+  public void databases_WithDifferentDbConnTypes_AreTheSame_IfOneConnTypeIsSubsetOfAnother_2LevelHierarchy() {
+    DatabaseInterface mssqlServerDatabaseMeta =  new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( "MSSQL" );
+    DatabaseInterface mssqlServerNativeDatabaseMeta =  new MSSQLServerNativeDatabaseMeta();
+    mssqlServerNativeDatabaseMeta.setPluginId( "MSSQLNATIVE" );
+
+    assertTrue( databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta,
+      mssqlServerNativeDatabaseMeta ) );
   }
 
+  @Test
+  public void databases_WithDifferentDbConnTypes_AreTheSame_IfOneConnTypeIsSubsetOfAnother_3LevelHierarchy() {
+    class MSSQLServerNativeDatabaseMetaChild extends MSSQLServerDatabaseMeta {
+      @Override
+      public String getPluginId() {
+        return "MSSQLNATIVE_CHILD";
+      }
+    }
+
+    DatabaseInterface mssqlServerDatabaseMeta = new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( "MSSQL" );
+    DatabaseInterface mssqlServerNativeDatabaseMetaChild = new MSSQLServerNativeDatabaseMetaChild();
+
+    assertTrue(
+      databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta, mssqlServerNativeDatabaseMetaChild ) );
+  }
 
 }


### PR DESCRIPTION
In general this PR makes previous attempt more expandable.
[Previous approach] (https://github.com/pentaho/pentaho-kettle/pull/2311/files#diff-e00fc57465837a5bbc7698705df3df30R1184) doesn't work for those who will write their own plugins, extending from the existing once.
This PR is made to fix this issue.

**What was done**
- Checking whether the underlying database for two DatabaseInterface's is the same depending on the class hierarchy (if check by pluginId fails).
- Tests covering this case are written.
- Some tests are refactored due to changes in method parameters.

@akhayrutdinov , review it please

@pamval , @pedrofvteixeira , could you run WM, please?