### PR TITLE
[SP-2660] - Backport of PDI-14854 - NPE in Excel Writer Step  caused …

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/excelwriter/ExcelWriterStep.java
+++ b/engine/src/org/pentaho/di/trans/steps/excelwriter/ExcelWriterStep.java
@@ -52,6 +52,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ResultFile;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.vfs.KettleVFS;
@@ -89,8 +90,13 @@ public class ExcelWriterStep extends BaseStep implements StepInterface {
     if ( first ) {
 
       first = false;
-      data.outputRowMeta = getInputRowMeta().clone();
-      data.inputRowMeta = getInputRowMeta().clone();
+      if ( r == null ) {
+        data.outputRowMeta = new RowMeta();
+        data.inputRowMeta = new RowMeta();
+      } else {
+        data.outputRowMeta = getInputRowMeta().clone();
+        data.inputRowMeta = getInputRowMeta().clone();
+      }
 
       // if we are supposed to init the file up front, here we go
       if ( !meta.isDoNotOpenNewFileInit() ) {


### PR DESCRIPTION
…by fix for PDI-11374 (5.4 Suite)

Generate an empty RowMeta, as some settings require an empty file be
created before finishing.

@mattcasters , @brosander, here is the backport of https://github.com/pentaho/pentaho-kettle/pull/2135 to 5.4. Thanks.