### PR TITLE
[BACKLOG-7972] - Hadoop File Output: Hadoop Clusters dropdown doesn't…

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInputMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInputMeta.java
@@ -818,7 +818,7 @@ public class TextFileInputMeta extends BaseStepMeta implements StepMetaInterface
         Node excludefilemasknode = XMLHandler.getSubNodeByNr( filenode, "exclude_filemask", i );
         Node fileRequirednode = XMLHandler.getSubNodeByNr( filenode, "file_required", i );
         Node includeSubFoldersnode = XMLHandler.getSubNodeByNr( filenode, "include_subfolders", i );
-        fileName[i] = loadSource( filenode, filenamenode, i );
+        fileName[i] = loadSource( filenode, filenamenode, i, metaStore );
         fileMask[i] = XMLHandler.getNodeValue( filemasknode );
         excludeFileMask[i] = XMLHandler.getNodeValue( excludefilemasknode );
         fileRequired[i] = XMLHandler.getNodeValue( fileRequirednode );
@@ -2047,7 +2047,7 @@ public class TextFileInputMeta extends BaseStepMeta implements StepMetaInterface
     setFileName( fileName );
   }
 
-  protected String loadSource( Node filenode, Node filenamenode, int i ) {
+  protected String loadSource( Node filenode, Node filenamenode, int i, IMetaStore metaStore ) {
     return XMLHandler.getNodeValue( filenamenode );
   }
 


### PR DESCRIPTION
… preserve selected cluster after reopen a transformation

return api in TextFileInputMeta to have metastore for loadSource method, needed for HadoopFileInputMeta, adaptate interface to use StringBuilder instead of StringBuffer as in engine, write tests to fail on api changed in engine again