### PR TITLE
[SP-2716] Backport of PDI-5537 - "Memory Group By" changes data types of the summation fields (6.1 Suite)

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -751,6 +751,14 @@ public class Const {
     "KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL";
 
   /**
+   * System wide flag to control behavior of the Memory Group By step in case of SUM and AVERAGE aggregation. (PDI-5537)
+   * 'Y' preserves the old behavior and always returns a Number type for SUM and Average aggregations
+   * 'N' enables the documented behavior of returning the same type as the input fields use (correct behavior).
+   */
+  public static final String KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE =
+    "KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE";
+
+  /**
    * You can use this variable to speed up hostname lookup.
    * Hostname lookup is performed by Kettle so that it is capable of logging the server on which a job or transformation is executed.
    */

--- a/engine/src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupBy.java
+++ b/engine/src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupBy.java
@@ -66,6 +66,7 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
 
   private boolean allNullsAreZero = false;
   private boolean minNullIsValued = false;
+  private boolean compatibilityMode = false;
 
   public MemoryGroupBy( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
     Trans trans ) {
@@ -75,6 +76,7 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
     data = (MemoryGroupByData) stepDataInterface;
   }
 
+  @Override
   public boolean processRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
     meta = (MemoryGroupByMeta) smi;
     data = (MemoryGroupByData) sdi;
@@ -89,6 +91,8 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
       allNullsAreZero = ValueMetaBase.convertStringToBoolean( val );
       val = getVariable( Const.KETTLE_AGGREGATION_MIN_NULL_IS_VALUED, "N" );
       minNullIsValued = ValueMetaBase.convertStringToBoolean( val );
+      compatibilityMode = ValueMetaBase.convertStringToBoolean(
+        getVariable( Const.KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE, "N" ) );
 
       // What is the output looking like?
       //
@@ -305,7 +309,7 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
               aggregate.distinctObjs[i].add( obj );
             }
           }
-          aggregate.counts[i] = (long) aggregate.distinctObjs[i].size();
+          aggregate.counts[i] = aggregate.distinctObjs[i].size();
           break;
         case MemoryGroupByMeta.TYPE_GROUP_COUNT_ALL:
           if ( !subjMeta.isNull( subj ) ) {
@@ -407,8 +411,6 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
           vMeta = new ValueMetaNumber( meta.getAggregateField()[i] );
           v = new ArrayList<Double>();
           break;
-        case MemoryGroupByMeta.TYPE_GROUP_SUM:
-        case MemoryGroupByMeta.TYPE_GROUP_AVERAGE:
         case MemoryGroupByMeta.TYPE_GROUP_STANDARD_DEVIATION:
           vMeta = new ValueMetaNumber( meta.getAggregateField()[i] );
           break;
@@ -416,6 +418,11 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
         case MemoryGroupByMeta.TYPE_GROUP_COUNT_ANY:
         case MemoryGroupByMeta.TYPE_GROUP_COUNT_ALL:
           vMeta = new ValueMetaInteger( meta.getAggregateField()[i] );
+          break;
+        case MemoryGroupByMeta.TYPE_GROUP_SUM:
+        case MemoryGroupByMeta.TYPE_GROUP_AVERAGE:
+          vMeta = !compatibilityMode && subjMeta.isNumeric() ? subjMeta.clone() : new ValueMetaNumber();
+          vMeta.setName( meta.getAggregateField()[i] );
           break;
         case MemoryGroupByMeta.TYPE_GROUP_FIRST:
         case MemoryGroupByMeta.TYPE_GROUP_LAST:
@@ -535,13 +542,13 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
 
   }
 
+  @Override
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (MemoryGroupByMeta) smi;
     data = (MemoryGroupByData) sdi;
 
     if ( super.init( smi, sdi ) ) {
       data.map = new HashMap<HashEntry, Aggregate>( 5000 );
-
       return true;
     }
     return false;
@@ -553,6 +560,7 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
     ( (MemoryGroupByData) sdi ).clear();
   }
 
