### PR TITLE
[PDI-15118] User with no schedule permissions has access to schedule perspective

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Future;
 import javax.xml.ws.WebServiceException;
 
 import org.apache.commons.lang.BooleanUtils;
-import org.eclipse.swt.widgets.Display;
 import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleSecurityException;
@@ -149,19 +148,7 @@ public class PurRepositoryConnector implements IRepositoryConnector {
           if ( log.isBasic() ) {
             log.logBasic( BaseMessages.getString( PKG, "PurRepositoryConnector.CreateServiceProvider.End" ) ); //$NON-NLS-1$
           }
-          boolean canSchedule = allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),
-            IAbsSecurityProvider.SCHEDULE_CONTENT_ACTION );
-          Display.getDefault().asyncExec( new Runnable() {
-            public void run() {
-              final String schedulePerspectiveId = "schedulerPerspective";
-              SpoonPerspectiveManager perspectiveManager = SpoonPerspectiveManager.getInstance();
-              if ( canSchedule ) {
-                perspectiveManager.showPerspective( schedulePerspectiveId );
-              } else {
-                perspectiveManager.hidePerspective( schedulePerspectiveId );
-              }
-            }
-          } );
+
           // If the user does not have access to administer security we do not
           // need to added them to the service list
           if ( allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/EESpoonPlugin.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/EESpoonPlugin.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import org.pentaho.di.ui.spoon.ChangedWarningDialog;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.spoon.SpoonLifecycleListener;
 import org.pentaho.di.ui.spoon.SpoonPerspective;
+import org.pentaho.di.ui.spoon.SpoonPerspectiveManager;
 import org.pentaho.di.ui.spoon.SpoonPlugin;
 import org.pentaho.di.ui.spoon.SpoonPluginCategories;
 import org.pentaho.di.ui.spoon.SpoonPluginInterface;
@@ -148,10 +149,12 @@ public class EESpoonPlugin implements SpoonPluginInterface, SpoonLifecycleListen
     } catch ( KettleException e ) {
       try {
         getMainSpoonContainer();
-        XulMessageBox messageBox = (XulMessageBox) spoonXulContainer.getDocumentRoot().createElement( "messagebox" );//$NON-NLS-1$
-        messageBox.setTitle( BaseMessages.getString( PKG, "Dialog.Success" ) );//$NON-NLS-1$
-        messageBox.setAcceptLabel( BaseMessages.getString( PKG, "Dialog.Ok" ) );//$NON-NLS-1$
-        messageBox.setMessage( BaseMessages.getString( PKG, "AbsController.RoleActionPermission.Success" ) );//$NON-NLS-1$
+        XulMessageBox messageBox =
+          (XulMessageBox) spoonXulContainer.getDocumentRoot().createElement( "messagebox" ); //$NON-NLS-1$
+        messageBox.setTitle( BaseMessages.getString( PKG, "Dialog.Success" ) ); //$NON-NLS-1$
+        messageBox.setAcceptLabel( BaseMessages.getString( PKG, "Dialog.Ok" ) ); //$NON-NLS-1$
+        messageBox
+          .setMessage( BaseMessages.getString( PKG, "AbsController.RoleActionPermission.Success" ) ); //$NON-NLS-1$
         messageBox.open();
       } catch ( Exception ex ) {
         e.printStackTrace();
@@ -220,11 +223,14 @@ public class EESpoonPlugin implements SpoonPluginInterface, SpoonLifecycleListen
     boolean createPermitted = securityProvider.isAllowed( IAbsSecurityProvider.CREATE_CONTENT_ACTION );
     boolean executePermitted = securityProvider.isAllowed( IAbsSecurityProvider.EXECUTE_CONTENT_ACTION );
     boolean adminPermitted = securityProvider.isAllowed( IAbsSecurityProvider.ADMINISTER_SECURITY_ACTION );
-    enablePermission( createPermitted, executePermitted, adminPermitted );
+    boolean schedulePermitted = securityProvider.isAllowed( IAbsSecurityProvider.SCHEDULE_CONTENT_ACTION );
+
+    enablePermission( createPermitted, executePermitted, adminPermitted, schedulePermitted );
   }
 
-  private void enablePermission( boolean createPermitted, boolean executePermitted, boolean adminPermitted ) {
+  private void enablePermission( boolean createPermitted, boolean executePermitted, boolean adminPermitted, boolean schedulePermitted ) {
     updateMenuState( createPermitted, executePermitted );
+    updateSchedulePerspective( schedulePermitted );
     updateChangedWarningDialog( createPermitted );
   }
 
@@ -356,6 +362,17 @@ public class EESpoonPlugin implements SpoonPluginInterface, SpoonLifecycleListen
     }
   }
 
+  void updateSchedulePerspective( boolean schedulePermitted ) {
+    final String schedulePerspectiveId = "schedulerPerspective";
+    final SpoonPerspectiveManager perspectiveManager = getPerspectiveManager();
+
+    if ( schedulePermitted ) {
+      perspectiveManager.showPerspective( schedulePerspectiveId );
+    } else {
+      perspectiveManager.hidePerspective( schedulePerspectiveId );
+    }
+  }
+
   public static void updateChangedWarningDialog( boolean overrideDefaultDialogBehavior ) {
     if ( !overrideDefaultDialogBehavior ) {
       // Update the ChangedWarningDialog - Disable the yes button
@@ -472,5 +489,12 @@ public class EESpoonPlugin implements SpoonPluginInterface, SpoonLifecycleListen
         spoonXulContainer = Spoon.getInstance().getMainSpoonContainer();
       }
     }
+  }
+
+  /**
+   * For testing
+   */
+  SpoonPerspectiveManager getPerspectiveManager() {
+    return SpoonPerspectiveManager.getInstance();
   }
 }

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/ui/repository/EESpoonPluginTest.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/ui/repository/EESpoonPluginTest.java
@@ -1,0 +1,54 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.pentaho.di.ui.repository;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.ui.spoon.SpoonPerspectiveManager;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.anyBoolean;
+
+public class EESpoonPluginTest {
+  private static EESpoonPlugin eeSpoonPlugin;
+  private static SpoonPerspectiveManager perspectiveManager;
+
+  @Before
+  public void setUp() {
+    eeSpoonPlugin = mock( EESpoonPlugin.class );
+    doCallRealMethod().when( eeSpoonPlugin ).updateSchedulePerspective( anyBoolean() );
+
+    perspectiveManager = mock( SpoonPerspectiveManager.class );
+    doReturn( perspectiveManager ).when( eeSpoonPlugin ).getPerspectiveManager();
+  }
+
+  @Test
+  public void schedulePerspectiveIsShownWhenUserHasPermissionsForScheduling() {
+    eeSpoonPlugin.updateSchedulePerspective( true );
+    verify( perspectiveManager ).showPerspective( "schedulerPerspective" );
+  }
+
+  @Test
+  public void schedulePerspectiveIsHiddenWhenUserHasNoPermissionsForScheduling() {
+    eeSpoonPlugin.updateSchedulePerspective( false );
+    verify( perspectiveManager ).hidePerspective( "schedulerPerspective" );
+  }
+}
+


### PR DESCRIPTION
- Removing asynchronous call to UI components, when connecting to PurRepository.
- Moving the logic of schedule perspective updates to EESpoonPlugins (will be triggered on each repo-connect/disconnect event).
- Test written
- Checkstyle applied