### PR TITLE
[SP-2667] Backport of PDI-15125 - In Zip File job entry, exclude patt…

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
+++ b/engine/src/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -371,7 +371,7 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
           FileObject sourceFileOrFolder = KettleVFS.getFileObject( localSourceFilename );
           boolean isSourceDirectory = sourceFileOrFolder.getType().equals( FileType.FOLDER );
           final Pattern pattern;
-          final Pattern patternexclude;
+          final Pattern patternExclude;
 
           if ( isSourceDirectory ) {
             // Let's prepare the pattern matcher for performance reasons.
@@ -383,49 +383,22 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
               pattern = null;
             }
             if ( !Const.isEmpty( realWildcardExclude ) ) {
-              patternexclude = Pattern.compile( realWildcardExclude );
+              patternExclude = Pattern.compile( realWildcardExclude );
             } else {
-              patternexclude = null;
+              patternExclude = null;
             }
 
             // Target is a directory
             // Get all the files in the directory...
             //
             if ( includingSubFolders ) {
-              fileList = sourceFileOrFolder.findFiles( new FileSelector() {
-
-                public boolean traverseDescendents( FileSelectInfo fileInfo ) throws Exception {
-                  return true;
-                }
-
-                public boolean includeFile( FileSelectInfo fileInfo ) throws Exception {
-                  boolean include;
-
-                  // Only include files in the sub-folders...
-                  // When we include sub-folders we match the whole filename, not just the base-name
-                  //
-                  if ( fileInfo.getFile().getType().equals( FileType.FILE ) ) {
-                    include = true;
-                    if ( pattern != null ) {
-                      String name = fileInfo.getFile().getName().getPath();
-                      include = pattern.matcher( name ).matches();
-                    }
-                    if ( include && patternexclude != null ) {
-                      String name = fileInfo.getFile().getName().getPath();
-                      include = !pattern.matcher( name ).matches();
-                    }
-                  } else {
-                    include = false;
-                  }
-                  return include;
-                }
-              } );
+              fileList = sourceFileOrFolder.findFiles( new ZipJobEntryPatternFileSelector( pattern, patternExclude ) );
             } else {
               fileList = sourceFileOrFolder.getChildren();
             }
           } else {
             pattern = null;
-            patternexclude = null;
+            patternExclude = null;
 
             // Target is a file
             fileList = new FileObject[] { sourceFileOrFolder };
@@ -562,8 +535,8 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
                   getIt = matcher.matches();
                 }
 
-                if ( patternexclude != null ) {
-                  Matcher matcherexclude = patternexclude.matcher( filename );
+                if ( patternExclude != null ) {
+                  Matcher matcherexclude = patternExclude.matcher( filename );
                   getItexclude = matcherexclude.matches();
                 }
               }
@@ -1169,4 +1142,46 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
   public void setStoredSourcePathDepth( String storedSourcePathDepth ) {
     this.storedSourcePathDepth = storedSourcePathDepth;
   }
+
+  /**
+   * Helper class providing pattern restrictions for
+   * file names to be zipped
+   */
+  public static class ZipJobEntryPatternFileSelector implements FileSelector {
+
+    private Pattern pattern;
+    private Pattern patternExclude;
+
+    public ZipJobEntryPatternFileSelector( Pattern pattern, Pattern patternExclude ) {
+      this.pattern = pattern;
+      this.patternExclude = patternExclude;
+    }
+
+    public boolean traverseDescendents( FileSelectInfo fileInfo ) throws Exception {
+      return true;
+    }
+
+    public boolean includeFile( FileSelectInfo fileInfo ) throws Exception {
+      boolean include;
+
+      // Only include files in the sub-folders...
+      // When we include sub-folders we match the whole filename, not just the base-name
+      //
+      if ( fileInfo.getFile().getType().equals( FileType.FILE ) ) {
+        include = true;
+        if ( pattern != null ) {
+          String name = fileInfo.getFile().getName().getBaseName();
+          include = pattern.matcher( name ).matches();
+        }
+        if ( include && patternExclude != null ) {
+          String name = fileInfo.getFile().getName().getBaseName();
+          include = !patternExclude.matcher( name ).matches();
+        }
+      } else {
+        include = false;
+      }
+      return include;
+    }
+  }
+
 }

