### PR TITLE
[SP-2638] Backport of PDI-14950 - Spoon does not pass instanceName parameter to MSSQL Server JDBC connection string (5.4 Suite)	

### DIFF
--- a/core/src/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseMeta.java
@@ -1094,52 +1094,99 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
       databaseName = environmentSubstitute( getDatabaseName() );
     }
     baseUrl = databaseInterface.getURL( hostname, port, databaseName );
-    StringBuffer url = new StringBuffer( environmentSubstitute( baseUrl ) );
+    String url = environmentSubstitute( baseUrl );
+
 
     if ( databaseInterface.supportsOptionsInURL() ) {
-      // OK, now add all the options...
-      String optionIndicator = getExtraOptionIndicator();
-      String optionSeparator = getExtraOptionSeparator();
-      String valueSeparator = getExtraOptionValueSeparator();
-
-      Map<String, String> map = getExtraOptions();
-      if ( map.size() > 0 ) {
-        Iterator<String> iterator = map.keySet().iterator();
-        boolean first = true;
-        while ( iterator.hasNext() ) {
-          String typedParameter = iterator.next();
-          int dotIndex = typedParameter.indexOf( '.' );
-          if ( dotIndex >= 0 ) {
-            String typeCode = typedParameter.substring( 0, dotIndex );
-            String parameter = typedParameter.substring( dotIndex + 1 );
-            String value = map.get( typedParameter );
-
-            // Only add to the URL if it's the same database type code...
-            //
-            if ( databaseInterface.getPluginId().equals( typeCode ) ) {
-              if ( first && url.indexOf( valueSeparator ) == -1 ) {
-                url.append( optionIndicator );
-              } else {
-                url.append( optionSeparator );
-              }
-
-              url.append( parameter );
-              if ( !Const.isEmpty( value ) && !value.equals( EMPTY_OPTIONS_STRING ) ) {
-                url.append( valueSeparator ).append( value );
-              }
-              first = false;
-            }
-          }
-        }
-      }
+      url = appendExtraOptions( url, getExtraOptions() );
     }
     // else {
     // We need to put all these options in a Properties file later (Oracle & Co.)
     // This happens at connect time...
     // }
 
-    return url.toString();
+    return url;
   }
