### PR TITLE
[SP-2676] Backport of PDI-15118 - User with no schedule permissions has access to schedule perspective (6.1 Suite)

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepositoryConnector.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Future;
 import javax.xml.ws.WebServiceException;
 
 import org.apache.commons.lang.BooleanUtils;
-import org.eclipse.swt.widgets.Display;
 import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleSecurityException;
@@ -44,7 +43,6 @@ import org.pentaho.di.ui.repository.pur.services.ILockService;
 import org.pentaho.di.ui.repository.pur.services.IRevisionService;
 import org.pentaho.di.ui.repository.pur.services.IRoleSupportSecurityManager;
 import org.pentaho.di.ui.repository.pur.services.ITrashService;
-import org.pentaho.di.ui.spoon.SpoonPerspectiveManager;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
@@ -149,19 +147,7 @@ public class PurRepositoryConnector implements IRepositoryConnector {
           if ( log.isBasic() ) {
             log.logBasic( BaseMessages.getString( PKG, "PurRepositoryConnector.CreateServiceProvider.End" ) ); //$NON-NLS-1$
           }
-          final boolean canSchedule = allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),
-            IAbsSecurityProvider.SCHEDULE_CONTENT_ACTION );
-          Display.getDefault().asyncExec( new Runnable() {
-            public void run() {
-              final String schedulePerspectiveId = "schedulerPerspective";
-              SpoonPerspectiveManager perspectiveManager = SpoonPerspectiveManager.getInstance();
-              if ( canSchedule ) {
-                perspectiveManager.showPerspective( schedulePerspectiveId );
-              } else {
-                perspectiveManager.hidePerspective( schedulePerspectiveId );
-              }
-            }
-          } );
+
           // If the user does not have access to administer security we do not
           // need to added them to the service list
           if ( allowedActionsContains( (AbsSecurityProvider) result.getSecurityProvider(),

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/EESpoonPlugin.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/EESpoonPlugin.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import org.pentaho.di.ui.spoon.ChangedWarningDialog;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.spoon.SpoonLifecycleListener;
 import org.pentaho.di.ui.spoon.SpoonPerspective;
+import org.pentaho.di.ui.spoon.SpoonPerspectiveManager;
 import org.pentaho.di.ui.spoon.SpoonPlugin;
 import org.pentaho.di.ui.spoon.SpoonPluginCategories;
 import org.pentaho.di.ui.spoon.SpoonPluginInterface;
@@ -148,10 +149,12 @@ public class EESpoonPlugin implements SpoonPluginInterface, SpoonLifecycleListen
     } catch ( KettleException e ) {
       try {
         getMainSpoonContainer();
-        XulMessageBox messageBox = (XulMessageBox) spoonXulContainer.getDocumentRoot().createElement( "messagebox" );//$NON-NLS-1$
-        messageBox.setTitle( BaseMessages.getString( PKG, "Dialog.Success" ) );//$NON-NLS-1$
-        messageBox.setAcceptLabel( BaseMessages.getString( PKG, "Dialog.Ok" ) );//$NON-NLS-1$
-        messageBox.setMessage( BaseMessages.getString( PKG, "AbsController.RoleActionPermission.Success" ) );//$NON-NLS-1$
+        XulMessageBox messageBox =
+          (XulMessageBox) spoonXulContainer.getDocumentRoot().createElement( "messagebox" ); //$NON-NLS-1$
+        messageBox.setTitle( BaseMessages.getString( PKG, "Dialog.Success" ) ); //$NON-NLS-1$
+        messageBox.setAcceptLabel( BaseMessages.getString( PKG, "Dialog.Ok" ) ); //$NON-NLS-1$
+        messageBox
+          .setMessage( BaseMessages.getString( PKG, "AbsController.RoleActionPermission.Success" ) ); //$NON-NLS-1$
         messageBox.open();
       } catch ( Exception ex ) {
         e.printStackTrace();
@@ -214,17 +217,21 @@ public class EESpoonPlugin implements SpoonPluginInterface, SpoonLifecycleListen
    */
   private void doOnSecurityCleanup() {
     updateMenuState( true, true );
+    updateSchedulePerspective( false );
   }
 
   private void enablePermission( IAbsSecurityProvider securityProvider ) throws KettleException {
     boolean createPermitted = securityProvider.isAllowed( IAbsSecurityProvider.CREATE_CONTENT_ACTION );
     boolean executePermitted = securityProvider.isAllowed( IAbsSecurityProvider.EXECUTE_CONTENT_ACTION );
     boolean adminPermitted = securityProvider.isAllowed( IAbsSecurityProvider.ADMINISTER_SECURITY_ACTION );
-    enablePermission( createPermitted, executePermitted, adminPermitted );
+    boolean schedulePermitted = securityProvider.isAllowed( IAbsSecurityProvider.SCHEDULE_CONTENT_ACTION );
+
+    enablePermission( createPermitted, executePermitted, adminPermitted, schedulePermitted );
   }
 
-  private void enablePermission( boolean createPermitted, boolean executePermitted, boolean adminPermitted ) {
+  private void enablePermission( boolean createPermitted, boolean executePermitted, boolean adminPermitted, boolean schedulePermitted ) {
     updateMenuState( createPermitted, executePermitted );
+    updateSchedulePerspective( schedulePermitted );
     updateChangedWarningDialog( createPermitted );
   }
 
@@ -299,7 +306,7 @@ public class EESpoonPlugin implements SpoonPluginInterface, SpoonLifecycleListen
    * @param executePermitted
    *          - if true, we enable menu-items requiring execute permissions
    */
-  private void updateMenuState( boolean createPermitted, boolean executePermitted ) {
+  void updateMenuState( boolean createPermitted, boolean executePermitted ) {
     Document doc = getDocumentRoot();
     if ( doc != null ) {
       // Main spoon menu
@@ -353,6 +360,17 @@ public class EESpoonPlugin implements SpoonPluginInterface, SpoonLifecycleListen
       if ( transCopyContextMenu != null ) {
         transCopyContextMenu.setDisabled( !exportAllowed );
       }
+    }
+  }
+
+  void updateSchedulePerspective( final boolean schedulePermitted ) {
+    final String schedulePerspectiveId = "schedulerPerspective";
+    final SpoonPerspectiveManager perspectiveManager = getPerspectiveManager();
+
+    if ( schedulePermitted ) {
+      perspectiveManager.showPerspective( schedulePerspectiveId );
+    } else {
+      perspectiveManager.hidePerspective( schedulePerspectiveId );
     }
   }
 
@@ -472,5 +490,12 @@ public class EESpoonPlugin implements SpoonPluginInterface, SpoonLifecycleListen
         spoonXulContainer = Spoon.getInstance().getMainSpoonContainer();
       }
     }
+  }
+
+  /**
+   * For testing
+   */
+  SpoonPerspectiveManager getPerspectiveManager() {
+    return SpoonPerspectiveManager.getInstance();
   }
 }

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/ui/repository/EESpoonPluginTest.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/ui/repository/EESpoonPluginTest.java
@@ -1,0 +1,60 @@
+/*!
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.pentaho.di.ui.repository;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.ui.spoon.SpoonLifecycleListener;
+import org.pentaho.di.ui.spoon.SpoonPerspectiveManager;
+
+import static org.mockito.Mockito.*;
+
+public class EESpoonPluginTest {
+  private static EESpoonPlugin eeSpoonPlugin;
+  private static SpoonPerspectiveManager perspectiveManager;
+
+  @Before
+  public void setUp() {
+    eeSpoonPlugin = mock( EESpoonPlugin.class );
+    doCallRealMethod().when( eeSpoonPlugin ).updateSchedulePerspective( anyBoolean() );
+
+    perspectiveManager = mock( SpoonPerspectiveManager.class );
+    doReturn( perspectiveManager ).when( eeSpoonPlugin ).getPerspectiveManager();
+  }
+
+  @Test
+  public void schedulePerspectiveIsShownWhenUserHasPermissionsForScheduling() {
+    eeSpoonPlugin.updateSchedulePerspective( true );
+    verify( perspectiveManager ).showPerspective( "schedulerPerspective" );
+  }
+
+  @Test
+  public void schedulePerspectiveIsHiddenWhenUserHasNoPermissionsForScheduling() {
+    eeSpoonPlugin.updateSchedulePerspective( false );
+    verify( perspectiveManager ).hidePerspective( "schedulerPerspective" );
+  }
+
+  @Test
+  public void schedulePerspectiveIsHiddenWhenUserDisconnectsFromRepository() {
+    doCallRealMethod().when( eeSpoonPlugin ).onEvent( SpoonLifecycleListener.SpoonLifeCycleEvent.REPOSITORY_DISCONNECTED );
+
+    eeSpoonPlugin.onEvent( SpoonLifecycleListener.SpoonLifeCycleEvent.REPOSITORY_DISCONNECTED );
+
+    verify( perspectiveManager ).hidePerspective( "schedulerPerspective" );
+  }
+}
+

--- a/ui/src/org/pentaho/di/ui/spoon/SpoonPerspectiveManager.java
+++ b/ui/src/org/pentaho/di/ui/spoon/SpoonPerspectiveManager.java
@@ -24,6 +24,7 @@ package org.pentaho.di.ui.spoon;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -171,9 +172,16 @@ public class SpoonPerspectiveManager {
 
     /**
      * Removes {@code perspectiveName} from {@code perspectivesCombo}
+     * if it exists in {@code perspectivesCombo}.
      */
     void removePerspective( final String perspectiveName ) {
-      perspectivesCombo.remove( perspectiveName );
+      if ( perspectiveExists( perspectiveName ) ) {
+        perspectivesCombo.remove( perspectiveName );
+      }
+    }
+
+    boolean perspectiveExists( String perspectiveName ) {
+      return Arrays.asList( perspectivesCombo.getItems() ).contains( perspectiveName );
     }
 
     /**

--- a/ui/test-src/org/pentaho/di/ui/spoon/SpoonPerspectiveManagerTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/SpoonPerspectiveManagerTest.java
@@ -87,6 +87,7 @@ public class SpoonPerspectiveManagerTest {
   @Test
   public void hidePerspective() {
     SpoonPerspectiveManager.PerspectiveManager perspectiveManager = perspectiveManagerMap.get( perspective );
+    doReturn( true ).when( perspectiveManager ).perspectiveExists( PERSPECTIVE_NAME );
     spoonPerspectiveManager.hidePerspective( perspective.getId() );
 
     verify( perspectiveManager ).removePerspective( PERSPECTIVE_NAME );


### PR DESCRIPTION
- Removing asynchronous call to UI components, when connecting to PurRepository.
- Moving the logic of schedule perspective updates to EESpoonPlugins (will be triggered on each repo-connect/disconnect event).
- Test written
- Checkstyle applied

There are two differs from fix in master:
1. Perspectives in 6.1 are build by "CCombo" class, that throws an error, when removing an element, that doesn't exist their. So, we check if an element exists before removing.
2. On master, after disconnecting the repo, Schedule perspective becomes disabled. To be consistent in behavior, I added this disabling in 6.1 too, by changing perspective visibility on "repository disconnect" event.