### PR TITLE
[PDI-15118] User with no schedule permissions has access to schedule perspective

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import javax.xml.ws.WebServiceException;
 
 import org.apache.commons.lang.BooleanUtils;
+import org.eclipse.swt.widgets.Display;
 import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleSecurityException;
@@ -34,7 +35,6 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.IUser;
 import org.pentaho.di.repository.RepositorySecurityManager;
 import org.pentaho.di.repository.RepositorySecurityProvider;
-import org.pentaho.di.repository.pur.PurRepository;
 import org.pentaho.di.repository.pur.model.EEUserInfo;
 import org.pentaho.di.ui.repository.pur.services.IAbsSecurityManager;
 import org.pentaho.di.ui.repository.pur.services.IAbsSecurityProvider;
@@ -44,6 +44,7 @@ import org.pentaho.di.ui.repository.pur.services.ILockService;
 import org.pentaho.di.ui.repository.pur.services.IRevisionService;
 import org.pentaho.di.ui.repository.pur.services.IRoleSupportSecurityManager;
 import org.pentaho.di.ui.repository.pur.services.ITrashService;
+import org.pentaho.di.ui.spoon.SpoonPerspectiveManager;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
@@ -148,6 +149,19 @@ public class PurRepositoryConnector implements IRepositoryConnector {
           if ( log.isBasic() ) {
             log.logBasic( BaseMessages.getString( PKG, "PurRepositoryConnector.CreateServiceProvider.End" ) ); //$NON-NLS-1$
           }
+          boolean canSchedule = allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),
+            IAbsSecurityProvider.SCHEDULE_CONTENT_ACTION );
+          Display.getDefault().asyncExec( new Runnable() {
+            public void run() {
+              final String schedulePerspectiveId = "schedulerPerspective";
+              SpoonPerspectiveManager perspectiveManager = SpoonPerspectiveManager.getInstance();
+              if ( canSchedule ) {
+                perspectiveManager.showPerspective( schedulePerspectiveId );
+              } else {
+                perspectiveManager.hidePerspective( schedulePerspectiveId );
+              }
+            }
+          } );
           // If the user does not have access to administer security we do not
           // need to added them to the service list
           if ( allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),

--- a/ui/src/org/pentaho/di/ui/spoon/SpoonPerspectiveManager.java
+++ b/ui/src/org/pentaho/di/ui/spoon/SpoonPerspectiveManager.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -104,7 +104,7 @@ public class SpoonPerspectiveManager {
     this.startupPerspective = startupPerspective;
   }
 
