### PR TITLE
[BISERVER-13110] If there are some transformations/jobs which names differs only by whitespace/underscore symbol, only transformations/jobs with underscore symbol in it's name will be restored after backup/restore operation.

### DIFF
--- a/plugins/pdi-pur-plugin/src/com/pentaho/repository/importexport/PDIImportFileHandler.java
+++ b/plugins/pdi-pur-plugin/src/com/pentaho/repository/importexport/PDIImportFileHandler.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.pentaho.repository.importexport;
 
 import java.util.List;
 
+import org.pentaho.di.repository.pur.PurRepository;
 import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
@@ -39,12 +40,11 @@ public class PDIImportFileHandler extends RepositoryFileImportFileHandler implem
   protected RepositoryFile createFile( final RepositoryFileImportBundle bundle, final String repositoryPath,
       final IRepositoryFileData data ) throws PlatformImportException {
 
-    RepositoryFileImportBundle pdiBundle = bundle;
     String originalName = bundle.getName();
-    pdiBundle.setName( PDIImportUtil.checkAndSanitize( originalName ) );
-    pdiBundle.setTitle( originalName );
+    bundle.setName( PurRepository.checkAndSanitize( originalName ) );
+    bundle.setTitle( originalName );
 
-    return super.createFile( pdiBundle, repositoryPath, data );
+    return super.createFile( bundle, repositoryPath, data );
   }
 
   @Override

--- a/plugins/pdi-pur-plugin/src/com/pentaho/repository/importexport/PDIImportUtil.java
+++ b/plugins/pdi-pur-plugin/src/com/pentaho/repository/importexport/PDIImportUtil.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryObjectType;
 import org.pentaho.di.repository.utils.IRepositoryFactory;
