### PR TITLE
[TEST] Fixing IT tests

### DIFF
--- a/plugins/pdi-pur-plugin/ivy.xml
+++ b/plugins/pdi-pur-plugin/ivy.xml
@@ -29,6 +29,7 @@
       changing="true" transitive="false" conf="compile->default"/>
     <dependency org="pentaho" name="pentaho-platform-repository" rev="${dependency.bi-platform.revision}"
       changing="true" transitive="false" />
+    <dependency org="org.yaml" name="snakeyaml" rev="1.7" conf="default->default" transitive="false"/>
     <dependency org="pentaho" name="pentaho-platform-extensions" rev="${dependency.bi-platform.revision}"
       changing="true" transitive="false" conf="compile->default"/>
     <dependency org="pentaho" name="pentaho-xul-core" rev="${dependency.pentaho-xul.revision}"


### PR DESCRIPTION
IT tests are broken because of: https://github.com/pentaho/pentaho-platform/commit/006922cd99b7d78602eeac48234df0662b243539#diff-1104b650dc14a9bec1183f54df14745aR39

PUR-plugin uses MagicAceDefinition class (that uses classes from newly added *org.yaml* package) somewhere between creating jcrSessionFactory bean, and as there is no depencency for *org.yaml* for pur, and as a dependeny to pentaho-repository is not transitive we get NoClassDefFoundError.
Thats the cause off falling IT tests.


