### PR TITLE
[BACKLOG-8241] - Move the writing out of the Metadata-Injected KTR ...

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/metainject/MetaInject.java
+++ b/engine/src/org/pentaho/di/trans/steps/metainject/MetaInject.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *


### PR DESCRIPTION
…from before execution to after to allow for customizations to MDI to happen in a step's init() method. This allows for complex data structures to be handled in a manual fashion when traditional annotation-based MDI isn't sufficient.
