### PR TITLE
[SP-2589] - Backport of PDI-14999 - 'Split Field to Rows' step fails with NullPointerException after import into repository (5.4 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/splitfieldtorows/SplitFieldToRows.java
+++ b/engine/src/org/pentaho/di/trans/steps/splitfieldtorows/SplitFieldToRows.java
@@ -153,10 +153,11 @@ public class SplitFieldToRows extends BaseStep implements StepInterface {
       data.rownr = 1L;
 
       try {
+        String delimiter = Const.nullToEmpty( meta.getDelimiter() );
         if ( meta.isDelimiterRegex() ) {
-          data.delimiterPattern = Pattern.compile( environmentSubstitute( meta.getDelimiter() ) );
+          data.delimiterPattern = Pattern.compile( environmentSubstitute( delimiter ) );
         } else {
-          data.delimiterPattern = Pattern.compile( Pattern.quote( environmentSubstitute( meta.getDelimiter() ) ) );
+          data.delimiterPattern = Pattern.compile( Pattern.quote( environmentSubstitute( delimiter ) ) );
         }
       } catch ( PatternSyntaxException pse ) {
         log.logError( pse.getMessage() );

--- a/engine/test-src/org/pentaho/di/trans/steps/splitfieldtorows/SplitFieldToRowsTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/splitfieldtorows/SplitFieldToRowsTest.java
@@ -1,0 +1,50 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.splitfieldtorows;
+
+import org.junit.Test;
+import org.pentaho.di.trans.steps.StepMockUtil;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class SplitFieldToRowsTest {
+
+  @Test
+  public void interpretsNullDelimiterAsEmpty() throws Exception {
+    SplitFieldToRows step =
+      StepMockUtil.getStep( SplitFieldToRows.class, SplitFieldToRowsMeta.class, "handlesNullDelimiter" );
+
+    SplitFieldToRowsMeta meta = new SplitFieldToRowsMeta();
+    meta.setDelimiter( null );
+    meta.setDelimiterRegex( false );
+
+    SplitFieldToRowsData data = new SplitFieldToRowsData();
+
+    step.init( meta, data );
+    // empty string should be quoted --> \Q\E
+    assertEquals( "\\Q\\E", data.delimiterPattern.pattern() );
+  }
+}


### PR DESCRIPTION
- manually handle `null` value of `delimiter` property
(cherry-picked from 47560270a85b39b4767f4db9d19998c182063e6b)

@brosander, review it please. This is a backport of https://github.com/pentaho/pentaho-kettle/pull/2282 