### PR TITLE
[BACKLOG-7972] - Hadoop File Output: Hadoop Clusters dropdown doesn't…

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -199,7 +199,7 @@
     <dependency org="org.codehaus.enunciate" name="enunciate-core-annotations" rev="1.27"   transitive="false" />
 
     <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.3" transitive="false"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.16" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.19.1" transitive="false"/>
 
     <!-- Salesforce plugin dependency -->
     <dependency org="pentaho"         name="salesforce-partner" rev="24.0"/>

--- a/engine/ivy.xml
+++ b/engine/ivy.xml
@@ -47,10 +47,10 @@
     <dependency org="jfree"                            name="jcommon"              rev="1.0.16"          transitive="false"/>
     <dependency org="com.googlecode.json-simple"       name="json-simple"          rev="1.1"             transitive="false"/>
     <dependency org="jsonpath"                         name="jsonpath"             rev="1.0"             transitive="false"/>
-    <dependency org="com.sun.jersey.contribs"          name="jersey-apache-client" rev="1.16"            transitive="false"/>
-    <dependency org="com.sun.jersey"                   name="jersey-bundle"        rev="1.16"            transitive="false"/>
-    <dependency org="com.sun.jersey"                   name="jersey-client"        rev="1.16"            transitive="false"/>
-    <dependency org="com.sun.jersey"                   name="jersey-core"          rev="1.16"            transitive="false"/>
+    <dependency org="com.sun.jersey.contribs"          name="jersey-apache-client" rev="1.19.1"          transitive="false"/>
+    <dependency org="com.sun.jersey"                   name="jersey-bundle"        rev="1.19.1"          transitive="false"/>
+    <dependency org="com.sun.jersey"                   name="jersey-client"        rev="1.19.1"          transitive="false"/>
+    <dependency org="com.sun.jersey"                   name="jersey-core"          rev="1.19.1"          transitive="false"/>
     <dependency org="jexcelapi"                        name="jxl"                  rev="2.6.12"          transitive="false"/>
     <dependency org="ldapjdk"                          name="ldapjdk"              rev="20000524"        transitive="false"/>
     <dependency org="monetdb"                          name="monetdb-jdbc"         rev="2.8"             transitive="false"/>

--- a/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInputMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInputMeta.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -818,7 +818,7 @@ public class TextFileInputMeta extends BaseStepMeta implements StepMetaInterface
         Node excludefilemasknode = XMLHandler.getSubNodeByNr( filenode, "exclude_filemask", i );
         Node fileRequirednode = XMLHandler.getSubNodeByNr( filenode, "file_required", i );
         Node includeSubFoldersnode = XMLHandler.getSubNodeByNr( filenode, "include_subfolders", i );
-        fileName[i] = loadSource( filenode, filenamenode, i );
+        fileName[i] = loadSource( filenode, filenamenode, i, metaStore );
         fileMask[i] = XMLHandler.getNodeValue( filemasknode );
         excludeFileMask[i] = XMLHandler.getNodeValue( excludefilemasknode );
         fileRequired[i] = XMLHandler.getNodeValue( fileRequirednode );
@@ -2047,7 +2047,7 @@ public class TextFileInputMeta extends BaseStepMeta implements StepMetaInterface
     setFileName( fileName );
   }
 
-  protected String loadSource( Node filenode, Node filenamenode, int i ) {
+  protected String loadSource( Node filenode, Node filenamenode, int i, IMetaStore metaStore ) {
     return XMLHandler.getNodeValue( filenamenode );
   }
 

--- a/plugins/pdi-pur-plugin/ivy.xml
+++ b/plugins/pdi-pur-plugin/ivy.xml
@@ -117,9 +117,9 @@
     <dependency org="org.mortbay.jetty" name="jetty-util" rev="6.1.21" transitive="false" conf="test->default" />
 
     <!-- jersey -->
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart"     rev="1.16" transitive="false" conf="compile->default"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.16" transitive="false" conf="compile->default"/>
-    <dependency org="com.sun.jersey"          name="jersey-bundle"        rev="1.16" transitive="false" conf="compile->default"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart"     rev="1.19.1" transitive="false" conf="compile->default"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.19.1" transitive="false" conf="compile->default"/>
+    <dependency org="com.sun.jersey"          name="jersey-bundle"        rev="1.19.1" transitive="false" conf="compile->default"/>
 
     <!-- To support Enunciate Annotations in Resource classes 1.21.1 -->
     <dependency org="org.codehaus.enunciate" name="enunciate-core-annotations" rev="1.28"/>


### PR DESCRIPTION
… preserve selected cluster after reopen a transformation

return api in TextFileInputMeta to have metastore for loadSource method, needed for HadoopFileInputMeta, adaptate interface to use StringBuilder instead of StringBuffer as in engine, write tests to fail on api changed in engine again

update version for jersey to 1.19.1 due to incompatibility jersey before 1.19 with java 1.8(was reproduced with fail )