### PR TITLE
[BACKLOG-7186] - Metadata Injection for Metadata Injection step - rename method to prevent error: 'reference to call ambiguous'

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
@@ -439,8 +439,8 @@ public class MetaInjectMeta extends BaseStepMeta implements StepMetaInterface, S
   }
 
   @Injection( name = "TRANS_OBJECT_ID" )
-  public void setTransObjectId( String transObjectIdString ) {
-    this.transObjectId = new StringObjectId( transObjectIdString );
+  public void setTransStringObjectId( String transStringObjectId ) {
+    this.transObjectId = new StringObjectId( transStringObjectId );
   }
 
   /**


### PR DESCRIPTION
@pamval please find someone to merge this PR as it fixes compilation error.

@lgrill-pentaho