+
+  protected String appendExtraOptions( String url, Map<String, String> extraOptions ) {
+    if ( extraOptions.isEmpty() ) {
+      return url;
+    }
+
+    StringBuilder urlBuilder = new StringBuilder( url );
+
+    final String optionIndicator = getExtraOptionIndicator();
+    final String optionSeparator = getExtraOptionSeparator();
+    final String valueSeparator = getExtraOptionValueSeparator();
+
+    Iterator<String> iterator = extraOptions.keySet().iterator();
+    boolean first = true;
+    while ( iterator.hasNext() ) {
+      String typedParameter = iterator.next();
+      int dotIndex = typedParameter.indexOf( '.' );
+      if ( dotIndex == -1 ) {
+        continue;
+      }
+
+      final String value = extraOptions.get( typedParameter );
+      if ( Const.isEmpty( value ) || value.equals( EMPTY_OPTIONS_STRING ) ) {
+        // skip this science no value is provided
+        continue;
+      }
+
+      final String typeCode = typedParameter.substring( 0, dotIndex );
+      final String parameter = typedParameter.substring( dotIndex + 1 );
+
+      // Only add to the URL if it's the same database type code,
+      // or underlying database is the same for both id's, and any subset of
+      // connection settings for one database is valid for another
+      boolean dbForBothDbInterfacesIsSame = false;
+      try {
+        DatabaseInterface primaryDb = getDbInterface( typeCode );
+        dbForBothDbInterfacesIsSame = databaseForBothDbInterfacesIsTheSame( primaryDb, getDatabaseInterface() );
+      } catch ( KettleDatabaseException e ) {
+        getGeneralLogger().logError(
+          "DatabaseInterface with " + typeCode + " database type is not found! Parameter " + parameter
+            + "won't be appended to URL" );
+      }
+
+      if ( dbForBothDbInterfacesIsSame ) {
+        if ( first && url.indexOf( valueSeparator ) == -1 ) {
+          urlBuilder.append( optionIndicator );
+        } else {
+          urlBuilder.append( optionSeparator );
+        }
+
+        urlBuilder.append( parameter ).append( valueSeparator ).append( value );
+        first = false;
+      }
+    }
+
+    return urlBuilder.toString();
+  }
+
+  /**
+   * This method is designed to identify whether the actual database for two database connection types is the same.
+   * This situation can occur in two cases:
+   * 1. plugin id of {@code primary} is the same as plugin id of {@code secondary}
+   * 2. {@code secondary} is a descendant {@code primary} (with any deepness).
+   */
+  protected boolean databaseForBothDbInterfacesIsTheSame( DatabaseInterface primary, DatabaseInterface secondary ) {
+    if ( primary == null || secondary == null ) {
+      throw new IllegalArgumentException( "DatabaseInterface shouldn't be null." );
+    }
+
+    if ( primary.getPluginId() == null || secondary.getPluginId() == null ) {
+      return false;
+    }
+
+    if ( primary.getPluginId().equals( secondary.getPluginId() ) ) {
+      return true;
+    }
+
+    return primary.getClass().isAssignableFrom( secondary.getClass() );
+  }
+
 
   public Properties getConnectionProperties() {
     Properties properties = new Properties();
@@ -1171,21 +1218,21 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   }
 
   public String getExtraOptionIndicator() {
-    return databaseInterface.getExtraOptionIndicator();
+    return getDatabaseInterface( ).getExtraOptionIndicator();
   }
 
   /**
    * @return The extra option separator in database URL for this platform (usually this is semicolon ; )
    */
   public String getExtraOptionSeparator() {
-    return databaseInterface.getExtraOptionSeparator();
+    return getDatabaseInterface( ).getExtraOptionSeparator();
   }
 
   /**
    * @return The extra option value separator in database URL for this platform (usually this is the equal sign = )
    */
   public String getExtraOptionValueSeparator() {
-    return databaseInterface.getExtraOptionValueSeparator();
+    return getDatabaseInterface( ).getExtraOptionValueSeparator();
   }
 
   /**
@@ -2886,5 +2933,19 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
    */
   public void setReadOnly( boolean readOnly ) {
     this.readOnly = readOnly;
+  }
+
+  /**
+   * For testing
+   */
+  protected LogChannelInterface getGeneralLogger() {
+    return LogChannel.GENERAL;
+  }
+
+  /**
+   * For testing
+   */
+  protected DatabaseInterface getDbInterface( String typeCode ) throws KettleDatabaseException {
+    return getDatabaseInterface( typeCode );
   }
 }

