### PR TITLE
[SP-2721] Backport of PDI-15152 - Google Analytics Input Step does not accept empty filter as a variable (6.1 Suite)

### DIFF
--- a/plugins/googleanalytics/src/org/pentaho/di/trans/steps/googleanalytics/GaInputStep.java
+++ b/plugins/googleanalytics/src/org/pentaho/di/trans/steps/googleanalytics/GaInputStep.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -183,7 +183,7 @@ public class GaInputStep extends BaseStep implements StepInterface {
         }
       }
 
-      if ( !Const.isEmpty( meta.getFilters() ) ) {
+      if ( !Const.isEmpty( meta.getFilters() ) && !Const.isEmpty( environmentSubstitute( meta.getFilters() ) ) ) {
         query.setFilters( environmentSubstitute( meta.getFilters() ) );
       }
       if ( !Const.isEmpty( meta.getSort() ) ) {


### PR DESCRIPTION
Check if the variable-substituted filter is not empty before trying to set a filter.

Backport of https://github.com/pentaho/pentaho-kettle/pull/2390