### PR TITLE
Multiway Merge Join step loses all settings after saving to PDI repos…

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/multimerge/MultiMergeJoinMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/multimerge/MultiMergeJoinMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,6 +24,7 @@ package org.pentaho.di.trans.steps.multimerge;
 
 import java.util.List;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
@@ -135,14 +136,13 @@ public class MultiMergeJoinMeta extends BaseStepMeta implements StepMetaInterfac
   public String getXML() {
     StringBuilder retval = new StringBuilder();
 
-    List<StreamInterface> infoStreams = getStepIOMeta().getInfoStreams();
-
+    String[] inputStepsNames  = inputSteps != null ? inputSteps : ArrayUtils.EMPTY_STRING_ARRAY;
     retval.append( "    " ).append( XMLHandler.addTagValue( "join_type", getJoinType() ) );
-    for ( int i = 0; i < infoStreams.size(); i++ ) {
-      retval.append( "    " ).append( XMLHandler.addTagValue( "step" + i, infoStreams.get( i ).getStepname() ) );
+    for ( int i = 0; i < inputStepsNames.length; i++ ) {
+      retval.append( "    " ).append( XMLHandler.addTagValue( "step" + i, inputStepsNames[ i ] ) );
     }
 
-    retval.append( "    " ).append( XMLHandler.addTagValue( "number_input", infoStreams.size() ) );
+    retval.append( "    " ).append( XMLHandler.addTagValue( "number_input", inputStepsNames.length ) );
     retval.append( "    " ).append( XMLHandler.openTag( "keys" ) ).append( Const.CR );
     for ( int i = 0; i < keyFields.length; i++ ) {
       retval.append( "      " ).append( XMLHandler.addTagValue( "key", keyFields[i] ) );

--- a/engine/test-src/org/pentaho/di/trans/steps/multimerge/MultiMergeJoinMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/multimerge/MultiMergeJoinMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Assert;
 
 /**
  * @author Tatsiana_Kasiankova
@@ -48,4 +49,14 @@ public class MultiMergeJoinMetaTest {
     assertArrayEquals( inputSteps, multiMergeMeta.getInputSteps() );
   }
 
+  @Test
+  public void testGetXml() {
+    String[] inputSteps = new String[] { "Step1", "Step2" };
+    multiMergeMeta.setInputSteps( inputSteps );
+    multiMergeMeta.setKeyFields( new String[] {"Key1", "Key2"} );
+    String xml = multiMergeMeta.getXML();
+    Assert.assertTrue( xml.contains( "step0" ) );
+    Assert.assertTrue( xml.contains( "step1" ) );
+
+  }
 }


### PR DESCRIPTION
Multiway Merge Join step loses all settings after saving to PDI repository
http://jira.pentaho.com/browse/PDI-15146
Now kettle uses step names for exporting steps in XML. We can not used  StreamInterface (infoStreams) because after kettle cloned TransMeta StepIOMetaInterface (ioMeta) is null after changing PDI-14419. See comment org.pentaho.di.trans.step.BaseStepMeta#clone.
@brosander @mchen-len-son Could you please review?