### PR TITLE
[BACKLOG-7186] - Metadata Injection for Metadata Injection step - fix test

### DIFF
--- a/plugins/kettle-xml-plugin/test-src/org/pentaho/di/trans/steps/addxml/AddXMLMetaInjectionTest.java
+++ b/plugins/kettle-xml-plugin/test-src/org/pentaho/di/trans/steps/addxml/AddXMLMetaInjectionTest.java
@@ -141,12 +141,4 @@ public class AddXMLMetaInjectionTest extends BaseMetadataInjectionTest<AddXMLMet
     } );
   }
 
-  private static int[] getTypeCodes( String[] typeNames ) {
-    int[] typeCodes = new int[typeNames.length];
-    for ( int i = 0; i < typeNames.length; i++ ) {
-      typeCodes[i] = ValueMetaBase.getType( typeNames[i] );
-    }
-    return typeCodes;
-  }
-
 }


### PR DESCRIPTION
@pamval, @bmorrise  please review. I removed getTypeCodes method from AddXMLMetaInjectionTest so now it uses the same method from BaseMetadataInjectionTest class.