### PR TITLE
[BACKLOG-5453] Add the field "webapp name" for Pentaho Data Service database type (SWT Dialog)

### DIFF
--- a/dbdialog/src/org/pentaho/ui/database/databasedialog.properties
+++ b/dbdialog/src/org/pentaho/ui/database/databasedialog.properties
@@ -116,3 +116,4 @@ DatabaseDialog.button.RestoreDefaults=Restore Defaults
 
 DatabaseDialog.label.UseIntegratedSecurity=Use Integrated Security
 DatabaseDialog.label.ConnectionIsReadOnly=This connection is read-only.
+DatabaseDialog.label.WebAppName=Web App Name:

--- a/dbdialog/src/org/pentaho/ui/database/event/DataHandler.java
+++ b/dbdialog/src/org/pentaho/ui/database/event/DataHandler.java
@@ -86,6 +86,9 @@ public class DataHandler extends AbstractXulEventHandler {
   public static final SortedMap<String, DatabaseInterface> connectionMap = new TreeMap<>();
   public static final Map<String, String> connectionNametoID = new HashMap<>();
 
+  // Kettle thin related
+  private static final String WEB_APPLICATION_NAME = "WEB_APPLICATION_NAME";
+
   // The connectionMap allows us to keep track of the connection
   // type we are working with and the correlating database interface
 
@@ -166,10 +169,12 @@ public class DataHandler extends AbstractXulEventHandler {
 
   // MS SQL Server specific
   private XulCheckbox doubleDecimalSeparatorCheck;
-  // private XulCheckbox mssqlIntegratedSecurity;
 
   // MySQL specific
   private XulCheckbox resultStreamingCursorCheck;
+
+  // Pentaho data services specific
+  private XulTextbox webAppName;
 
   // ==== Options Panel ==== //
 
@@ -1259,6 +1264,10 @@ public class DataHandler extends AbstractXulEventHandler {
         MSSQLServerNativeDatabaseMeta.ATTRIBUTE_USE_INTEGRATED_SECURITY,
         useIntegratedSecurity != null ? useIntegratedSecurity.toString() : "false" );
     }
+
+    if ( webAppName != null ) {
+      meta.getAttributes().put( WEB_APPLICATION_NAME, webAppName.getValue() );
+    }
   }
 
   private void setConnectionSpecificInfo( DatabaseMeta meta ) {
@@ -1347,6 +1356,14 @@ public class DataHandler extends AbstractXulEventHandler {
         useIntegratedSecurityCheck.setChecked( false );
       }
     }
+
+    if ( webAppName != null ) {
+      if ( databaseMeta != null && databaseMeta.getAttributes().containsKey( WEB_APPLICATION_NAME ) ) {
+        webAppName.setValue( databaseMeta.getAttributes().getProperty( WEB_APPLICATION_NAME ) );
+      } else if ( databaseMeta == null || !databaseMeta.getExtraOptions().containsKey( "KettleThin.webappname" ) ) {
+        webAppName.setValue( "pentaho-di" );
+      }
+    }
   }
 
   protected void getControls() {
@@ -1375,6 +1392,7 @@ public class DataHandler extends AbstractXulEventHandler {
     clientBox = (XulTextbox) document.getElementById( "client-text" );
     doubleDecimalSeparatorCheck = (XulCheckbox) document.getElementById( "decimal-separator-check" );
     resultStreamingCursorCheck = (XulCheckbox) document.getElementById( "result-streaming-check" );
+    webAppName = (XulTextbox) document.getElementById( "web-application-name-text" );
     poolingCheck = (XulCheckbox) document.getElementById( "use-pool-check" );
     clusteringCheck = (XulCheckbox) document.getElementById( "use-cluster-check" );
     clusterParameterDescriptionLabel = (XulLabel) document.getElementById( "cluster-parameter-description-label" );

--- a/dbdialog/src/org/pentaho/ui/database/kettlethin_native.xul
+++ b/dbdialog/src/org/pentaho/ui/database/kettlethin_native.xul
@@ -6,6 +6,8 @@
     <textbox pen:customclass="variabletextbox" id="server-host-name-text" />
     <label id="port-number-label" value="${DatabaseDialog.label.PortNumber}" />
     <textbox pen:customclass="variabletextbox" id="port-number-text" />
+    <label id="web-app-name-label" value="${DatabaseDialog.label.WebAppName}" />
+    <textbox pen:customclass="variabletextbox" id="web-application-name-text" />
     <label id="username-label" value="${DatabaseDialog.label.Username}" />
     <textbox pen:customclass="variabletextbox" id="username-text" />
     <label id="password-label" value="${DatabaseDialog.label.Password}" />

--- a/dbdialog/test-src/org/pentaho/ui/database/event/DataHandlerTest.java
+++ b/dbdialog/test-src/org/pentaho/ui/database/event/DataHandlerTest.java
@@ -21,6 +21,7 @@
  ******************************************************************************/
 package org.pentaho.ui.database.event;
 
+import java.util.Properties;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -75,6 +76,7 @@ public class DataHandlerTest {
   XulTextbox userNameBox;
   XulTextbox passwordBox;
   XulTextbox serverInstanceBox;
+  XulTextbox webappName;
   XulMessageBox messageBox;
   XulRoot generalDatasourceWindow;
 
@@ -120,6 +122,9 @@ public class DataHandlerTest {
     when( document.getElementById( "instance-text" ) ).thenReturn( serverInstanceBox );
     when( serverInstanceBox.getValue() ).thenReturn( "instance" );
     when( serverInstanceBox.getAttributeValue( "shouldDisablePortIfPopulated" ) ).thenReturn( "true" );
+    webappName = mock( XulTextbox.class );
+    when( document.getElementById( "web-application-name-text" ) ).thenReturn( webappName );
+    when( webappName.getValue() ).thenReturn( "webappName" );
 
     messageBox = mock( XulMessageBox.class );
     when( document.createElement( "messagebox" ) ).thenReturn( messageBox );
@@ -176,6 +181,7 @@ public class DataHandlerTest {
     when( dbInterface.getDefaultDatabasePort() ).thenReturn( 5309 );
     when( connectionBox.getSelectedItem() ).thenReturn( "myDb" );
     DataHandler.connectionMap.put( "myDb", dbInterface );
+    dataHandler.getData();
     dataHandler.loadAccessData();
   }
 
@@ -227,6 +233,7 @@ public class DataHandlerTest {
 
     DatabaseMeta dbMeta = mock( DatabaseMeta.class );
     when( dbMeta.getAccessType() ).thenReturn( DatabaseMeta.TYPE_ACCESS_JNDI );
+    when( dbMeta.getAttributes() ).thenReturn( new Properties() );
 
     when( accessBox.getSelectedItem() ).thenReturn( "JNDI" );
     when( deckOptionsBox.getSelectedIndex() ).thenReturn( -1 );
@@ -239,8 +246,11 @@ public class DataHandlerTest {
   }
 
   @Test
-  public void testPushCache() throws Exception {
-
+  public void testPushPopCache() throws Exception {
+    dataHandler.getData();
+    dataHandler.pushCache();
+    dataHandler.popCache();
+    verify( webappName ).setValue( "pentaho-di" );
   }
 
   @Test


### PR DESCRIPTION
- Add field for webappName
- Store webappName as a separate parameter
- Provide default value for webappName

Data services part is in https://github.com/pentaho/pdi-dataservice-plugin/pull/65
@hudak 