### PR TITLE
[SP-2694] Backport of PDI-14852 - setVariable in Javascript Step with scope of parent job does not work (6.1 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
+++ b/engine/src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
@@ -79,6 +79,7 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.steps.loadfileinput.LoadFileInput;
 
@@ -106,6 +107,15 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
     "moveFile", "execProcess", "isEmpty", "isMailValid", "escapeXml", "removeDigits", "initCap",
     "protectXMLCDATA", "unEscapeXml", "escapeSQL", "escapeHtml", "unEscapeHtml", "loadFileContent",
     "getOcuranceString", "removeCRLF" };
+
+
+  enum VariableScope {
+    SYSTEM,
+    ROOT,
+    PARENT,
+    GRAND_PARENT
+  }
+
 
   // This is only used for reading, so no concurrency problems.
   // todo: move in the real variables of the step.
@@ -395,11 +405,11 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
     if ( ArgList.length == 1 ) {
       try {
         if ( isNull( ArgList[0] ) ) {
-          return new Double( Double.NaN );
+          return Double.NaN;
         } else if ( isUndefined( ArgList[0] ) ) {
           return Context.getUndefinedValue();
         } else {
-          return new Double( Math.ceil( Context.toNumber( ArgList[0] ) ) );
+          return Math.ceil( Context.toNumber( ArgList[ 0 ] ) );
         }
       } catch ( Exception e ) {
         return null;
@@ -1692,14 +1702,14 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
   // Resolve an IP address
   public static String resolveIP( Context actualContext, Scriptable actualObject, Object[] ArgList,
     Function FunctionContext ) {
-    String sRC = "";
+    String sRC;
     if ( ArgList.length == 2 ) {
       try {
-        InetAddress addr = InetAddress.getByName( Context.toString( ArgList[0] ) );
+        InetAddress address = InetAddress.getByName( Context.toString( ArgList[0] ) );
         if ( Context.toString( ArgList[1] ).equals( "IP" ) ) {
-          sRC = addr.getHostName();
+          sRC = address.getHostName();
         } else {
-          sRC = addr.getHostAddress();
+          sRC = address.getHostAddress();
         }
         if ( sRC.equals( Context.toString( ArgList[0] ) ) ) {
           sRC = "-";
@@ -1790,77 +1800,92 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
     }
   }
 
-  // Setting Variable
-  public static void setVariable( Context actualContext, Scriptable actualObject, Object[] ArgList,
-    Function FunctionContext ) {
-    String sArg1 = "";
-    String sArg2 = "";
-    String sArg3 = "";
-    if ( ArgList.length == 3 ) {
-      try {
-        Object scmo = actualObject.get( "_step_", actualObject );
-        Object scmO = Context.jsToJava( scmo, StepInterface.class );
-        if ( scmO instanceof StepInterface ) {
-          StepInterface scm = (StepInterface) scmO;
+  public static void setVariable( Context actualContext, Scriptable actualObject, Object[] arguments,
+    Function functionContext ) {
 
-          sArg1 = Context.toString( ArgList[0] );
-          sArg2 = Context.toString( ArgList[1] );
-          sArg3 = Context.toString( ArgList[2] );
-
-          if ( "s".equals( sArg3 ) ) {
-            // System wide properties
-            System.setProperty( sArg1, sArg2 );
-
-            // Set also all the way to the root as else we will take
-            // stale values
-            scm.setVariable( sArg1, sArg2 );
-
-            VariableSpace parentSpace = scm.getParentVariableSpace();
-            while ( parentSpace != null ) {
-              parentSpace.setVariable( sArg1, sArg2 );
-              parentSpace = parentSpace.getParentVariableSpace();
-            }
-          } else if ( "r".equals( sArg3 ) ) {
-            // Upto the root... this should be the default.
-            scm.setVariable( sArg1, sArg2 );
-
-            VariableSpace parentSpace = scm.getParentVariableSpace();
-            while ( parentSpace != null ) {
-              parentSpace.setVariable( sArg1, sArg2 );
-              parentSpace = parentSpace.getParentVariableSpace();
-            }
-          } else if ( "p".equals( sArg3 ) ) {
-            // Upto the parent
-            scm.setVariable( sArg1, sArg2 );
-
-            VariableSpace parentSpace = scm.getParentVariableSpace();
-            if ( parentSpace != null ) {
-              parentSpace.setVariable( sArg1, sArg2 );
-            }
-          } else if ( "g".equals( sArg3 ) ) {
-            // Upto the grand parent
-            scm.setVariable( sArg1, sArg2 );
-
-            VariableSpace parentSpace = scm.getParentVariableSpace();
-            if ( parentSpace != null ) {
-              parentSpace.setVariable( sArg1, sArg2 );
-              VariableSpace grandParentSpace = parentSpace.getParentVariableSpace();
-              if ( grandParentSpace != null ) {
-                grandParentSpace.setVariable( sArg1, sArg2 );
-              }
-            }
-          } else {
-            throw Context.reportRuntimeError( "The argument type of function call "
-              + "setVariable should either be \"s\", \"r\", \"p\", or \"g\"." );
-          }
-        }
-        // Ignore else block for now... if we're executing via the Test Button
-
-      } catch ( Exception e ) {
-        throw Context.reportRuntimeError( e.toString() );
-      }
-    } else {
+    if ( arguments.length != 3 ) {
       throw Context.reportRuntimeError( "The function call setVariable requires 3 arguments." );
+    }
+
+      Object stepObject = Context.jsToJava( actualObject.get( "_step_", actualObject ), StepInterface.class );
+      if ( stepObject instanceof StepInterface ) {
+        StepInterface step = (StepInterface) stepObject;
+        Trans trans = step.getTrans();
+        final String variableName = Context.toString( arguments[ 0 ] );
+        final String variableValue = Context.toString( arguments[ 1 ] );
+        final VariableScope variableScope = getVariableScope( Context.toString( arguments[ 2 ] ) );
+
+        switch( variableScope ) {
+          case PARENT:
+            setParentScopeVariable( trans, variableName, variableValue );
+            break;
+          case GRAND_PARENT:
+            setGrandParentScopeVariable( trans, variableName, variableValue );
+            break;
+          case ROOT:
+            setRootScopeVariable( trans, variableName, variableValue );
+            break;
+          case SYSTEM:
+            setSystemScopeVariable( trans, variableName, variableValue );
+            break;
+        }
+      }
+  }
+
+  static void setRootScopeVariable( Trans trans, String variableName, String variableValue ) {
+    trans.setVariable( variableName, variableValue );
+
+    VariableSpace parentSpace = trans.getParentVariableSpace();
+    while ( parentSpace != null ) {
+      parentSpace.setVariable( variableName, variableValue );
+      parentSpace = parentSpace.getParentVariableSpace();
+    }
+  }
+
+  static void setSystemScopeVariable( Trans trans, final String variableName, final String variableValue ) {
+    System.setProperty( variableName, variableValue );
+
+    // Set also all the way to the root as else we will take
+    //  stale values
+    setRootScopeVariable( trans, variableName, variableValue );
+  }
+
+  static void setParentScopeVariable( Trans trans, String variableName, String variableValue ) {
+    trans.setVariable( variableName, variableValue );
+
+    VariableSpace parentSpace = trans.getParentVariableSpace();
+    if ( parentSpace != null ) {
+      parentSpace.setVariable( variableName, variableValue );
+    }
+  }
+
+   static void setGrandParentScopeVariable( Trans trans, String variableName, String variableValue ) {
+    trans.setVariable( variableName, variableValue );
+
+    VariableSpace parentSpace = trans.getParentVariableSpace();
+    if ( parentSpace != null ) {
+      parentSpace.setVariable( variableName, variableValue );
+      VariableSpace grandParentSpace = parentSpace.getParentVariableSpace();
+      if ( grandParentSpace != null ) {
+        grandParentSpace.setVariable( variableName, variableValue );
+      }
+    }
+  }
+
+
+  static VariableScope getVariableScope( String codeOfScope ) {
+    switch( codeOfScope ) {
+      case "s":
+        return VariableScope.SYSTEM;
+      case "r":
+        return VariableScope.ROOT;
+      case "p":
+        return VariableScope.PARENT;
+      case "g":
+        return VariableScope.GRAND_PARENT;
+      default:
+        throw Context.reportRuntimeError( "The argument type of function call "
+          + "setVariable should either be \"s\", \"r\", \"p\", or \"g\"." );
     }
   }
 
@@ -2580,7 +2605,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
         while ( ( ligne = br.readLine() ) != null ) {
           buffer.append( ligne );
         }
-        // if (processrun.exitValue()!=0) throw Context.reportRuntimeError("Error while running " + ArgList[0]);
+        // if (processrun.exitValue()!=0) throw Context.reportRuntimeError("Error while running " + arguments[0]);
 
         retval = buffer.toString();
 
@@ -2623,7 +2648,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
 
   public static Boolean isMailValid( Context actualContext, Scriptable actualObject, Object[] ArgList,
     Function FunctionContext ) {
-    Boolean retval = Boolean.FALSE;
+    Boolean isValid;
     if ( ArgList.length == 1 ) {
       try {
         if ( isUndefined( ArgList[0] ) ) {
@@ -2641,12 +2666,12 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
           return Boolean.FALSE;
         }
 
-        retval = Boolean.TRUE;
+        isValid = Boolean.TRUE;
 
       } catch ( Exception e ) {
         throw Context.reportRuntimeError( "Error in isMailValid function: " + e.getMessage() );
       }
-      return retval;
+      return isValid;
     } else {
       throw Context.reportRuntimeError( "The function call isMailValid is not valid" );
     }

--- a/engine/src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
+++ b/engine/src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1807,29 +1807,29 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
       throw Context.reportRuntimeError( "The function call setVariable requires 3 arguments." );
     }
 
-      Object stepObject = Context.jsToJava( actualObject.get( "_step_", actualObject ), StepInterface.class );
-      if ( stepObject instanceof StepInterface ) {
-        StepInterface step = (StepInterface) stepObject;
-        Trans trans = step.getTrans();
-        final String variableName = Context.toString( arguments[ 0 ] );
-        final String variableValue = Context.toString( arguments[ 1 ] );
-        final VariableScope variableScope = getVariableScope( Context.toString( arguments[ 2 ] ) );
+    Object stepObject = Context.jsToJava( actualObject.get( "_step_", actualObject ), StepInterface.class );
+    if ( stepObject instanceof StepInterface ) {
+      StepInterface step = (StepInterface) stepObject;
+      Trans trans = step.getTrans();
+      final String variableName = Context.toString( arguments[ 0 ] );
+      final String variableValue = Context.toString( arguments[ 1 ] );
+      final VariableScope variableScope = getVariableScope( Context.toString( arguments[ 2 ] ) );
 
-        switch( variableScope ) {
-          case PARENT:
-            setParentScopeVariable( trans, variableName, variableValue );
-            break;
-          case GRAND_PARENT:
-            setGrandParentScopeVariable( trans, variableName, variableValue );
-            break;
-          case ROOT:
-            setRootScopeVariable( trans, variableName, variableValue );
-            break;
-          case SYSTEM:
-            setSystemScopeVariable( trans, variableName, variableValue );
-            break;
-        }
+      switch ( variableScope ) {
+        case PARENT:
+          setParentScopeVariable( trans, variableName, variableValue );
+          break;
+        case GRAND_PARENT:
+          setGrandParentScopeVariable( trans, variableName, variableValue );
+          break;
+        case ROOT:
+          setRootScopeVariable( trans, variableName, variableValue );
+          break;
+        case SYSTEM:
+          setSystemScopeVariable( trans, variableName, variableValue );
+          break;
       }
+    }
   }
 
   static void setRootScopeVariable( Trans trans, String variableName, String variableValue ) {
@@ -1859,7 +1859,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
     }
   }
 
-   static void setGrandParentScopeVariable( Trans trans, String variableName, String variableValue ) {
+  static void setGrandParentScopeVariable( Trans trans, String variableName, String variableValue ) {
     trans.setVariable( variableName, variableValue );
 
     VariableSpace parentSpace = trans.getParentVariableSpace();
@@ -1874,7 +1874,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
 
 
   static VariableScope getVariableScope( String codeOfScope ) {
-    switch( codeOfScope ) {
+    switch ( codeOfScope ) {
       case "s":
         return VariableScope.SYSTEM;
       case "r":
@@ -1891,7 +1891,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
 
   // Returning EnvironmentVar
   public static String getVariable( Context actualContext, Scriptable actualObject, Object[] ArgList,
-    Function FunctionContext ) {
+                                    Function FunctionContext ) {
     String sRC = "";
     String sArg1 = "";
     String sArg2 = "";
@@ -1903,8 +1903,8 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
         if ( scmO instanceof StepInterface ) {
           StepInterface scm = (StepInterface) Context.jsToJava( scmO, StepInterface.class );
 
-          sArg1 = Context.toString( ArgList[0] );
-          sArg2 = Context.toString( ArgList[1] );
+          sArg1 = Context.toString( ArgList[ 0 ] );
+          sArg2 = Context.toString( ArgList[ 1 ] );
           return scm.getVariable( sArg1, sArg2 );
         } else {
           // running via the Test button in a dialog

--- a/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValueAddFunctions_GetVariableScopeTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValueAddFunctions_GetVariableScopeTest.java
@@ -1,0 +1,57 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.scriptvalues_mod;
+
+import org.junit.Test;
+import org.mozilla.javascript.EvaluatorException;
+
+import static junit.framework.Assert.assertEquals;
+
+public class ScriptValueAddFunctions_GetVariableScopeTest {
+
+  @Test
+  public void getSystemVariableScope() {
+    assertEquals( ScriptValuesAddedFunctions.getVariableScope( "s" ), ScriptValuesAddedFunctions.VariableScope.SYSTEM );
+  }
+
+  @Test
+  public void getRootVariableScope() {
+    assertEquals( ScriptValuesAddedFunctions.getVariableScope( "r" ), ScriptValuesAddedFunctions.VariableScope.ROOT );
+  }
+
+  @Test
+  public void getParentVariableScope() {
+    assertEquals( ScriptValuesAddedFunctions.getVariableScope( "p" ), ScriptValuesAddedFunctions.VariableScope.PARENT );
+  }
+
+  @Test
+  public void getGrandParentVariableScope() {
+    assertEquals( ScriptValuesAddedFunctions.getVariableScope( "g" ),
+      ScriptValuesAddedFunctions.VariableScope.GRAND_PARENT );
+  }
+
+  @Test( expected = EvaluatorException.class )
+  public void getNonExistingVariableScope() {
+    ScriptValuesAddedFunctions.getVariableScope( "dummy" );
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValueAddFunctions_SetVariableScopeTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValueAddFunctions_SetVariableScopeTest.java
@@ -1,0 +1,232 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.scriptvalues_mod;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.trans.Trans;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+public class ScriptValueAddFunctions_SetVariableScopeTest {
+  private static final String VARIABLE_NAME = "variable-name";
+  private static final String VARIABLE_VALUE = "variable-value";
+
+  @Test
+  public void setParentScopeVariable_ParentIsTrans() {
+    Trans parent = createTrans();
+    Trans child = createTrans( parent );
+
+    ScriptValuesAddedFunctions.setParentScopeVariable( child, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( child ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( parent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+  @Test
+  public void setParentScopeVariable_ParentIsJob() {
+    Job parent = createJob();
+    Trans child = createTrans( parent );
+
+    ScriptValuesAddedFunctions.setParentScopeVariable( child, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( child ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( parent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+  @Test
+  public void setParentScopeVariable_NoParent() {
+    Trans trans = createTrans( );
+
+    ScriptValuesAddedFunctions.setParentScopeVariable( trans, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( trans ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+
+  @Test
+  public void setGrandParentScopeVariable_TwoLevelHierarchy() {
+    Trans parent = createTrans( );
+    Trans child = createTrans( parent );
+
+    ScriptValuesAddedFunctions.setGrandParentScopeVariable( child, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( child ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( parent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+
+  @Test
+  public void setGrandParentScopeVariable_ThreeLevelHierarchy() {
+    Job grandParent = createJob();
+    Trans parent = createTrans( grandParent );
+    Trans child = createTrans( parent );
+
+    ScriptValuesAddedFunctions.setGrandParentScopeVariable( child, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( child ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( parent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( grandParent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+  @Test
+  public void setGrandParentScopeVariable_FourLevelHierarchy() {
+    Job grandGrandParent = createJob();
+    Trans grandParent = createTrans( grandGrandParent );
+    Trans parent = createTrans( grandParent );
+    Trans child = createTrans( parent );
+
+    ScriptValuesAddedFunctions.setGrandParentScopeVariable( child, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( child ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( parent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( grandParent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( grandGrandParent, never() ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+  @Test
+  public void setGrandParentScopeVariable_NoParent() {
+    Trans trans = createTrans( );
+
+    ScriptValuesAddedFunctions.setGrandParentScopeVariable( trans, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( trans ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+  @Test
+  public void setRootScopeVariable_TwoLevelHierarchy() {
+    Trans parent = createTrans( );
+    Trans child = createTrans( parent );
+
+    ScriptValuesAddedFunctions.setRootScopeVariable( child, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( child ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( parent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+  @Test
+  public void setRootScopeVariable_FourLevelHierarchy() {
+    Job grandGrandParent = createJob();
+    Trans grandParent = createTrans( grandGrandParent );
+    Trans parent = createTrans( grandParent );
+    Trans child = createTrans( parent );
+
+    ScriptValuesAddedFunctions.setRootScopeVariable( child, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( child ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( parent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( grandParent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    verify( grandGrandParent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+  @Test
+  public void setRootScopeVariable_NoParent() {
+    Trans trans = createTrans( );
+
+    ScriptValuesAddedFunctions.setRootScopeVariable( trans, VARIABLE_NAME, VARIABLE_VALUE );
+
+    verify( trans ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+  }
+
+
+  @Test
+  public void setSystemScopeVariable_NoParent() {
+    Trans trans = createTrans();
+
+    Assert.assertNull( System.getProperty( VARIABLE_NAME ) );
+
+    try {
+      ScriptValuesAddedFunctions.setSystemScopeVariable( trans, VARIABLE_NAME, VARIABLE_VALUE );
+
+      Assert.assertEquals( System.getProperty( VARIABLE_NAME ), VARIABLE_VALUE );
+      verify( trans ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    } finally {
+      System.clearProperty( VARIABLE_NAME );
+    }
+
+  }
+
+  @Test
+  public void setSystemScopeVariable_FourLevelHierarchy() {
+    Job grandGrandParent = createJob();
+    Trans grandParent = createTrans( grandGrandParent );
+    Trans parent = createTrans( grandParent );
+    Trans child = createTrans( parent );
+
+    Assert.assertNull( System.getProperty( VARIABLE_NAME ) );
+
+    try {
+      ScriptValuesAddedFunctions.setSystemScopeVariable( child, VARIABLE_NAME, VARIABLE_VALUE );
+
+      Assert.assertEquals( System.getProperty( VARIABLE_NAME ), VARIABLE_VALUE );
+
+      verify( child ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+      verify( parent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+      verify( grandParent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+      verify( grandGrandParent ).setVariable( eq( VARIABLE_NAME ), eq( VARIABLE_VALUE ) );
+    } finally {
+      System.clearProperty( VARIABLE_NAME );
+    }
+  }
+
+
+
+
+  private Trans createTrans( Trans parent ) {
+    Trans trans = createTrans();
+
+    trans.setParent( parent );
+    trans.setParentVariableSpace( parent );
+
+    return trans;
+  }
+
+
+  private Trans createTrans( Job parent ) {
+    Trans trans = createTrans();
+
+    trans.setParentJob( parent );
+    trans.setParentVariableSpace( parent );
+
+    return trans;
+  }
+
+  private Trans createTrans() {
+    Trans trans = new Trans();
+    trans.setLog( mock( LogChannelInterface.class ) );
+
+    trans = spy( trans );
+
+    return trans;
+  }
+
+  private Job createJob() {
+    Job job = new Job(  );
+    job = spy( job );
+
+    return job;
+  }
+}


### PR DESCRIPTION
- Refactoring (changing variable names, representing variable scopes as enums, separating logic of setting variable on different scope-levels in different methods)
- Starting to climb variable-space hierarchy from the step's transformation (not from the step itself, as the first call to step's parent will lead to the transformation itself, which is not the expected behavior)

It's a backport of https://github.com/pentaho/pentaho-kettle/pull/2524