### PR TITLE
[PDI-14948] Transformation with Metadata Injection runs endlessly if no input is received by Injection Step

### DIFF
--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -1442,6 +1442,10 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
 
     heartbeat = startHeartbeat( getHeartbeatIntervalInSeconds() );
 
+    if ( steps.isEmpty() ) {
+      fireTransFinishedListeners();
+    }
+
     if ( log.isDetailed() ) {
       log.logDetailed( BaseMessages.getString( PKG, "Trans.Log.TransformationHasAllocated", String.valueOf( steps
           .size() ), String.valueOf( rowsets.size() ) ) );

--- a/engine/test-src/org/pentaho/di/trans/TransTest.java
+++ b/engine/test-src/org/pentaho/di/trans/TransTest.java
@@ -26,11 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -87,6 +83,23 @@ public class TransTest {
     trans.setLog( Mockito.mock( LogChannelInterface.class ) );
     trans.prepareExecution( null );
     trans.startThreads();
+  }
+
+  /**
+   * PDI-14948 - Execution of trans with no steps never ends
+   */
+  @Test( timeout = 1000 )
+  public void transWithNoStepsIsNotEndless() throws Exception {
+    Trans transWithNoSteps = new Trans( new TransMeta() );
+    transWithNoSteps = spy( transWithNoSteps );
+
+    transWithNoSteps.prepareExecution( new String[] {} );
+
+    transWithNoSteps.startThreads();
+
+    // check trans lifecycle is not corrupted
+    verify( transWithNoSteps ).fireTransStartedListeners();
+    verify( transWithNoSteps ).fireTransFinishedListeners();
   }
 
   @Test


### PR DESCRIPTION
- When starting threads, check if transformation has any step to run, and finish it, if it has no steps.
- Test written
- Checkstyle applied