### PR TITLE
[BACKLOG-7168] - Data Services fails if SQL contains "=NULL"

### DIFF
--- a/core/src/org/pentaho/di/core/Condition.java
+++ b/core/src/org/pentaho/di/core/Condition.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -76,7 +76,7 @@ public class Condition implements Cloneable, XMLInterface {
 
   public static final String[] functions = new String[] {
     "=", "<>", "<", "<=", ">", ">=", "REGEXP", "IS NULL", "IS NOT NULL", "IN LIST", "CONTAINS", "STARTS WITH",
-    "ENDS WITH", "LIKE", "TRUE", };
+    "ENDS WITH", "LIKE", "TRUE" };
 
   public static final int FUNC_EQUAL = 0;
   public static final int FUNC_NOT_EQUAL = 1;
@@ -375,7 +375,7 @@ public class Condition implements Cloneable, XMLInterface {
       if ( isAtomic() ) {
 
         if ( function == FUNC_TRUE ) {
-          return true;
+          return !negate;
         }
 
         // Get fieldnrs left value

--- a/core/test-src/org/pentaho/di/core/ConditionTest.java
+++ b/core/test-src/org/pentaho/di/core/ConditionTest.java
@@ -1,0 +1,41 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.pentaho.di.core.row.RowMeta;
+
+public class ConditionTest extends TestCase {
+
+  @Test
+  public void testNegatedTrueFuncEvaluatesAsFalse() throws Exception {
+    String left = "test_filed";
+    String right = "test_value";
+    int func = Condition.FUNC_TRUE;
+    boolean negate = true;
+
+    Condition condition = new Condition( negate, left, func, right, null );
+    assertFalse( condition.evaluate( new RowMeta(), new Object[]{ "test" } ) );
+  }
+}


### PR DESCRIPTION
Added an additional processing to the unknown of expression, which сondition is always FALSE