+import org.pentaho.platform.plugin.services.importer.PlatformImportException;
+import org.pentaho.platform.web.http.api.resources.services.FileService;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -54,8 +56,6 @@ public class PDIImportUtil {
    * @param repositoryName
    * @return
    * @throws KettleException
-   * @throws KettleSecurityException
-   * @throws ActionExecutionException
    */
   public static Repository connectToRepository( String repositoryName ) throws KettleException {
     return repositoryFactory.connect( repositoryName );
@@ -111,39 +111,6 @@ public class PDIImportUtil {
     } catch ( TransformerException e ) {
       e.printStackTrace();
       return null;
-    }
-  }
-
-  public static String checkAndSanitize( final String in ) {
-    if ( in == null ) {
-      throw new IllegalArgumentException();
-    }
-    String extension = null;
-    if ( in.endsWith( RepositoryObjectType.CLUSTER_SCHEMA.getExtension() ) ) {
-      extension = RepositoryObjectType.CLUSTER_SCHEMA.getExtension();
-    } else if ( in.endsWith( RepositoryObjectType.DATABASE.getExtension() ) ) {
-      extension = RepositoryObjectType.DATABASE.getExtension();
-    } else if ( in.endsWith( RepositoryObjectType.JOB.getExtension() ) ) {
-      extension = RepositoryObjectType.JOB.getExtension();
-    } else if ( in.endsWith( RepositoryObjectType.PARTITION_SCHEMA.getExtension() ) ) {
-      extension = RepositoryObjectType.PARTITION_SCHEMA.getExtension();
-    } else if ( in.endsWith( RepositoryObjectType.SLAVE_SERVER.getExtension() ) ) {
-      extension = RepositoryObjectType.SLAVE_SERVER.getExtension();
-    } else if ( in.endsWith( RepositoryObjectType.TRANSFORMATION.getExtension() ) ) {
-      extension = RepositoryObjectType.TRANSFORMATION.getExtension();
-    }
-    String out = in;
-    if ( extension != null ) {
-      out = out.substring( 0, out.length() - extension.length() );
-    }
-    if ( out.contains( "/" ) || out.equals( ".." ) || out.equals( "." ) || StringUtils.isBlank( out ) ) {
-      throw new IllegalArgumentException();
-    }
-    out = out.replaceAll( "[/:\\[\\]\\*'\"\\|\\s\\.]", "_" ); //$NON-NLS-1$//$NON-NLS-2$
-    if ( extension != null ) {
-      return out + extension;
-    } else {
-      return out;
     }
   }
 

--- a/plugins/pdi-pur-plugin/src/com/pentaho/repository/importexport/PDIImportUtil.java
+++ b/plugins/pdi-pur-plugin/src/com/pentaho/repository/importexport/PDIImportUtil.java
@@ -36,13 +36,9 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.repository.Repository;
-import org.pentaho.di.repository.RepositoryObjectType;
 import org.pentaho.di.repository.utils.IRepositoryFactory;
-import org.pentaho.platform.plugin.services.importer.PlatformImportException;
-import org.pentaho.platform.web.http.api.resources.services.FileService;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
@@ -1,6 +1,6 @@
 //CHECKSTYLE:FileLength:OFF
 /*!
-* Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,9 +17,6 @@
 */
 
 package org.pentaho.di.repository.pur;
-
-import static org.pentaho.di.repository.RepositoryObjectType.JOB;
-import static org.pentaho.di.repository.RepositoryObjectType.TRANSFORMATION;
 
 import java.io.Serializable;
 import java.lang.reflect.Proxy;
@@ -734,7 +731,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
           return null;
         } else {
           return path + ( path.endsWith( RepositoryFile.SEPARATOR ) ? "" : RepositoryFile.SEPARATOR ) + sanitizedName
-              + TRANSFORMATION.getExtension();
+              + RepositoryObjectType.TRANSFORMATION.getExtension();
         }
       }
       case PARTITION_SCHEMA: {
@@ -755,7 +752,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
           return null;
         } else {
           return path + ( path.endsWith( RepositoryFile.SEPARATOR ) ? "" : RepositoryFile.SEPARATOR ) + sanitizedName
-              + JOB.getExtension();
+              + RepositoryObjectType.JOB.getExtension();
         }
       }
       default: {
@@ -852,7 +849,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
           List<RepositoryFile>
               deletedChildren =
               pur.getDeletedFiles( dir.getObjectId().getId(),
-                  name + TRANSFORMATION.getExtension() );
+                  name + RepositoryObjectType.TRANSFORMATION.getExtension() );
           if ( !deletedChildren.isEmpty() ) {
             return new StringObjectId( deletedChildren.get( 0 ).getId().toString() );
           } else {
@@ -899,7 +896,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
           // file either never existed or has been deleted
           List<RepositoryFile>
               deletedChildren =
-              pur.getDeletedFiles( dir.getObjectId().getId(), name + JOB.getExtension() );
+              pur.getDeletedFiles( dir.getObjectId().getId(), name + RepositoryObjectType.JOB.getExtension() );
           if ( !deletedChildren.isEmpty() ) {
             return new StringObjectId( deletedChildren.get( 0 ).getId().toString() );
           } else {
@@ -966,7 +963,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
         }
         case TRANSFORMATION: {
           parentFolderIds.add( dirId.getId() );
-          filters.add( "*" + TRANSFORMATION.getExtension() ); //$NON-NLS-1$
+          filters.add( "*" + RepositoryObjectType.TRANSFORMATION.getExtension() ); //$NON-NLS-1$
           break;
         }
         case PARTITION_SCHEMA: {
@@ -986,7 +983,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
         }
         case JOB: {
           parentFolderIds.add( dirId.getId() );
-          filters.add( "*" + JOB.getExtension() ); //$NON-NLS-1$
+          filters.add( "*" + RepositoryObjectType.JOB.getExtension() ); //$NON-NLS-1$
           break;
         }
         case TRANS_DATA_SERVICE: {
@@ -1030,7 +1027,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
         }
         case TRANSFORMATION: {
           parentFolderPaths.add( dirPath );
-          filters.add( "*" + TRANSFORMATION.getExtension() ); //$NON-NLS-1$
+          filters.add( "*" + RepositoryObjectType.TRANSFORMATION.getExtension() ); //$NON-NLS-1$
           break;
         }
         case PARTITION_SCHEMA: {
@@ -1050,7 +1047,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
         }
         case JOB: {
           parentFolderPaths.add( dirPath );
-          filters.add( "*" + JOB.getExtension() ); //$NON-NLS-1$
+          filters.add( "*" + RepositoryObjectType.JOB.getExtension() ); //$NON-NLS-1$
           break;
         }
         default: {
@@ -1273,18 +1270,18 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   public ObjectId getJobId( final String name, final RepositoryDirectoryInterface repositoryDirectory )
     throws KettleException {
     try {
-      return getObjectId( name, repositoryDirectory, JOB, false );
+      return getObjectId( name, repositoryDirectory, RepositoryObjectType.JOB, false );
     } catch ( Exception e ) {
       String path = repositoryDirectory != null ? repositoryDirectory.toString() : "null";
       throw new IdNotFoundException( "Unable to get ID for job [" + name + "]", e, name, path,
-          JOB );
+        RepositoryObjectType.JOB );
     }
   }
 
   @Override
   public String[] getJobNames( ObjectId idDirectory, boolean includeDeleted ) throws KettleException {
     try {
-      List<RepositoryFile> children = getAllFilesOfType( idDirectory, JOB, includeDeleted );
+      List<RepositoryFile> children = getAllFilesOfType( idDirectory, RepositoryObjectType.JOB, includeDeleted );
       List<String> names = new ArrayList<String>();
       for ( RepositoryFile file : children ) {
         names.add( file.getTitle() );
@@ -1298,7 +1295,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   @Override
   public List<RepositoryElementMetaInterface> getJobObjects( ObjectId idDirectory, boolean includeDeleted )
     throws KettleException {
-    return getPdiObjects( idDirectory, Arrays.asList( new RepositoryObjectType[] { JOB } ),
+    return getPdiObjects( idDirectory, Arrays.asList( new RepositoryObjectType[] { RepositoryObjectType.JOB } ),
         includeDeleted );
   }
 
@@ -1433,11 +1430,11 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   public ObjectId getTransformationID( String name, RepositoryDirectoryInterface repositoryDirectory )
     throws KettleException {
     try {
-      return getObjectId( name, repositoryDirectory, TRANSFORMATION, false );
+      return getObjectId( name, repositoryDirectory, RepositoryObjectType.TRANSFORMATION, false );
     } catch ( Exception e ) {
       String path = repositoryDirectory != null ? repositoryDirectory.toString() : "null";
       throw new IdNotFoundException( "Unable to get ID for job [" + name + "]", e, name, path,
-          TRANSFORMATION );
+        RepositoryObjectType.TRANSFORMATION );
     }
   }
 
@@ -1446,7 +1443,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
     try {
       List<RepositoryFile>
           children =
-          getAllFilesOfType( idDirectory, TRANSFORMATION, includeDeleted );
+          getAllFilesOfType( idDirectory, RepositoryObjectType.TRANSFORMATION, includeDeleted );
       List<String> names = new ArrayList<String>();
       for ( RepositoryFile file : children ) {
         names.add( file.getTitle() );
@@ -1461,7 +1458,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   public List<RepositoryElementMetaInterface> getTransformationObjects( ObjectId idDirectory, boolean includeDeleted )
     throws KettleException {
     return getPdiObjects( idDirectory, Arrays
-        .asList( new RepositoryObjectType[] { TRANSFORMATION } ), includeDeleted );
+        .asList( new RepositoryObjectType[] { RepositoryObjectType.TRANSFORMATION } ), includeDeleted );
   }
 
   protected List<RepositoryElementMetaInterface> getPdiObjects( ObjectId dirId, List<RepositoryObjectType> objectTypes,
@@ -1498,10 +1495,10 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   }
 
   public static RepositoryObjectType getObjectType( final String filename ) throws KettleException {
-    if ( filename.endsWith( TRANSFORMATION.getExtension() ) ) {
-      return TRANSFORMATION;
-    } else if ( filename.endsWith( JOB.getExtension() ) ) {
-      return JOB;
+    if ( filename.endsWith( RepositoryObjectType.TRANSFORMATION.getExtension() ) ) {
+      return RepositoryObjectType.TRANSFORMATION;
+    } else if ( filename.endsWith( RepositoryObjectType.JOB.getExtension() ) ) {
+      return RepositoryObjectType.JOB;
     } else if ( filename.endsWith( RepositoryObjectType.DATABASE.getExtension() ) ) {
       return RepositoryObjectType.DATABASE;
     } else if ( filename.endsWith( RepositoryObjectType.SLAVE_SERVER.getExtension() ) ) {
@@ -1705,7 +1702,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   public ObjectId renameJob( ObjectId idJobForRename, String versionComment,
                              RepositoryDirectoryInterface newDirectory, String newJobName )
     throws KettleException {
-    return renameTransOrJob( idJobForRename, versionComment, newDirectory, newJobName, JOB,
+    return renameTransOrJob( idJobForRename, versionComment, newDirectory, newJobName, RepositoryObjectType.JOB,
         "PurRepository.ERROR_0006_UNABLE_TO_RENAME_JOB" );
   }
 
@@ -1720,7 +1717,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   public ObjectId renameTransformation( ObjectId idTransForRename, String versionComment,
                                         RepositoryDirectoryInterface newDirectory, String newTransName )
     throws KettleException {
-    return renameTransOrJob( idTransForRename, versionComment, newDirectory, newTransName, TRANSFORMATION,
+    return renameTransOrJob( idTransForRename, versionComment, newDirectory, newTransName, RepositoryObjectType.TRANSFORMATION,
         "PurRepository.ERROR_0006_UNABLE_TO_RENAME_TRANS" );
   }
 
@@ -1863,10 +1860,10 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
     String filename = element.getName();
     switch ( element.getRepositoryElementType() ) {
       case TRANSFORMATION:
-        filename += TRANSFORMATION.getExtension();
+        filename += RepositoryObjectType.TRANSFORMATION.getExtension();
         break;
       case JOB:
-        filename += JOB.getExtension();
+        filename += RepositoryObjectType.JOB.getExtension();
         break;
       case DATABASE:
         filename += RepositoryObjectType.DATABASE.getExtension();
@@ -2045,7 +2042,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
     throws KettleException {
     String absPath = null;
     try {
-      absPath = getPath( transName, parentDir, TRANSFORMATION );
+      absPath = getPath( transName, parentDir, RepositoryObjectType.TRANSFORMATION );
       if ( absPath == null ) {
         // Couldn't resolve path, throw an exception
         throw new KettleFileException( BaseMessages.getString( PKG,
@@ -2142,7 +2139,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
                           String versionId ) throws KettleException {
     String absPath = null;
     try {
-      absPath = getPath( jobname, parentDir, JOB );
+      absPath = getPath( jobname, parentDir, RepositoryObjectType.JOB );
       if ( absPath == null ) {
         // Couldn't resolve path, throw an exception
         throw new KettleFileException(
@@ -2240,14 +2237,14 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
       extension = RepositoryObjectType.CLUSTER_SCHEMA.getExtension();
     } else if ( in.endsWith( RepositoryObjectType.DATABASE.getExtension() ) ) {
       extension = RepositoryObjectType.DATABASE.getExtension();
-    } else if ( in.endsWith( JOB.getExtension() ) ) {
-      extension = JOB.getExtension();
+    } else if ( in.endsWith( RepositoryObjectType.JOB.getExtension() ) ) {
+      extension = RepositoryObjectType.JOB.getExtension();
     } else if ( in.endsWith( RepositoryObjectType.PARTITION_SCHEMA.getExtension() ) ) {
       extension = RepositoryObjectType.PARTITION_SCHEMA.getExtension();
     } else if ( in.endsWith( RepositoryObjectType.SLAVE_SERVER.getExtension() ) ) {
       extension = RepositoryObjectType.SLAVE_SERVER.getExtension();
-    } else if ( in.endsWith( TRANSFORMATION.getExtension() ) ) {
-      extension = TRANSFORMATION.getExtension();
+    } else if ( in.endsWith( RepositoryObjectType.TRANSFORMATION.getExtension() ) ) {
+      extension = RepositoryObjectType.TRANSFORMATION.getExtension();
     }
     String out = in;
     if ( extension != null ) {
@@ -2578,7 +2575,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   @Override
   public List<RepositoryElementMetaInterface> getJobAndTransformationObjects( ObjectId id_directory,
                                                                               boolean includeDeleted ) throws KettleException {
-    return getPdiObjects( id_directory, Arrays.asList( JOB, TRANSFORMATION ), includeDeleted );
+    return getPdiObjects( id_directory, Arrays.asList( RepositoryObjectType.JOB, RepositoryObjectType.TRANSFORMATION ), includeDeleted );
   }
 
   @Override
@@ -2739,7 +2736,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   @Override
   public String[] getJobsUsingDatabase( ObjectId id_database ) throws KettleException {
     List<String> result = new ArrayList<String>();
-    for ( RepositoryFile file : getReferrers( id_database, Collections.singletonList( JOB ) ) ) {
+    for ( RepositoryFile file : getReferrers( id_database, Collections.singletonList( RepositoryObjectType.JOB ) ) ) {
       result.add( file.getPath() );
     }
     return result.toArray( new String[result.size()] );
@@ -2748,7 +2745,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   @Override
   public String[] getTransformationsUsingDatabase( ObjectId id_database ) throws KettleException {
     List<String> result = new ArrayList<String>();
-    for ( RepositoryFile file : getReferrers( id_database, Collections.singletonList( TRANSFORMATION ) ) ) {
+    for ( RepositoryFile file : getReferrers( id_database, Collections.singletonList( RepositoryObjectType.TRANSFORMATION ) ) ) {
       result.add( file.getPath() );
     }
     return result.toArray( new String[result.size()] );

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
@@ -2231,7 +2231,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rep
   /**
    * Performs one-way conversion on incoming String to produce a syntactically valid JCR path (section 4.6 Path Syntax).
    */
-  protected static String checkAndSanitize( final String in ) {
+  public static String checkAndSanitize( final String in ) {
     if ( in == null ) {
       throw new IllegalArgumentException();
     }

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/metastore/PurRepositoryMetaStore.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/metastore/PurRepositoryMetaStore.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
  */
 package org.pentaho.di.repository.pur.metastore;
 
-import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.repository.pur.PurRepository;

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/metastore/PurRepositoryMetaStore.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/metastore/PurRepositoryMetaStore.java
@@ -289,10 +289,10 @@ public class PurRepositoryMetaStore extends MemoryMetaStore implements IMetaStor
     RepositoryFile elementTypeFolder = validateElementTypeRepositoryFolder( namespace, elementType );
 
     RepositoryFile elementFile =
-        new RepositoryFile.Builder( checkAndSanitize( element.getName() ) ).title( element.getName() )
+        new RepositoryFile.Builder( PurRepository.checkAndSanitize( element.getName() ) ).title( element.getName() )
             .versioned( false ).build();
 
-    DataNode elementDataNode = new DataNode( checkAndSanitize( element.getName() ) );
+    DataNode elementDataNode = new DataNode( PurRepository.checkAndSanitize( element.getName() ) );
     elementToDataNode( element, elementDataNode );
 
     RepositoryFile createdFile =
@@ -344,7 +344,7 @@ public class PurRepositoryMetaStore extends MemoryMetaStore implements IMetaStor
       throw new MetaStoreException( "The element to update with id " + elementId + " could not be found in the store" );
     }
 
-    DataNode elementDataNode = new DataNode( checkAndSanitize( element.getName() ) );
+    DataNode elementDataNode = new DataNode( PurRepository.checkAndSanitize( element.getName() ) );
     elementToDataNode( element, elementDataNode );
 
     RepositoryFile updatedFile = pur.updateFile( existingFile, new NodeRepositoryFileData( elementDataNode ), null );
@@ -544,20 +544,6 @@ public class PurRepositoryMetaStore extends MemoryMetaStore implements IMetaStor
     return null; // new RepositoryFileAcl.Builder(RepositoryFileAcl.Builder).entriesInheriting(true).build()
   }
 
-  /**
-   * Performs one-way conversion on incoming String to produce a syntactically valid JCR path (section 4.6 Path Syntax).
-   */
-  protected static String checkAndSanitize( final String in ) {
-    if ( in == null ) {
-      throw new IllegalArgumentException();
-    }
-    String out = in;
-    if ( out.contains( "/" ) || out.equals( ".." ) || out.equals( "." ) || StringUtils.isBlank( out ) ) {
-      throw new IllegalArgumentException();
-    }
-    out = out.replaceAll( "[/:\\[\\]\\*'\"\\|\\s\\.]", "_" ); //$NON-NLS-1$//$NON-NLS-2$
-    return out;
-  }
 
   @Override
   public IMetaStoreElementType newElementType( String namespace ) throws MetaStoreException {


### PR DESCRIPTION
- Change name due to [KETTLE_COMPATIBILITY_PUR_OLD_NAMING_MODE property] (https://help.pentaho.com/Documentation/5.2/0T0/040/010) value. This property is specially created for handling such situations. 
- Remove duplicates of checkAndSanitize methods all over the project
- Checkstyle applied

[Here is an IT test] (https://github.com/pentaho/pentaho-kettle/blob/master/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryIT.java#L560) covering this method. 
It wasn't covering this case before this PR, because checkAndSanitize method was duplicated over the project several time in different variations. IT test used the only correct written variation. For now all incorrect variations are removed and all calls refer to a correct one (that is tested in a link above)

@akhayrutdinov , review it please.

@pamval, @pedrofvteixeira , could you run WM on this PR?