### PR TITLE
[PDI-15181] Delete Files job entry will delete all files under the install directory when file location parameter is blank

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFiles.java
+++ b/engine/src/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFiles.java
@@ -22,12 +22,17 @@
 
 package org.pentaho.di.job.entries.deletefiles;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.job.entry.validator.AbstractFileValidator;
 import org.pentaho.di.job.entry.validator.AndValidator;
 import org.pentaho.di.job.entry.validator.JobEntryValidatorUtils;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -71,16 +76,16 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
 
   private static Class<?> PKG = JobEntryDeleteFiles.class; // for i18n purposes, needed by Translator2!!
 
-  public boolean argFromPrevious;
+  private boolean argFromPrevious;
 
-  public boolean includeSubfolders;
+  private boolean includeSubfolders;
 
-  public String[] arguments;
+  private String[] arguments;
 
-  public String[] filemasks;
+  private String[] filemasks;
 
-  public JobEntryDeleteFiles( String n ) {
-    super( n, "" );
+  public JobEntryDeleteFiles( String jobName ) {
+    super( jobName, "" );
     argFromPrevious = false;
     arguments = null;
 
@@ -91,20 +96,20 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
     this( "" );
   }
 
-  public void allocate( int nrFields ) {
-    arguments = new String[nrFields];
-    filemasks = new String[nrFields];
+  public void allocate( int numberOfFields ) {
+    arguments = new String[ numberOfFields ];
+    filemasks = new String[ numberOfFields ];
   }
 
   public Object clone() {
-    JobEntryDeleteFiles je = (JobEntryDeleteFiles) super.clone();
+    JobEntryDeleteFiles jobEntry = (JobEntryDeleteFiles) super.clone();
     if ( arguments != null ) {
       int nrFields = arguments.length;
-      je.allocate( nrFields );
-      System.arraycopy( arguments, 0, je.arguments, 0, nrFields );
-      System.arraycopy( filemasks, 0, je.filemasks, 0, nrFields );
+      jobEntry.allocate( nrFields );
+      System.arraycopy( arguments, 0, jobEntry.arguments, 0, nrFields );
+      System.arraycopy( filemasks, 0, jobEntry.filemasks, 0, nrFields );
     }
-    return je;
+    return jobEntry;
   }
 
   public String getXML() {
@@ -137,12 +142,10 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
 
       Node fields = XMLHandler.getSubNode( entrynode, "fields" );
 
-      // How many field arguments?
-      int nrFields = XMLHandler.countNodes( fields, "field" );
-      allocate( nrFields );
+      int numberOfFields = XMLHandler.countNodes( fields, "field" );
+      allocate( numberOfFields );
 
-      // Read them all...
-      for ( int i = 0; i < nrFields; i++ ) {
+      for ( int i = 0; i < numberOfFields; i++ ) {
         Node fnode = XMLHandler.getSubNodeByNr( fields, "field", i );
 
         arguments[i] = XMLHandler.getTagValue( fnode, "name" );
@@ -159,14 +162,12 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
       argFromPrevious = rep.getJobEntryAttributeBoolean( id_jobentry, "arg_from_previous" );
       includeSubfolders = rep.getJobEntryAttributeBoolean( id_jobentry, "include_subfolders" );
 
-      // How many arguments?
-      int argnr = rep.countNrJobEntryAttributes( id_jobentry, "name" );
-      allocate( argnr );
+      int numberOfArgs = rep.countNrJobEntryAttributes( id_jobentry, "name" );
+      allocate( numberOfArgs );
 
-      // Read them all...
-      for ( int a = 0; a < argnr; a++ ) {
-        arguments[a] = rep.getJobEntryAttributeString( id_jobentry, a, "name" );
-        filemasks[a] = rep.getJobEntryAttributeString( id_jobentry, a, "filemask" );
+      for ( int i = 0; i < numberOfArgs; i++ ) {
+        arguments[i] = rep.getJobEntryAttributeString( id_jobentry, i, "name" );
+        filemasks[i] = rep.getJobEntryAttributeString( id_jobentry, i, "filemask" );
       }
     } catch ( KettleException dbe ) {
       throw new KettleException( BaseMessages.getString( PKG, "JobEntryDeleteFiles.UnableToLoadFromRepo", String
@@ -193,83 +194,114 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
   }
 
   public Result execute( Result result, int nr ) throws KettleException {
-    List<RowMetaAndData> rows = result.getRows();
-    RowMetaAndData resultRow = null;
+    List<RowMetaAndData> resultRows = result.getRows();
 
-    int NrErrFiles = 0;
-
+    int numberOfErrFiles = 0;
     result.setResult( false );
     result.setNrErrors( 1 );
 
-    if ( argFromPrevious ) {
-      if ( log.isDetailed() ) {
-        logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.FoundPreviousRows", String
-          .valueOf( ( rows != null ? rows.size() : 0 ) ) ) );
-      }
+    if ( argFromPrevious && log.isDetailed() ) {
+      logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.FoundPreviousRows", String
+        .valueOf( ( resultRows != null ? resultRows.size() : 0 ) ) ) );
     }
 
-    if ( argFromPrevious && rows != null ) { // Copy the input row to the (command line) arguments
-      for ( int iteration = 0; iteration < rows.size() && !parentJob.isStopped(); iteration++ ) {
-        resultRow = rows.get( iteration );
+    Multimap<String, String> pathToMaskMap = populateDataForJobExecution( resultRows );
 
-        String args_previous = resultRow.getString( 0, null );
-        String fmasks_previous = resultRow.getString( 1, null );
-
-        // ok we can process this file/folder
+    for ( Map.Entry<String, String> pathToMask : pathToMaskMap.entries() ) {
+      final String filePath = pathToMask.getKey();
+      if ( filePath.trim().isEmpty() ) {
+        // Relative paths are permitted, and providing an empty path means deleting all files inside a root pdi-folder.
+        // It is much more likely to be a mistake than a desirable action, so we don't delete anything (see PDI-15181)
         if ( log.isDetailed() ) {
-          logDetailed( BaseMessages.getString(
-            PKG, "JobEntryDeleteFiles.ProcessingRow", args_previous, fmasks_previous ) );
+          logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.NoPathProvided" ) );
+        }
+      } else {
+        final String fileMask = pathToMask.getValue();
+
+        if ( parentJob.isStopped() ) {
+          break;
         }
 
-        if ( !ProcessFile( args_previous, fmasks_previous, parentJob ) ) {
-          NrErrFiles++;
-        }
-      }
-    } else if ( arguments != null ) {
-
-      for ( int i = 0; i < arguments.length && !parentJob.isStopped(); i++ ) {
-
-        // ok we can process this file/folder
-        if ( log.isDetailed() ) {
-          logDetailed( BaseMessages.getString(
-            PKG, "JobEntryDeleteFiles.ProcessingArg", arguments[i], filemasks[i] ) );
-        }
-        if ( !ProcessFile( arguments[i], filemasks[i], parentJob ) ) {
-          NrErrFiles++;
+        if ( !processFile( filePath, fileMask, parentJob ) ) {
+          numberOfErrFiles++;
         }
       }
     }
 
-    if ( NrErrFiles == 0 ) {
+    if ( numberOfErrFiles == 0 ) {
       result.setResult( true );
       result.setNrErrors( 0 );
     } else {
-      result.setNrErrors( NrErrFiles );
+      result.setNrErrors( numberOfErrFiles );
       result.setResult( false );
     }
 
     return result;
   }
 
-  private boolean ProcessFile( String filename, String wildcard, Job parentJob ) {
+  /**
+   * For job execution path to files and file masks should be provided.
+   * These values can be obtained in two ways:
+   * 1. As an argument of a current job entry
+   * 2. As a table, that comes as a result of execution previous job/transformation.
+   *
+   * As the logic of processing this data is the same for both of this cases, we first
+   * populate this data (in this method) and then process it.
+   *
+   * We are using guava multimap here, because if allows key duplication and there could be a
+   * situation where two paths to one folder with different wildcards are provided.
+   */
+  private Multimap<String, String> populateDataForJobExecution( List<RowMetaAndData> rowsFromPreviousMeta ) throws KettleValueException {
+    Multimap<String, String> pathToMaskMap = ArrayListMultimap.create();
+    if ( argFromPrevious && rowsFromPreviousMeta != null ) {
+      for ( RowMetaAndData resultRow : rowsFromPreviousMeta ) {
+        if (resultRow.size() < 2){
+          logError( BaseMessages.getString(
+            PKG, "JobDeleteFiles.Error.InvalidNumberOfRowsFromPrevMeta", resultRow.size() ) );
+          return pathToMaskMap;
+        }
+        String pathToFile = resultRow.getString( 0, null );
+        String fileMask = resultRow.getString( 1, null );
+
+        if ( log.isDetailed() ) {
+          logDetailed( BaseMessages.getString(
+            PKG, "JobEntryDeleteFiles.ProcessingRow", pathToFile, fileMask ) );
+        }
+
+        pathToMaskMap.put( pathToFile, fileMask );
+      }
+    } else if ( arguments != null ) {
+      for ( int i = 0; i < arguments.length; i++ ) {
+        if ( log.isDetailed() ) {
+          logDetailed( BaseMessages.getString(
+            PKG, "JobEntryDeleteFiles.ProcessingArg", arguments[ i ], filemasks[ i ] ) );
+        }
+        pathToMaskMap.put( arguments[ i ], filemasks[ i ] );
+      }
+    }
+
+    return pathToMaskMap;
+  }
+
+  boolean processFile( String inputFileName, String inputWildcard, Job parentJob ) {
     boolean rcode = false;
-    FileObject filefolder = null;
-    String realFilefoldername = environmentSubstitute( filename );
-    String realwildcard = environmentSubstitute( wildcard );
+    FileObject fileFolder = null;
+    String realFileFolderName = environmentSubstitute( inputFileName );
+    String realWildCard = environmentSubstitute( inputWildcard );
 
     try {
-      filefolder = KettleVFS.getFileObject( realFilefoldername, this );
+      fileFolder = KettleVFS.getFileObject( realFileFolderName, this );
 
-      if ( filefolder.exists() ) {
+      if ( fileFolder.exists() ) {
         // the file or folder exists
-        if ( filefolder.getType() == FileType.FOLDER ) {
+        if ( fileFolder.getType() == FileType.FOLDER ) {
           // It's a folder
           if ( log.isDetailed() ) {
-            logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.ProcessingFolder", realFilefoldername ) );
+            logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.ProcessingFolder", realFileFolderName ) );
             // Delete Files
           }
 
-          int Nr = filefolder.delete( new TextFileSelector( filefolder.toString(), realwildcard, parentJob ) );
+          int Nr = fileFolder.delete( new TextFileSelector( fileFolder.toString(), realWildCard, parentJob ) );
 
           if ( log.isDetailed() ) {
             logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.TotalDeleted", String.valueOf( Nr ) ) );
@@ -278,14 +310,14 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
         } else {
           // It's a file
           if ( log.isDetailed() ) {
-            logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.ProcessingFile", realFilefoldername ) );
+            logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.ProcessingFile", realFileFolderName ) );
           }
-          boolean deleted = filefolder.delete();
+          boolean deleted = fileFolder.delete();
           if ( !deleted ) {
-            logError( BaseMessages.getString( PKG, "JobEntryDeleteFiles.CouldNotDeleteFile", realFilefoldername ) );
+            logError( BaseMessages.getString( PKG, "JobEntryDeleteFiles.CouldNotDeleteFile", realFileFolderName ) );
           } else {
             if ( log.isBasic() ) {
-              logBasic( BaseMessages.getString( PKG, "JobEntryDeleteFiles.FileDeleted", filename ) );
+              logBasic( BaseMessages.getString( PKG, "JobEntryDeleteFiles.FileDeleted", inputFileName ) );
             }
             rcode = true;
           }
@@ -293,17 +325,17 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
       } else {
         // File already deleted, no reason to try to delete it
         if ( log.isBasic() ) {
-          logBasic( BaseMessages.getString( PKG, "JobEntryDeleteFiles.FileAlreadyDeleted", realFilefoldername ) );
+          logBasic( BaseMessages.getString( PKG, "JobEntryDeleteFiles.FileAlreadyDeleted", realFileFolderName ) );
         }
         rcode = true;
       }
     } catch ( Exception e ) {
-      logError( BaseMessages.getString( PKG, "JobEntryDeleteFiles.CouldNotProcess", realFilefoldername, e
+      logError( BaseMessages.getString( PKG, "JobEntryDeleteFiles.CouldNotProcess", realFileFolderName, e
         .getMessage() ), e );
     } finally {
-      if ( filefolder != null ) {
+      if ( fileFolder != null ) {
         try {
-          filefolder.close();
+          fileFolder.close();
         } catch ( IOException ex ) {
           // Ignore
         }
@@ -331,55 +363,44 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
     }
 
     public boolean includeFile( FileSelectInfo info ) {
-      boolean returncode = false;
+      boolean doReturnCode = false;
       try {
 
         if ( !info.getFile().toString().equals( sourceFolder ) && !parentjob.isStopped() ) {
           // Pass over the Base folder itself
-
-          String short_filename = info.getFile().getName().getBaseName();
+          String shortFilename = info.getFile().getName().getBaseName();
 
           if ( !info.getFile().getParent().equals( info.getBaseFolder() ) ) {
-
             // Not in the Base Folder..Only if include sub folders
             if ( includeSubfolders
-              && ( info.getFile().getType() == FileType.FILE ) && GetFileWildcard( short_filename, fileWildcard ) ) {
+              && ( info.getFile().getType() == FileType.FILE ) && GetFileWildcard( shortFilename, fileWildcard ) ) {
               if ( log.isDetailed() ) {
                 logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.DeletingFile", info
                   .getFile().toString() ) );
               }
-
-              returncode = true;
-
+              doReturnCode = true;
             }
           } else {
             // In the Base Folder...
-
-            if ( ( info.getFile().getType() == FileType.FILE ) && GetFileWildcard( short_filename, fileWildcard ) ) {
+            if ( ( info.getFile().getType() == FileType.FILE ) && GetFileWildcard( shortFilename, fileWildcard ) ) {
               if ( log.isDetailed() ) {
                 logDetailed( BaseMessages.getString( PKG, "JobEntryDeleteFiles.DeletingFile", info
                   .getFile().toString() ) );
               }
-
-              returncode = true;
-
+              doReturnCode = true;
             }
-
           }
-
         }
-
       } catch ( Exception e ) {
-
         log.logError(
           BaseMessages.getString( PKG, "JobDeleteFiles.Error.Exception.DeleteProcessError" ), BaseMessages
             .getString( PKG, "JobDeleteFiles.Error.Exception.DeleteProcess", info.getFile().toString(), e
               .getMessage() ) );
 
-        returncode = false;
+        doReturnCode = false;
       }
 
-      return returncode;
+      return doReturnCode;
     }
 
     public boolean traverseDescendents( FileSelectInfo info ) {
@@ -391,7 +412,7 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
    *
    * @param selectedfile
    * @param wildcard
-   * @return True if the selectedfile matches the wildcard
+   * @return True if the selectedfile matches the inputWildcard
    **********************************************************/
   private boolean GetFileWildcard( String selectedfile, String wildcard ) {
     boolean getIt = true;
@@ -399,10 +420,8 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
     if ( !Const.isEmpty( wildcard ) ) {
       Pattern pattern = Pattern.compile( wildcard );
       // First see if the file matches the regular expression!
-      if ( pattern != null ) {
-        Matcher matcher = pattern.matcher( selectedfile );
-        getIt = matcher.matches();
-      }
+      Matcher matcher = pattern.matcher( selectedfile );
+      getIt = matcher.matches();
     }
 
     return getIt;
@@ -422,10 +441,10 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
 
   public void check( List<CheckResultInterface> remarks, JobMeta jobMeta, VariableSpace space,
     Repository repository, IMetaStore metaStore ) {
-    boolean res = JobEntryValidatorUtils.andValidator().validate( this, "arguments", remarks,
+    boolean isValid = JobEntryValidatorUtils.andValidator().validate( this, "arguments", remarks,
         AndValidator.putValidators( JobEntryValidatorUtils.notNullValidator() ) );
 
-    if ( !res ) {
+    if ( !isValid ) {
       return;
     }
 
@@ -453,6 +472,18 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
       }
     }
     return references;
+  }
+
+  public void setArguments( String[] arguments ) {
+    this.arguments = arguments;
+  }
+
+  public void setFilemasks( String[] filemasks ) {
+    this.filemasks = filemasks;
+  }
+
+  public void setArgFromPrevious( boolean argFromPrevious ) {
+    this.argFromPrevious = argFromPrevious;
   }
 
   public boolean isArgFromPrevious() {

--- a/engine/src/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFiles.java
+++ b/engine/src/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFiles.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,7 +30,6 @@ import org.pentaho.di.job.entry.validator.AndValidator;
 import org.pentaho.di.job.entry.validator.JobEntryValidatorUtils;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -255,7 +254,7 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
     Multimap<String, String> pathToMaskMap = ArrayListMultimap.create();
     if ( argFromPrevious && rowsFromPreviousMeta != null ) {
       for ( RowMetaAndData resultRow : rowsFromPreviousMeta ) {
-        if (resultRow.size() < 2){
+        if ( resultRow.size() < 2 ) {
           logError( BaseMessages.getString(
             PKG, "JobDeleteFiles.Error.InvalidNumberOfRowsFromPrevMeta", resultRow.size() ) );
           return pathToMaskMap;

--- a/engine/src/org/pentaho/di/job/entries/deletefiles/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/job/entries/deletefiles/messages/messages_en_US.properties
@@ -46,6 +46,8 @@ JobEntryDeleteFiles.FileAlreadyDeleted=File [{0}] already deleted.
 JobEntryDeleteFiles.ProcessingFolder=Processing folder [{0}]
 JobDeleteFiles.FilenameDelete.Tooltip=Remove selected files from the grid
 JobEntryDeleteFiles.UnableToSaveToRepo=Unable to save job entry of type 'delete files' to the repository for id_job\={0}
+JobEntryDeleteFiles.NoPathProvided=Argument with an empty path value is ignored.
 JobDeleteFiles.Error.Exception.DeleteProcessError=Error
 JobDeleteFiles.Error.Exception.DeleteProcess=Error while deleting file [{0}] : exception : [{1}]
+JobDeleteFiles.Error.InvalidNumberOfRowsFromPrevMeta=For executing Delete files job you should provide at least two rows of data (for path and mask). Only {0} row was found.
 JobGetMailsFromPOP.Error.NotAFolder=[{0}] is not a folder!

--- a/engine/test-src/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFilesTest.java
+++ b/engine/test-src/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFilesTest.java
@@ -1,0 +1,135 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.deletefiles;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.job.Job;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class JobEntryDeleteFilesTest {
+  private final String PATH_TO_FILE = "path/to/file";
+  private final String STRING_SPACES_ONLY = "   ";
+
+  private JobEntryDeleteFiles jobEntry;
+
+  @Before
+  public void setUp() throws Exception {
+    jobEntry = new JobEntryDeleteFiles();
+    Job parentJob = mock( Job.class );
+    doReturn( false ).when( parentJob ).isStopped();
+
+    jobEntry.setParentJob( parentJob );
+    jobEntry = spy( jobEntry );
+    doReturn( true ).when( jobEntry ).processFile( anyString(), anyString(), eq( parentJob ) );
+  }
+
+  @Test
+  public void filesWithNoPath_AreNotProcessed_ArgsOfCurrentJob() throws Exception {
+    jobEntry.setArguments( new String[] { Const.EMPTY_STRING, STRING_SPACES_ONLY } );
+    jobEntry.setFilemasks( new String[] { null, null } );
+    jobEntry.setArgFromPrevious( false );
+
+    jobEntry.execute( new Result(), 0 );
+    verify( jobEntry, never() ).processFile( anyString(), anyString(), any( Job.class ) );
+  }
+
+
+  @Test
+  public void filesWithPath_AreProcessed_ArgsOfCurrentJob() throws Exception {
+    String[] args = new String[] { PATH_TO_FILE };
+    jobEntry.setArguments( args );
+    jobEntry.setFilemasks( new String[] { null, null } );
+    jobEntry.setArgFromPrevious( false );
+
+    jobEntry.execute( new Result(), 0 );
+    verify( jobEntry, times( args.length ) ).processFile( anyString(), anyString(), any( Job.class ) );
+  }
+
+
+  @Test
+  public void filesWithNoPath_AreNotProcessed_ArgsOfPreviousMeta() throws Exception {
+    jobEntry.setArgFromPrevious( true );
+
+    Result prevMetaResult = new Result();
+    List<RowMetaAndData> metaAndDataList = new ArrayList<>();
+
+    metaAndDataList.add( constructRowMetaAndData( Const.EMPTY_STRING, null ) );
+    metaAndDataList.add( constructRowMetaAndData( STRING_SPACES_ONLY, null ) );
+
+    prevMetaResult.setRows( metaAndDataList );
+
+    jobEntry.execute( prevMetaResult, 0 );
+    verify( jobEntry, never() ).processFile( anyString(), anyString(), any( Job.class ) );
+  }
+
+  @Test
+  public void filesPath_AreProcessed_ArgsOfPreviousMeta() throws Exception {
+    jobEntry.setArgFromPrevious( true );
+
+    Result prevMetaResult = new Result();
+    List<RowMetaAndData> metaAndDataList = new ArrayList<>();
+
+    metaAndDataList.add( constructRowMetaAndData( PATH_TO_FILE, null ) );
+    prevMetaResult.setRows( metaAndDataList );
+
+    jobEntry.execute( prevMetaResult, 0 );
+    verify( jobEntry, times( metaAndDataList.size() ) ).processFile( anyString(), anyString(), any( Job.class ) );
+  }
+
+  @Test
+  public void specifyingTheSamePath_WithDifferentWildcards() throws Exception {
+    final String fileExtensionTxt = ".txt";
+    final String fileExtensionXml = ".xml";
+
+    String[] args = new String[] { PATH_TO_FILE, PATH_TO_FILE };
+    jobEntry.setArguments( args );
+    jobEntry.setFilemasks( new String[] { fileExtensionTxt, fileExtensionXml } );
+    jobEntry.setArgFromPrevious( false );
+
+    jobEntry.execute( new Result(), 0 );
+
+    verify( jobEntry ).processFile( eq( PATH_TO_FILE ), eq( fileExtensionTxt ), any( Job.class ) );
+    verify( jobEntry ).processFile( eq( PATH_TO_FILE ), eq( fileExtensionXml ), any( Job.class ) );
+  }
+
+  private RowMetaAndData constructRowMetaAndData( Object... data ) {
+    RowMeta meta = new RowMeta();
+    meta.addValueMeta( new ValueMetaString( "filePath" ) );
+    meta.addValueMeta( new ValueMetaString( "wildcard" ) );
+
+    return new RowMetaAndData( meta, data );
+  }
+
+}

--- a/ui/src/org/pentaho/di/ui/job/entries/deletefiles/JobEntryDeleteFilesDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/deletefiles/JobEntryDeleteFilesDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -370,7 +370,7 @@ public class JobEntryDeleteFilesDialog extends JobEntryDialog implements JobEntr
     wlFields.setLayoutData( fdlFields );
 
     String[] jobArgs = jobEntry.getArguments();
-    final int fieldsRows = (jobArgs == null) ? 1 : jobArgs.length;
+    final int fieldsRows = ( jobArgs == null ) ? 1 : jobArgs.length;
 
     ColumnInfo[] colinf =
       new ColumnInfo[] {

--- a/ui/src/org/pentaho/di/ui/job/entries/deletefiles/JobEntryDeleteFilesDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/deletefiles/JobEntryDeleteFilesDialog.java
@@ -212,7 +212,7 @@ public class JobEntryDeleteFilesDialog extends JobEntryDialog implements JobEntr
     wlPrevious.setLayoutData( fdlPrevious );
     wPrevious = new Button( wSettings, SWT.CHECK );
     props.setLook( wPrevious );
-    wPrevious.setSelection( jobEntry.argFromPrevious );
+    wPrevious.setSelection( jobEntry.isArgFromPrevious() );
     wPrevious.setToolTipText( BaseMessages.getString( PKG, "JobDeleteFiles.Previous.Tooltip" ) );
     fdPrevious = new FormData();
     fdPrevious.left = new FormAttachment( middle, 0 );
@@ -369,8 +369,8 @@ public class JobEntryDeleteFilesDialog extends JobEntryDialog implements JobEntr
     fdlFields.top = new FormAttachment( wFilemask, margin );
     wlFields.setLayoutData( fdlFields );
 
-    int rows = jobEntry.arguments == null ? 1 : ( jobEntry.arguments.length == 0 ? 0 : jobEntry.arguments.length );
-    final int FieldsRows = rows;
+    String[] jobArgs = jobEntry.getArguments();
+    final int fieldsRows = (jobArgs == null) ? 1 : jobArgs.length;
 
     ColumnInfo[] colinf =
       new ColumnInfo[] {
@@ -388,7 +388,7 @@ public class JobEntryDeleteFilesDialog extends JobEntryDialog implements JobEntr
 
     wFields =
       new TableView(
-        jobMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+        jobMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, fieldsRows, lsMod, props );
 
     fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );
@@ -397,13 +397,13 @@ public class JobEntryDeleteFilesDialog extends JobEntryDialog implements JobEntr
     fdFields.bottom = new FormAttachment( 100, -50 );
     wFields.setLayoutData( fdFields );
 
-    wlFields.setEnabled( !jobEntry.argFromPrevious );
-    wFields.setEnabled( !jobEntry.argFromPrevious );
+    wlFields.setEnabled( !jobEntry.isArgFromPrevious() );
+    wFields.setEnabled( !jobEntry.isArgFromPrevious() );
 
     // Add the file to the list of files...
     SelectionAdapter selA = new SelectionAdapter() {
       public void widgetSelected( SelectionEvent arg0 ) {
-        wFields.add( new String[] { wFilename.getText(), wFilemask.getText() } );
+        wFields.add( wFilename.getText(), wFilemask.getText() );
         wFilename.setText( "" );
         wFilemask.setText( "" );
         wFields.removeEmptyRows();
@@ -522,22 +522,28 @@ public class JobEntryDeleteFilesDialog extends JobEntryDialog implements JobEntr
     if ( jobEntry.getName() != null ) {
       wName.setText( jobEntry.getName() );
     }
+    String[] arguments = jobEntry.getArguments();
+    String[] fileMasks = jobEntry.getFilemasks();
 
-    if ( jobEntry.arguments != null ) {
-      for ( int i = 0; i < jobEntry.arguments.length; i++ ) {
+    if ( arguments != null ) {
+      for ( int i = 0; i < arguments.length; i++ ) {
+        final String argument = arguments[i];
+        final String fileMask = fileMasks[i];
+
         TableItem ti = wFields.table.getItem( i );
-        if ( jobEntry.arguments[i] != null ) {
-          ti.setText( 1, jobEntry.arguments[i] );
+        if ( argument != null ) {
+          ti.setText( 1, argument );
         }
-        if ( jobEntry.filemasks[i] != null ) {
-          ti.setText( 2, jobEntry.filemasks[i] );
+        if ( fileMask != null ) {
+          ti.setText( 2, fileMask );
         }
       }
       wFields.setRowNums();
       wFields.optWidth( true );
     }
-    wPrevious.setSelection( jobEntry.argFromPrevious );
-    wIncludeSubfolders.setSelection( jobEntry.includeSubfolders );
+
+    wPrevious.setSelection( jobEntry.isArgFromPrevious() );
+    wIncludeSubfolders.setSelection( jobEntry.isIncludeSubfolders() );
 
     wName.selectAll();
     wName.setFocus();
@@ -562,26 +568,31 @@ public class JobEntryDeleteFilesDialog extends JobEntryDialog implements JobEntr
     jobEntry.setIncludeSubfolders( wIncludeSubfolders.getSelection() );
     jobEntry.setPrevious( wPrevious.getSelection() );
 
-    int nritems = wFields.nrNonEmpty();
-    int nr = 0;
-    for ( int i = 0; i < nritems; i++ ) {
+    int numberOfItems = wFields.nrNonEmpty();
+    int numberOfValidArgs = 0;
+    for ( int i = 0; i < numberOfItems; i++ ) {
       String arg = wFields.getNonEmpty( i ).getText( 1 );
       if ( arg != null && arg.length() != 0 ) {
-        nr++;
+        numberOfValidArgs++;
       }
     }
-    jobEntry.arguments = new String[nr];
-    jobEntry.filemasks = new String[nr];
-    nr = 0;
-    for ( int i = 0; i < nritems; i++ ) {
-      String arg = wFields.getNonEmpty( i ).getText( 1 );
+    String[] arguments = new String[numberOfValidArgs];
+    String[] fileMasks = new String[numberOfValidArgs];
+
+    numberOfValidArgs = 0;
+    for ( int i = 0; i < numberOfItems; i++ ) {
+      String path = wFields.getNonEmpty( i ).getText( 1 );
       String wild = wFields.getNonEmpty( i ).getText( 2 );
-      if ( arg != null && arg.length() != 0 ) {
-        jobEntry.arguments[nr] = arg;
-        jobEntry.filemasks[nr] = wild;
-        nr++;
+      if ( path != null && path.length() != 0 ) {
+        arguments[numberOfValidArgs] = path;
+        fileMasks[numberOfValidArgs] = wild;
+        numberOfValidArgs++;
       }
     }
+
+    jobEntry.setFilemasks( fileMasks );
+    jobEntry.setArguments( arguments );
+
     dispose();
   }
 


### PR DESCRIPTION
**General description**
- Populate data before processing files.
- Checking whether the file path is blank before processing the file. Relative paths are permitted, and providing an empty path means deleting all files inside a root pdi-folder.
  It is much more likely to be a mistake than a desirable action, so we don't delete anything. We also don't consider this to be an error (see Jens comment about it, and just log about it if log is detailed).
- Adding some new messages.
- Refactoring (encapsulating  JobEntryDeleteFiles data,  editing some field names, simplifying some checks)
- Tests written
- Checkstyle applied



**More details about implementation**
 For job execution path to files and file masks should be provided.  These values can be obtained in two ways:
1. As an argument of a current job entry
2. As a table, that comes as a result of execution previous job/transformation.

 In the previous implementation we were checking the way we obtain data in if-else block, and were calling process function 2 times for each of the possible ways. Don't see any reason for duplicating this method calls, as the way we process the data doesn't depend on how we obtain it.
 So, I decided to separate the logic of obtaining the data in a populate method and represent populated data as a map.

*Advantages*
- Dividing a logic of obtaining arguments and wildcards and logic of processing this data ~ encapsulating logical of obtaining data in a separate method
- Treating file paths and  wildcards as a map and getting rid from working with two arrays, that is much less error-prone (BTW, I would rather refactor the class itself to have a map inside, instead of two arrays, but don't want to do such changes without a given permissions)
- More readable and maintainable code (in my opinion)


*Disadvantages*
- We are doing some extra work, because we first obtaining data and then processing it, instead of doing it at once. In fact we have 2 * N against N.
- Some extra memory for providing a map.

 I think that advantages outweigh, because in case of this step N (number of paths and wildcards) is not expected to be big. So the performance won't suffer.