--- a/core/src/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseMeta.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,7 +24,6 @@ package org.pentaho.di.core.database;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.pentaho.di.core.database.DatabaseMeta.indexOfName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -154,22 +153,22 @@ public class DatabaseMetaTest {
 
   @Test
   public void indexOfName_NullArray() {
-    assertEquals( -1, indexOfName( null, "" ) );
+    assertEquals( -1, DatabaseMeta.indexOfName( null, "" ) );
   }
 
   @Test
   public void indexOfName_NullName() {
-    assertEquals( -1, indexOfName( new String[] { "1" }, null ) );
+    assertEquals( -1, DatabaseMeta.indexOfName( new String[] { "1" }, null ) );
   }
 
   @Test
   public void indexOfName_ExactMatch() {
-    assertEquals( 1, indexOfName( new String[] { "a", "b", "c" }, "b" ) );
+    assertEquals( 1, DatabaseMeta.indexOfName( new String[] { "a", "b", "c" }, "b" ) );
   }
 
   @Test
   public void indexOfName_NonExactMatch() {
-    assertEquals( 1, indexOfName( new String[] { "a", "b", "c" }, "B" ) );
+    assertEquals( 1, DatabaseMeta.indexOfName( new String[] { "a", "b", "c" }, "B" ) );
   }
 
 

--- a/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseMetaTest.java
@@ -35,12 +35,23 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
 
 public class DatabaseMetaTest {
+  private DatabaseMeta databaseMeta;
+
+  @Before
+  public void setUp() {
+    databaseMeta = mock( DatabaseMeta.class );
+    when( databaseMeta
+      .databaseForBothDbInterfacesIsTheSame( any( DatabaseInterface.class ), any( DatabaseInterface.class ) ) )
+      .thenCallRealMethod();
+  }
+
   @Test
   public void testGetDatabaseInterfacesMapWontReturnNullIfCalledSimultaneouslyWithClear() throws InterruptedException, ExecutionException {
     final AtomicBoolean done = new AtomicBoolean( false );
@@ -159,5 +170,61 @@ public class DatabaseMetaTest {
   @Test
   public void indexOfName_NonExactMatch() {
     assertEquals( 1, indexOfName( new String[] { "a", "b", "c" }, "B" ) );
+  }
+
+
+  @Test
+  public void databases_WithSameDbConnTypes_AreTheSame() {
+    DatabaseInterface mssqlServerDatabaseMeta =  new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( "MSSQL" );
+
+    assertTrue( databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta, mssqlServerDatabaseMeta ) );
+  }
+
+  @Test
+  public void databases_WithSameDbConnTypes_AreNotSame_IfPluginIdIsNull() {
+    DatabaseInterface mssqlServerDatabaseMeta =  new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( null );
+
+    assertFalse( databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta, mssqlServerDatabaseMeta ) );
+  }
+
+  @Test
+  public void databases_WithDifferentDbConnTypes_AreDifferent_IfNonOfThemIsSubsetOfAnother() {
+    DatabaseInterface mssqlServerDatabaseMeta =  new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( "MSSQL" );
+    DatabaseInterface oracleDatabaseMeta = new OracleDatabaseMeta();
+    oracleDatabaseMeta.setPluginId( "ORACLE" );
+
+    assertFalse( databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta, oracleDatabaseMeta ) );
+  }
+
+  @Test
+  public void databases_WithDifferentDbConnTypes_AreTheSame_IfOneConnTypeIsSubsetOfAnother_2LevelHierarchy() {
+    DatabaseInterface mssqlServerDatabaseMeta =  new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( "MSSQL" );
+    DatabaseInterface mssqlServerNativeDatabaseMeta =  new MSSQLServerNativeDatabaseMeta();
+    mssqlServerNativeDatabaseMeta.setPluginId( "MSSQLNATIVE" );
+
+
+    assertTrue( databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta,
+      mssqlServerNativeDatabaseMeta ) );
+  }
+
+  @Test
+  public void databases_WithDifferentDbConnTypes_AreTheSame_IfOneConnTypeIsSubsetOfAnother_3LevelHierarchy() {
+    class MSSQLServerNativeDatabaseMetaChild extends MSSQLServerDatabaseMeta {
+      @Override
+      public String getPluginId() {
+        return "MSSQLNATIVE_CHILD";
+      }
+    }
+
+    DatabaseInterface mssqlServerDatabaseMeta = new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( "MSSQL" );
+    DatabaseInterface mssqlServerNativeDatabaseMetaChild = new MSSQLServerNativeDatabaseMetaChild();
+
+    assertTrue(
+      databaseMeta.databaseForBothDbInterfacesIsTheSame( mssqlServerDatabaseMeta, mssqlServerNativeDatabaseMetaChild ) );
   }
 }

