### PR TITLE
[SP-2665][PDI-14973] PDI Carte API allows reading the Kettle.properties entries

### DIFF
--- a/engine/src/org/pentaho/di/cluster/SlaveServer.java
+++ b/engine/src/org/pentaho/di/cluster/SlaveServer.java
@@ -123,7 +123,7 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
 
   private static int getNumberOfSlaveServerRetries() {
     try {
-      return Integer.parseInt(Const.NVL(System.getProperty( "KETTLE_CARTE_RETRIES" ), "0" ) );
+      return Integer.parseInt( Const.NVL( System.getProperty( "KETTLE_CARTE_RETRIES" ), "0" ) );
     } catch ( Exception e ) {
       return 0;
     }
@@ -131,7 +131,7 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
 
   public static int getBackoffIncrements() {
     try {
-      return Integer.parseInt(Const.NVL(System.getProperty( "KETTLE_CARTE_RETRY_BACKOFF_INCREMENTS" ), "1000" ) );
+      return Integer.parseInt( Const.NVL( System.getProperty( "KETTLE_CARTE_RETRY_BACKOFF_INCREMENTS" ), "1000" ) );
     } catch ( Exception e ) {
       return 1000;
     }

--- a/engine/src/org/pentaho/di/cluster/SlaveServer.java
+++ b/engine/src/org/pentaho/di/cluster/SlaveServer.java
@@ -855,7 +855,8 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
 
   public Properties getKettleProperties() throws Exception {
     String xml = execService( GetPropertiesServlet.CONTEXT_PATH + "/?xml=Y" );
-    InputStream in = new ByteArrayInputStream( xml.getBytes() );
+    String decryptedXml =  Encr.decryptPassword( xml );
+    InputStream in = new ByteArrayInputStream( decryptedXml.getBytes() );
     Properties properties = new Properties();
     properties.loadFromXML( in );
     return properties;

--- a/engine/src/org/pentaho/di/www/GetPropertiesServlet.java
+++ b/engine/src/org/pentaho/di/www/GetPropertiesServlet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,8 +23,10 @@
 package org.pentaho.di.www;
 
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.util.EnvUtil;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Properties;
@@ -48,11 +50,13 @@ public class GetPropertiesServlet extends BodyHttpServlet {
   WebResult generateBody( HttpServletRequest request, HttpServletResponse response, boolean useXML ) throws Exception {
     ServletOutputStream out = response.getOutputStream();
     Properties kettleProperties = EnvUtil.readProperties( Const.KETTLE_PROPERTIES );
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
     if ( useXML ) {
-      kettleProperties.storeToXML( out, "" );
+      kettleProperties.storeToXML( os, "" );
     } else {
-      kettleProperties.store( out, "" );
+      kettleProperties.store( os, "" );
     }
+    out.write( Encr.encryptPassword( os.toString() ).getBytes() );
     return null;
   }
 

--- a/engine/test-src/org/pentaho/di/cluster/SlaveServerTest.java
+++ b/engine/test-src/org/pentaho/di/cluster/SlaveServerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -55,6 +55,7 @@ import org.pentaho.di.core.encryption.TwoWayPasswordEncoderPluginType;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.util.EnvUtil;
+import org.pentaho.di.www.GetPropertiesServlet;
 
 /**
  * Tests for SlaveServer class
@@ -144,4 +145,22 @@ public class SlaveServerTest {
 
     assertTrue( !slaveServer.getName().equals( slaveServer2.getName() ) );
   }
+
+  @Test
+  public void testGetKettleProperties() throws Exception {
+    String encryptedResponse = "3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e6"
+      + "73d225554462d38223f3e0a3c21444f43545950452070726f706572"
+      + "746965730a202053595354454d2022687474703a2f2f6a6176612e737"
+      + "56e2e636f6d2f6474642f70726f706572746965732e647464223e0a3c"
+      + "70726f706572746965733e0a2020203c636f6d6d656e743e3c2f636f6d6d6"
+      + "56e743e0a2020203c656e747279206b65793d224167696c6542494461746162"
+      + "617365223e4167696c6542493c2f656e7470c7a6a5f445d7808bbb1cbc64d797bc84";
+    doReturn(
+      encryptedResponse )
+      .when( slaveServer ).execService( GetPropertiesServlet.CONTEXT_PATH + "/?xml=Y" );
+    slaveServer.getKettleProperties().getProperty( "AgileBIDatabase" );
+    assertEquals( "AgileBI", slaveServer.getKettleProperties().getProperty( "AgileBIDatabase" ) );
+
+  }
+
 }

--- a/engine/test-src/org/pentaho/di/www/GetPropertiesServletTest.java
+++ b/engine/test-src/org/pentaho/di/www/GetPropertiesServletTest.java
@@ -1,0 +1,91 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.encryption.Encr;
+import org.pentaho.di.core.encryption.TwoWayPasswordEncoderPluginType;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.util.EnvUtil;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link org.pentaho.di.www.GetPropertiesServlet}
+ */
+public class GetPropertiesServletTest {
+
+  @BeforeClass
+  public static void beforeClass() throws KettleException {
+    PluginRegistry.addPluginType( TwoWayPasswordEncoderPluginType.getInstance() );
+    PluginRegistry.init();
+    String passwordEncoderPluginID =
+      Const.NVL( EnvUtil.getSystemProperty( Const.KETTLE_PASSWORD_ENCODER_PLUGIN ), "Kettle" );
+    Encr.init( passwordEncoderPluginID );
+  }
+
+  @Test
+  public void getContextPath() throws Exception {
+
+    GetPropertiesServlet servlet = new GetPropertiesServlet();
+    servlet.setJettyMode( true );
+    HttpServletRequest mockHttpServletRequest = mock( HttpServletRequest.class );
+    HttpServletResponse mockHttpServletResponse = mock( HttpServletResponse.class );
+    StringWriter out = new StringWriter();
+    PrintWriter printWriter = new PrintWriter( out );
+
+    when( mockHttpServletRequest.getContextPath() ).thenReturn( GetPropertiesServlet.CONTEXT_PATH );
+    when( mockHttpServletRequest.getParameter( "xml" ) ).thenReturn( "Y" );
+    when( mockHttpServletResponse.getWriter() ).thenReturn( printWriter );
+
+    when( mockHttpServletResponse.getOutputStream() ).thenReturn( new ServletOutputStream() {
+      private ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+      @Override public void write( int b ) throws IOException {
+        baos.write( b );
+      }
+
+      public String toString() {
+        return baos.toString();
+      }
+    } );
+
+    servlet.doGet( mockHttpServletRequest, mockHttpServletResponse );
+    //check that response is not contains sample text
+    Assert.assertFalse( mockHttpServletResponse.getOutputStream().toString()
+      .startsWith( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" ) );
+  }
+}


### PR DESCRIPTION
[SP-2665][PDI-14973] PDI Carte API allows reading the Kettle.properties entries

http://jira.pentaho.com/browse/PDI-14973
Added encrypting for sending  properties Kettle.properties via GetPropertiesServlet.

@brosander Could you please merge it?