### PR TITLE
[CLEANUP] Cleanup Value references

### DIFF
--- a/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -3687,25 +3687,25 @@ public class ValueMetaBase implements ValueMetaInterface {
 
     if ( null_value == null ) {
       switch ( inValueType ) {
-        case Value.VALUE_TYPE_BOOLEAN:
+        case ValueMetaInterface.TYPE_BOOLEAN:
           null_value = Const.NULL_BOOLEAN;
           break;
-        case Value.VALUE_TYPE_STRING:
+        case ValueMetaInterface.TYPE_STRING:
           null_value = Const.NULL_STRING;
           break;
-        case Value.VALUE_TYPE_BIGNUMBER:
+        case ValueMetaInterface.TYPE_BIGNUMBER:
           null_value = Const.NULL_BIGNUMBER;
           break;
-        case Value.VALUE_TYPE_NUMBER:
+        case ValueMetaInterface.TYPE_NUMBER:
           null_value = Const.NULL_NUMBER;
           break;
-        case Value.VALUE_TYPE_INTEGER:
+        case ValueMetaInterface.TYPE_INTEGER:
           null_value = Const.NULL_INTEGER;
           break;
-        case Value.VALUE_TYPE_DATE:
+        case ValueMetaInterface.TYPE_DATE:
           null_value = Const.NULL_DATE;
           break;
-        case Value.VALUE_TYPE_BINARY:
+        case ValueMetaInterface.TYPE_BINARY:
           null_value = Const.NULL_BINARY;
           break;
         default:

--- a/core/src/org/pentaho/di/core/row/value/ValueMetaInternetAddress.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaInternetAddress.java
@@ -31,7 +31,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.Types;
 import java.util.Date;
 
-import org.pentaho.di.compatibility.Value;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
@@ -282,25 +281,25 @@ public class ValueMetaInternetAddress extends ValueMetaDate {
     String null_value = nullIf;
     if ( null_value == null ) {
       switch ( convertMeta.getType() ) {
-        case Value.VALUE_TYPE_BOOLEAN:
+        case ValueMetaInterface.TYPE_BOOLEAN:
           null_value = Const.NULL_BOOLEAN;
           break;
-        case Value.VALUE_TYPE_STRING:
+        case ValueMetaInterface.TYPE_STRING:
           null_value = Const.NULL_STRING;
           break;
-        case Value.VALUE_TYPE_BIGNUMBER:
+        case ValueMetaInterface.TYPE_BIGNUMBER:
           null_value = Const.NULL_BIGNUMBER;
           break;
-        case Value.VALUE_TYPE_NUMBER:
+        case ValueMetaInterface.TYPE_NUMBER:
           null_value = Const.NULL_NUMBER;
           break;
-        case Value.VALUE_TYPE_INTEGER:
+        case ValueMetaInterface.TYPE_INTEGER:
           null_value = Const.NULL_INTEGER;
           break;
-        case Value.VALUE_TYPE_DATE:
+        case ValueMetaInterface.TYPE_DATE:
           null_value = Const.NULL_DATE;
           break;
-        case Value.VALUE_TYPE_BINARY:
+        case ValueMetaInterface.TYPE_BINARY:
           null_value = Const.NULL_BINARY;
           break;
         default:

--- a/core/src/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -37,7 +37,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import org.pentaho.di.compatibility.Value;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
@@ -278,25 +277,25 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     String null_value = nullIf;
     if ( null_value == null ) {
       switch ( convertMeta.getType() ) {
-        case Value.VALUE_TYPE_BOOLEAN:
+        case ValueMetaInterface.TYPE_BOOLEAN:
           null_value = Const.NULL_BOOLEAN;
           break;
-        case Value.VALUE_TYPE_STRING:
+        case ValueMetaInterface.TYPE_STRING:
           null_value = Const.NULL_STRING;
           break;
-        case Value.VALUE_TYPE_BIGNUMBER:
+        case ValueMetaInterface.TYPE_BIGNUMBER:
           null_value = Const.NULL_BIGNUMBER;
           break;
-        case Value.VALUE_TYPE_NUMBER:
+        case ValueMetaInterface.TYPE_NUMBER:
           null_value = Const.NULL_NUMBER;
           break;
-        case Value.VALUE_TYPE_INTEGER:
+        case ValueMetaInterface.TYPE_INTEGER:
           null_value = Const.NULL_INTEGER;
           break;
-        case Value.VALUE_TYPE_DATE:
+        case ValueMetaInterface.TYPE_DATE:
           null_value = Const.NULL_DATE;
           break;
-        case Value.VALUE_TYPE_BINARY:
+        case ValueMetaInterface.TYPE_BINARY:
           null_value = Const.NULL_BINARY;
           break;
         default:

--- a/core/test-src/org/pentaho/di/compatibility/ValueTest.java
+++ b/core/test-src/org/pentaho/di/compatibility/ValueTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,6 +29,7 @@ import java.util.Date;
 
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.ValueMetaInterface;
 
 import junit.framework.TestCase;
 
@@ -1253,5 +1254,17 @@ public class ValueTest extends TestCase {
     assertTrue( vs2.isNull() );
     assertNull( vs2.getName() );
     assertNull( vs2.getOrigin() );
+  }
+
+  public void testValueMetaInterfaceEquality() {
+    assertEquals( ValueMetaInterface.TYPE_NONE, Value.VALUE_TYPE_NONE );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, Value.VALUE_TYPE_NUMBER );
+    assertEquals( ValueMetaInterface.TYPE_STRING, Value.VALUE_TYPE_STRING );
+    assertEquals( ValueMetaInterface.TYPE_DATE, Value.VALUE_TYPE_DATE );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, Value.VALUE_TYPE_BOOLEAN );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, Value.VALUE_TYPE_INTEGER );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, Value.VALUE_TYPE_BIGNUMBER );
+    assertEquals( ValueMetaInterface.TYPE_SERIALIZABLE, Value.VALUE_TYPE_SERIALIZABLE );
+    assertEquals( ValueMetaInterface.TYPE_BINARY, Value.VALUE_TYPE_BINARY );
   }
 }


### PR DESCRIPTION
Confirm that Value.Value_Type_X constants are the same as ValueMetaInterface.TYPE_X constants.
Update ValueMetaBase and related classes to use the correct constants