### PR TITLE
[PDI-15120] Export Linked Resources to XML fails if Text File Input contains empty row

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputMeta.java
@@ -34,6 +34,7 @@ import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.fileinput.FileInputList;
@@ -1247,8 +1248,13 @@ public class TextFileInputMeta extends
         // Replace the filename ONLY (folder or filename)
         //
         for ( int i = 0; i < inputFiles.fileName.length; i++ ) {
-          FileObject fileObject =
-              KettleVFS.getFileObject( space.environmentSubstitute( inputFiles.fileName[i] ), space );
+          final String fileName = inputFiles.fileName[ i ];
+          if ( fileName == null || fileName.isEmpty() ) {
+            continue;
+          }
+
+          FileObject fileObject = getFileObject( space.environmentSubstitute( fileName ), space );
+
           inputFiles.fileName[i] =
               resourceNamingInterface.nameResource( fileObject, space, Const.isEmpty( inputFiles.fileMask[i] ) );
         }
@@ -1330,5 +1336,12 @@ public class TextFileInputMeta extends
     return FileInputList.createFileList(
         space, inputFiles.fileName, inputFiles.fileMask, inputFiles.excludeFileMask,
         inputFiles.fileRequired, includeSubFolderBoolean() );
+  }
+
+  /**
+   * For testing
+   */
+  FileObject getFileObject( String vfsFileName, VariableSpace variableSpace ) throws KettleFileException {
+    return KettleVFS.getFileObject( variableSpace.environmentSubstitute( vfsFileName ), variableSpace );
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/fileinput/text/TextFileInputMetaTest.java
@@ -1,0 +1,75 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.fileinput.text;
+
+import org.apache.commons.vfs2.FileObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.util.StringUtil;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.resource.ResourceNamingInterface;
+import org.pentaho.di.trans.steps.fileinput.BaseFileInputStepMeta;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+
+public class TextFileInputMetaTest {
+  private static final String FILE_NAME_NULL = null;
+  private static final String FILE_NAME_EMPTY = StringUtil.EMPTY_STRING;
+  private static final String FILE_NAME_VALID_PATH = "path/to/file";
+
+  private TextFileInputMeta inputMeta;
+  private VariableSpace variableSpace;
+
+  @Before
+  public void setUp() throws Exception {
+    inputMeta = new TextFileInputMeta();
+    inputMeta = spy( inputMeta );
+    variableSpace = mock( VariableSpace.class );
+
+    doReturn( "<def>" ).when( variableSpace ).environmentSubstitute( anyString() );
+    doReturn( FILE_NAME_VALID_PATH ).when( variableSpace ).environmentSubstitute( FILE_NAME_VALID_PATH );
+    FileObject mockedFileObject = mock( FileObject.class );
+    doReturn( mockedFileObject ).when( inputMeta ).getFileObject( anyString(), eq( variableSpace ) );
+  }
+
+  @Test
+  public void whenExportingResourcesWeGetFileObjectsOnlyFromFilesWithNotNullAndNotEmptyFileNames() throws Exception {
+    inputMeta.inputFiles = new BaseFileInputStepMeta.InputFiles<>();
+    inputMeta.inputFiles.fileName = new String[] { FILE_NAME_NULL, FILE_NAME_EMPTY, FILE_NAME_VALID_PATH };
+    inputMeta.inputFiles.fileMask =
+      new String[] { StringUtil.EMPTY_STRING, StringUtil.EMPTY_STRING, StringUtil.EMPTY_STRING };
+
+    inputMeta.exportResources( variableSpace, null, mock( ResourceNamingInterface.class ), null, null );
+
+    verify( inputMeta ).getFileObject( FILE_NAME_VALID_PATH, variableSpace );
+    verify( inputMeta, never() ).getFileObject( FILE_NAME_NULL, variableSpace );
+    verify( inputMeta, never() ).getFileObject( FILE_NAME_EMPTY, variableSpace );
+  }
+
+}


### PR DESCRIPTION
- Adding null-checks before obtaining File Object from filename, that can be null.

**Summary**

After this fix behavior is the following:
- When exporting trans with empty filenames, they are kept empty and not converted to related path

**More details**

Situation is the following here:
In transformation's xml fileNames with empty strings are stored as <fileName/> and extracted as nulls when transformation is loaded.
First I wanted to store and load them as empty strings. But it was a bad idea - it leads us to some problems that are hard to overcome with such storing. Here the pitfall of this approach: when exporting trans with empty (non-null) strings in file name - they are converted into related path (root of kettle in this case). And in 99 % cases it's not what user expects.

So what we want here is exporting empty strings as they are, without converting them to related path.
We should also do this with empty strings for keeping consistency. Try running trans with textFileInput step with empty file name. It won't be treated as related path. But when exporting if with empty string it becomes related, that is not expected.