### PR TITLE
[PDI-15152] GA Filter allows empty variable values

### DIFF
--- a/plugins/googleanalytics/src/org/pentaho/di/trans/steps/googleanalytics/GaInputStep.java
+++ b/plugins/googleanalytics/src/org/pentaho/di/trans/steps/googleanalytics/GaInputStep.java
@@ -182,7 +182,7 @@ public class GaInputStep extends BaseStep implements StepInterface {
         }
       }
 
-      if ( !Const.isEmpty( meta.getFilters() ) ) {
+      if ( !Const.isEmpty( meta.getFilters() ) && !Const.isEmpty( environmentSubstitute( meta.getFilters() ) ) ) {
         query.setFilters( environmentSubstitute( meta.getFilters() ) );
       }
       if ( !Const.isEmpty( meta.getSort() ) ) {


### PR DESCRIPTION
Check if the variable-substituted filter is not empty before trying to set a filter