### PR TITLE
[SP-2596] - Backport of PDI-15013 - Create zip files runs successfully with wrong Source path (6.1 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
+++ b/engine/src/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -88,7 +88,7 @@ import org.w3c.dom.Node;
  *
  */
 public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntryInterface {
-  private static Class<?> PKG = JobEntryZipFile.class; // for i18n purposes, needed by Translator2!!
+  private static final Class<?> PKG = JobEntryZipFile.class; // for i18n purposes, needed by Translator2!!
 
   private String zipFilename;
   public int compressionRate;
@@ -280,7 +280,6 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
       if ( parentfolder != null ) {
         try {
           parentfolder.close();
-          parentfolder = null;
         } catch ( Exception ex ) {
           // Ignore
         }
@@ -294,7 +293,7 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     boolean createparentfolder ) {
     boolean Fileexists = false;
     File tempFile = null;
-    File fileZip = null;
+    File fileZip;
     boolean resultat = false;
     boolean renameOk = false;
     boolean orginExist = false;
@@ -302,11 +301,11 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     // Check if target file/folder exists!
     FileObject originFile = null;
     ZipInputStream zin = null;
-    byte[] buffer = null;
+    byte[] buffer;
     OutputStream dest = null;
     BufferedOutputStreamWithCloseDetection buff = null;
     ZipOutputStream out = null;
-    ZipEntry entry = null;
+    ZipEntry entry;
     String localSourceFilename = realSourceDirectoryOrFile;
 
     try {
@@ -366,7 +365,7 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
           // After Zip, Move files..User must give a destination Folder
 
           // Let's see if we deal with file or folder
-          FileObject[] fileList = null;
+          FileObject[] fileList;
 
           FileObject sourceFileOrFolder = KettleVFS.getFileObject( localSourceFilename );
           boolean isSourceDirectory = sourceFileOrFolder.getType().equals( FileType.FOLDER );
@@ -734,16 +733,13 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
           if ( zin != null ) {
             zin.close();
           }
-          if ( entry != null ) {
-            entry = null;
-          }
 
         } catch ( IOException ex ) {
           logError( "Error closing zip file entry for file '" + originFile.toString() + "'", ex );
         }
       }
     } else {
-      resultat = true;
+      resultat = false;
       if ( localrealZipfilename == null ) {
         logError( BaseMessages.getString( PKG, "JobZipFiles.No_ZipFile_Defined.Label" ) );
       }
@@ -839,10 +835,10 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     List<RowMetaAndData> rows = result.getRows();
 
     // reset values
-    String realZipfilename = null;
+    String realZipfilename;
     String realWildcard = null;
     String realWildcardExclude = null;
-    String realTargetdirectory = null;
+    String realTargetdirectory;
     String realMovetodirectory = environmentSubstitute( movetoDirectory );
 
     // Sanity check
@@ -892,11 +888,9 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
             realMovetodirectory = KettleVFS.getFilename( moveToDirectory );
             try {
               moveToDirectory.close();
-              moveToDirectory = null;
             } catch ( Exception e ) {
               logError( "Error moving to directory", e );
-              result.setResult( false );
-              result.setNrErrors( 1 );
+              SanityControlOK = false;
             }
           }
         }
@@ -904,9 +898,7 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     }
 
     if ( !SanityControlOK ) {
-      result.setNrErrors( 1 );
-      result.setResult( false );
-      return result;
+      return errorResult( result );
     }
 
     // arguments from previous
@@ -941,8 +933,7 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
               if ( !processRowFile(
                 parentJob, result, realZipfilename, realWildcard, realWildcardExclude, realTargetdirectory,
                 realMovetodirectory, createParentFolder ) ) {
-                result.setResult( false );
-                return result;
+                return errorResult( result );
               }
             } else {
               logError( "destination zip filename is empty! Ignoring row..." );
@@ -965,9 +956,13 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
         realWildcardExclude = environmentSubstitute( excludeWildCard );
         realTargetdirectory = environmentSubstitute( sourceDirectory );
 
-        result.setResult( processRowFile(
-          parentJob, result, realZipfilename, realWildcard, realWildcardExclude, realTargetdirectory,
-          realMovetodirectory, createParentFolder ) );
+        boolean success = processRowFile( parentJob, result, realZipfilename, realWildcard, realWildcardExclude,
+          realTargetdirectory, realMovetodirectory, createParentFolder );
+        if ( success ) {
+          result.setResult( true );
+        } else {
+          errorResult( result );
+        }
       } else {
         logError( "Source folder/file is empty! Ignoring row..." );
       }
@@ -977,9 +972,15 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     return result;
   }
 