+  @Override
   public void batchComplete() throws KettleException {
     // Empty the hash table
     //

--- a/engine/src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,11 +29,14 @@ import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaFactory;
+import org.pentaho.di.core.row.value.ValueMetaNone;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -211,6 +214,7 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
     this.valueField = valueField;
   }
 
+  @Override
   public void loadXML( Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore ) throws KettleXMLException {
     readData( stepnode );
   }
@@ -223,6 +227,7 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
     valueField = new String[nrfields];
   }
 
+  @Override
   public Object clone() {
     MemoryGroupByMeta retval = (MemoryGroupByMeta) super.clone();
     int nrFields = aggregateField.length;
@@ -307,6 +312,7 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
     return typeGroupLongDesc[i];
   }
 
+  @Override
   public void setDefault() {
     int sizegroup = 0;
     int nrfields = 0;
@@ -314,8 +320,13 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
     allocate( sizegroup, nrfields );
   }
 
+  @Override
   public void getFields( RowMetaInterface r, String origin, RowMetaInterface[] info, StepMeta nextStep,
     VariableSpace space, Repository repository, IMetaStore metaStore ) {
+    // Check compatibility mode
+    boolean compatibilityMode = ValueMetaBase.convertStringToBoolean(
+      space.getVariable( Const.KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE, "N" ) );
+
     // re-assemble a new row of metadata
     //
     RowMetaInterface fields = new RowMeta();
@@ -359,6 +370,12 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
             break;
           case TYPE_GROUP_SUM:
           case TYPE_GROUP_AVERAGE:
+            if ( !compatibilityMode && subj.isNumeric() ) {
+              value_type = subj.getType();
+            } else {
+              value_type = ValueMetaInterface.TYPE_NUMBER;
+            }
+            break;
           case TYPE_GROUP_MEDIAN:
           case TYPE_GROUP_PERCENTILE:
           case TYPE_GROUP_STANDARD_DEVIATION:
@@ -386,7 +403,14 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
         }
 
         if ( value_type != ValueMetaInterface.TYPE_NONE ) {
-          ValueMetaInterface v = new ValueMeta( value_name, value_type );
+          ValueMetaInterface v;
+          try {
+            v = ValueMetaFactory.createValueMeta( value_name, value_type );
+          } catch ( KettlePluginException e ) {
+            log.logError(
+              BaseMessages.getString( PKG, "MemoryGroupByMeta.Exception.UnknownValueMetaType" ), value_type, e );
+            v = new ValueMetaNone( value_name );
+          }
           v.setOrigin( origin );
           v.setLength( length, precision );
           fields.addValueMeta( v );
@@ -400,6 +424,7 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
     r.addRowMeta( fields );
   }
 
+  @Override
   public String getXML() {
     StringBuffer retval = new StringBuffer( 500 );
 
@@ -427,6 +452,7 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
     return retval.toString();
   }
 
+  @Override
   public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases ) throws KettleException {
     try {
       int groupsize = rep.countNrStepAttributes( id_step, "group_name" );
@@ -458,6 +484,7 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
     }
   }
 
+  @Override
   public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
     try {
       rep.saveStepAttribute( id_transformation, id_step, "give_back_row", alwaysGivingBackOneRow );
@@ -479,6 +506,7 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
     }
   }
 
+  @Override
   public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta,
     RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
     Repository repository, IMetaStore metaStore ) {
@@ -497,11 +525,13 @@ public class MemoryGroupByMeta extends BaseStepMeta implements StepMetaInterface
     }
   }
 
+  @Override
   public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int cnr,
     TransMeta transMeta, Trans trans ) {
     return new MemoryGroupBy( stepMeta, stepDataInterface, cnr, transMeta, trans );
   }
 
+  @Override
   public StepDataInterface getStepData() {
     return new MemoryGroupByData();
   }

--- a/engine/src/org/pentaho/di/trans/steps/memgroupby/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/trans/steps/memgroupby/messages/messages_en_US.properties
@@ -3,7 +3,8 @@
 #
 #Mon Apr 15 21:46:35 CEST 2013
 MemoryGroupByDialog.LineNrField.Label=Line number field name
