### PR TITLE
[BACKLOG-8520]  File index was off by one in prev commit.

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/joinrows/JoinRows.java
+++ b/engine/src/org/pentaho/di/trans/steps/joinrows/JoinRows.java
@@ -445,7 +445,7 @@ public class JoinRows extends BaseStep implements StepInterface {
 
     // Remove the temporary files...
     if ( data.file != null ) {
-      for ( int i = 0; i < data.file.length; i++ ) {
+      for ( int i = 1; i < data.file.length; i++ ) {
         data.file[i].delete();
       }
     }

--- a/engine/test-src/org/pentaho/di/trans/steps/joinrows/JoinRowsTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/joinrows/JoinRowsTest.java
@@ -69,7 +69,7 @@ public class JoinRowsTest {
   public void disposeDataFiles() throws Exception {
     File mockFile1 = Mockito.mock( File.class );
     File mockFile2 = Mockito.mock( File.class );
-    data.file = new File[]{ mockFile1, mockFile2 };
+    data.file = new File[]{ null, mockFile1, mockFile2 };
     getJoinRows().dispose( meta, data );
     verify( mockFile1, times( 1 ) ).delete();
     verify( mockFile2, times( 1 ) ).delete();


### PR DESCRIPTION
This resulted in an NPE during the dispose, leaving
files open and the step still running.
Indexing of temp files with this step begins with 1,
index 0 is used for RowMeta not stored to file.
(see .getRowData)