--- a/core/test-src/org/pentaho/di/core/database/DatabaseMeta_AppendExtraParamsTest.java
+++ b/core/test-src/org/pentaho/di/core/database/DatabaseMeta_AppendExtraParamsTest.java
@@ -1,0 +1,166 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.database;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.util.StringUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ *
+ * This test is designed to check that jdbc url (with no extra parameters)
+ * remains valid (sure, we check syntax only) after adding any extra parameters
+ * in spite of number of this parameters and their validity.
+ *
+ * @author Ivan_Nikolaichuk
+ */
+public class DatabaseMeta_AppendExtraParamsTest {
+  private static final String CONN_TYPE_MSSQL = "MSSQL";
+
+  private static final String STRING_EXTRA_OPTION = "extraOption";
+  private static final String STRING_OPTION_VALUE = "value";
+  private static final String STRING_DEFAULT = "<def>";
+
+  private DatabaseMeta meta;
+  private DatabaseInterface mssqlServerDatabaseMeta;
+
+  private final String CONN_URL_NO_EXTRA_OPTIONS = "jdbc:sqlserver://127.0.0.1:1433";
+
+  @Before
+  public void setUp() throws KettleDatabaseException {
+    meta = mock( DatabaseMeta.class );
+    mssqlServerDatabaseMeta = new MSSQLServerDatabaseMeta();
+    mssqlServerDatabaseMeta.setPluginId( CONN_TYPE_MSSQL );
+    doReturn( mssqlServerDatabaseMeta ).when( meta ).getDatabaseInterface();
+
+    doCallRealMethod().when( meta ).appendExtraOptions( anyString(), anyMapOf( String.class, String.class ) );
+    doCallRealMethod().when( meta )
+      .databaseForBothDbInterfacesIsTheSame( any( DatabaseInterface.class ), any( DatabaseInterface.class ) );
+    doCallRealMethod().when( meta ).getExtraOptionIndicator();
+    doCallRealMethod().when( meta ).getExtraOptionSeparator();
+    doCallRealMethod().when( meta ).getExtraOptionValueSeparator();
+    doReturn( mock( LogChannelInterface.class ) ).when( meta ).getGeneralLogger();
+    doReturn( mssqlServerDatabaseMeta ).when( meta ).getDbInterface( CONN_TYPE_MSSQL );
+
+  }
+
+  @Test
+  public void urlNotChanges_WhenNoExtraOptionsGiven() {
+    Map<String, String> extraOptions = generateExtraOptions( CONN_TYPE_MSSQL, 0 );
+
+    String connUrlWithExtraOptions = meta.appendExtraOptions( CONN_URL_NO_EXTRA_OPTIONS, extraOptions );
+    assertEquals( CONN_URL_NO_EXTRA_OPTIONS, connUrlWithExtraOptions );
+  }
+
+  /**
+   * Extra option key is expected to be in pattern: ConnType.key If ConnType and key are not divided by point, extra
+   * option is considered to be invalid
+   */
+  @Test
+  public void urlNotChanges_WhenExtraOptionIsInvalid() {
+    Map<String, String> extraOptions = generateExtraOptions( CONN_TYPE_MSSQL, 0 );
+    extraOptions.put( STRING_DEFAULT, STRING_DEFAULT );
+
+    String connUrlWithExtraOptions = meta.appendExtraOptions( CONN_URL_NO_EXTRA_OPTIONS, extraOptions );
+    assertEquals( CONN_URL_NO_EXTRA_OPTIONS, connUrlWithExtraOptions );
+  }
+
+  @Test
+  public void extraOptionsAreNotAppended_WhenTheyAreEmpty() {
+    Map<String, String> extraOptions = generateExtraOptions( CONN_TYPE_MSSQL, 0 );
+    final String validKey = CONN_TYPE_MSSQL + "." + "key";
+    extraOptions.put( validKey, StringUtil.EMPTY_STRING );
+    extraOptions.put( validKey, DatabaseMeta.EMPTY_OPTIONS_STRING );
+
+    String connUrlWithExtraOptions = meta.appendExtraOptions( CONN_URL_NO_EXTRA_OPTIONS, extraOptions );
+    assertEquals( CONN_URL_NO_EXTRA_OPTIONS, connUrlWithExtraOptions );
+  }
+
+  @Test
+  public void extraOptionsAreNotAppended_WhenConnTypePointsToAnotherDataBase() throws Exception {
+    Map<String, String> extraOptions = generateExtraOptions( STRING_DEFAULT, 2 );
+
+    // emulate that there is no database with STRING_DEFAULT plugin id.
+    doThrow( new KettleDatabaseException(  ) ).when( meta ).getDbInterface( STRING_DEFAULT );
+    String connUrlWithExtraOptions = meta.appendExtraOptions( CONN_URL_NO_EXTRA_OPTIONS, extraOptions );
+    assertEquals( CONN_URL_NO_EXTRA_OPTIONS, connUrlWithExtraOptions );
+  }
+
+
+  @Test
+  public void urlIsValid_AfterAddingValidExtraOptions() {
+    Map<String, String> extraOptions = generateExtraOptions( CONN_TYPE_MSSQL, 1 );
+
+    String expectedExtraOptionsUrl =
+      STRING_EXTRA_OPTION + 0 + mssqlServerDatabaseMeta.getExtraOptionValueSeparator() + STRING_OPTION_VALUE + 0;
+    String expectedUrl =
+      CONN_URL_NO_EXTRA_OPTIONS + mssqlServerDatabaseMeta.getExtraOptionSeparator() + expectedExtraOptionsUrl;
+
+    String connUrlWithExtraOptions = meta.appendExtraOptions( CONN_URL_NO_EXTRA_OPTIONS, extraOptions );
+    assertEquals( expectedUrl, connUrlWithExtraOptions );
+  }
+
+
+  @Test
+  public void onlyValidExtraOptions_AreAppendedToUrl() {
+    Map<String, String> extraOptions = generateExtraOptions( CONN_TYPE_MSSQL, 1 );
+    extraOptions.put( STRING_DEFAULT, STRING_DEFAULT );
+    extraOptions.put( CONN_TYPE_MSSQL + "." + "key1", StringUtil.EMPTY_STRING );
+    extraOptions.put( CONN_TYPE_MSSQL + "." + "key2", DatabaseMeta.EMPTY_OPTIONS_STRING );
+
+    String expectedExtraOptionsUrl =
+      STRING_EXTRA_OPTION + 0 + mssqlServerDatabaseMeta.getExtraOptionValueSeparator() + STRING_OPTION_VALUE + 0;
+    String expectedUrl =
+      CONN_URL_NO_EXTRA_OPTIONS + mssqlServerDatabaseMeta.getExtraOptionSeparator() + expectedExtraOptionsUrl;
+
+
+    String connUrlWithExtraOptions = meta.appendExtraOptions( CONN_URL_NO_EXTRA_OPTIONS, extraOptions );
+    assertEquals( expectedUrl, connUrlWithExtraOptions );
+  }
+
+  /**
+   * Extra option is considered to be valid if it is build in pattern: ConnType.key
+   * <b>All generated extra options generated by this method are valid.</b>
+   */
+  public Map<String, String> generateExtraOptions( final String connType, int numberOfOptions ) {
+    Map<String, String> map = new HashMap<String, String>( numberOfOptions );
+    for ( int i = 0; i < numberOfOptions; i++ ) {
+      String uniqueExtraOption = STRING_EXTRA_OPTION + i;
+      String optionVal = STRING_OPTION_VALUE + i;
+      map.put( connType + "." + uniqueExtraOption, optionVal );
+    }
+
+    return map;
+  }
+}


### PR DESCRIPTION
-  Validating extra parameter value before appending it's key to url.
- Tests written
- Checking whether the underlying database for two DatabaseInterface's is the same depending on the class hierarchy (if check by pluginId fails).

@brosander , could you review it please?
It is a **backport** for this PR's: https://github.com/pentaho/pentaho-kettle/pull/2311, https://github.com/pentaho/pentaho-kettle/pull/2342,  https://github.com/pentaho/pentaho-kettle/pull/2355