-MemoryGroupByMeta.TypeGroupLongDesc.CUMUMALTIVE_SUM=Cumulative sum (all rows option only\!) 
+MemoryGroupByMeta.TypeGroupLongDesc.CUMUMALTIVE_SUM=Cumulative sum (all rows option only\!)
+MemoryGroupByMeta.Exception.UnknownValueMetaType=Unable to create value meta for type {0}. {1}.
 MemoryGroupByMeta.Exception.UnableToLoadStepInfoFromXML=Unable to load step info from XML
 MemoryGroupByMeta.TypeGroupLongDesc.STANDARD_DEVIATION=Standard deviation
 MemoryGroupByDialog.GroupByWarningDialog.Option2=Please, don''t show this warning anymore.

--- a/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByAggregationTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByAggregationTest.java
@@ -22,6 +22,44 @@
 
 package org.pentaho.di.trans.steps.memgroupby;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepMeta;
+
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Optional;
@@ -34,37 +72,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.TreeBasedTable;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.pentaho.di.core.Const;
-import org.pentaho.di.core.RowMetaAndData;
-import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.row.RowMeta;
-import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaInteger;
-import org.pentaho.di.core.row.value.ValueMetaString;
-import org.pentaho.di.core.variables.Variables;
-import org.pentaho.di.trans.Trans;
-import org.pentaho.di.trans.TransMeta;
-import org.pentaho.di.trans.step.StepMeta;
-
-import java.util.List;
-import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith( org.mockito.runners.MockitoJUnitRunner.class )
 public class MemoryGroupByAggregationTest {
@@ -90,18 +97,88 @@ public class MemoryGroupByAggregationTest {
   private RowMeta rowMeta;
   private TreeBasedTable<Integer, Integer, Optional<Object>> data;
 
-  @Before public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUpBeforeClass() throws KettleException {
+    KettleClientEnvironment.init();
+  }
+
+  @Before
+  public void setUp() throws Exception {
     rowMeta = new RowMeta();
     data = TreeBasedTable.create();
     variables = new Variables();
     aggregates = Maps.newHashMap( default_aggregates );
   }
 
-  @Test public void testDefault() throws Exception {
+  @Test
+  public void testDefault() throws Exception {
     addColumn( new ValueMetaInteger( "intg" ), 0L, 1L, 1L, 10L );
     addColumn( new ValueMetaInteger( "nul" ) );
     addColumn( new ValueMetaInteger( "mix1" ), -1L, 2L );
     addColumn( new ValueMetaInteger( "mix2" ), null, 7L );
+    addColumn( new ValueMetaNumber( "mix3" ), -1.0, 2.5 );
+    addColumn( new ValueMetaDate( "date1" ), new Date( 1L ), new Date( 2L ) );
+
+    RowMetaAndData output = runStep();
+
+    assertThat( output.getInteger( "intg_min" ), is( 0L ) );
+    assertThat( output.getInteger( "intg_max" ), is( 10L ) );
+    assertThat( output.getInteger( "intg_sum" ), is( 12L ) );
+    assertThat( output.getInteger( "intg_ave" ), is( 3L ) );
+    assertThat( output.getInteger( "intg_count" ), is( 4L ) );
+    assertThat( output.getInteger( "intg_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "intg_count_distinct" ), is( 3L ) );
+
+    assertThat( output.getInteger( "nul_min" ), nullValue() );
+    assertThat( output.getInteger( "nul_max" ), nullValue() );
+    assertThat( output.getInteger( "nul_sum" ), nullValue() );
+    assertThat( output.getInteger( "nul_ave" ), nullValue() );
+    assertThat( output.getInteger( "nul_count" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "nul_count_distinct" ), is( 0L ) );
+
+    assertThat( output.getInteger( "mix1_max" ), is( 2L ) );
+    assertThat( output.getInteger( "mix1_min" ), is( -1L ) );
+    assertThat( output.getInteger( "mix1_sum" ), is( 1L ) );
+    assertThat( output.getInteger( "mix1_ave" ), is( 0L ) );
+    assertThat( output.getInteger( "mix1_count" ), is( 2L ) );
+    assertThat( output.getInteger( "mix1_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "mix1_count_distinct" ), is( 2L ) );
+
+    assertThat( output.getInteger( "mix2_max" ), is( 7L ) );
+    assertThat( output.getInteger( "mix2_min" ), is( 7L ) );
+    assertThat( output.getInteger( "mix2_sum" ), is( 7L ) );
+    assertThat( output.getNumber( "mix2_ave", Double.NaN ), is( 7.0 ) );
+    assertThat( output.getInteger( "mix2_count" ), is( 1L ) );
+    assertThat( output.getInteger( "mix2_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "mix2_count_distinct" ), is( 1L ) );
+
+    assertThat( output.getNumber( "mix3_max", Double.NaN ), is( 2.5 ) );
+    assertThat( output.getNumber( "mix3_min", Double.NaN ), is( -1.0 ) );
+    assertThat( output.getNumber( "mix3_sum", Double.NaN ), is( 1.5 ) );
+    assertThat( output.getNumber( "mix3_ave", Double.NaN ), is( 0.75 ) );
+    assertThat( output.getInteger( "mix3_count" ), is( 2L ) );
+    assertThat( output.getInteger( "mix3_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "mix3_count_distinct" ), is( 2L ) );
+
+    assertThat( output.getNumber( "date1_min", Double.NaN ), is( 1.0 ) );
+    assertThat( output.getNumber( "date1_max", Double.NaN ), is( 2.0 ) );
+    assertThat( output.getNumber( "date1_sum", Double.NaN ), is( 3.0 ) );
+    assertThat( output.getNumber( "date1_ave", Double.NaN ), is( 1.5 ) );
+    assertThat( output.getInteger( "date1_count" ), is( 2L ) );
+    assertThat( output.getInteger( "date1_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "date1_count_distinct" ), is( 2L ) );
+  }
+
+  @Test
+  public void testCompatibility() throws KettleException {
+    variables.setVariable( Const.KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE, "Y" );
+
+    addColumn( new ValueMetaInteger( "intg" ), 0L, 1L, 1L, 10L );
+    addColumn( new ValueMetaInteger( "nul" ) );
+    addColumn( new ValueMetaInteger( "mix1" ), -1L, 2L );
+    addColumn( new ValueMetaInteger( "mix2" ), null, 7L );
+    addColumn( new ValueMetaNumber( "mix3" ), -1.0, 2.5 );
 
     RowMetaAndData output = runStep();
 
@@ -136,9 +213,18 @@ public class MemoryGroupByAggregationTest {
     assertThat( output.getInteger( "mix2_count" ), is( 1L ) );
     assertThat( output.getInteger( "mix2_count_any" ), is( 4L ) );
     assertThat( output.getInteger( "mix2_count_distinct" ), is( 1L ) );
+
+    assertThat( output.getNumber( "mix3_max", Double.NaN ), is( 2.5 ) );
+    assertThat( output.getNumber( "mix3_min", Double.NaN ), is( -1.0 ) );
+    assertThat( output.getNumber( "mix3_sum", Double.NaN ), is( 1.5 ) );
+    assertThat( output.getNumber( "mix3_ave", Double.NaN ), is( 0.75 ) );
+    assertThat( output.getInteger( "mix3_count" ), is( 2L ) );
+    assertThat( output.getInteger( "mix3_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "mix3_count_distinct" ), is( 2L ) );
   }
 
-  @Test public void testNullMin() throws Exception {
+  @Test
+  public void testNullMin() throws Exception {
     variables.setVariable( Const.KETTLE_AGGREGATION_MIN_NULL_IS_VALUED, "Y" );
 
     addColumn( new ValueMetaInteger( "intg" ), null, 0L, 1L, -1L );
@@ -156,8 +242,9 @@ public class MemoryGroupByAggregationTest {
   }
 
   @Test
-  public void testNullsAreZero() throws Exception {
+  public void testNullsAreZeroCompatible() throws Exception {
     variables.setVariable( Const.KETTLE_AGGREGATION_ALL_NULLS_ARE_ZERO, "Y" );
+    variables.setVariable( Const.KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE, "Y" );
 
     addColumn( new ValueMetaInteger( "nul" ) );
     addColumn( new ValueMetaInteger( "both" ), -2L, 0L, null, 10L );
@@ -179,6 +266,41 @@ public class MemoryGroupByAggregationTest {
     assertThat( output.getInteger( "both_count" ), is( 3L ) );
     assertThat( output.getInteger( "both_count_any" ), is( 4L ) );
     assertThat( output.getInteger( "both_count_distinct" ), is( 3L ) );
+  }
+
+  @Test
+  public void testNullsAreZeroDefault() throws Exception {
+    variables.setVariable( Const.KETTLE_AGGREGATION_ALL_NULLS_ARE_ZERO, "Y" );
+
+    addColumn( new ValueMetaInteger( "nul" ) );
+    addColumn( new ValueMetaInteger( "both" ), -2L, 0L, null, 10L );
+    addColumn( new ValueMetaNumber( "both_num" ), -2.0, 0.0, null, 10.0 );
+
+    RowMetaAndData output = runStep();
+
+    assertThat( output.getInteger( "nul_min" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_max" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_sum" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_ave" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_count" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "nul_count_distinct" ), is( 0L ) );
+
+    assertThat( output.getInteger( "both_max" ), is( 10L ) );
+    assertThat( output.getInteger( "both_min" ), is( -2L ) );
+    assertThat( output.getInteger( "both_sum" ), is( 8L ) );
+    assertThat( output.getInteger( "both_ave" ), is( 2L ) );
+    assertThat( output.getInteger( "both_count" ), is( 3L ) );
+    assertThat( output.getInteger( "both_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "both_count_distinct" ), is( 3L ) );
+
+    assertThat( output.getNumber( "both_num_max", Double.NaN ), is( 10.0 ) );
+    assertThat( output.getNumber( "both_num_min", Double.NaN ), is( -2.0 ) );
+    assertThat( output.getNumber( "both_num_sum", Double.NaN ), is( 8.0 ) );
+    assertEquals( 2.666666, output.getNumber( "both_num_ave", Double.NaN ), 0.000001 /* delta */ );
+    assertThat( output.getInteger( "both_num_count" ), is( 3L ) );
+    assertThat( output.getInteger( "both_num_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "both_num_count_distinct" ), is( 3L ) );
   }
 
   @Test

--- a/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByMetaTest.java
@@ -1,0 +1,328 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.memgroupby;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBigNumber;
+import org.pentaho.di.core.row.value.ValueMetaBinary;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaInternetAddress;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.row.value.ValueMetaTimestamp;
+import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
+import org.pentaho.di.trans.steps.loadsave.initializer.InitializerInterface;
+import org.pentaho.di.trans.steps.loadsave.validator.ArrayLoadSaveValidator;
+import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+import org.pentaho.di.trans.steps.loadsave.validator.IntLoadSaveValidator;
+import org.pentaho.di.trans.steps.loadsave.validator.PrimitiveIntArrayLoadSaveValidator;
+import org.pentaho.di.trans.steps.loadsave.validator.StringLoadSaveValidator;
+
+public class MemoryGroupByMetaTest implements InitializerInterface<MemoryGroupByMeta> {
+  LoadSaveTester<MemoryGroupByMeta> loadSaveTester;
+  Class<MemoryGroupByMeta> testMetaClass = MemoryGroupByMeta.class;
+
+  @Before
+  public void setUpLoadSave() throws Exception {
+    KettleEnvironment.init();
+    PluginRegistry.init( true );
+    List<String> attributes =
+      Arrays.asList( "alwaysGivingBackOneRow", "groupField", "aggregateField", "subjectField", "aggregateType", "valueField" );
+
+    FieldLoadSaveValidator<String[]> stringArrayLoadSaveValidator =
+      new ArrayLoadSaveValidator<String>( new StringLoadSaveValidator(), 5 );
+
+    Map<String, FieldLoadSaveValidator<?>> attrValidatorMap = new HashMap<String, FieldLoadSaveValidator<?>>();
+    attrValidatorMap.put( "groupField", stringArrayLoadSaveValidator );
+    attrValidatorMap.put( "aggregateField", stringArrayLoadSaveValidator );
+    attrValidatorMap.put( "subjectField", stringArrayLoadSaveValidator );
+    attrValidatorMap.put( "valueField", stringArrayLoadSaveValidator );
+    attrValidatorMap.put( "aggregateType", new PrimitiveIntArrayLoadSaveValidator(
+      new IntLoadSaveValidator( MemoryGroupByMeta.typeGroupCode.length ), 5 ) );
+
+    Map<String, FieldLoadSaveValidator<?>> typeValidatorMap = new HashMap<String, FieldLoadSaveValidator<?>>();
+
+    loadSaveTester =
+      new LoadSaveTester<MemoryGroupByMeta>( testMetaClass, attributes, new ArrayList<String>(), new ArrayList<String>(),
+        new HashMap<String, String>(), new HashMap<String, String>(), attrValidatorMap, typeValidatorMap, this );
+  }
+
+  // Call the allocate method on the LoadSaveTester meta class
+  @Override
+  public void modify( MemoryGroupByMeta someMeta ) {
+    someMeta.allocate( 5, 5 );
+  }
+
+  @Test
+  public void testSerialization() throws KettleException {
+    loadSaveTester.testSerialization();
+  }
+
+  private RowMetaInterface getInputRowMeta() {
+    RowMetaInterface rm = new RowMeta();
+    rm.addValueMeta( new ValueMetaString( "myGroupField2" ) );
+    rm.addValueMeta( new ValueMetaString( "myGroupField1" ) );
+    rm.addValueMeta( new ValueMetaString( "myString" ) );
+    rm.addValueMeta( new ValueMetaInteger( "myInteger" ) );
+    rm.addValueMeta( new ValueMetaNumber( "myNumber" ) );
+    rm.addValueMeta( new ValueMetaBigNumber( "myBigNumber" ) );
+    rm.addValueMeta( new ValueMetaBinary( "myBinary" ) );
+    rm.addValueMeta( new ValueMetaBoolean( "myBoolean" ) );
+    rm.addValueMeta( new ValueMetaDate( "myDate" ) );
+    rm.addValueMeta( new ValueMetaTimestamp( "myTimestamp" ) );
+    rm.addValueMeta( new ValueMetaInternetAddress( "myInternetAddress" ) );
+    return rm;
+  }
+  @Test
+  public void testGetFields() {
+    final String stepName = "this step name";
+    MemoryGroupByMeta meta = new MemoryGroupByMeta();
+    meta.setDefault();
+    meta.allocate( 1, 17 );
+
+    // Declare input fields
+    RowMetaInterface rm = getInputRowMeta();
+
+    String[] groupFields = new String[2];
+    groupFields[0] = "myGroupField1";
+    groupFields[1] = "myGroupField2";
+
+    String[] aggregateFields = new String[24];
+    String[] subjectFields = new String[24];
+    int[] aggregateTypes = new int[24];
+    String[] valueFields = new String[24];
+
+    subjectFields[0] = "myString";
+    aggregateTypes[0] = MemoryGroupByMeta.TYPE_GROUP_CONCAT_COMMA;
+    aggregateFields[0] = "ConcatComma";
+    valueFields[0] = null;
+
+    subjectFields[1] = "myString";
+    aggregateTypes[1] = MemoryGroupByMeta.TYPE_GROUP_CONCAT_STRING;
+    aggregateFields[1] = "ConcatString";
+    valueFields[1] = "|";
+
+    subjectFields[2] = "myString";
+    aggregateTypes[2] = MemoryGroupByMeta.TYPE_GROUP_COUNT_ALL;
+    aggregateFields[2] = "CountAll";
+    valueFields[2] = null;
+
+    subjectFields[3] = "myString";
+    aggregateTypes[3] = MemoryGroupByMeta.TYPE_GROUP_COUNT_ANY;
+    aggregateFields[3] = "CountAny";
+    valueFields[3] = null;
+
+    subjectFields[4] = "myString";
+    aggregateTypes[4] = MemoryGroupByMeta.TYPE_GROUP_COUNT_DISTINCT;
+    aggregateFields[4] = "CountDistinct";
+    valueFields[4] = null;
+
+    subjectFields[5] = "myString";
+    aggregateTypes[5] = MemoryGroupByMeta.TYPE_GROUP_FIRST;
+    aggregateFields[5] = "First(String)";
+    valueFields[5] = null;
+
+    subjectFields[6] = "myInteger";
+    aggregateTypes[6] = MemoryGroupByMeta.TYPE_GROUP_FIRST;
+    aggregateFields[6] = "First(Integer)";
+    valueFields[6] = null;
+
+    subjectFields[7] = "myNumber";
+    aggregateTypes[7] = MemoryGroupByMeta.TYPE_GROUP_FIRST_INCL_NULL;
+    aggregateFields[7] = "FirstInclNull(Number)";
+    valueFields[7] = null;
+
+    subjectFields[8] = "myBigNumber";
+    aggregateTypes[8] = MemoryGroupByMeta.TYPE_GROUP_FIRST_INCL_NULL;
+    aggregateFields[8] = "FirstInclNull(BigNumber)";
+    valueFields[8] = null;
+
+    subjectFields[9] = "myBinary";
+    aggregateTypes[9] = MemoryGroupByMeta.TYPE_GROUP_LAST;
+    aggregateFields[9] = "Last(Binary)";
+    valueFields[9] = null;
+
+    subjectFields[10] = "myBoolean";
+    aggregateTypes[10] = MemoryGroupByMeta.TYPE_GROUP_LAST;
+    aggregateFields[10] = "Last(Boolean)";
+    valueFields[10] = null;
+
+    subjectFields[11] = "myDate";
+    aggregateTypes[11] = MemoryGroupByMeta.TYPE_GROUP_LAST_INCL_NULL;
+    aggregateFields[11] = "LastInclNull(Date)";
+    valueFields[11] = null;
+
+    subjectFields[12] = "myTimestamp";
+    aggregateTypes[12] = MemoryGroupByMeta.TYPE_GROUP_LAST_INCL_NULL;
+    aggregateFields[12] = "LastInclNull(Timestamp)";
+    valueFields[12] = null;
+
+    subjectFields[13] = "myInternetAddress";
+    aggregateTypes[13] = MemoryGroupByMeta.TYPE_GROUP_MAX;
+    aggregateFields[13] = "Max(InternetAddress)";
+    valueFields[13] = null;
+
+    subjectFields[14] = "myString";
+    aggregateTypes[14] = MemoryGroupByMeta.TYPE_GROUP_MAX;
+    aggregateFields[14] = "Max(String)";
+    valueFields[14] = null;
+
+    subjectFields[15] = "myInteger";
+    aggregateTypes[15] = MemoryGroupByMeta.TYPE_GROUP_MEDIAN; // Always returns Number
+    aggregateFields[15] = "Median(Integer)";
+    valueFields[15] = null;
+
+    subjectFields[16] = "myNumber";
+    aggregateTypes[16] = MemoryGroupByMeta.TYPE_GROUP_MIN;
+    aggregateFields[16] = "Min(Number)";
+    valueFields[16] = null;
+
+    subjectFields[17] = "myBigNumber";
+    aggregateTypes[17] = MemoryGroupByMeta.TYPE_GROUP_MIN;
+    aggregateFields[17] = "Min(BigNumber)";
+    valueFields[17] = null;
+
+    subjectFields[18] = "myBinary";
+    aggregateTypes[18] = MemoryGroupByMeta.TYPE_GROUP_PERCENTILE;
+    aggregateFields[18] = "Percentile(Binary)";
+    valueFields[18] = "0.5";
+
+    subjectFields[19] = "myBoolean";
+    aggregateTypes[19] = MemoryGroupByMeta.TYPE_GROUP_STANDARD_DEVIATION;
+    aggregateFields[19] = "StandardDeviation(Boolean)";
+    valueFields[19] = null;
+
+    subjectFields[20] = "myDate";
+    aggregateTypes[20] = MemoryGroupByMeta.TYPE_GROUP_SUM;
+    aggregateFields[20] = "Sum(Date)";
+    valueFields[20] = null;
+
+    subjectFields[21] = "myInteger";
+    aggregateTypes[21] = MemoryGroupByMeta.TYPE_GROUP_SUM;
+    aggregateFields[21] = "Sum(Integer)";
+    valueFields[21] = null;
+
+    subjectFields[22] = "myInteger";
+    aggregateTypes[22] = MemoryGroupByMeta.TYPE_GROUP_AVERAGE;
+    aggregateFields[22] = "Average(Integer)";
+    valueFields[22] = null;
+
+    subjectFields[23] = "myDate";
+    aggregateTypes[23] = MemoryGroupByMeta.TYPE_GROUP_AVERAGE;
+    aggregateFields[23] = "Average(Date)";
+    valueFields[23] = null;
+
+    meta.setGroupField( groupFields );
+    meta.setSubjectField( subjectFields );
+    meta.setAggregateType( aggregateTypes );
+    meta.setAggregateField( aggregateFields );
+    meta.setValueField( valueFields );
+
+    Variables vars = new Variables();
+    meta.getFields( rm, stepName, null, null, vars, null, null );
+    assertNotNull( rm );
+    assertEquals( 26, rm.size() );
+    assertTrue( rm.indexOfValue( "myGroupField1" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "myGroupField1" ) ).getType() );
+    assertTrue( rm.indexOfValue( "myGroupField2" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "myGroupField2" ) ).getType() );
+    assertTrue( rm.indexOfValue( "myGroupField2" ) > rm.indexOfValue( "myGroupField1" ) );
+    assertTrue( rm.indexOfValue( "ConcatComma" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "ConcatComma" ) ).getType() );
+    assertTrue( rm.indexOfValue( "ConcatString" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "ConcatString" ) ).getType() );
+    assertTrue( rm.indexOfValue( "CountAll" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "CountAll" ) ).getType() );
+    assertTrue( rm.indexOfValue( "CountAny" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "CountAny" ) ).getType() );
+    assertTrue( rm.indexOfValue( "CountDistinct" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "CountDistinct" ) ).getType() );
+    assertTrue( rm.indexOfValue( "First(String)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "First(String)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "First(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "First(Integer)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "FirstInclNull(Number)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "FirstInclNull(Number)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "FirstInclNull(BigNumber)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, rm.getValueMeta( rm.indexOfValue( "FirstInclNull(BigNumber)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Last(Binary)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_BINARY, rm.getValueMeta( rm.indexOfValue( "Last(Binary)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Last(Boolean)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, rm.getValueMeta( rm.indexOfValue( "Last(Boolean)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "LastInclNull(Date)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_DATE, rm.getValueMeta( rm.indexOfValue( "LastInclNull(Date)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "LastInclNull(Timestamp)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_TIMESTAMP, rm.getValueMeta( rm.indexOfValue( "LastInclNull(Timestamp)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Max(InternetAddress)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INET, rm.getValueMeta( rm.indexOfValue( "Max(InternetAddress)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Max(String)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "Max(String)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Median(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Median(Integer)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Min(Number)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Min(Number)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Min(BigNumber)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, rm.getValueMeta( rm.indexOfValue( "Min(BigNumber)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Percentile(Binary)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Percentile(Binary)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "StandardDeviation(Boolean)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "StandardDeviation(Boolean)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Sum(Date)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Sum(Date)" ) ).getType() ); // Force changed to Numeric
+    assertTrue( rm.indexOfValue( "Sum(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "Sum(Integer)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Average(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "Average(Integer)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Average(Date)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Average(Date)" ) ).getType() );
+
+    // Test Compatibility
+    rm = getInputRowMeta();
+    vars.setVariable( Const.KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE, "Y" );
+    meta.getFields( rm, stepName, null, null, vars, null, null );
+    assertNotNull( rm );
+    assertEquals( 26, rm.size() );
+    assertTrue( rm.indexOfValue( "Average(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Average(Integer)" ) ).getType() );
+  }
+}


### PR DESCRIPTION
- SUM and Average should return the same type as they are aggregating, instead of always Numeric (w/ decimal) values.
- Checkstyle applied

It's a backport of https://github.com/pentaho/pentaho-kettle/pull/2248