### PR TITLE
[SP-2593] Backport of PDI-15018 - DI Server security not behaving properly. (6.1 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/repository/RepositoryOperation.java
+++ b/engine/src/org/pentaho/di/repository/RepositoryOperation.java
@@ -26,10 +26,10 @@ public enum RepositoryOperation {
 
   READ_TRANSFORMATION( "Read transformation" ), MODIFY_TRANSFORMATION( "Modify transformation" ),
     DELETE_TRANSFORMATION( "Delete transformation" ), EXECUTE_TRANSFORMATION( "Execute transformation" ),
-    LOCK_TRANSFORMATION( "Lock transformation" ),
+    LOCK_TRANSFORMATION( "Lock transformation" ), SCHEDULE_TRANSFORMATION("Schedule transformation"),
 
     READ_JOB( "Read job" ), MODIFY_JOB( "Modify job" ), DELETE_JOB( "Delete job" ), EXECUTE_JOB( "Execute job" ),
-    LOCK_JOB( "Lock job" ),
+    LOCK_JOB( "Lock job" ), SCHEDULE_JOB("Schedule job"),
 
     MODIFY_DATABASE( "Modify database connection" ), DELETE_DATABASE( "Delete database connection" ),
     EXPLORE_DATABASE( "Explore database connection" ),

--- a/engine/src/org/pentaho/di/repository/RepositoryOperation.java
+++ b/engine/src/org/pentaho/di/repository/RepositoryOperation.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,23 +25,23 @@ package org.pentaho.di.repository;
 public enum RepositoryOperation {
 
   READ_TRANSFORMATION( "Read transformation" ), MODIFY_TRANSFORMATION( "Modify transformation" ),
-    DELETE_TRANSFORMATION( "Delete transformation" ), EXECUTE_TRANSFORMATION( "Execute transformation" ),
-    LOCK_TRANSFORMATION( "Lock transformation" ), SCHEDULE_TRANSFORMATION("Schedule transformation"),
+  DELETE_TRANSFORMATION( "Delete transformation" ), EXECUTE_TRANSFORMATION( "Execute transformation" ),
+  LOCK_TRANSFORMATION( "Lock transformation" ), SCHEDULE_TRANSFORMATION( "Schedule transformation" ),
 
-    READ_JOB( "Read job" ), MODIFY_JOB( "Modify job" ), DELETE_JOB( "Delete job" ), EXECUTE_JOB( "Execute job" ),
-    LOCK_JOB( "Lock job" ), SCHEDULE_JOB("Schedule job"),
+  READ_JOB( "Read job" ), MODIFY_JOB( "Modify job" ), DELETE_JOB( "Delete job" ), EXECUTE_JOB( "Execute job" ),
+  LOCK_JOB( "Lock job" ), SCHEDULE_JOB( "Schedule job" ),
 
-    MODIFY_DATABASE( "Modify database connection" ), DELETE_DATABASE( "Delete database connection" ),
-    EXPLORE_DATABASE( "Explore database connection" ),
+  MODIFY_DATABASE( "Modify database connection" ), DELETE_DATABASE( "Delete database connection" ),
+  EXPLORE_DATABASE( "Explore database connection" ),
 
-    MODIFY_SLAVE_SERVER( "Modify slave server" ), DELETE_SLAVE_SERVER( "Delete slave server" ),
+  MODIFY_SLAVE_SERVER( "Modify slave server" ), DELETE_SLAVE_SERVER( "Delete slave server" ),
 
-    MODIFY_CLUSTER_SCHEMA( "Modify cluster schema" ), DELETE_CLUSTER_SCHEMA( "Delete cluster schema" ),
+  MODIFY_CLUSTER_SCHEMA( "Modify cluster schema" ), DELETE_CLUSTER_SCHEMA( "Delete cluster schema" ),
 
-    MODIFY_PARTITION_SCHEMA( "Modify partition schema" ), DELETE_PARTITION_SCHEMA( "Delete partition schema" ),
+  MODIFY_PARTITION_SCHEMA( "Modify partition schema" ), DELETE_PARTITION_SCHEMA( "Delete partition schema" ),
 
-    CREATE_DIRECTORY( "Create directory" ), RENAME_DIRECTORY( "Rename directory" ),
-    DELETE_DIRECTORY( "Delete directory" );
+  CREATE_DIRECTORY( "Create directory" ), RENAME_DIRECTORY( "Rename directory" ),
+  DELETE_DIRECTORY( "Delete directory" );
 
   private final String description;
 

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/AbsSecurityProvider.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/AbsSecurityProvider.java
@@ -19,7 +19,6 @@ package org.pentaho.di.repository.pur;
 import java.util.List;
 
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.exception.KettleSecurityException;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.IUser;
 import org.pentaho.di.repository.RepositoryOperation;
@@ -87,20 +86,37 @@ public class AbsSecurityProvider extends PurRepositorySecurityProvider implement
   }
 
   @Override
-  public void validateAction( RepositoryOperation... operations ) throws KettleException, KettleSecurityException {
+  public void validateAction( RepositoryOperation... operations ) throws KettleException {
 
     for ( RepositoryOperation operation : operations ) {
-      if ( ( operation == RepositoryOperation.EXECUTE_TRANSFORMATION )
-          || ( operation == RepositoryOperation.EXECUTE_JOB ) ) {
-        if ( isAllowed( IAbsSecurityProvider.EXECUTE_CONTENT_ACTION ) == false ) {
-          throw new KettleException( operation + " : permission not allowed" );
-        }
-      } else if ( ( operation == RepositoryOperation.MODIFY_TRANSFORMATION )
-          || ( operation == RepositoryOperation.MODIFY_JOB ) ) {
-        if ( isAllowed( IAbsSecurityProvider.CREATE_CONTENT_ACTION ) == false ) {
-          throw new KettleException( operation + " : permission not allowed" );
-        }
+      switch( operation ) {
+        case EXECUTE_TRANSFORMATION:
+        case EXECUTE_JOB:
+          checkOperationAllowed( EXECUTE_CONTENT_ACTION );
+          break;
+
+        case MODIFY_TRANSFORMATION:
+        case MODIFY_JOB:
+          checkOperationAllowed( CREATE_CONTENT_ACTION );
+          break;
+
+        case SCHEDULE_TRANSFORMATION:
+        case SCHEDULE_JOB:
+          checkOperationAllowed( SCHEDULE_CONTENT_ACTION );
+          break;
       }
     }
   }
+
+  /**
+   *
+   * @throws KettleException
+   *           if an operation is not allowed
+   */
+  private void checkOperationAllowed( String operation ) throws KettleException {
+    if ( !isAllowed( operation ) ) {
+      throw new KettleException( operation + " : permission not allowed" );
+    }
+  }
+
 }

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/AbsSecurityProvider.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/AbsSecurityProvider.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class AbsSecurityProvider extends PurRepositorySecurityProvider implement
       return isAllowedActiveCache.get( actionName );
     } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( AbsSecurityProvider.class,
-          "AbsSecurityProvider.ERROR_0002_UNABLE_TO_ACCESS_IS_ALLOWED" ), e );//$NON-NLS-1$
+          "AbsSecurityProvider.ERROR_0002_UNABLE_TO_ACCESS_IS_ALLOWED" ), e ); //$NON-NLS-1$
     }
   }
 