+  private Result errorResult( Result result ) {
+    result.setNrErrors( 1 );
+    result.setResult( false );
+    return result;
+  }
+
   public String getFullFilename( String filename, boolean add_date, boolean add_time, boolean specify_format,
     String datetime_folder ) {
-    String retval = "";
+    String retval;
     if ( Const.isEmpty( filename ) ) {
       return null;
     }

--- a/engine/src/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
+++ b/engine/src/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
@@ -22,13 +22,6 @@
 
 package org.pentaho.di.job.entries.zipfile;
 
-import static org.pentaho.di.job.entry.validator.AbstractFileValidator.putVariableSpace;
-import static org.pentaho.di.job.entry.validator.AndValidator.putValidators;
-import static org.pentaho.di.job.entry.validator.FileDoesNotExistValidator.putFailIfExists;
-import static org.pentaho.di.job.entry.validator.JobEntryValidatorUtils.andValidator;
-import static org.pentaho.di.job.entry.validator.JobEntryValidatorUtils.fileDoesNotExistValidator;
-import static org.pentaho.di.job.entry.validator.JobEntryValidatorUtils.notBlankValidator;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -72,6 +65,10 @@ import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryBase;
 import org.pentaho.di.job.entry.JobEntryInterface;
+import org.pentaho.di.job.entry.validator.AbstractFileValidator;
+import org.pentaho.di.job.entry.validator.AndValidator;
+import org.pentaho.di.job.entry.validator.FileDoesNotExistValidator;
+import org.pentaho.di.job.entry.validator.JobEntryValidatorUtils;
 import org.pentaho.di.job.entry.validator.ValidatorContext;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
@@ -1131,20 +1128,23 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
   public void check( List<CheckResultInterface> remarks, JobMeta jobMeta, VariableSpace space,
     Repository repository, IMetaStore metaStore ) {
     ValidatorContext ctx1 = new ValidatorContext();
-    putVariableSpace( ctx1, getVariables() );
-    putValidators( ctx1, notBlankValidator(), fileDoesNotExistValidator() );
+    AbstractFileValidator.putVariableSpace( ctx1, getVariables() );
+    AndValidator.putValidators( ctx1, JobEntryValidatorUtils.notBlankValidator(),
+      JobEntryValidatorUtils.fileDoesNotExistValidator() );
     if ( 3 == ifZipFileExists ) {
       // execute method fails if the file already exists; we should too
-      putFailIfExists( ctx1, true );
+      FileDoesNotExistValidator.putFailIfExists( ctx1, true );
     }
-    andValidator().validate( this, "zipFilename", remarks, ctx1 );
+    JobEntryValidatorUtils.andValidator().validate( this, "zipFilename", remarks, ctx1 );
 
     if ( 2 == afterZip ) {
       // setting says to move
-      andValidator().validate( this, "moveToDirectory", remarks, putValidators( notBlankValidator() ) );
+      JobEntryValidatorUtils.andValidator().validate( this, "moveToDirectory", remarks,
+        AndValidator.putValidators( JobEntryValidatorUtils.notBlankValidator() ) );
     }
 
-    andValidator().validate( this, "sourceDirectory", remarks, putValidators( notBlankValidator() ) );
+    JobEntryValidatorUtils.andValidator().validate( this, "sourceDirectory", remarks,
+      AndValidator.putValidators( JobEntryValidatorUtils.notBlankValidator() ) );
 
   }
 

--- a/engine/test-src/org/pentaho/di/job/entries/zipfile/JobEntryZipFileIT.java
+++ b/engine/test-src/org/pentaho/di/job/entries/zipfile/JobEntryZipFileIT.java
@@ -1,0 +1,97 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.zipfile;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.vfs2.FileObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.job.Job;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class JobEntryZipFileIT {
+
+  @BeforeClass
+  public static void init() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  @Test
+  public void processFileIndicatesFailure() throws Exception {
+    JobEntryZipFile entry = new JobEntryZipFile();
+    assertFalse(
+      entry.processRowFile( new Job(), new Result(), "file://\nfake-path\n", null, null, null, null, false ) );
+  }
+
+  @Test
+  public void processFile_ReturnsTrue_OnSuccess() throws Exception {
+    final String zipPath = "ram://pdi-15013.zip";
+    final String content = "temp file";
+    final File tempFile = createTempFile( content );
+    tempFile.deleteOnExit();
+    try {
+      Result result = new Result();
+      JobEntryZipFile entry = new JobEntryZipFile();
+      assertTrue(
+        entry.processRowFile( new Job(), result, zipPath, null, null, tempFile.getAbsolutePath(), null, false ) );
+    } finally {
+      tempFile.delete();
+    }
+
+    FileObject zip = KettleVFS.getFileObject( zipPath );
+    assertTrue( "Zip archive should be created", zip.exists() );
+
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    IOUtils.copy( zip.getContent().getInputStream(), os );
+
+    ZipInputStream zis = new ZipInputStream( new ByteArrayInputStream( os.toByteArray() ) );
+    ZipEntry entry = zis.getNextEntry();
+    assertEquals( "Input file should be put into the archive", tempFile.getName(), entry.getName() );
+
+    os.reset();
+    IOUtils.copy( zis, os );
+    assertEquals( "File's content should be equal to original", content, new String( os.toByteArray() ) );
+  }
+
+  private static File createTempFile( String content ) throws Exception {
+    File file = File.createTempFile( "JobEntryZipFileIT", ".txt" );
+    try ( PrintWriter pw = new PrintWriter( file ) ) {
+      pw.print( content );
+    }
+    return file;
+  }
+}


### PR DESCRIPTION
- fail on non-existing path
- in JobEntryZipFile, remove useless assignments (highlighted by Intelij)
- add tests
(cherry-picked from ef893f58535aa489e7c959f1c23ec06ae7f3c811)

@brosander, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/2338 