### PR TITLE
[PDI-6748] - Mondrian Input Step: pan.sh / kitchen.sh ignore mondrian…

### DIFF
--- a/assembly/package-res/classes/mondrian.properties
+++ b/assembly/package-res/classes/mondrian.properties
@@ -1,4 +1,4 @@
-s# This software is subject to the terms of the Eclipse Public License v1.0
+# This software is subject to the terms of the Eclipse Public License v1.0
 # Agreement, available at the following URL:
 # http://www.eclipse.org/legal/epl-v10.html.
 # You must accept the terms of that agreement to use this software.
@@ -41,19 +41,7 @@ s# This software is subject to the terms of the Eclipse Public License v1.0
 # * ERROR:  throw an instance of
 # NativeEvaluationUnsupportedException
 #
-mondrian.native.unsupported.alert=WARN
-
-###############################################################################
-# Positive integer property that determines how many rows are read from sql executions between checks for whether the current mdx query has been cancelled.
-# Setting the interval too small may result in a performance hit when reading large result sets;
-# setting it too high can cause a big delay between the query being marked as cancelled and system resources associated to it being released.
-#
-#mondrian.rolap.cancelPhaseInterval=10000
-
-# Detect the number of cursor's iterations between checking if the a current state of execution is "Cancel"
-# or timeout limitation was exceeded.
-#
-mondrian.util.checkCancelOrTimeoutInterval=100000
+#mondrian.native.unsupported.alert=OFF
 
 ###############################################################################
 # Boolean property that controls whether the MDX parser resolves uses
@@ -73,6 +61,13 @@ mondrian.util.checkCancelOrTimeoutInterval=100000
 # number of cells that are batched together when building segments.
 #
 #mondrian.rolap.cellBatchSize=-1
+
+###############################################################################
+# Positive integer property that determines loop iterations number between checks for whether the current mdx query has been cancelled or timeout was exceeded.
+# Setting the interval too small may result in a performance degradation when reading large result sets;
+# setting it too high can cause a big delay between the query being marked as cancelled or timeout was exceeded and system resources associated to it being released.
+#
+#mondrian.util.checkCancelOrTimeoutInterval=1000
 
 ###############################################################################
 # Boolean property that controls whether aggregate tables
@@ -336,18 +331,10 @@ mondrian.util.checkCancelOrTimeoutInterval=100000
 # mondrian.foodmart.jdbcURL.oracle=jdbc:oracle:thin:@//host:port/service_name
 # mondrian.foodmart.jdbcURL=jdbc:oracle:thin:foodmart/foodmart@//stilton:1521/orcl
 # mondrian.foodmart.jdbcURL=jdbc:oracle:oci8:foodmart/foodmart@orcl
-   #mondrian.foodmart.jdbcURL=jdbc:oracle:thin:@10.177.176.208:1521:XE
-#mondrian.foodmart.jdbcURL=jdbc:oracle:thin:foodmart/foodmart@//10.177.176.208:1521:XE/foodmart
 # mondrian.foodmart.jdbcUser=FOODMART
-   #mondrian.foodmart.jdbcUser=foodmart
 # mondrian.foodmart.jdbcPassword=oracle
-   #mondrian.foodmart.jdbcPassword=foodmart
 # mondrian.jdbcDrivers=oracle.jdbc.OracleDriver
-   #mondrian.jdbcDrivers=oracle.jdbc.OracleDriver
 # driver.classpath=/home/jhyde/open/mondrian/lib/ojdbc14.jar
-#driver.classpath=d:/soft/libs/drivers/oracle/ojdbc14.jar
-   #driver.classpath=d:/soft/libs/drivers/oracle/ojdbc14.jar
-   #driver.classpath=d:/soft/libs/drivers/oracle/ojdbc14.jar
 #
 # ### ODBC (Microsoft Access) ###
 #
@@ -363,14 +350,12 @@ mondrian.util.checkCancelOrTimeoutInterval=100000
 #
 # ###  MySQL: can have user and password set in JDBC URL ###
 #
