### PR TITLE
[SP-2676] Backport of PDI-15118 - User with no schedule permissions has access to schedule perspective (6.1 Suite)

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import javax.xml.ws.WebServiceException;
 
 import org.apache.commons.lang.BooleanUtils;
+import org.eclipse.swt.widgets.Display;
 import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleSecurityException;
@@ -34,7 +35,6 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.IUser;
 import org.pentaho.di.repository.RepositorySecurityManager;
 import org.pentaho.di.repository.RepositorySecurityProvider;
-import org.pentaho.di.repository.pur.PurRepository;
 import org.pentaho.di.repository.pur.model.EEUserInfo;
 import org.pentaho.di.ui.repository.pur.services.IAbsSecurityManager;
 import org.pentaho.di.ui.repository.pur.services.IAbsSecurityProvider;
@@ -44,6 +44,7 @@ import org.pentaho.di.ui.repository.pur.services.ILockService;
 import org.pentaho.di.ui.repository.pur.services.IRevisionService;
 import org.pentaho.di.ui.repository.pur.services.IRoleSupportSecurityManager;
 import org.pentaho.di.ui.repository.pur.services.ITrashService;
+import org.pentaho.di.ui.spoon.SpoonPerspectiveManager;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
@@ -148,6 +149,19 @@ public class PurRepositoryConnector implements IRepositoryConnector {
           if ( log.isBasic() ) {
             log.logBasic( BaseMessages.getString( PKG, "PurRepositoryConnector.CreateServiceProvider.End" ) ); //$NON-NLS-1$
           }
+          boolean canSchedule = allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),
+            IAbsSecurityProvider.SCHEDULE_CONTENT_ACTION );
+          Display.getDefault().asyncExec( new Runnable() {
+            public void run() {
+              final String schedulePerspectiveId = "schedulerPerspective";
+              SpoonPerspectiveManager perspectiveManager = SpoonPerspectiveManager.getInstance();
+              if ( canSchedule ) {
+                perspectiveManager.showPerspective( schedulePerspectiveId );
+              } else {
+                perspectiveManager.hidePerspective( schedulePerspectiveId );
+              }
+            }
+          } );
           // If the user does not have access to administer security we do not
           // need to added them to the service list
           if ( allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
@@ -149,7 +149,7 @@ public class PurRepositoryConnector implements IRepositoryConnector {
           if ( log.isBasic() ) {
             log.logBasic( BaseMessages.getString( PKG, "PurRepositoryConnector.CreateServiceProvider.End" ) ); //$NON-NLS-1$
           }
-          boolean canSchedule = allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),
+          final boolean canSchedule = allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),
             IAbsSecurityProvider.SCHEDULE_CONTENT_ACTION );
           Display.getDefault().asyncExec( new Runnable() {
             public void run() {

--- a/ui/src/org/pentaho/di/ui/spoon/SpoonPerspectiveManager.java
+++ b/ui/src/org/pentaho/di/ui/spoon/SpoonPerspectiveManager.java
@@ -457,7 +457,7 @@ public class SpoonPerspectiveManager {
           toolbar.forceFocus();
         }
       } );
-      
+
       perspectivesCombo.addKeyListener( new KeyAdapter() {
         public void keyPressed( KeyEvent event ) {
           if ( event.character == SWT.CR ) {

--- a/ui/src/org/pentaho/di/ui/spoon/SpoonPerspectiveManager.java
+++ b/ui/src/org/pentaho/di/ui/spoon/SpoonPerspectiveManager.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
@@ -79,7 +80,7 @@ public class SpoonPerspectiveManager {
 
   private final Map<Class<? extends SpoonPerspective>, SpoonPerspective> perspectives;
 
-  private final Map<SpoonPerspective, PerspectiveInitializer> initializerMap;
+  private final Map<SpoonPerspective, PerspectiveManager> perspectiveManagerMap;
 
   private final LinkedHashSet<SpoonPerspective> orderedPerspectives;
 
@@ -103,13 +104,17 @@ public class SpoonPerspectiveManager {
     this.startupPerspective = startupPerspective;
   }
 
+  Map<SpoonPerspective, PerspectiveManager> getPerspectiveManagerMap() {
+    return Collections.unmodifiableMap( perspectiveManagerMap );
+  }
+
   protected static class SpoonPerspectiveComparator implements Comparator<SpoonPerspective> {
     public int compare( SpoonPerspective o1, SpoonPerspective o2 ) {
       return o1.getId().compareTo( o2.getId() );
     }
   }
 
-  private class PerspectiveInitializer {
+  static class PerspectiveManager {
     private final SpoonPerspective per;
 
     private final XulVbox box;
@@ -119,9 +124,10 @@ public class SpoonPerspectiveManager {
     private final SwtToolbarbutton btn;
     private final CCombo perspectivesCombo;
     private final String name;
+    private boolean initialized;
 
-    public PerspectiveInitializer( SpoonPerspective per, XulVbox box, XulToolbar mainToolbar, SwtToolbarbutton btn,
-        CCombo perspectivesCombo, String name ) {
+    public PerspectiveManager( SpoonPerspective per, XulVbox box, XulToolbar mainToolbar, SwtToolbarbutton btn,
+                               CCombo perspectivesCombo, String name ) {
       super();
       this.per = per;
       this.box = box;
@@ -129,9 +135,17 @@ public class SpoonPerspectiveManager {
       this.btn = btn;
       this.perspectivesCombo = perspectivesCombo;
       this.name = name;
+      initialized = false;
     }
 
-    public void initialize() {
+    public void initializeIfNeeded() {
+      if ( !initialized ) {
+        performInit();
+        initialized = true;
+      }
+    }
+
+    void performInit() {
       per.getUI().setParent( (Composite) box.getManagedObject() );
       per.getUI().layout();
       ( (Composite) mainToolbar.getManagedObject() ).layout( true, true );
@@ -153,12 +167,32 @@ public class SpoonPerspectiveManager {
         }
       } );
     }
+
+
+    /**
+     * Removes {@code perspectiveName} from {@code perspectivesCombo}
+     */
+    void removePerspective( final String perspectiveName ) {
+      perspectivesCombo.remove( perspectiveName );
+    }
+
+    /**
+     * Adds {@code perspectiveName} to {@code perspectivesCombo} if there is no perspective with such name.
+     */
+    boolean addPerspectiveNameIfNotExists( final String perspectiveName ) {
+      if ( perspectivesCombo.indexOf( perspectiveName ) == -1 ) {
+        perspectivesCombo.add( perspectiveName );
+        return true;
+      }
+
+      return false;
+    }
   }
 
   @SuppressWarnings( "rawtypes" )
   private SpoonPerspectiveManager() {
     perspectives = new LinkedHashMap<Class<? extends SpoonPerspective>, SpoonPerspective>();
-    initializerMap = new HashMap<SpoonPerspective, PerspectiveInitializer>();
+    perspectiveManagerMap = new HashMap<SpoonPerspective, PerspectiveManager>();
     orderedPerspectives = new LinkedHashSet<SpoonPerspective>();
   }
 
@@ -207,6 +241,51 @@ public class SpoonPerspectiveManager {
   }
 
   /**
+   * Changes perspective visibility due to {@code hidePerspective} value.
+   * If perspective exists already, and we want to make it visible, no new perspective will be added.
+   *
+   */
+  private void changePerspectiveVisibility( final String perspectiveId, boolean hidePerspective ) {
+    PerspectiveManager perspectiveManager;
+
+    for ( SpoonPerspective sp : getPerspectiveManagerMap().keySet() ) {
+      if ( sp.getId().equals( perspectiveId ) ) {
+        perspectiveManager = getPerspectiveManagerMap().get( sp );
+        if ( hidePerspective ) {
+          perspectiveManager.removePerspective( sp.getDisplayName( Locale.getDefault() ) );
+        } else {
+          boolean perspectiveAdded =
+            perspectiveManager.addPerspectiveNameIfNotExists( sp.getDisplayName( Locale.getDefault() ) );
+          if ( !perspectiveAdded ) {
+            if ( getLogger().isBasic() ) {
+              getLogger()
+                .logBasic( "Perspective with id: " + perspectiveId + " exists already. No need to add another one." );
+            }
+          }
+        }
+
+        return;
+      }
+    }
+
+    getLogger().logError( "Perspective with " + perspectiveId + " is not found." );
+  }
+
+  /**
+   * Shows perspective with {@code perspectiveId} if it is not shown yet.
+   */
+  public void showPerspective( final String perspectiveId ) {
+    changePerspectiveVisibility( perspectiveId, false );
+  }
+
+  /**
+   * Hides perspective with {@code perspectiveId}.
+   */
+  public void hidePerspective( final String perspectiveId ) {
+    changePerspectiveVisibility( perspectiveId, true );
+  }
+
+  /**
    * Returns an unmodifiable List of perspectives in no set order.
    *
    * @return
@@ -228,11 +307,10 @@ public class SpoonPerspectiveManager {
         }
       }
     }
-    Spoon.getInstance().enableMenus();
+    getSpoon().enableMenus();
   }
 
   /**
-   *
    * Activates the given instance of the class literal passed in. Activating a perspective first deactivates the current
    * perspective removing any overlays its applied to the UI. It then switches the main deck to display the perspective
    * UI and applies the optional overlays to the main Spoon XUL container.
@@ -252,9 +330,9 @@ public class SpoonPerspectiveManager {
     if ( sp == null ) {
       throw new KettleException( "Could not locate perspective by class: " + clazz );
     }
-    PerspectiveInitializer perspectiveInitializer = initializerMap.remove( sp );
-    if ( perspectiveInitializer != null ) {
-      perspectiveInitializer.initialize();
+    PerspectiveManager perspectiveManager = getPerspectiveManagerMap().get( sp );
+    if ( perspectiveManager != null ) {
+      perspectiveManager.initializeIfNeeded();
     }
     unloadPerspective( activePerspective );
     activePerspective = sp;
@@ -296,7 +374,7 @@ public class SpoonPerspectiveManager {
 
     sp.setActive( true );
     deck.setSelectedIndex( deck.getChildNodes().indexOf( deck.getElementById( "perspective-" + sp.getId() ) ) );
-    Spoon.getInstance().enableMenus();
+    getSpoon().enableMenus();
   }
 
   /**
@@ -453,8 +531,9 @@ public class SpoonPerspectiveManager {
       box.setFlex( 1 );
       deck.addChild( box );
 
-      PerspectiveInitializer perspectiveInitializer =
-          new PerspectiveInitializer( per, box, mainToolbar, btn, perspectivesCombo, name );
+      PerspectiveManager perspectiveManager =
+          new PerspectiveManager( per, box, mainToolbar, btn, perspectivesCombo, name );
+      perspectiveManagerMap.put( per, perspectiveManager );
       // Need to force init for main perspective even if it won't be shown
       if ( perspectiveIdx == y || y == 0 ) {
         if ( perspectiveIdx == y ) {
@@ -464,10 +543,9 @@ public class SpoonPerspectiveManager {
           }
           perClass = per.getClass();
         }
+
         // force init
-        perspectiveInitializer.initialize();
-      } else {
-        initializerMap.put( per, perspectiveInitializer );
+        perspectiveManager.initializeIfNeeded();
       }
       y++;
       installedPerspectives.add( per );
@@ -483,5 +561,19 @@ public class SpoonPerspectiveManager {
         // TODO Auto-generated catch block
       }
     }
+  }
+
+
+  /**
+   * For testing
+   */
+  Spoon getSpoon() {
+    return Spoon.getInstance();
+  }
+  /**
+   * For testing
+   */
+  LogChannelInterface getLogger() {
+    return log;
   }
 }

--- a/ui/test-src/org/pentaho/di/ui/spoon/SpoonPerspectiveManagerTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/SpoonPerspectiveManagerTest.java
@@ -1,0 +1,167 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.spoon;
+
+import org.eclipse.swt.custom.CCombo;
+import org.eclipse.swt.widgets.Composite;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.EngineMetaInterface;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.ui.xul.XulOverlay;
+import org.pentaho.ui.xul.containers.XulDeck;
+import org.pentaho.ui.xul.containers.XulToolbar;
+import org.pentaho.ui.xul.containers.XulVbox;
+import org.pentaho.ui.xul.impl.XulEventHandler;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+
+public class SpoonPerspectiveManagerTest {
+  private static final String PERSPECTIVE_ID = "perspective-id";
+  private static final String PERSPECTIVE_NAME = "perspective-name";
+
+  private Map<SpoonPerspective, SpoonPerspectiveManager.PerspectiveManager> perspectiveManagerMap;
+  private static SpoonPerspectiveManager spoonPerspectiveManager;
+  private SpoonPerspective perspective;
+
+  @Before
+  public void setUp() throws Exception {
+    spoonPerspectiveManager = SpoonPerspectiveManager.getInstance();
+    spoonPerspectiveManager = spy( spoonPerspectiveManager );
+
+    perspective = new DummyPerspective();
+    spoonPerspectiveManager.addPerspective( perspective );
+
+    // emulate we have one perspective, that is not inited yet.
+    perspectiveManagerMap = emulatePerspectiveManagerMap( perspective );
+
+    doReturn( perspectiveManagerMap ).when( spoonPerspectiveManager ).getPerspectiveManagerMap();
+    doReturn( mock( Spoon.class ) ).when( spoonPerspectiveManager ).getSpoon();
+    spoonPerspectiveManager.setDeck( mock( XulDeck.class ) );
+    doReturn( mock( LogChannelInterface.class ) ).when( spoonPerspectiveManager ).getLogger();
+  }
+
+
+  @Test
+  public void perspectiveIsInitializedOnlyOnce() throws KettleException {
+    SpoonPerspectiveManager.PerspectiveManager perspectiveManager = perspectiveManagerMap.get( perspective );
+
+    spoonPerspectiveManager.activatePerspective( perspective.getClass() );
+    // it's the first time this perspective gets active, so it should be initialized after this call
+    verify( perspectiveManager ).performInit();
+
+    spoonPerspectiveManager.activatePerspective( perspective.getClass() );
+    // make sure that perspective was inited only after first activation
+    verify( perspectiveManager ).performInit();
+  }
+
+
+  @Test
+  public void hidePerspective() {
+    SpoonPerspectiveManager.PerspectiveManager perspectiveManager = perspectiveManagerMap.get( perspective );
+    spoonPerspectiveManager.hidePerspective( perspective.getId() );
+
+    verify( perspectiveManager ).removePerspective( PERSPECTIVE_NAME );
+  }
+
+  @Test
+  public void showPerspective() {
+    SpoonPerspectiveManager.PerspectiveManager perspectiveManager = perspectiveManagerMap.get( perspective );
+    spoonPerspectiveManager.showPerspective( perspective.getId() );
+
+    verify( perspectiveManager ).addPerspectiveNameIfNotExists( PERSPECTIVE_NAME );
+  }
+
+
+
+  private Map<SpoonPerspective, SpoonPerspectiveManager.PerspectiveManager> emulatePerspectiveManagerMap(
+    SpoonPerspective... perspectives ) {
+    Map<SpoonPerspective, SpoonPerspectiveManager.PerspectiveManager> spoonPerspectiveManagerMap = new HashMap<>();
+
+    for ( SpoonPerspective perspective : perspectives ) {
+      spoonPerspectiveManagerMap.put( perspective, createPerspectiveManager( perspective ) );
+    }
+    return spoonPerspectiveManagerMap;
+  }
+
+  private SpoonPerspectiveManager.PerspectiveManager createPerspectiveManager( SpoonPerspective perspective ) {
+    SpoonPerspectiveManager.PerspectiveManager perspectiveManager =
+      new SpoonPerspectiveManager.PerspectiveManager( perspective, mock(
+        XulVbox.class ), mock( XulToolbar.class ), null, mock( CCombo.class ),
+        perspective.getDisplayName( Locale.getDefault() ) );
+
+    perspectiveManager = spy( perspectiveManager );
+    doNothing().when( perspectiveManager ).performInit();
+
+    return perspectiveManager;
+  }
+
+
+  private class DummyPerspective implements SpoonPerspective {
+
+    @Override public String getId() {
+      return PERSPECTIVE_ID;
+    }
+
+    @Override public Composite getUI() {
+      return null;
+    }
+
+    @Override public String getDisplayName( Locale l ) {
+      return PERSPECTIVE_NAME;
+    }
+
+    @Override public InputStream getPerspectiveIcon() {
+      return null;
+    }
+
+    @Override public void setActive( boolean active ) {
+
+    }
+
+    @Override public List<XulOverlay> getOverlays() {
+      return null;
+    }
+
+    @Override public List<XulEventHandler> getEventHandlers() {
+      return null;
+    }
+
+    @Override public void addPerspectiveListener( SpoonPerspectiveListener listener ) {
+
+    }
+
+    @Override public EngineMetaInterface getActiveMeta() {
+      return null;
+    }
+  }
+
+}


### PR DESCRIPTION
- When logging to repository check whether user is allowed to schedule content and remove "Schedule perspective" it he has no permissions for this.
- provided an ability to manipulate perspective's UI list from SpoonPerspectiveManager.
- Tests written
- Checkstyle applied

If I understand the idea of PerspectiveInitializer class, it's goal was to make lazy initialization for all perspectived, except the first one, that would be inited immediately. Other perspectives would be initialized when needed and removed from initializerMap.

So, PerspectiveInitializer encapsulates the list of perspectives, and is the only place where perspective list can be accessible and changed.

I added few more methods there: for adding and removing perspective names (unfortunately there is no oppotunity to 'hide' element in CCombo class, so we are removing and adding), keeping the existing behavior the same:
1. In first init only main perspective is initialized.
2. Each perspective is initialized only once, regarding how many times it was active.