--- a/engine/test-src/org/pentaho/di/job/entries/zipfile/ZipJobEntryPatternFileSelectorTest.java
+++ b/engine/test-src/org/pentaho/di/job/entries/zipfile/ZipJobEntryPatternFileSelectorTest.java
@@ -1,0 +1,119 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.zipfile;
+
+import org.apache.commons.vfs2.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.di.core.util.Assert;
+import java.util.regex.Pattern;
+
+public class ZipJobEntryPatternFileSelectorTest {
+
+  private FileSelector fileSelector;
+  private FileSelectInfo fileSelectInfoMock;
+  private FileObject fileObjectMock;
+  FileName fileNameMock;
+
+  private static final String PATTERN = "^.*\\.(txt)$";
+  private static final String PATTERN_FILE_NAME = "do-not-open.txt";
+  private static final String EXCLUDE_PATTERN = "^.*\\.(sh)$";
+  private static final String EXCLUDE_PATTERN_FILE_NAME = "performance-boost.sh";
+
+  @Before
+  public void init() throws FileSystemException {
+    fileSelectInfoMock = Mockito.mock( FileSelectInfo.class );
+    fileSelector = new JobEntryZipFile
+      .ZipJobEntryPatternFileSelector( Pattern.compile( PATTERN ), Pattern.compile( EXCLUDE_PATTERN ) );
+    fileObjectMock = Mockito.mock( FileObject.class );
+    fileNameMock = Mockito.mock( FileName.class );
+
+    Mockito.when( fileSelectInfoMock.getFile() ).thenReturn( fileObjectMock );
+    Mockito.when( fileObjectMock.getType() ).thenReturn( FileType.FILE );
+    Mockito.when( fileObjectMock.getName() ).thenReturn( fileNameMock );
+    Mockito.when( fileNameMock.getBaseName() ).thenReturn( PATTERN_FILE_NAME );
+
+  }
+
+  @Test
+  public void testPatternNull() throws Exception {
+    fileSelector = new JobEntryZipFile.ZipJobEntryPatternFileSelector( null, Pattern.compile( EXCLUDE_PATTERN ) );
+    boolean includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertTrue( includeFile );
+
+    Mockito.when( fileNameMock.getBaseName() ).thenReturn( EXCLUDE_PATTERN_FILE_NAME );
+    includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertFalse( includeFile );
+  }
+
+  @Test
+  public void testExcludePatternNull() throws Exception {
+    fileSelector = new JobEntryZipFile.ZipJobEntryPatternFileSelector( Pattern.compile( PATTERN ), null );
+    boolean includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertTrue( includeFile );
+
+    Mockito.when( fileNameMock.getBaseName() ).thenReturn( EXCLUDE_PATTERN_FILE_NAME );
+    includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertFalse( includeFile );
+  }
+
+  @Test
+  public void testPatternAndExcludePatternNull() throws Exception {
+    fileSelector = new JobEntryZipFile.ZipJobEntryPatternFileSelector( null, null );
+    boolean includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertTrue( includeFile );
+
+    Mockito.when( fileNameMock.getBaseName() ).thenReturn( EXCLUDE_PATTERN_FILE_NAME );
+    includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertTrue( includeFile );
+  }
+
+  @Test
+  public void testMatchesPattern() throws Exception {
+    boolean includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertTrue( includeFile );
+  }
+
+  @Test
+  public void testMatchesExcludePattern() throws Exception {
+    Mockito.when( fileNameMock.getBaseName() ).thenReturn( EXCLUDE_PATTERN_FILE_NAME );
+    boolean includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertFalse( includeFile );
+  }
+
+  @Test
+  public void testMatchesPatternAndExcludePattern() throws Exception {
+    fileSelector =
+      new JobEntryZipFile.ZipJobEntryPatternFileSelector( Pattern.compile( PATTERN ), Pattern.compile( PATTERN ) );
+    boolean includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertFalse( includeFile );
+  }
+
+  @Test
+  public void testDifferentFileType() throws Exception {
+    Mockito.when( fileObjectMock.getType() ).thenReturn( FileType.IMAGINARY );
+    boolean includeFile = fileSelector.includeFile( fileSelectInfoMock );
+    Assert.assertFalse( includeFile );
+  }
+}


### PR DESCRIPTION
[SP-2667] Backport of PDI-15125 - In Zip File job entry, exclude pattern does not work if a folder with subfolders is selected as source (6.1 Suite)