### PR TITLE
[TEST] Allow meta changes during LoadSaveTester

### DIFF
--- a/engine/test-src/org/pentaho/di/job/entry/loadSave/JobEntryLoadSaveTestSupport.java
+++ b/engine/test-src/org/pentaho/di/job/entry/loadSave/JobEntryLoadSaveTestSupport.java
@@ -68,15 +68,9 @@ public abstract class JobEntryLoadSaveTestSupport<T extends JobEntryInterface> {
   }
 
   @Test
-  public void xmlSerialization() throws Exception {
-    tester.testXmlRoundTrip();
+  public void testSerialization() throws KettleException {
+    tester.testSerialization();
   }
-
-  @Test
-  public void repositorySerialization() throws Exception {
-    tester.testRepoRoundTrip();
-  }
-
 
   protected abstract Class<T> getJobEntryClass();
 

--- a/engine/test-src/org/pentaho/di/trans/steps/loadsave/LoadSaveTester.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/loadsave/LoadSaveTester.java
@@ -38,6 +38,7 @@ import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.steps.loadsave.getter.Getter;
+import org.pentaho.di.trans.steps.loadsave.initializer.StepMetaInitializer;
 import org.pentaho.di.trans.steps.loadsave.setter.Setter;
 import org.pentaho.di.trans.steps.loadsave.validator.DatabaseMetaLoadSaveValidator;
 import org.pentaho.di.trans.steps.loadsave.validator.DefaultFieldLoadSaveValidatorFactory;
@@ -53,16 +54,19 @@ public class LoadSaveTester {
   private final JavaBeanManipulator<? extends StepMetaInterface> manipulator;
   private final FieldLoadSaveValidatorFactory fieldLoadSaveValidatorFactory;
   private final List<DatabaseMeta> databases;
+  private final StepMetaInitializer<?> stepMetaInitializer;
 
   public LoadSaveTester( Class<? extends StepMetaInterface> clazz, List<String> commonAttributes,
     List<String> xmlAttributes, List<String> repoAttributes, Map<String, String> getterMap,
     Map<String, String> setterMap, Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorAttributeMap,
-    Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorTypeMap ) {
+    Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorTypeMap,
+    StepMetaInitializer<?> stepMetaInitializer ) {
     this.clazz = clazz;
     this.xmlAttributes = new ArrayList<String>( commonAttributes );
     this.xmlAttributes.addAll( xmlAttributes );
     this.repoAttributes = new ArrayList<String>( commonAttributes );
     this.repoAttributes.addAll( commonAttributes );
+    this.stepMetaInitializer = stepMetaInitializer;
     List<String> combinedAttributes = new ArrayList<String>( commonAttributes );
     combinedAttributes.addAll( repoAttributes );
     combinedAttributes.addAll( xmlAttributes );
@@ -75,6 +79,14 @@ public class LoadSaveTester {
     fieldLoadSaveValidatorFactory =
       new DefaultFieldLoadSaveValidatorFactory( fieldLoadSaveValidatorMethodMap, fieldLoadSaveValidatorTypeMap );
     databases = new ArrayList<DatabaseMeta>();
+  }
+
+  public LoadSaveTester( Class<? extends StepMetaInterface> clazz, List<String> commonAttributes,
+      List<String> xmlAttributes, List<String> repoAttributes, Map<String, String> getterMap,
+      Map<String, String> setterMap, Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorAttributeMap,
+      Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorTypeMap ) {
+    this( clazz, commonAttributes, xmlAttributes, repoAttributes, getterMap, setterMap,
+      fieldLoadSaveValidatorAttributeMap, fieldLoadSaveValidatorTypeMap, null );
   }
 
   public LoadSaveTester( Class<? extends StepMetaInterface> clazz, List<String> commonAttributes,
@@ -183,8 +195,39 @@ public class LoadSaveTester {
     }
   }
 
+  public void testSerialization() throws KettleException {
+    testXmlRoundTrip();
+    testRepoRoundTrip();
+    testClone();
+    testMixedXmlRepoRoundTrip();
+  }
+
+  protected void testClone() throws KettleException {
+    StepMetaInterface metaToSave = createMeta();
+    if ( stepMetaInitializer != null ) {
+      stepMetaInitializer.modify( metaToSave );
+    }
+    Map<String, FieldLoadSaveValidator<?>> validatorMap =
+      createValidatorMapAndInvokeSetters( xmlAttributes, metaToSave );
+
+    StepMetaInterface metaLoaded = (StepMetaInterface) metaToSave.clone();
+    validateLoadedMeta( xmlAttributes, validatorMap, metaToSave, metaLoaded );
+    validateLoadedMeta( repoAttributes, validatorMap, metaToSave, metaLoaded );
+  }
+
+  /**
+   * @deprecated the {@link #testSerialization()} method should be used instead,
+   *             as additional tests may be added in the future to cover other
+   *             topics related to step serialization
+   * @throws KettleException
+   */
+  @Deprecated
+  // TODO Change method visibility to protected
   public void testXmlRoundTrip() throws KettleException {
     StepMetaInterface metaToSave = createMeta();
+    if ( stepMetaInitializer != null ) {
+      stepMetaInitializer.modify( metaToSave );
+    }
     Map<String, FieldLoadSaveValidator<?>> validatorMap =
       createValidatorMapAndInvokeSetters( xmlAttributes, metaToSave );
     StepMetaInterface metaLoaded = createMeta();
@@ -194,13 +237,23 @@ public class LoadSaveTester {
       databases, (IMetaStore) null );
     validateLoadedMeta( xmlAttributes, validatorMap, metaToSave, metaLoaded );
 
-    // Test clone() method
-    metaLoaded = (StepMetaInterface) metaToSave.clone();
-    validateLoadedMeta( xmlAttributes, validatorMap, metaToSave, metaLoaded );
+    // TODO Remove after method visibility changed, it should be called in testSerialization
+    testClone();
   }
 
+  /**
+   * @deprecated the {@link #testSerialization()} method should be used instead,
+   *             as additional tests may be added in the future to cover other
+   *             topics related to step serialization
+   * @throws KettleException
+   */
+  @Deprecated
+  // TODO Change method visibility to protected
   public void testRepoRoundTrip() throws KettleException {
     StepMetaInterface metaToSave = createMeta();
+    if ( stepMetaInitializer != null ) {
+      stepMetaInitializer.modify( metaToSave );
+    }
     Map<String, FieldLoadSaveValidator<?>> validatorMap =
       createValidatorMapAndInvokeSetters( repoAttributes, metaToSave );
     StepMetaInterface metaLoaded = createMeta();
@@ -210,11 +263,28 @@ public class LoadSaveTester {
     validateLoadedMeta( repoAttributes, validatorMap, metaToSave, metaLoaded );
   }
 
-  public List<DatabaseMeta> getDatabases() {
-    return databases;
+  protected void testMixedXmlRepoRoundTrip() throws KettleException {
+    StepMetaInterface metaToSave = createMeta();
+    if ( stepMetaInitializer != null ) {
+      stepMetaInitializer.modify( metaToSave );
+    }
+    Map<String, FieldLoadSaveValidator<?>> validatorMap =
+      createValidatorMapAndInvokeSetters( repoAttributes, metaToSave );
+    StepMetaInterface metaRepoLoaded = createMeta();
+    Repository rep = new MemoryRepository();
+    metaToSave.saveRep( rep, null, null, null );
+    metaRepoLoaded.readRep( rep, (IMetaStore) null, null, databases );
+
+    String xml = "<step>" + metaRepoLoaded.getXML() + "</step>";
+    InputStream is = new ByteArrayInputStream( xml.getBytes() );
+    StepMetaInterface metaXMLLoaded = createMeta();
+    metaXMLLoaded.loadXML( XMLHandler.getSubNode( XMLHandler.loadXMLFile( is, null, false, false ), "step" ),
+      databases, (IMetaStore) null );
+
+    validateLoadedMeta( xmlAttributes, validatorMap, metaToSave, metaXMLLoaded );
   }
 
-  public void addDatabase( DatabaseMeta db ) {
+  protected void addDatabase( DatabaseMeta db ) {
     if ( !databases.contains( db ) ) {
       databases.add( db );
     }

--- a/engine/test-src/org/pentaho/di/trans/steps/loadsave/initializer/InitializerInterface.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/loadsave/initializer/InitializerInterface.java
@@ -1,0 +1,41 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.loadsave.initializer;
+
+public interface InitializerInterface<T> {
+
+  /**
+   * Perform in-place modifications to the stepMeta before
+   * FieldLoadSaveValidator classes are called on the stepMeta
+   * 
+   * @deprecated The stepMeta class should be updated so that
+   * developers can instantiate the stepMeta, and immediately
+   * call setter methods.  Commonly, this is used for steps
+   * that define an allocate method, which pre-populate
+   * empty arrays
+   * 
+   * @param stepMeta The stepMeta class
+   */
+  @Deprecated
+  public void modify( T object );
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/loadsave/initializer/JobEntryInitializer.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/loadsave/initializer/JobEntryInitializer.java
@@ -1,0 +1,33 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.loadsave.initializer;
+
+import org.pentaho.di.job.entry.JobEntryInterface;
+
+public abstract class JobEntryInitializer<T extends JobEntryInterface>
+  implements InitializerInterface<JobEntryInterface> {
+
+  @Override
+  public abstract void modify( JobEntryInterface object );
+
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/loadsave/initializer/StepMetaInitializer.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/loadsave/initializer/StepMetaInitializer.java
@@ -1,0 +1,33 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.loadsave.initializer;
+
+import org.pentaho.di.trans.step.StepMetaInterface;
+
+public abstract class StepMetaInitializer<T extends StepMetaInterface>
+  implements InitializerInterface<StepMetaInterface> {
+
+  @Override
+  public abstract void modify( StepMetaInterface object );
+
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/rest/RestIT.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/rest/RestIT.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -49,10 +49,6 @@ import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepMeta;
-import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
-import org.pentaho.di.trans.steps.loadsave.validator.ArrayLoadSaveValidator;
-import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
-import org.pentaho.di.trans.steps.loadsave.validator.StringLoadSaveValidator;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 
 import com.sun.jersey.api.container.httpserver.HttpServerFactory;
@@ -207,36 +203,5 @@ public class RestIT {
     assertTrue( rest.processRow( stepMockHelper.processRowsStepMetaInterface, data ) );
     Object[] out = ( (RestHandler) rest ).getOutputRow();
     assertTrue( meta.equals( out, expectedRow, index ) );
-  }
-
-
-  @Test
-  public void testLoadSaveRoundTrip() throws KettleException {
-    List<String> attributes =
-        Arrays.asList( "applicationType", "method", "url", "urlInField", "dynamicMethod", "methodFieldName",
-            "urlField", "bodyField", "httpLogin", "httpPassword", "proxyHost", "proxyPort", "preemptive",
-            "trustStoreFile", "trustStorePassword", "headerField", "headerName", "parameterField", "parameterName",
-            "matrixParameterField", "matrixParameterName", "fieldName", "resultCodeFieldName", "responseTimeFieldName",
-            "responseHeaderFieldName" );
-
-    Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorAttributeMap =
-        new HashMap<String, FieldLoadSaveValidator<?>>();
-
-    // Arrays need to be consistent length
-    FieldLoadSaveValidator<String[]> stringArrayLoadSaveValidator =
-        new ArrayLoadSaveValidator<String>( new StringLoadSaveValidator(), 25 );
-    fieldLoadSaveValidatorAttributeMap.put( "headerField", stringArrayLoadSaveValidator );
-    fieldLoadSaveValidatorAttributeMap.put( "headerName", stringArrayLoadSaveValidator );
-    fieldLoadSaveValidatorAttributeMap.put( "parameterField", stringArrayLoadSaveValidator );
-    fieldLoadSaveValidatorAttributeMap.put( "parameterName", stringArrayLoadSaveValidator );
-    fieldLoadSaveValidatorAttributeMap.put( "matrixParameterField", stringArrayLoadSaveValidator );
-    fieldLoadSaveValidatorAttributeMap.put( "matrixParameterName", stringArrayLoadSaveValidator );
-
-    LoadSaveTester loadSaveTester =
-        new LoadSaveTester( RestMeta.class, attributes, new HashMap<String, String>(), new HashMap<String, String>(),
-            fieldLoadSaveValidatorAttributeMap, new HashMap<String, FieldLoadSaveValidator<?>>() );
-
-    loadSaveTester.testRepoRoundTrip();
-    loadSaveTester.testXmlRoundTrip();
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/rest/RestMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/rest/RestMetaTest.java
@@ -1,0 +1,83 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.rest;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.encryption.Encr;
+import org.pentaho.di.core.encryption.TwoWayPasswordEncoderPluginType;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.util.EnvUtil;
+import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
+import org.pentaho.di.trans.steps.loadsave.validator.ArrayLoadSaveValidator;
+import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+import org.pentaho.di.trans.steps.loadsave.validator.StringLoadSaveValidator;
+
+public class RestMetaTest {
+
+  @BeforeClass
+  public static void beforeClass() throws KettleException {
+    PluginRegistry.addPluginType( TwoWayPasswordEncoderPluginType.getInstance() );
+    PluginRegistry.init();
+    String passwordEncoderPluginID =
+      Const.NVL( EnvUtil.getSystemProperty( Const.KETTLE_PASSWORD_ENCODER_PLUGIN ), "Kettle" );
+    Encr.init( passwordEncoderPluginID );
+  }
+
+  @Test
+  public void testLoadSaveRoundTrip() throws KettleException {
+    List<String> attributes =
+      Arrays.asList( "applicationType", "method", "url", "urlInField", "dynamicMethod", "methodFieldName",
+        "urlField", "bodyField", "httpLogin", "httpPassword", "proxyHost", "proxyPort", "preemptive",
+        "trustStoreFile", "trustStorePassword", "headerField", "headerName", "parameterField", "parameterName",
+        "matrixParameterField", "matrixParameterName", "fieldName", "resultCodeFieldName", "responseTimeFieldName",
+        "responseHeaderFieldName" );
+
+    Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorAttributeMap =
+      new HashMap<String, FieldLoadSaveValidator<?>>();
+
+    // Arrays need to be consistent length
+    FieldLoadSaveValidator<String[]> stringArrayLoadSaveValidator =
+      new ArrayLoadSaveValidator<String>( new StringLoadSaveValidator(), 25 );
+    fieldLoadSaveValidatorAttributeMap.put( "headerField", stringArrayLoadSaveValidator );
+    fieldLoadSaveValidatorAttributeMap.put( "headerName", stringArrayLoadSaveValidator );
+    fieldLoadSaveValidatorAttributeMap.put( "parameterField", stringArrayLoadSaveValidator );
+    fieldLoadSaveValidatorAttributeMap.put( "parameterName", stringArrayLoadSaveValidator );
+    fieldLoadSaveValidatorAttributeMap.put( "matrixParameterField", stringArrayLoadSaveValidator );
+    fieldLoadSaveValidatorAttributeMap.put( "matrixParameterName", stringArrayLoadSaveValidator );
+
+    LoadSaveTester loadSaveTester =
+      new LoadSaveTester( RestMeta.class, attributes, new HashMap<String, String>(), new HashMap<String, String>(),
+        fieldLoadSaveValidatorAttributeMap, new HashMap<String, FieldLoadSaveValidator<?>>() );
+
+    loadSaveTester.testRepoRoundTrip();
+    loadSaveTester.testXmlRoundTrip();
+  }
+}


### PR DESCRIPTION
Some steps require calling allocate() before calling some setter methods.
Pass the object back to a user-defined Initializer class, in order for the allocate() or other methods to be called as needed.