@@ -89,7 +89,7 @@ public class AbsSecurityProvider extends PurRepositorySecurityProvider implement
   public void validateAction( RepositoryOperation... operations ) throws KettleException {
 
     for ( RepositoryOperation operation : operations ) {
-      switch( operation ) {
+      switch ( operation ) {
         case EXECUTE_TRANSFORMATION:
         case EXECUTE_JOB:
           checkOperationAllowed( EXECUTE_CONTENT_ACTION );

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/pur/services/IAbsSecurityProvider.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/pur/services/IAbsSecurityProvider.java
@@ -31,21 +31,23 @@ import org.pentaho.di.repository.RepositorySecurityProvider;
  */
 
 public interface IAbsSecurityProvider extends RepositorySecurityProvider {
-  public final static String CREATE_CONTENT_ROLE = "org.pentaho.di.creator"; //$NON-NLS-1$
+  String CREATE_CONTENT_ROLE = "org.pentaho.di.creator"; //$NON-NLS-1$
 
-  public final static String READ_CONTENT_ROLE = "org.pentaho.di.reader";//$NON-NLS-1$
+  String READ_CONTENT_ROLE = "org.pentaho.di.reader";//$NON-NLS-1$
 
-  public final static String ADMINISTER_SECURITY_ROLE = "org.pentaho.di.securityAdministrator";//$NON-NLS-1$
+  String ADMINISTER_SECURITY_ROLE = "org.pentaho.di.securityAdministrator";//$NON-NLS-1$
 
-  public final static String CREATE_CONTENT_ACTION = "org.pentaho.repository.create"; //$NON-NLS-1$
+  String CREATE_CONTENT_ACTION = "org.pentaho.repository.create"; //$NON-NLS-1$
 
-  public final static String READ_CONTENT_ACTION = "org.pentaho.repository.read";//$NON-NLS-1$
+  String READ_CONTENT_ACTION = "org.pentaho.repository.read";//$NON-NLS-1$
 
-  public final static String EXECUTE_CONTENT_ACTION = "org.pentaho.repository.execute";//$NON-NLS-1$
+  String EXECUTE_CONTENT_ACTION = "org.pentaho.repository.execute";//$NON-NLS-1$
 
-  public final static String ADMINISTER_SECURITY_ACTION = "org.pentaho.security.administerSecurity";//$NON-NLS-1$
+  String SCHEDULE_CONTENT_ACTION = "org.pentaho.scheduler.manage";
 
-  public final static String NAMESPACE = "org.pentaho"; //$NON-NLS-1$
+  String ADMINISTER_SECURITY_ACTION = "org.pentaho.security.administerSecurity";//$NON-NLS-1$
+
+  String NAMESPACE = "org.pentaho"; //$NON-NLS-1$
 
   /**
    * Returns {@code true} if the the action should be allowed.

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/pur/services/IAbsSecurityProvider.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/pur/services/IAbsSecurityProvider.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,19 +33,19 @@ import org.pentaho.di.repository.RepositorySecurityProvider;
 public interface IAbsSecurityProvider extends RepositorySecurityProvider {
   String CREATE_CONTENT_ROLE = "org.pentaho.di.creator"; //$NON-NLS-1$
 
-  String READ_CONTENT_ROLE = "org.pentaho.di.reader";//$NON-NLS-1$
+  String READ_CONTENT_ROLE = "org.pentaho.di.reader"; //$NON-NLS-1$
 
-  String ADMINISTER_SECURITY_ROLE = "org.pentaho.di.securityAdministrator";//$NON-NLS-1$
+  String ADMINISTER_SECURITY_ROLE = "org.pentaho.di.securityAdministrator"; //$NON-NLS-1$
 
   String CREATE_CONTENT_ACTION = "org.pentaho.repository.create"; //$NON-NLS-1$
 
-  String READ_CONTENT_ACTION = "org.pentaho.repository.read";//$NON-NLS-1$
+  String READ_CONTENT_ACTION = "org.pentaho.repository.read"; //$NON-NLS-1$
 
-  String EXECUTE_CONTENT_ACTION = "org.pentaho.repository.execute";//$NON-NLS-1$
+  String EXECUTE_CONTENT_ACTION = "org.pentaho.repository.execute"; //$NON-NLS-1$
 
   String SCHEDULE_CONTENT_ACTION = "org.pentaho.scheduler.manage";
 
-  String ADMINISTER_SECURITY_ACTION = "org.pentaho.security.administerSecurity";//$NON-NLS-1$
+  String ADMINISTER_SECURITY_ACTION = "org.pentaho.security.administerSecurity"; //$NON-NLS-1$
 
   String NAMESPACE = "org.pentaho"; //$NON-NLS-1$
 

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/AbsSecurityProviderTest.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/AbsSecurityProviderTest.java
@@ -1,0 +1,86 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.pentaho.di.repository.pur;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.RepositoryOperation;
+import org.pentaho.di.repository.UserInfo;
+import org.pentaho.di.ui.repository.pur.services.IAbsSecurityProvider;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class AbsSecurityProviderTest {
+  private AbsSecurityProvider provider;
+
+  @Before
+  public void setUp() {
+    provider = new AbsSecurityProvider( new PurRepository(), new PurRepositoryMeta(), new UserInfo(),
+      mock( ServiceManager.class ) );
+    provider = spy( provider );
+  }
+
+  @Test( expected = KettleException.class )
+  public void exceptionThrown_WhenOperationNotAllowed_ExecuteOperation() throws Exception {
+
+    setOperationPermissions( IAbsSecurityProvider.EXECUTE_CONTENT_ACTION, false );
+    provider.validateAction( RepositoryOperation.EXECUTE_TRANSFORMATION );
+  }
+
+  @Test( expected = KettleException.class )
+  public void exceptionThrown_WhenOperationNotAllowed_ScheduleOperation() throws Exception {
+
+    setOperationPermissions( IAbsSecurityProvider.SCHEDULE_CONTENT_ACTION, false );
+    provider.validateAction( RepositoryOperation.SCHEDULE_JOB );
+  }
+
+  @Test( expected = KettleException.class )
+  public void exceptionThrown_WhenOperationNotAllowed_CreateOperation() throws Exception {
+
+    setOperationPermissions( IAbsSecurityProvider.CREATE_CONTENT_ACTION, false );
+    provider.validateAction( RepositoryOperation.MODIFY_JOB );
+  }
+
+  @Test
+  public void noExceptionThrown_WhenOperationIsAllowed_ScheduleOperation() throws Exception {
+
+    setOperationPermissions( IAbsSecurityProvider.EXECUTE_CONTENT_ACTION, true );
+    provider.validateAction( RepositoryOperation.EXECUTE_JOB );
+  }
+
+  @Test
+  public void noExceptionThrown_WhenOperationIsAllowed_CreateOperation() throws Exception {
+
+    setOperationPermissions( IAbsSecurityProvider.SCHEDULE_CONTENT_ACTION, true );
+    provider.validateAction( RepositoryOperation.SCHEDULE_TRANSFORMATION );
+  }
+
+  @Test
+  public void noExceptionThrown_WhenOperationIsAllowed_ExecuteOperation() throws Exception {
+
+    setOperationPermissions( IAbsSecurityProvider.CREATE_CONTENT_ACTION, true );
+    provider.validateAction( RepositoryOperation.MODIFY_TRANSFORMATION );
+  }
+
+  private void setOperationPermissions( String operation, boolean isAllowed ) throws Exception {
+    doReturn( isAllowed ).when( provider ).isAllowed( operation );
+  }
+}


### PR DESCRIPTION
- Since we have a separate "Schedule content" permission in permission list, we separately check permissions for this operation.
- Checkstyle applied
- Test written


More details:

**AbsSecurityProvider**
- Added check for scheduling action
- Refactored code a little

**IAbsSecurityProvider**
- Added constant for scheduling action
- Removed unnecessary public static final on fields, as this is done by default since this are variables of an interface.

**RepositoryOperation**
- Added enums for job and trans scheduling



@akhayrutdinov, review it please, it is a backport of https://github.com/pentaho/pentaho-kettle/pull/2326

@pamval, @pedrofvteixeira , run WM for this PR please