### PR TITLE
[PDI-14852] - setVariable in Javascript Step with scope of parent job does not work

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
+++ b/engine/src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
@@ -77,8 +77,9 @@ import org.pentaho.di.core.gui.SpoonInterface;
 import org.pentaho.di.core.row.RowDataUtil;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.util.EnvUtil;
-import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.steps.loadfileinput.LoadFileInput;
 
@@ -1807,52 +1808,68 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
           sArg2 = Context.toString( ArgList[1] );
           sArg3 = Context.toString( ArgList[2] );
 
-          if ( "s".equals( sArg3 ) ) {
-            // System wide properties
-            System.setProperty( sArg1, sArg2 );
+          Job parentJob = null;
 
-            // Set also all the way to the root as else we will take
-            // stale values
-            scm.setVariable( sArg1, sArg2 );
+          // variables are always set in the step and in the hosting transformation
+          scm.setVariable(sArg1,sArg2);
+          Trans trans = scm.getTrans();
+          if (trans != null) {
+            trans.setVariable(sArg1,sArg2);
 
-            VariableSpace parentSpace = scm.getParentVariableSpace();
-            while ( parentSpace != null ) {
-              parentSpace.setVariable( sArg1, sArg2 );
-              parentSpace = parentSpace.getParentVariableSpace();
+            // Set the variable in a potential parent transformation (in case of sub-transformation)
+            while ( trans.getParentTrans() != null ) {
+              trans = trans.getParentTrans();
+              trans.setVariable( sArg1, sArg2);
             }
-          } else if ( "r".equals( sArg3 ) ) {
-            // Upto the root... this should be the default.
-            scm.setVariable( sArg1, sArg2 );
-
-            VariableSpace parentSpace = scm.getParentVariableSpace();
-            while ( parentSpace != null ) {
-              parentSpace.setVariable( sArg1, sArg2 );
-              parentSpace = parentSpace.getParentVariableSpace();
-            }
-          } else if ( "p".equals( sArg3 ) ) {
-            // Upto the parent
-            scm.setVariable( sArg1, sArg2 );
-
-            VariableSpace parentSpace = scm.getParentVariableSpace();
-            if ( parentSpace != null ) {
-              parentSpace.setVariable( sArg1, sArg2 );
-            }
-          } else if ( "g".equals( sArg3 ) ) {
-            // Upto the grand parent
-            scm.setVariable( sArg1, sArg2 );
-
-            VariableSpace parentSpace = scm.getParentVariableSpace();
-            if ( parentSpace != null ) {
-              parentSpace.setVariable( sArg1, sArg2 );
-              VariableSpace grandParentSpace = parentSpace.getParentVariableSpace();
-              if ( grandParentSpace != null ) {
-                grandParentSpace.setVariable( sArg1, sArg2 );
-              }
-            }
-          } else {
-            throw Context.reportRuntimeError( "The argument type of function call "
-              + "setVariable should either be \"s\", \"r\", \"p\", or \"g\"." );
+            parentJob = trans.getParentJob();
           }
+
+          switch (sArg3) {
+            case "s":
+              System.setProperty( sArg1, sArg2 );
+
+              // Set the variable up to job hierarchy.
+              while ( parentJob != null ) {
+                parentJob.setVariable( sArg1, sArg2);
+                parentJob = parentJob.getParentJob();
+              }
+              break;
+
+            case "r":
+              // Set the variable up to job hierarchy.
+              while ( parentJob != null ) {
+                parentJob.setVariable( sArg1, sArg2);
+                parentJob = parentJob.getParentJob();
+              }
+              break;
+
+            case "g":
+              Job gpJob = null;
+
+              // Set the variable on the parent job
+              if ( parentJob != null ) {
+                parentJob.setVariable( sArg1, sArg2);
+                gpJob = parentJob.getParentJob();
+              }
+
+              // Set the variable on the grand-parent job
+              if ( gpJob != null ) {
+                gpJob.setVariable( sArg1, sArg2 );
+              }
+              break;
+
+            case "p":
+              // Set the variable on the parent job
+              if ( parentJob != null ) {
+                parentJob.setVariable( sArg1, sArg2);
+              }
+              break;
+
+            default:
+              throw Context.reportRuntimeError( "The argument type of function call "
+                      + "setVariable should either be \"s\", \"r\", \"p\", or \"g\"." );
+          }
+
         }
         // Ignore else block for now... if we're executing via the Test Button
 

--- a/engine/src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
+++ b/engine/src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
@@ -1811,26 +1811,26 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
           Job parentJob = null;
 
           // variables are always set in the step and in the hosting transformation
-          scm.setVariable(sArg1,sArg2);
+          scm.setVariable( sArg1, sArg2 );
           Trans trans = scm.getTrans();
-          if (trans != null) {
-            trans.setVariable(sArg1,sArg2);
+          if ( trans != null ) {
+            trans.setVariable( sArg1, sArg2 );
 
             // Set the variable in a potential parent transformation (in case of sub-transformation)
             while ( trans.getParentTrans() != null ) {
               trans = trans.getParentTrans();
-              trans.setVariable( sArg1, sArg2);
+              trans.setVariable( sArg1, sArg2 );
             }
             parentJob = trans.getParentJob();
           }
 
-          switch (sArg3) {
+          switch ( sArg3 ) {
             case "s":
               System.setProperty( sArg1, sArg2 );
 
               // Set the variable up to job hierarchy.
               while ( parentJob != null ) {
-                parentJob.setVariable( sArg1, sArg2);
+                parentJob.setVariable( sArg1, sArg2 );
                 parentJob = parentJob.getParentJob();
               }
               break;
@@ -1838,7 +1838,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
             case "r":
               // Set the variable up to job hierarchy.
               while ( parentJob != null ) {
-                parentJob.setVariable( sArg1, sArg2);
+                parentJob.setVariable( sArg1, sArg2 );
                 parentJob = parentJob.getParentJob();
               }
               break;
@@ -1848,7 +1848,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
 
               // Set the variable on the parent job
               if ( parentJob != null ) {
-                parentJob.setVariable( sArg1, sArg2);
+                parentJob.setVariable( sArg1, sArg2 );
                 gpJob = parentJob.getParentJob();
               }
 
@@ -1861,7 +1861,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
             case "p":
               // Set the variable on the parent job
               if ( parentJob != null ) {
-                parentJob.setVariable( sArg1, sArg2);
+                parentJob.setVariable( sArg1, sArg2 );
               }
               break;
 

--- a/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctionsTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctionsTest.java
@@ -1,3 +1,25 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.di.trans.steps.scriptvalues_mod;
 
 import org.junit.*;
@@ -8,7 +30,6 @@ import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.steps.StepMockUtil;
-
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -16,223 +37,223 @@ import static org.mockito.Mockito.*;
  * @author Andrea Torre
  */
 public class ScriptValuesAddedFunctionsTest {
-    ScriptValuesMod step;
-    ScriptValuesMetaMod meta;
-    ScriptValuesModData data;
-    String variableKey;
-    String variableValue;
+  ScriptValuesMod step;
+  ScriptValuesMetaMod meta;
+  ScriptValuesModData data;
+  String variableKey;
+  String variableValue;
 
-    @BeforeClass
-    public static void initKettle() throws Exception {
-        KettleEnvironment.init();
-    }
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
 
-    @Before
-    public void setUp() throws Exception {
-        step = StepMockUtil.getStep( ScriptValuesMod.class, ScriptValuesMetaMod.class, "test" );
-        meta = new ScriptValuesMetaMod();
-        data = new ScriptValuesModData();
+  @Before
+  public void setUp() throws Exception {
+    step = StepMockUtil.getStep( ScriptValuesMod.class, ScriptValuesMetaMod.class, "test" );
+    meta = new ScriptValuesMetaMod();
+    data = new ScriptValuesModData();
 
-        RowMeta input = new RowMeta();
-        input.addValueMeta(new ValueMetaString("variable_name"));
-        input.addValueMeta(new ValueMetaString("variable_data"));
-        step.setInputRowMeta(input);
-        step = spy(step);
+    RowMeta input = new RowMeta();
+    input.addValueMeta( new ValueMetaString( "variable_name" ) );
+    input.addValueMeta( new ValueMetaString( "variable_data" ) );
+    step.setInputRowMeta( input );
+    step = spy( step );
 
-        variableKey = "var_1";
-        variableValue = "dont panic";
-        doReturn(new Object[] {variableKey, variableValue}).when(step).getRow();
-        meta.setCompatible(false);
-        meta.allocate(0);
-    }
+    variableKey = "var_1";
+    variableValue = "dont panic";
+    doReturn( new Object[] {variableKey, variableValue} ).when( step ).getRow();
+    meta.setCompatible( false );
+    meta.allocate( 0 );
+  }
 
-    private void setTestMetaAtVariableLevel(String level){
-        meta.setJSScripts( new ScriptValuesScript[] {
-                new ScriptValuesScript( ScriptValuesScript.TRANSFORM_SCRIPT, "script",
-                        "setVariable(variable_name, variable_data, '" + level + "')" )
-        } );
-    }
+  private void setTestMetaAtVariableLevel( String level ) {
+    meta.setJSScripts( new ScriptValuesScript[] {
+      new ScriptValuesScript( ScriptValuesScript.TRANSFORM_SCRIPT, "script",
+          "setVariable(variable_name, variable_data, '" + level + "')" )
+    } );
+  }
 
-    @Test
-    public void shouldSetVariableAtSystemLevel() throws KettleException {
-        setTestMetaAtVariableLevel("s");
+  @Test
+  public void shouldSetVariableAtSystemLevel() throws KettleException {
+    setTestMetaAtVariableLevel( "s" );
 
-        step.init( meta, data );
-        Trans m_trans = mock(Trans.class);
-        when(step.getTrans()).thenReturn(m_trans);
+    step.init( meta, data );
+    Trans m_trans = mock( Trans.class );
+    when( step.getTrans() ).thenReturn( m_trans );
 
-        Trans m_parentTrans = mock(Trans.class);
-        when(m_trans.getParentTrans()).thenReturn(m_parentTrans);
+    Trans m_parentTrans = mock( Trans.class );
+    when( m_trans.getParentTrans() ).thenReturn( m_parentTrans );
 
-        Job m_parentJob = mock(Job.class);
-        when(m_parentTrans.getParentJob()).thenReturn(m_parentJob);
+    Job m_parentJob = mock( Job.class );
+    when( m_parentTrans.getParentJob() ).thenReturn( m_parentJob );
 
-        Job m_grandParentJob = mock(Job.class);
-        when(m_parentJob.getParentJob()).thenReturn(m_grandParentJob);
+    Job m_grandParentJob = mock( Job.class );
+    when( m_parentJob.getParentJob() ).thenReturn( m_grandParentJob );
 
-        Job m_rootJob = mock(Job.class);
-        when(m_grandParentJob.getParentJob()).thenReturn(m_rootJob);
+    Job m_rootJob = mock( Job.class );
+    when( m_grandParentJob.getParentJob() ).thenReturn( m_rootJob );
 
-        step.processRow(meta, data);
+    step.processRow( meta, data );
 
-        // check the variable set in the step
-        assertTrue(step.getVariable(variableKey).equals(variableValue));
+    // check the variable set in the step
+    assertTrue( step.getVariable( variableKey ).equals( variableValue ) );
 
-        // check variable has been set in the transformation where the step is defined
-        verify(m_trans).setVariable(variableKey, variableValue);
+    // check variable has been set in the transformation where the step is defined
+    verify( m_trans ).setVariable( variableKey, variableValue );
 
-        // check variable has been set in a parent transformation (in case of sub-trans)
-        verify(m_parentTrans).setVariable(variableKey, variableValue);
+    // check variable has been set in a parent transformation (in case of sub-trans)
+    verify( m_parentTrans ).setVariable( variableKey, variableValue );
 
-        // check the variable set in the JVM
-        assertTrue(System.getProperty(variableKey).equals(variableValue));
+    // check the variable set in the JVM
+    assertTrue( System.getProperty( variableKey ).equals( variableValue ) );
 
-        // check the variable set in the parent Job
-        verify(m_parentJob).setVariable(variableKey, variableValue);
+    // check the variable set in the parent Job
+    verify( m_parentJob ).setVariable( variableKey, variableValue );
 
-        // check the variable set in the grand parent Job if any
-        verify(m_grandParentJob).setVariable(variableKey, variableValue);
+    // check the variable set in the grand parent Job if any
+    verify( m_grandParentJob ).setVariable( variableKey, variableValue );
 
-        // check the variable set in the root Job if any
-        verify(m_rootJob).setVariable(variableKey, variableValue);
-    }
+    // check the variable set in the root Job if any
+    verify( m_rootJob ).setVariable( variableKey, variableValue );
+  }
 
-    @Test
-    public void shouldSetVariableAtRootJobLevel() throws KettleException {
-        setTestMetaAtVariableLevel("r");
+  @Test
+  public void shouldSetVariableAtRootJobLevel() throws KettleException {
+    setTestMetaAtVariableLevel( "r" );
 
-        step.init( meta, data );
-        Trans m_trans = mock(Trans.class);
-        when(step.getTrans()).thenReturn(m_trans);
+    step.init( meta, data );
+    Trans m_trans = mock( Trans.class );
+    when( step.getTrans() ).thenReturn( m_trans );
 
-        Trans m_parentTrans = mock(Trans.class);
-        when(m_trans.getParentTrans()).thenReturn(m_parentTrans);
+    Trans m_parentTrans = mock( Trans.class );
+    when( m_trans.getParentTrans() ).thenReturn( m_parentTrans );
 
-        Job m_parentJob = mock(Job.class);
-        when(m_parentTrans.getParentJob()).thenReturn(m_parentJob);
+    Job m_parentJob = mock( Job.class );
+    when( m_parentTrans.getParentJob() ).thenReturn( m_parentJob );
 
-        Job m_grandParentJob = mock(Job.class);
-        when(m_parentJob.getParentJob()).thenReturn(m_grandParentJob);
+    Job m_grandParentJob = mock( Job.class );
+    when( m_parentJob.getParentJob() ).thenReturn( m_grandParentJob );
 
-        Job m_rootJob = mock(Job.class);
-        when(m_grandParentJob.getParentJob()).thenReturn(m_rootJob);
+    Job m_rootJob = mock( Job.class );
+    when( m_grandParentJob.getParentJob() ).thenReturn( m_rootJob );
 
-        step.processRow(meta, data);
+    step.processRow( meta, data );
 
-        // check the variable set in the step
-        assertTrue(step.getVariable(variableKey).equals(variableValue));
+    // check the variable set in the step
+    assertTrue( step.getVariable( variableKey ).equals( variableValue ) );
 
-        // check variable has been set in the transformation where the step is defined
-        verify(m_trans).setVariable(variableKey, variableValue);
+    // check variable has been set in the transformation where the step is defined
+    verify( m_trans ).setVariable( variableKey, variableValue );
 
-        // check variable has been set in a parent transformation (in case of sub-trans)
-        verify(m_parentTrans).setVariable(variableKey, variableValue);
+    // check variable has been set in a parent transformation (in case of sub-trans)
+    verify( m_parentTrans ).setVariable( variableKey, variableValue );
 
-        // check the variable is NOT set in the JVM
-        assertNull("Variable should not be set in the JVM", System.getProperty(variableKey));
+    // check the variable is NOT set in the JVM
+    assertNull( "Variable should not be set in the JVM", System.getProperty( variableKey ) );
 
-        // check the variable set in the parent Job
-        verify(m_parentJob).setVariable(variableKey, variableValue);
+    // check the variable set in the parent Job
+    verify( m_parentJob ).setVariable( variableKey, variableValue );
 
-        // check the variable set in the grand parent Job if any
-        verify(m_grandParentJob).setVariable(variableKey, variableValue);
+    // check the variable set in the grand parent Job if any
+    verify( m_grandParentJob ).setVariable( variableKey, variableValue );
 
-        // check the variable set in the root Job if any
-        verify(m_rootJob).setVariable(variableKey, variableValue);
-    }
+    // check the variable set in the root Job if any
+    verify( m_rootJob ).setVariable( variableKey, variableValue );
+  }
 
-    @Test
-    public void shouldSetVariableAtGrandParentJobLevel() throws KettleException {
-        setTestMetaAtVariableLevel("g");
+  @Test
+  public void shouldSetVariableAtGrandParentJobLevel() throws KettleException {
+    setTestMetaAtVariableLevel( "g" );
 
-        step.init( meta, data );
-        Trans m_trans = mock(Trans.class);
-        when(step.getTrans()).thenReturn(m_trans);
+    step.init( meta, data );
+    Trans m_trans = mock( Trans.class );
+    when( step.getTrans() ).thenReturn( m_trans );
 
-        Trans m_parentTrans = mock(Trans.class);
-        when(m_trans.getParentTrans()).thenReturn(m_parentTrans);
+    Trans m_parentTrans = mock( Trans.class );
+    when( m_trans.getParentTrans() ).thenReturn( m_parentTrans );
 
-        Job m_parentJob = mock(Job.class);
-        when(m_parentTrans.getParentJob()).thenReturn(m_parentJob);
+    Job m_parentJob = mock( Job.class );
+    when( m_parentTrans.getParentJob() ).thenReturn( m_parentJob );
 
-        Job m_grandParentJob = mock(Job.class);
-        when(m_parentJob.getParentJob()).thenReturn(m_grandParentJob);
+    Job m_grandParentJob = mock( Job.class );
+    when( m_parentJob.getParentJob() ).thenReturn( m_grandParentJob );
 
-        Job m_rootJob = mock(Job.class);
-        when(m_grandParentJob.getParentJob()).thenReturn(m_rootJob);
+    Job m_rootJob = mock( Job.class );
+    when( m_grandParentJob.getParentJob() ).thenReturn( m_rootJob );
 
-        step.processRow(meta, data);
+    step.processRow( meta, data );
 
-        // check the variable set in the step
-        assertTrue(step.getVariable(variableKey).equals(variableValue));
+    // check the variable set in the step
+    assertTrue( step.getVariable( variableKey ).equals( variableValue ) );
 
-        // check variable has been set in the transformation where the step is defined
-        verify(m_trans).setVariable(variableKey, variableValue);
+    // check variable has been set in the transformation where the step is defined
+    verify( m_trans ).setVariable( variableKey, variableValue );
 
-        // check variable has been set in a parent transformation (in case of sub-trans)
-        verify(m_parentTrans).setVariable(variableKey, variableValue);
+    // check variable has been set in a parent transformation (in case of sub-trans)
+    verify( m_parentTrans ).setVariable( variableKey, variableValue );
 
-        // check the variable is NOT set in the JVM
-        assertNull("Variable should not be set in the JVM", System.getProperty(variableKey));
+    // check the variable is NOT set in the JVM
+    assertNull( "Variable should not be set in the JVM", System.getProperty( variableKey ) );
 
-        // check the variable set in the parent Job
-        verify(m_parentJob).setVariable(variableKey, variableValue);
+    // check the variable set in the parent Job
+    verify( m_parentJob ).setVariable( variableKey, variableValue );
 
-        // check the variable set in the grand parent Job if any
-        verify(m_grandParentJob).setVariable(variableKey, variableValue);
+    // check the variable set in the grand parent Job if any
+    verify( m_grandParentJob ).setVariable( variableKey, variableValue );
 
-        // check the setVariable method has NOT been called on a root Job
-        verify(m_rootJob, never()).setVariable(variableKey, variableValue);
-    }
+    // check the setVariable method has NOT been called on a root Job
+    verify( m_rootJob, never() ).setVariable( variableKey, variableValue );
+  }
 
-    @Test
-    public void shouldSetVariableAtParentJobLevel() throws KettleException {
-        setTestMetaAtVariableLevel("p");
+  @Test
+  public void shouldSetVariableAtParentJobLevel() throws KettleException {
+    setTestMetaAtVariableLevel( "p" );
 
-        step.init( meta, data );
-        Trans m_trans = mock(Trans.class);
-        when(step.getTrans()).thenReturn(m_trans);
+    step.init( meta, data );
+    Trans m_trans = mock( Trans.class );
+    when( step.getTrans() ).thenReturn( m_trans );
 
-        Trans m_parentTrans = mock(Trans.class);
-        when(m_trans.getParentTrans()).thenReturn(m_parentTrans);
+    Trans m_parentTrans = mock( Trans.class );
+    when( m_trans.getParentTrans() ).thenReturn( m_parentTrans );
 
-        Job m_parentJob = mock(Job.class);
-        when(m_parentTrans.getParentJob()).thenReturn(m_parentJob);
+    Job m_parentJob = mock( Job.class );
+    when( m_parentTrans.getParentJob() ).thenReturn( m_parentJob );
 
-        Job m_grandParentJob = mock(Job.class);
-        when(m_parentJob.getParentJob()).thenReturn(m_grandParentJob);
+    Job m_grandParentJob = mock( Job.class );
+    when( m_parentJob.getParentJob() ).thenReturn( m_grandParentJob );
 
-        Job m_rootJob = mock(Job.class);
-        when(m_grandParentJob.getParentJob()).thenReturn(m_rootJob);
+    Job m_rootJob = mock( Job.class );
+    when( m_grandParentJob.getParentJob() ).thenReturn( m_rootJob );
 
-        step.processRow(meta, data);
+    step.processRow( meta, data );
 
-        // check the variable set in the step
-        assertTrue(step.getVariable(variableKey).equals(variableValue));
+    // check the variable set in the step
+    assertTrue( step.getVariable( variableKey ).equals( variableValue ) );
 
-        // check variable has been set in the transformation where the step is defined
-        verify(m_trans).setVariable(variableKey, variableValue);
+    // check variable has been set in the transformation where the step is defined
+    verify( m_trans ).setVariable( variableKey, variableValue );
 
-        // check variable has been set in a parent transformation (in case of sub-trans)
-        verify(m_parentTrans).setVariable(variableKey, variableValue);
+    // check variable has been set in a parent transformation (in case of sub-trans)
+    verify( m_parentTrans ).setVariable( variableKey, variableValue );
 
-        // check the variable is NOT set in the JVM
-        assertNull("Variable should not be set in the JVM", System.getProperty(variableKey));
+    // check the variable is NOT set in the JVM
+    assertNull( "Variable should not be set in the JVM", System.getProperty( variableKey ) );
 
-        // check the variable set in the parent Job
-        verify(m_parentJob).setVariable(variableKey, variableValue);
+    // check the variable set in the parent Job
+    verify( m_parentJob ).setVariable( variableKey, variableValue );
 
-        // check the variable set in the grand parent Job if any
-        verify(m_grandParentJob,never()).setVariable(variableKey, variableValue);
+    // check the variable set in the grand parent Job if any
+    verify( m_grandParentJob, never() ).setVariable( variableKey, variableValue );
 
-        // check the setVariable method has NOT been called on a root Job
-        verify(m_rootJob, never()).setVariable(variableKey, variableValue);
-    }
+    // check the setVariable method has NOT been called on a root Job
+    verify( m_rootJob, never() ).setVariable( variableKey, variableValue );
+  }
 
 
-    @After
-    public void tearDown() throws Exception {
-        // remove the variable from the JVM
-        System.clearProperty(variableKey);
-    }
+  @After
+  public void tearDown() throws Exception {
+    // remove the variable from the JVM
+    System.clearProperty( variableKey );
+  }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctionsTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctionsTest.java
@@ -1,0 +1,238 @@
+package org.pentaho.di.trans.steps.scriptvalues_mod;
+
+import org.junit.*;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.steps.StepMockUtil;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrea Torre
+ */
+public class ScriptValuesAddedFunctionsTest {
+    ScriptValuesMod step;
+    ScriptValuesMetaMod meta;
+    ScriptValuesModData data;
+    String variableKey;
+    String variableValue;
+
+    @BeforeClass
+    public static void initKettle() throws Exception {
+        KettleEnvironment.init();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        step = StepMockUtil.getStep( ScriptValuesMod.class, ScriptValuesMetaMod.class, "test" );
+        meta = new ScriptValuesMetaMod();
+        data = new ScriptValuesModData();
+
+        RowMeta input = new RowMeta();
+        input.addValueMeta(new ValueMetaString("variable_name"));
+        input.addValueMeta(new ValueMetaString("variable_data"));
+        step.setInputRowMeta(input);
+        step = spy(step);
+
+        variableKey = "var_1";
+        variableValue = "dont panic";
+        doReturn(new Object[] {variableKey, variableValue}).when(step).getRow();
+        meta.setCompatible(false);
+        meta.allocate(0);
+    }
+
+    private void setTestMetaAtVariableLevel(String level){
+        meta.setJSScripts( new ScriptValuesScript[] {
+                new ScriptValuesScript( ScriptValuesScript.TRANSFORM_SCRIPT, "script",
+                        "setVariable(variable_name, variable_data, '" + level + "')" )
+        } );
+    }
+
+    @Test
+    public void shouldSetVariableAtSystemLevel() throws KettleException {
+        setTestMetaAtVariableLevel("s");
+
+        step.init( meta, data );
+        Trans m_trans = mock(Trans.class);
+        when(step.getTrans()).thenReturn(m_trans);
+
+        Trans m_parentTrans = mock(Trans.class);
+        when(m_trans.getParentTrans()).thenReturn(m_parentTrans);
+
+        Job m_parentJob = mock(Job.class);
+        when(m_parentTrans.getParentJob()).thenReturn(m_parentJob);
+
+        Job m_grandParentJob = mock(Job.class);
+        when(m_parentJob.getParentJob()).thenReturn(m_grandParentJob);
+
+        Job m_rootJob = mock(Job.class);
+        when(m_grandParentJob.getParentJob()).thenReturn(m_rootJob);
+
+        step.processRow(meta, data);
+
+        // check the variable set in the step
+        assertTrue(step.getVariable(variableKey).equals(variableValue));
+
+        // check variable has been set in the transformation where the step is defined
+        verify(m_trans).setVariable(variableKey, variableValue);
+
+        // check variable has been set in a parent transformation (in case of sub-trans)
+        verify(m_parentTrans).setVariable(variableKey, variableValue);
+
+        // check the variable set in the JVM
+        assertTrue(System.getProperty(variableKey).equals(variableValue));
+
+        // check the variable set in the parent Job
+        verify(m_parentJob).setVariable(variableKey, variableValue);
+
+        // check the variable set in the grand parent Job if any
+        verify(m_grandParentJob).setVariable(variableKey, variableValue);
+
+        // check the variable set in the root Job if any
+        verify(m_rootJob).setVariable(variableKey, variableValue);
+    }
+
+    @Test
+    public void shouldSetVariableAtRootJobLevel() throws KettleException {
+        setTestMetaAtVariableLevel("r");
+
+        step.init( meta, data );
+        Trans m_trans = mock(Trans.class);
+        when(step.getTrans()).thenReturn(m_trans);
+
+        Trans m_parentTrans = mock(Trans.class);
+        when(m_trans.getParentTrans()).thenReturn(m_parentTrans);
+
+        Job m_parentJob = mock(Job.class);
+        when(m_parentTrans.getParentJob()).thenReturn(m_parentJob);
+
+        Job m_grandParentJob = mock(Job.class);
+        when(m_parentJob.getParentJob()).thenReturn(m_grandParentJob);
+
+        Job m_rootJob = mock(Job.class);
+        when(m_grandParentJob.getParentJob()).thenReturn(m_rootJob);
+
+        step.processRow(meta, data);
+
+        // check the variable set in the step
+        assertTrue(step.getVariable(variableKey).equals(variableValue));
+
+        // check variable has been set in the transformation where the step is defined
+        verify(m_trans).setVariable(variableKey, variableValue);
+
+        // check variable has been set in a parent transformation (in case of sub-trans)
+        verify(m_parentTrans).setVariable(variableKey, variableValue);
+
+        // check the variable is NOT set in the JVM
+        assertNull("Variable should not be set in the JVM", System.getProperty(variableKey));
+
+        // check the variable set in the parent Job
+        verify(m_parentJob).setVariable(variableKey, variableValue);
+
+        // check the variable set in the grand parent Job if any
+        verify(m_grandParentJob).setVariable(variableKey, variableValue);
+
+        // check the variable set in the root Job if any
+        verify(m_rootJob).setVariable(variableKey, variableValue);
+    }
+
+    @Test
+    public void shouldSetVariableAtGrandParentJobLevel() throws KettleException {
+        setTestMetaAtVariableLevel("g");
+
+        step.init( meta, data );
+        Trans m_trans = mock(Trans.class);
+        when(step.getTrans()).thenReturn(m_trans);
+
+        Trans m_parentTrans = mock(Trans.class);
+        when(m_trans.getParentTrans()).thenReturn(m_parentTrans);
+
+        Job m_parentJob = mock(Job.class);
+        when(m_parentTrans.getParentJob()).thenReturn(m_parentJob);
+
+        Job m_grandParentJob = mock(Job.class);
+        when(m_parentJob.getParentJob()).thenReturn(m_grandParentJob);
+
+        Job m_rootJob = mock(Job.class);
+        when(m_grandParentJob.getParentJob()).thenReturn(m_rootJob);
+
+        step.processRow(meta, data);
+
+        // check the variable set in the step
+        assertTrue(step.getVariable(variableKey).equals(variableValue));
+
+        // check variable has been set in the transformation where the step is defined
+        verify(m_trans).setVariable(variableKey, variableValue);
+
+        // check variable has been set in a parent transformation (in case of sub-trans)
+        verify(m_parentTrans).setVariable(variableKey, variableValue);
+
+        // check the variable is NOT set in the JVM
+        assertNull("Variable should not be set in the JVM", System.getProperty(variableKey));
+
+        // check the variable set in the parent Job
+        verify(m_parentJob).setVariable(variableKey, variableValue);
+
+        // check the variable set in the grand parent Job if any
+        verify(m_grandParentJob).setVariable(variableKey, variableValue);
+
+        // check the setVariable method has NOT been called on a root Job
+        verify(m_rootJob, never()).setVariable(variableKey, variableValue);
+    }
+
+    @Test
+    public void shouldSetVariableAtParentJobLevel() throws KettleException {
+        setTestMetaAtVariableLevel("p");
+
+        step.init( meta, data );
+        Trans m_trans = mock(Trans.class);
+        when(step.getTrans()).thenReturn(m_trans);
+
+        Trans m_parentTrans = mock(Trans.class);
+        when(m_trans.getParentTrans()).thenReturn(m_parentTrans);
+
+        Job m_parentJob = mock(Job.class);
+        when(m_parentTrans.getParentJob()).thenReturn(m_parentJob);
+
+        Job m_grandParentJob = mock(Job.class);
+        when(m_parentJob.getParentJob()).thenReturn(m_grandParentJob);
+
+        Job m_rootJob = mock(Job.class);
+        when(m_grandParentJob.getParentJob()).thenReturn(m_rootJob);
+
+        step.processRow(meta, data);
+
+        // check the variable set in the step
+        assertTrue(step.getVariable(variableKey).equals(variableValue));
+
+        // check variable has been set in the transformation where the step is defined
+        verify(m_trans).setVariable(variableKey, variableValue);
+
+        // check variable has been set in a parent transformation (in case of sub-trans)
+        verify(m_parentTrans).setVariable(variableKey, variableValue);
+
+        // check the variable is NOT set in the JVM
+        assertNull("Variable should not be set in the JVM", System.getProperty(variableKey));
+
+        // check the variable set in the parent Job
+        verify(m_parentJob).setVariable(variableKey, variableValue);
+
+        // check the variable set in the grand parent Job if any
+        verify(m_grandParentJob,never()).setVariable(variableKey, variableValue);
+
+        // check the setVariable method has NOT been called on a root Job
+        verify(m_rootJob, never()).setVariable(variableKey, variableValue);
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        // remove the variable from the JVM
+        System.clearProperty(variableKey);
+    }
+}


### PR DESCRIPTION
Fixes the issue. Now the setVariables function in the Modified Javascript step has a behaviour consistent with the Set Variable step and correctly handles all scopes, even when the transformation that hosts the step is a mapped one.

The bulk of the change is a replacement of the previous implementation based on VariableSpace with a chain of Trans - Job objects to define the relationship parent-child.

Also unit tests have been added covering the various scope setting.