### PR TITLE
[BACKLOG-8389] - Upgrade antlr to version 3.5.2 across Pentaho product suite - changes for Kettle Engine repository

### DIFF
--- a/engine/ivy.xml
+++ b/engine/ivy.xml
@@ -29,9 +29,8 @@
     <!--  Pentaho reporting dependencies -->
     <dependency org="${dependency.reporting-engine.group}" name="pentaho-reporting-engine-classic-core" rev="${dependency.pentaho-reporting.revision}" changing="true" transitive="true"/>
 
-
     <!-- Third-party (external) dependencies -->
-    <dependency org="org.antlr"                        name="antlr"                rev="3.4-complete"    transitive="false"/>    
+    <dependency org="org.antlr"                        name="antlr-complete"       rev="3.5.2"           transitive="false"/>
     <dependency org="commons-validator"                name="commons-validator"    rev="1.3.1"           transitive="false"/>
     <dependency org="com.enterprisedt"                 name="edtftpj"              rev="2.1.0"           transitive="false"/>
     <dependency org="com.googlecode.jsendnsca"         name="jsendnsca"            rev="2.0.1"           transitive="false"/>


### PR DESCRIPTION
Replace antrl-3.4-complete with antlr-complete-3.5.2.

To build pentaho-kettle  it previously needs to build:

 - pentaho-reporting (pentaho-reporting-engine-classic-core) as it was changed to use antlr-complete-3.5.2 (pentaho/pentaho-reporting#792);