### PR TITLE
[SP-2678] Backport of PDI-15246 - Group By with include all rows option does not clean up temp files (5.4 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/groupby/GroupBy.java
+++ b/engine/src/org/pentaho/di/trans/steps/groupby/GroupBy.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -129,7 +129,7 @@ public class GroupBy extends BaseStep implements StepInterface {
         }
         if ( ( r != null ) && ( data.subjectnrs[ i ] < 0 ) ) {
           logError( BaseMessages.getString( PKG, "GroupBy.Log.AggregateSubjectFieldCouldNotFound",
-              meta.getSubjectField()[ i ] ) );
+            meta.getSubjectField()[ i ] ) );
           setErrors( 1 );
           stopAll();
           return false;
@@ -192,8 +192,8 @@ public class GroupBy extends BaseStep implements StepInterface {
       data.groupAggMeta.addRowMeta( data.aggMeta );
     }
 
-    if ( r == null ) // no more input to be expected... (or none received in the first place)
-    {
+    if ( r == null ) {
+      // no more input to be expected... (or none received in the first place)
       handleLastOfGroup();
       setOutputDone();
       return false;
@@ -686,65 +686,65 @@ public class GroupBy extends BaseStep implements StepInterface {
    */
   Object[] getAggregateResult() throws KettleValueException {
 
-    if (data.subjectnrs == null) {
-      return new Object[0];
+    if ( data.subjectnrs == null ) {
+      return new Object[ 0 ];
     }
 
     Object[] result = new Object[ data.subjectnrs.length ];
 
-      for ( int i = 0; i < data.subjectnrs.length; i++ ) {
-        Object ag = data.agg[ i ];
-        switch ( meta.getAggregateType()[ i ] ) {
-          case GroupByMeta.TYPE_GROUP_SUM:
-            break;
-          case GroupByMeta.TYPE_GROUP_AVERAGE:
-            ag =
-              ValueDataUtil.divide( data.aggMeta.getValueMeta( i ), ag, new ValueMeta(
-                "c", ValueMetaInterface.TYPE_INTEGER ), new Long( data.counts[ i ] ) );
-            break;
-          case GroupByMeta.TYPE_GROUP_MEDIAN:
-          case GroupByMeta.TYPE_GROUP_PERCENTILE:
-            double percentile = 50.0;
-            if ( meta.getAggregateType()[ i ] == GroupByMeta.TYPE_GROUP_PERCENTILE ) {
-              percentile = Double.parseDouble( meta.getValueField()[ i ] );
-            }
-            @SuppressWarnings( "unchecked" )
-            List<Double> valuesList = (List<Double>) data.agg[ i ];
-            double[] values = new double[ valuesList.size() ];
-            for ( int v = 0; v < values.length; v++ ) {
-              values[ v ] = valuesList.get( v );
-            }
-            ag = new Percentile().evaluate( values, percentile );
-            break;
-          case GroupByMeta.TYPE_GROUP_COUNT_ANY:
-          case GroupByMeta.TYPE_GROUP_COUNT_ALL:
-            ag = new Long( data.counts[ i ] );
-            break;
-          case GroupByMeta.TYPE_GROUP_COUNT_DISTINCT:
-            break;
-          case GroupByMeta.TYPE_GROUP_MIN:
-            break;
-          case GroupByMeta.TYPE_GROUP_MAX:
-            break;
-          case GroupByMeta.TYPE_GROUP_STANDARD_DEVIATION:
-            double sum = (Double) ag / data.counts[ i ];
-            ag = Double.valueOf( Math.sqrt( sum ) );
-            break;
-          case GroupByMeta.TYPE_GROUP_CONCAT_COMMA:
-          case GroupByMeta.TYPE_GROUP_CONCAT_STRING:
-            ag = ( (StringBuilder) ag ).toString();
-            break;
-          default:
-            break;
-        }
-        if ( ag == null && allNullsAreZero ) {
-          // PDI-10250, 6960 seems all rows for min function was nulls...
-          // get output subject meta based on original subject meta calculation
-          ValueMetaInterface vm = data.aggMeta.getValueMeta( i );
-          ag = ValueDataUtil.getZeroForValueMetaType( vm );
-        }
-        result[ i ] = ag;
+    for ( int i = 0; i < data.subjectnrs.length; i++ ) {
+      Object ag = data.agg[ i ];
+      switch ( meta.getAggregateType()[ i ] ) {
+        case GroupByMeta.TYPE_GROUP_SUM:
+          break;
+        case GroupByMeta.TYPE_GROUP_AVERAGE:
+          ag =
+            ValueDataUtil.divide( data.aggMeta.getValueMeta( i ), ag, new ValueMeta(
+              "c", ValueMetaInterface.TYPE_INTEGER ), new Long( data.counts[ i ] ) );
+          break;
+        case GroupByMeta.TYPE_GROUP_MEDIAN:
+        case GroupByMeta.TYPE_GROUP_PERCENTILE:
+          double percentile = 50.0;
+          if ( meta.getAggregateType()[ i ] == GroupByMeta.TYPE_GROUP_PERCENTILE ) {
+            percentile = Double.parseDouble( meta.getValueField()[ i ] );
+          }
+          @SuppressWarnings( "unchecked" )
+          List<Double> valuesList = (List<Double>) data.agg[ i ];
+          double[] values = new double[ valuesList.size() ];
+          for ( int v = 0; v < values.length; v++ ) {
+            values[ v ] = valuesList.get( v );
+          }
+          ag = new Percentile().evaluate( values, percentile );
+          break;
+        case GroupByMeta.TYPE_GROUP_COUNT_ANY:
+        case GroupByMeta.TYPE_GROUP_COUNT_ALL:
+          ag = new Long( data.counts[ i ] );
+          break;
+        case GroupByMeta.TYPE_GROUP_COUNT_DISTINCT:
+          break;
+        case GroupByMeta.TYPE_GROUP_MIN:
+          break;
+        case GroupByMeta.TYPE_GROUP_MAX:
+          break;
+        case GroupByMeta.TYPE_GROUP_STANDARD_DEVIATION:
+          double sum = (Double) ag / data.counts[ i ];
+          ag = Double.valueOf( Math.sqrt( sum ) );
+          break;
+        case GroupByMeta.TYPE_GROUP_CONCAT_COMMA:
+        case GroupByMeta.TYPE_GROUP_CONCAT_STRING:
+          ag = ( (StringBuilder) ag ).toString();
+          break;
+        default:
+          break;
       }
+      if ( ag == null && allNullsAreZero ) {
+        // PDI-10250, 6960 seems all rows for min function was nulls...
+        // get output subject meta based on original subject meta calculation
+        ValueMetaInterface vm = data.aggMeta.getValueMeta( i );
+        ag = ValueDataUtil.getZeroForValueMetaType( vm );
+      }
+      result[ i ] = ag;
+    }
 
     return result;
 

--- a/engine/src/org/pentaho/di/trans/steps/groupby/GroupByData.java
+++ b/engine/src/org/pentaho/di/trans/steps/groupby/GroupByData.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/org/pentaho/di/trans/steps/groupby/GroupByData.java
+++ b/engine/src/org/pentaho/di/trans/steps/groupby/GroupByData.java
@@ -66,16 +66,16 @@ public class GroupByData extends BaseStepData implements StepDataInterface {
 
   public File tempFile;
 
-  public FileOutputStream fos;
+  public FileOutputStream fosToTempFile;
 
-  public DataOutputStream dos;
+  public DataOutputStream dosToTempFile;
 
   public int rowsOnFile;
 
   public boolean firstRead;
 
-  public FileInputStream fis;
-  public DataInputStream dis;
+  public FileInputStream fisToTmpFile;
+  public DataInputStream disToTmpFile;
 
   public Object[] groupResult;
 

--- a/engine/src/org/pentaho/di/trans/steps/groupby/GroupByMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/groupby/GroupByMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/org/pentaho/di/trans/steps/groupby/GroupByMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/groupby/GroupByMeta.java
@@ -407,13 +407,13 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     aggregateIgnored = false;
     aggregateIgnoredField = null;
 
-    int sizegroup = 0;
-    int nrfields = 0;
+    int sizeGroup = 0;
+    int numberOfFields = 0;
 
-    allocate( sizegroup, nrfields );
+    allocate( sizeGroup, numberOfFields );
   }
 
-  public void getFields( RowMetaInterface r, String origin, RowMetaInterface[] info, StepMeta nextStep,
+  public void getFields( RowMetaInterface rowMeta, String origin, RowMetaInterface[] info, StepMeta nextStep,
                          VariableSpace space, Repository repository, IMetaStore metaStore ) {
     // re-assemble a new row of metadata
     //
@@ -423,7 +423,7 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
       // Add the grouping fields in the correct order...
       //
       for ( int i = 0; i < groupField.length; i++ ) {
-        ValueMetaInterface valueMeta = r.searchValueMeta( groupField[ i ] );
+        ValueMetaInterface valueMeta = rowMeta.searchValueMeta( groupField[ i ] );
         if ( valueMeta != null ) {
           fields.addValueMeta( valueMeta );
         }
@@ -431,16 +431,16 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
     } else {
       // Add all the original fields from the incoming row meta
       //
-      fields.addRowMeta( r );
+      fields.addRowMeta( rowMeta );
     }
 
     // Re-add aggregates
     //
     for ( int i = 0; i < subjectField.length; i++ ) {
-      ValueMetaInterface subj = r.searchValueMeta( subjectField[ i ] );
+      ValueMetaInterface subj = rowMeta.searchValueMeta( subjectField[ i ] );
       if ( subj != null || aggregateType[ i ] == TYPE_GROUP_COUNT_ANY ) {
-        String value_name = aggregateField[ i ];
-        int value_type = ValueMetaInterface.TYPE_NONE;
+        String valueName = aggregateField[ i ];
+        int valueType = ValueMetaInterface.TYPE_NONE;
         int length = -1;
         int precision = -1;
 
@@ -455,23 +455,23 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
           case TYPE_GROUP_LAST_INCL_NULL:
           case TYPE_GROUP_MIN:
           case TYPE_GROUP_MAX:
-            value_type = subj.getType();
+            valueType = subj.getType();
             break;
           case TYPE_GROUP_COUNT_DISTINCT:
           case TYPE_GROUP_COUNT_ANY:
           case TYPE_GROUP_COUNT_ALL:
-            value_type = ValueMetaInterface.TYPE_INTEGER;
+            valueType = ValueMetaInterface.TYPE_INTEGER;
             break;
           case TYPE_GROUP_CONCAT_COMMA:
-            value_type = ValueMetaInterface.TYPE_STRING;
+            valueType = ValueMetaInterface.TYPE_STRING;
             break;
           case TYPE_GROUP_STANDARD_DEVIATION:
           case TYPE_GROUP_MEDIAN:
           case TYPE_GROUP_PERCENTILE:
-            value_type = ValueMetaInterface.TYPE_NUMBER;
+            valueType = ValueMetaInterface.TYPE_NUMBER;
             break;
           case TYPE_GROUP_CONCAT_STRING:
-            value_type = ValueMetaInterface.TYPE_STRING;
+            valueType = ValueMetaInterface.TYPE_STRING;
             break;
           default:
             break;
@@ -479,8 +479,8 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
 
         // Change type from integer to number in case off averages for cumulative average
         //
-        if ( aggregateType[ i ] == TYPE_GROUP_CUMULATIVE_AVERAGE && value_type == ValueMetaInterface.TYPE_INTEGER ) {
-          value_type = ValueMetaInterface.TYPE_NUMBER;
+        if ( aggregateType[ i ] == TYPE_GROUP_CUMULATIVE_AVERAGE && valueType == ValueMetaInterface.TYPE_INTEGER ) {
+          valueType = ValueMetaInterface.TYPE_NUMBER;
           precision = -1;
           length = -1;
         } else if ( aggregateType[ i ] == TYPE_GROUP_COUNT_ALL
@@ -488,17 +488,17 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
           length = ValueMetaInterface.DEFAULT_INTEGER_LENGTH;
           precision = 0;
         } else if ( aggregateType[ i ] == TYPE_GROUP_SUM
-            && value_type != ValueMetaInterface.TYPE_INTEGER && value_type != ValueMetaInterface.TYPE_NUMBER
-            && value_type != ValueMetaInterface.TYPE_BIGNUMBER ) {
+            && valueType != ValueMetaInterface.TYPE_INTEGER && valueType != ValueMetaInterface.TYPE_NUMBER
+            && valueType != ValueMetaInterface.TYPE_BIGNUMBER ) {
           // If it ain't numeric, we change it to Number
           //
-          value_type = ValueMetaInterface.TYPE_NUMBER;
+          valueType = ValueMetaInterface.TYPE_NUMBER;
           precision = -1;
           length = -1;
         }
 
-        if ( value_type != ValueMetaInterface.TYPE_NONE ) {
-          ValueMetaInterface v = new ValueMeta( value_name, value_type );
+        if ( valueType != ValueMetaInterface.TYPE_NONE ) {
+          ValueMetaInterface v = new ValueMeta( valueName, valueType );
           v.setOrigin( origin );
           v.setLength( length, precision );
           fields.addValueMeta( v );
@@ -519,8 +519,8 @@ public class GroupByMeta extends BaseStepMeta implements StepMetaInterface {
 
     // Now that we have all the fields we want, we should clear the original row and replace the values...
     //
-    r.clear();
-    r.addRowMeta( fields );
+    rowMeta.clear();
+    rowMeta.addRowMeta( fields );
   }
 
   public String getXML() {

--- a/engine/src/org/pentaho/di/trans/steps/groupby/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/trans/steps/groupby/messages/messages_en_US.properties
@@ -18,7 +18,7 @@ GroupByDialog.Group.Label=The fields that make up the group\:
 GroupByDialog.FailedToGetFields.DialogTitle=Get fields failed
 GroupBy.LineNumber=Linenr 
 GroupByDialog.AlwaysAddResult.ToolTip=To make sure we always output a correct count aggregation we always output at least one row, even if there were no input rows.\nThis makes the behavior consistent with the aggregation in an SQL GROUP BY.
-GroupBy.Exception.UnableToCloseInputStream=Unable to close input stream\!
+GroupBy.Exception.UnableToCloseInputStream=Unable to close input stream to file {0}
 GroupByMeta.TypeGroupLongDesc.CONCAT_ALL=Number of Values (N)
 GroupByMeta.Exception.UnableToSaveStepInfoToRepository=Unable to save step information to the repository for id_step\=
 GroupByMeta.TypeGroupLongDesc.CUMUMALTIVE_SUM=Cumulative sum (all rows option only\!) 
@@ -54,6 +54,7 @@ GroupByMeta.TypeGroupLongDesc.SUM=Sum
 GroupByMeta.Exception.UnableToLoadStepInfoFromXML=Unable to load step info from XML
 GroupByMeta.TypeGroupLongDesc.FIRST_INCL_NULL=First value
 GroupBy.Exception.UnableToCreateTemporaryFile=Unable to create temporary file
+GroupBy.Exception.UnableToDeleteTemporaryFile=Unable to delete temporary file: {0}
 GroupByMeta.TypeGroupLongDesc.COUNT_DISTINCT=Number of Distinct Values (N)
 GroupByDialog.Stepname.Label=Step name 
 GroupByMeta.TypeGroupLongDesc.MAX=Maximum

--- a/engine/test-src/org/pentaho/di/trans/steps/groupby/GroupByTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/groupby/GroupByTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/test-src/org/pentaho/di/trans/steps/groupby/GroupByTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/groupby/GroupByTest.java
@@ -22,15 +22,19 @@
 
 package org.pentaho.di.trans.steps.groupby;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
-
-import junit.framework.TestCase;
 
 import org.junit.After;
 import org.junit.Before;
@@ -48,10 +52,11 @@ import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import org.pentaho.metastore.api.IMetaStore;
 
-public class GroupByTest extends TestCase {
+public class GroupByTest  {
   private StepMockHelper<GroupByMeta, GroupByData> mockHelper;
 
   @Before
@@ -153,5 +158,25 @@ public class GroupByTest extends TestCase {
     assertTrue( outputFields.getValueMeta( 7 ).getName().equals( "concat_comma_field" ) );
     assertTrue( outputFields.getValueMeta( 8 ).getType() == ValueMeta.TYPE_STRING );
     assertTrue( outputFields.getValueMeta( 8 ).getName().equals( "concat_custom_field" ) );
+  }
+
+
+  @Test
+  public void testTempFileIsDeleted_AfterCallingDisposeMethod() throws Exception {
+    GroupByData groupByData = new GroupByData();
+    groupByData.tempFile = File.createTempFile( "test", ".txt" );
+
+    // emulate connections to file are opened
+    groupByData.fosToTempFile = new FileOutputStream( groupByData.tempFile );
+    groupByData.fisToTmpFile = new FileInputStream( groupByData.tempFile );
+
+    GroupBy groupBySpy = Mockito.spy( new GroupBy( mockHelper.stepMeta, groupByData, 0,
+      mockHelper.transMeta, mockHelper.trans ) );
+
+    assertTrue( groupByData.tempFile.exists() );
+    groupBySpy.dispose( mock( StepMetaInterface.class ), groupByData );
+    // check file is deleted
+    assertFalse( groupByData.tempFile.exists() );
+
   }
 }


### PR DESCRIPTION
- Closing streams before deleting file
- Refactoring
- Tests written

More details:

**GroupBy**
- Closing streams before deleting files.
- Logging an error if stream can't be closed
- Logging detailed message if temp file wasn't deleted. I've chosen this log level because in most cases temp file wouldn't be deleted because streams to this file are not closed (and we do log about close-stream error)
- Refactoring

**GroupByData**
- Changed name of streams, pointing that they are related to temp file only.

**GroupByMeta**
- Refactoring some field names

**GroupByTest**
- Updating to JUnit 4.0
- Added positive test for temp file deletion
- No negative test added, as in this case it would be equivalent to testing logger.

**messages**
- Added message, notifying that temp file wasn't deleting
- Refactored a message, notifying that connection to file wasn't closed. Pointing to the path of the file, where an error occurred.