-    mondrian.foodmart.jdbcURL=jdbc:mysql://localhost/foodmart_mysql?user=root&password=root
- #mondrian.foodmart.jdbcURL=jdbc:mysql://10.177.176.207/foodmart?user=foodmart&password=foodmart
- #mondrian.foodmart.jdbcURL=jdbc:mysql://localhost/foodmart
- #mondrian.foodmart.jdbcUser=root
- #mondrian.foodmart.jdbcPassword=root
-    mondrian.jdbcDrivers=com.mysql.jdbc.Driver
- #driver.classpath=D:/mysql-connector-3.1.12
-    driver.classpath=d:/soft/libs/drivers/mysql-connector-java-5.0.8/mysql-connector-java-5.0.8-bin.jar
+# mondrian.foodmart.jdbcURL=jdbc:mysql://localhost/foodmart?user=foodmart&password=foodmart
+# mondrian.foodmart.jdbcURL=jdbc:mysql://localhost/foodmart
+# mondrian.foodmart.jdbcUser=foodmart
+# mondrian.foodmart.jdbcPassword=foodmart
+# mondrian.jdbcDrivers=com.mysql.jdbc.Driver
+# driver.classpath=D:/mysql-connector-3.1.12
 #
 # ###  NuoDB ###
 #
@@ -392,10 +377,10 @@ mondrian.util.checkCancelOrTimeoutInterval=100000
 #
 # ### Postgres: needs user and password ###
 #
- #mondrian.foodmart.jdbcURL=jdbc:postgresql://localhost/FM3
- #mondrian.foodmart.jdbcUser=postgres
- #mondrian.foodmart.jdbcPassword=pgAdmin
- #mondrian.jdbcDrivers=org.postgresql.Driver
+# mondrian.foodmart.jdbcURL=jdbc:postgresql://localhost/FM3
+# mondrian.foodmart.jdbcUser=postgres
+# mondrian.foodmart.jdbcPassword=pgAdmin
+# mondrian.jdbcDrivers=org.postgresql.Driver
 #
 # ### Neoview ###
 #
@@ -548,6 +533,21 @@ mondrian.util.checkCancelOrTimeoutInterval=100000
 #mondrian.rolap.aggregates.jdbcFactoryClass=
 
 ###############################################################################
+# Property which governs whether child members or members of a level are precached
+#                 when child or level members are requested within a
+#                 query expression.  For example,
+#                 if an expression references two child members in the store dimension,
+#                 like { [Store].[USA].[CA], [Store].[USA].[OR] }, precaching will
+#                 load *all* children under [USA] rather than just the 2 requested.
+#                 The threshold value is
+#                 compared against the cardinality of the level to determine
+#                 whether or not precaching should be performed.  If cardinality is
+#                 lower than the threshold value Mondrian will precache.  Setting
+#                 this property to 0 effectively disables precaching.
+#
+#mondrian.rolap.precache.threshold=300
+
+###############################################################################
 # String property that holds the
 # name of the class whose resource bundle is to be used to for this
 # schema. For example, if the class is com.acme.MyResource,
@@ -570,7 +570,7 @@ mondrian.util.checkCancelOrTimeoutInterval=100000
 # Examples:
 #
 #
- log4j.configuration=file://full/path/log4j.xml
+# log4j.configuration=file://full/path/log4j.xml
 # log4j.configuration=file:log4j.properties
 #
 #log4j.configuration=
@@ -588,7 +588,7 @@ mondrian.util.checkCancelOrTimeoutInterval=100000
 # * DB2: 2,500
 # * Other: 10,000
 #
-#mondrian.rolap.maxConstraints=10281
+#mondrian.rolap.maxConstraints=1000
 
 ###############################################################################
 # Boolean property that defines the maximum number of passes
@@ -767,7 +767,7 @@ mondrian.util.checkCancelOrTimeoutInterval=100000
 # Property that defines the timeout value (in seconds) for queries. A
 # value of 0 (the default) indicates no timeout.
 #
-mondrian.rolap.queryTimeout=10
+#mondrian.rolap.queryTimeout=0
 
 ###############################################################################
 # Boolean property that determines whether Mondrian should read


### PR DESCRIPTION
….properties.

- was added actual mondrian.properties according to mondrian.properties.template under mondrian project.

@pamval, here is the PR that adjusts mondrian.properties to mondrian.properties.template under mondrian project. The file that was commited here: https://github.com/pentaho/pentaho-kettle/pull/2647/files was my own version for developing and testing mondrian itself. Thanks.