-  Map<SpoonPerspective,PerspectiveManager> getPerspectiveManagerMap() {
+  Map<SpoonPerspective, PerspectiveManager> getPerspectiveManagerMap() {
     return Collections.unmodifiableMap( perspectiveManagerMap );
   }
 

--- a/ui/test-src/org/pentaho/di/ui/spoon/SpoonPerspectiveManagerTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/SpoonPerspectiveManagerTest.java
@@ -85,7 +85,7 @@ public class SpoonPerspectiveManagerTest {
 
 
   @Test
-  public void hidePerspective(){
+  public void hidePerspective() {
     SpoonPerspectiveManager.PerspectiveManager perspectiveManager = perspectiveManagerMap.get( perspective );
     spoonPerspectiveManager.hidePerspective( perspective.getId() );
 
@@ -93,7 +93,7 @@ public class SpoonPerspectiveManagerTest {
   }
 
   @Test
-  public void showPerspective(){
+  public void showPerspective() {
     SpoonPerspectiveManager.PerspectiveManager perspectiveManager = perspectiveManagerMap.get( perspective );
     spoonPerspectiveManager.showPerspective( perspective.getId() );
 
@@ -125,7 +125,7 @@ public class SpoonPerspectiveManagerTest {
   }
 
 
-  private class DummyPerspective implements SpoonPerspective{
+  private class DummyPerspective implements SpoonPerspective {
 
     @Override public String getId() {
       return PERSPECTIVE_ID;

--- a/ui/test-src/org/pentaho/di/ui/spoon/SpoonPerspectiveManagerTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/SpoonPerspectiveManagerTest.java
@@ -1,0 +1,167 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.spoon;
+
+import org.eclipse.swt.custom.CCombo;
+import org.eclipse.swt.widgets.Composite;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.EngineMetaInterface;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.ui.xul.XulOverlay;
+import org.pentaho.ui.xul.containers.XulDeck;
+import org.pentaho.ui.xul.containers.XulToolbar;
+import org.pentaho.ui.xul.containers.XulVbox;
+import org.pentaho.ui.xul.impl.XulEventHandler;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+
+public class SpoonPerspectiveManagerTest {
+  private static final String PERSPECTIVE_ID = "perspective-id";
+  private static final String PERSPECTIVE_NAME = "perspective-name";
+
+  private Map<SpoonPerspective, SpoonPerspectiveManager.PerspectiveManager> perspectiveManagerMap;
+  private static SpoonPerspectiveManager spoonPerspectiveManager;
+  private SpoonPerspective perspective;
+
+  @Before
+  public void setUp() throws Exception {
+    spoonPerspectiveManager = SpoonPerspectiveManager.getInstance();
+    spoonPerspectiveManager = spy( spoonPerspectiveManager );
+
+    perspective = new DummyPerspective();
+    spoonPerspectiveManager.addPerspective( perspective );
+
+    // emulate we have one perspective, that is not inited yet.
+    perspectiveManagerMap = emulatePerspectiveManagerMap( perspective );
+
+    doReturn( perspectiveManagerMap ).when( spoonPerspectiveManager ).getPerspectiveManagerMap();
+    doReturn( mock( Spoon.class ) ).when( spoonPerspectiveManager ).getSpoon();
+    spoonPerspectiveManager.setDeck( mock( XulDeck.class ) );
+    doReturn( mock( LogChannelInterface.class ) ).when( spoonPerspectiveManager ).getLogger();
+  }
+
+
+  @Test
+  public void perspectiveIsInitializedOnlyOnce() throws KettleException {
+    SpoonPerspectiveManager.PerspectiveManager perspectiveManager = perspectiveManagerMap.get( perspective );
+
+    spoonPerspectiveManager.activatePerspective( perspective.getClass() );
+    // it's the first time this perspective gets active, so it should be initialized after this call
+    verify( perspectiveManager ).performInit();
+
+    spoonPerspectiveManager.activatePerspective( perspective.getClass() );
+    // make sure that perspective was inited only after first activation
+    verify( perspectiveManager ).performInit();
+  }
+
+
+  @Test
+  public void hidePerspective(){
+    SpoonPerspectiveManager.PerspectiveManager perspectiveManager = perspectiveManagerMap.get( perspective );
+    spoonPerspectiveManager.hidePerspective( perspective.getId() );
+
+    verify( perspectiveManager ).removePerspective( PERSPECTIVE_NAME );
+  }
+
+  @Test
+  public void showPerspective(){
+    SpoonPerspectiveManager.PerspectiveManager perspectiveManager = perspectiveManagerMap.get( perspective );
+    spoonPerspectiveManager.showPerspective( perspective.getId() );
+
+    verify( perspectiveManager ).addPerspectiveNameIfNotExists( PERSPECTIVE_NAME );
+  }
+
+
+
+  private Map<SpoonPerspective, SpoonPerspectiveManager.PerspectiveManager> emulatePerspectiveManagerMap(
+    SpoonPerspective... perspectives ) {
+    Map<SpoonPerspective, SpoonPerspectiveManager.PerspectiveManager> spoonPerspectiveManagerMap = new HashMap<>();
+
+    for ( SpoonPerspective perspective : perspectives ) {
+      spoonPerspectiveManagerMap.put( perspective, createPerspectiveManager( perspective ) );
+    }
+    return spoonPerspectiveManagerMap;
+  }
+
+  private SpoonPerspectiveManager.PerspectiveManager createPerspectiveManager( SpoonPerspective perspective ) {
+    SpoonPerspectiveManager.PerspectiveManager perspectiveManager =
+      new SpoonPerspectiveManager.PerspectiveManager( perspective, mock(
+        XulVbox.class ), mock( XulToolbar.class ), null, mock( CCombo.class ),
+        perspective.getDisplayName( Locale.getDefault() ) );
+
+    perspectiveManager = spy( perspectiveManager );
+    doNothing().when( perspectiveManager ).performInit();
+
+    return perspectiveManager;
+  }
+
+
+  private class DummyPerspective implements SpoonPerspective{
+
+    @Override public String getId() {
+      return PERSPECTIVE_ID;
+    }
+
+    @Override public Composite getUI() {
+      return null;
+    }
+
+    @Override public String getDisplayName( Locale l ) {
+      return PERSPECTIVE_NAME;
+    }
+
+    @Override public InputStream getPerspectiveIcon() {
+      return null;
+    }
+
+    @Override public void setActive( boolean active ) {
+
+    }
+
+    @Override public List<XulOverlay> getOverlays() {
+      return null;
+    }
+
+    @Override public List<XulEventHandler> getEventHandlers() {
+      return null;
+    }
+
+    @Override public void addPerspectiveListener( SpoonPerspectiveListener listener ) {
+
+    }
+
+    @Override public EngineMetaInterface getActiveMeta() {
+      return null;
+    }
+  }
+
+}


### PR DESCRIPTION
- When logging to repository check whether user is allowed to schedule content and remove "Schedule perspective" it he has no permissions for this.
- provided an ability to manipulate perspective's UI list from SpoonPerspectiveManager.
- Tests written
- Checkstyle applied

If I understand the idea of PerspectiveInitializer class, it's goal was to make lazy initialization for all perspectived, except the first one, that would be inited immediately. Other perspectives would be initialized when needed and removed from initializerMap.

So, PerspectiveInitializer encapsulates the list of perspectives, and is the only place where perspective list can be accessible and changed.

I added few more methods there: for adding and removing perspective names (unfortunately there is no oppotunity to 'hide' element in CCombo class, so we are removing and adding), keeping the existing behavior the same:
1. In first init only main perspective is initialized.
2. Each perspective is initialized only once, regarding how many times it was active.