### PR TITLE
[BACKLOG-7972] - jersey version back to 1.16 due to using this versio…

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -199,7 +199,7 @@
     <dependency org="org.codehaus.enunciate" name="enunciate-core-annotations" rev="1.27"   transitive="false" />
 
     <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.3" transitive="false"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.16" transitive="false"/>
 
     <!-- Salesforce plugin dependency -->
     <dependency org="pentaho"         name="salesforce-partner" rev="24.0"/>

--- a/engine/ivy.xml
+++ b/engine/ivy.xml
@@ -47,10 +47,10 @@
     <dependency org="jfree"                            name="jcommon"              rev="1.0.16"          transitive="false"/>
     <dependency org="com.googlecode.json-simple"       name="json-simple"          rev="1.1"             transitive="false"/>
     <dependency org="jsonpath"                         name="jsonpath"             rev="1.0"             transitive="false"/>
-    <dependency org="com.sun.jersey.contribs"          name="jersey-apache-client" rev="1.19.1"          transitive="false"/>
-    <dependency org="com.sun.jersey"                   name="jersey-bundle"        rev="1.19.1"          transitive="false"/>
-    <dependency org="com.sun.jersey"                   name="jersey-client"        rev="1.19.1"          transitive="false"/>
-    <dependency org="com.sun.jersey"                   name="jersey-core"          rev="1.19.1"          transitive="false"/>
+    <dependency org="com.sun.jersey.contribs"          name="jersey-apache-client" rev="1.16"          transitive="false"/>
+    <dependency org="com.sun.jersey"                   name="jersey-bundle"        rev="1.16"          transitive="false"/>
+    <dependency org="com.sun.jersey"                   name="jersey-client"        rev="1.16"          transitive="false"/>
+    <dependency org="com.sun.jersey"                   name="jersey-core"          rev="1.16"          transitive="false"/>
     <dependency org="jexcelapi"                        name="jxl"                  rev="2.6.12"          transitive="false"/>
     <dependency org="ldapjdk"                          name="ldapjdk"              rev="20000524"        transitive="false"/>
     <dependency org="monetdb"                          name="monetdb-jdbc"         rev="2.8"             transitive="false"/>

--- a/plugins/pdi-pur-plugin/ivy.xml
+++ b/plugins/pdi-pur-plugin/ivy.xml
@@ -117,9 +117,9 @@
     <dependency org="org.mortbay.jetty" name="jetty-util" rev="6.1.21" transitive="false" conf="test->default" />
 
     <!-- jersey -->
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart"     rev="1.19.1" transitive="false" conf="compile->default"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.19.1" transitive="false" conf="compile->default"/>
-    <dependency org="com.sun.jersey"          name="jersey-bundle"        rev="1.19.1" transitive="false" conf="compile->default"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart"     rev="1.16" transitive="false" conf="compile->default"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.16" transitive="false" conf="compile->default"/>
+    <dependency org="com.sun.jersey"          name="jersey-bundle"        rev="1.16" transitive="false" conf="compile->default"/>
 
     <!-- To support Enunciate Annotations in Resource classes 1.21.1 -->
     <dependency org="org.codehaus.enunciate" name="enunciate-core-annotations" rev="1.28"/>


### PR DESCRIPTION
…n on di ba server
integration tests will now fail with old jersey version but
more investigation will be done in spike http://jira.pentaho.com/browse/BACKLOG-8388