### PR TITLE
[SP-2717] Backport of PDI-5537 - "Memory Group By" changes data types  of the summation fields (5.4 Suite)

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -736,6 +736,14 @@ public class Const {
     "KETTLE_COMPATIBILITY_TEXT_FILE_OUTPUT_APPEND_NO_HEADER";
 
   /**
+   * System wide flag to control behavior of the Memory Group By step in case of SUM and AVERAGE aggregation. (PDI-5537)
+   * 'Y' preserves the old behavior and always returns a Number type for SUM and Average aggregations
+   * 'N' enables the documented behavior of returning the same type as the input fields use (correct behavior).
+   */
+  public static final String KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE =
+    "KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE";
+
+  /**
    * You can use this variable to speed up hostname lookup.
    * Hostname lookup is performed by Kettle so that it is capable of logging the server on which a job or transformation is executed.
    */

--- a/engine/src/org/pentaho/di/trans/steps/memgroupby/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/trans/steps/memgroupby/messages/messages_en_US.properties
@@ -3,7 +3,8 @@
 #
 #Mon Apr 15 21:46:35 CEST 2013
 MemoryGroupByDialog.LineNrField.Label=Line number field name
-MemoryGroupByMeta.TypeGroupLongDesc.CUMUMALTIVE_SUM=Cumulative sum (all rows option only\!) 
+MemoryGroupByMeta.TypeGroupLongDesc.CUMUMALTIVE_SUM=Cumulative sum (all rows option only\!)
+MemoryGroupByMeta.Exception.UnknownValueMetaType=Unable to create value meta for type {0}. {1}.
 MemoryGroupByMeta.Exception.UnableToLoadStepInfoFromXML=Unable to load step info from XML
 MemoryGroupByMeta.TypeGroupLongDesc.STANDARD_DEVIATION=Standard deviation
 MemoryGroupByDialog.GroupByWarningDialog.Option2=Please, don''t show this warning anymore.

--- a/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByAggregationTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByAggregationTest.java
@@ -1,0 +1,267 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.memgroupby;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepMeta;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Optional;
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.TreeBasedTable;
+
+/**
+ * @author nhudak
+ */
+
+@RunWith( org.mockito.runners.MockitoJUnitRunner.class )
+public class MemoryGroupByAggregationTest {
+
+  private Variables variables;
+  private Map<String, Integer> aggregates;
+
+  public static final String STEP_NAME = "testStep";
+  private static final ImmutableMap<String, Integer> default_aggregates;
+
+  static {
+    default_aggregates = ImmutableMap.<String, Integer>builder()
+      .put( "min", MemoryGroupByMeta.TYPE_GROUP_MIN )
+      .put( "max", MemoryGroupByMeta.TYPE_GROUP_MAX )
+      .put( "sum", MemoryGroupByMeta.TYPE_GROUP_SUM )
+      .put( "ave", MemoryGroupByMeta.TYPE_GROUP_AVERAGE )
+      .put( "count", MemoryGroupByMeta.TYPE_GROUP_COUNT_ALL )
+      .put( "count_any", MemoryGroupByMeta.TYPE_GROUP_COUNT_ANY )
+      .put( "count_distinct", MemoryGroupByMeta.TYPE_GROUP_COUNT_DISTINCT )
+      .build();
+  }
+
+  private RowMeta rowMeta;
+  private TreeBasedTable<Integer, Integer, Optional<Object>> data;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws KettleException {
+    KettleClientEnvironment.init();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    rowMeta = new RowMeta();
+    data = TreeBasedTable.create();
+    variables = new Variables();
+    aggregates = Maps.newHashMap( default_aggregates );
+  }
+
+  @Test
+  public void testNullMin() throws Exception {
+    variables.setVariable( Const.KETTLE_AGGREGATION_MIN_NULL_IS_VALUED, "Y" );
+
+    addColumn( new ValueMetaInteger( "intg" ), null, 0L, 1L, -1L );
+    addColumn( new ValueMetaString( "str" ), "A", null, "B", null );
+
+    aggregates = Maps.toMap( ImmutableList.of( "min", "max" ), Functions.forMap( default_aggregates ) );
+
+    RowMetaAndData output = runStep();
+
+    assertThat( output.getInteger( "intg_min" ), nullValue() );
+    assertThat( output.getInteger( "intg_max" ), is( 1L ) );
+
+    assertThat( output.getString( "str_min", null ), nullValue() );
+    assertThat( output.getString( "str_max", "invalid" ), is( "B" ) );
+  }
+
+  @Test
+  public void avgOfIntegersIsRoundedToIntegerWhenValueMetaIsIntegerAndCompatibilityVariableIsOff() throws Exception {
+    variables.setVariable( Const.KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE, "N" );
+    addColumn( new ValueMetaInteger( "integers" ), 2L, 3L );
+
+    RowMetaAndData output = runStep();
+    Assert.assertEquals( output.getNumber( "integers_ave", -1.0 ), 2.0 );
+  }
+
+  @Test
+  public void avgOfIntegersIsNumberValueWhenValueMetaIsIntegerAndCompatibilityVariableIsOn() throws Exception {
+    variables.setVariable( Const.KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE, "Y" );
+    addColumn( new ValueMetaInteger( "integers" ), 2L, 3L );
+
+    RowMetaAndData output = runStep();
+    Assert.assertEquals( output.getNumber( "integers_ave", -1.0 ), 2.5 );
+  }
+
+  @Test
+  public void testNullsAreZeroDefault() throws Exception {
+    variables.setVariable( Const.KETTLE_AGGREGATION_ALL_NULLS_ARE_ZERO, "Y" );
+
+    addColumn( new ValueMetaInteger( "nul" ) );
+    addColumn( new ValueMetaInteger( "both" ), -2L, 0L, null, 10L );
+    addColumn( new ValueMetaNumber( "both_num" ), -2.0, 0.0, null, 10.0 );
+
+    RowMetaAndData output = runStep();
+
+    assertThat( output.getInteger( "nul_min" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_max" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_sum" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_ave" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_count" ), is( 0L ) );
+    assertThat( output.getInteger( "nul_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "nul_count_distinct" ), is( 0L ) );
+
+    assertThat( output.getInteger( "both_max" ), is( 10L ) );
+    assertThat( output.getInteger( "both_min" ), is( -2L ) );
+    assertThat( output.getInteger( "both_sum" ), is( 8L ) );
+    assertThat( output.getInteger( "both_ave" ), is( 2L ) );
+    assertThat( output.getInteger( "both_count" ), is( 3L ) );
+    assertThat( output.getInteger( "both_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "both_count_distinct" ), is( 3L ) );
+
+    assertThat( output.getNumber( "both_num_max", Double.NaN ), is( 10.0 ) );
+    assertThat( output.getNumber( "both_num_min", Double.NaN ), is( -2.0 ) );
+    assertThat( output.getNumber( "both_num_sum", Double.NaN ), is( 8.0 ) );
+    assertEquals( 2.666666, output.getNumber( "both_num_ave", Double.NaN ), 0.000001 /* delta */ );
+    assertThat( output.getInteger( "both_num_count" ), is( 3L ) );
+    assertThat( output.getInteger( "both_num_count_any" ), is( 4L ) );
+    assertThat( output.getInteger( "both_num_count_distinct" ), is( 3L ) );
+  }
+
+  private RowMetaAndData runStep() throws KettleException {
+    // Allocate meta
+    List<String> aggKeys = ImmutableList.copyOf( aggregates.keySet() );
+    MemoryGroupByMeta meta = new MemoryGroupByMeta();
+    meta.allocate( 0, rowMeta.size() * aggKeys.size() );
+    for ( int i = 0; i < rowMeta.size(); i++ ) {
+      String name = rowMeta.getValueMeta( i ).getName();
+      for ( int j = 0; j < aggKeys.size(); j++ ) {
+        String aggKey = aggKeys.get( j );
+        int index = i * aggKeys.size() + j;
+
+        meta.getAggregateField()[index] = name + "_" + aggKey;
+        meta.getSubjectField()[index] = name;
+        meta.getAggregateType()[index] = aggregates.get( aggKey );
+      }
+    }
+
+    MemoryGroupByData data = new MemoryGroupByData();
+    data.map = Maps.newHashMap();
+
+    // Add to trans
+    TransMeta transMeta = mock( TransMeta.class );
+    StepMeta stepMeta = new StepMeta( STEP_NAME, meta );
+    when( transMeta.findStep( STEP_NAME ) ).thenReturn( stepMeta );
+
+    // Spy on step, regrettable but we need to easily inject rows
+    MemoryGroupBy step = spy( new MemoryGroupBy( stepMeta, data, 0, transMeta, mock( Trans.class ) ) );
+    step.copyVariablesFrom( variables );
+    doNothing().when( step ).putRow( (RowMetaInterface) any(), (Object[]) any() );
+    doNothing().when( step ).setOutputDone();
+
+    // Process rows
+    doReturn( rowMeta ).when( step ).getInputRowMeta();
+    for ( Object[] row : getRows() ) {
+      doReturn( row ).when( step ).getRow();
+      assertThat( step.processRow( meta, data ), is( true ) );
+    }
+    verify( step, never() ).putRow( (RowMetaInterface) any(), (Object[]) any() );
+
+    // Mark stop
+    doReturn( null ).when( step ).getRow();
+    assertThat( step.processRow( meta, data ), is( false ) );
+    verify( step ).setOutputDone();
+
+    // Collect output
+    ArgumentCaptor<RowMetaInterface> rowMetaCaptor = ArgumentCaptor.forClass( RowMetaInterface.class );
+    ArgumentCaptor<Object[]> rowCaptor = ArgumentCaptor.forClass( Object[].class );
+    verify( step ).putRow( rowMetaCaptor.capture(), rowCaptor.capture() );
+
+    return new RowMetaAndData( rowMetaCaptor.getValue(), rowCaptor.getValue() );
+  }
+
+  private void addColumn( ValueMetaInterface meta, Object... values ) {
+    int column = rowMeta.size();
+
+    rowMeta.addValueMeta( meta );
+    for ( int row = 0; row < values.length; row++ ) {
+      data.put( row, column, Optional.fromNullable( values[row] ) );
+    }
+  }
+
+  private Iterable<Object[]> getRows() {
+    if ( data.isEmpty() ) {
+      return ImmutableSet.of();
+    }
+
+    Range<Integer> rows = Range.closed( 0, data.rowMap().lastKey() );
+
+    return FluentIterable.from( ContiguousSet.create( rows, DiscreteDomain.integers() ) )
+      .transform( Functions.forMap( data.rowMap(), ImmutableMap.<Integer, Optional<Object>>of() ) )
+      .transform( new Function<Map<Integer, Optional<Object>>, Object[]>() {
+        @Override public Object[] apply( Map<Integer, Optional<Object>> input ) {
+          Object[] row = new Object[rowMeta.size()];
+          for ( Map.Entry<Integer, Optional<Object>> entry : input.entrySet() ) {
+            row[entry.getKey()] = entry.getValue().orNull();
+          }
+          return row;
+        }
+      } );
+  }
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByMetaTest.java
@@ -1,0 +1,281 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.memgroupby;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBigNumber;
+import org.pentaho.di.core.row.value.ValueMetaBinary;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaInternetAddress;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.row.value.ValueMetaTimestamp;
+import org.pentaho.di.core.variables.Variables;
+
+public class MemoryGroupByMetaTest  {
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  private RowMetaInterface getInputRowMeta() {
+    RowMetaInterface rm = new RowMeta();
+    rm.addValueMeta( new ValueMetaString( "myGroupField2" ) );
+    rm.addValueMeta( new ValueMetaString( "myGroupField1" ) );
+    rm.addValueMeta( new ValueMetaString( "myString" ) );
+    rm.addValueMeta( new ValueMetaInteger( "myInteger" ) );
+    rm.addValueMeta( new ValueMetaNumber( "myNumber" ) );
+    rm.addValueMeta( new ValueMetaBigNumber( "myBigNumber" ) );
+    rm.addValueMeta( new ValueMetaBinary( "myBinary" ) );
+    rm.addValueMeta( new ValueMetaBoolean( "myBoolean" ) );
+    rm.addValueMeta( new ValueMetaDate( "myDate" ) );
+    rm.addValueMeta( new ValueMetaTimestamp( "myTimestamp" ) );
+    rm.addValueMeta( new ValueMetaInternetAddress( "myInternetAddress" ) );
+    return rm;
+  }
+
+  @Test
+  public void testGetFields() {
+    final String stepName = "this step name";
+    MemoryGroupByMeta meta = new MemoryGroupByMeta();
+    meta.setDefault();
+    meta.allocate( 1, 17 );
+
+    // Declare input fields
+    RowMetaInterface rm = getInputRowMeta();
+
+    String[] groupFields = new String[2];
+    groupFields[0] = "myGroupField1";
+    groupFields[1] = "myGroupField2";
+
+    String[] aggregateFields = new String[24];
+    String[] subjectFields = new String[24];
+    int[] aggregateTypes = new int[24];
+    String[] valueFields = new String[24];
+
+    subjectFields[0] = "myString";
+    aggregateTypes[0] = MemoryGroupByMeta.TYPE_GROUP_CONCAT_COMMA;
+    aggregateFields[0] = "ConcatComma";
+    valueFields[0] = null;
+
+    subjectFields[1] = "myString";
+    aggregateTypes[1] = MemoryGroupByMeta.TYPE_GROUP_CONCAT_STRING;
+    aggregateFields[1] = "ConcatString";
+    valueFields[1] = "|";
+
+    subjectFields[2] = "myString";
+    aggregateTypes[2] = MemoryGroupByMeta.TYPE_GROUP_COUNT_ALL;
+    aggregateFields[2] = "CountAll";
+    valueFields[2] = null;
+
+    subjectFields[3] = "myString";
+    aggregateTypes[3] = MemoryGroupByMeta.TYPE_GROUP_COUNT_ANY;
+    aggregateFields[3] = "CountAny";
+    valueFields[3] = null;
+
+    subjectFields[4] = "myString";
+    aggregateTypes[4] = MemoryGroupByMeta.TYPE_GROUP_COUNT_DISTINCT;
+    aggregateFields[4] = "CountDistinct";
+    valueFields[4] = null;
+
+    subjectFields[5] = "myString";
+    aggregateTypes[5] = MemoryGroupByMeta.TYPE_GROUP_FIRST;
+    aggregateFields[5] = "First(String)";
+    valueFields[5] = null;
+
+    subjectFields[6] = "myInteger";
+    aggregateTypes[6] = MemoryGroupByMeta.TYPE_GROUP_FIRST;
+    aggregateFields[6] = "First(Integer)";
+    valueFields[6] = null;
+
+    subjectFields[7] = "myNumber";
+    aggregateTypes[7] = MemoryGroupByMeta.TYPE_GROUP_FIRST_INCL_NULL;
+    aggregateFields[7] = "FirstInclNull(Number)";
+    valueFields[7] = null;
+
+    subjectFields[8] = "myBigNumber";
+    aggregateTypes[8] = MemoryGroupByMeta.TYPE_GROUP_FIRST_INCL_NULL;
+    aggregateFields[8] = "FirstInclNull(BigNumber)";
+    valueFields[8] = null;
+
+    subjectFields[9] = "myBinary";
+    aggregateTypes[9] = MemoryGroupByMeta.TYPE_GROUP_LAST;
+    aggregateFields[9] = "Last(Binary)";
+    valueFields[9] = null;
+
+    subjectFields[10] = "myBoolean";
+    aggregateTypes[10] = MemoryGroupByMeta.TYPE_GROUP_LAST;
+    aggregateFields[10] = "Last(Boolean)";
+    valueFields[10] = null;
+
+    subjectFields[11] = "myDate";
+    aggregateTypes[11] = MemoryGroupByMeta.TYPE_GROUP_LAST_INCL_NULL;
+    aggregateFields[11] = "LastInclNull(Date)";
+    valueFields[11] = null;
+
+    subjectFields[12] = "myTimestamp";
+    aggregateTypes[12] = MemoryGroupByMeta.TYPE_GROUP_LAST_INCL_NULL;
+    aggregateFields[12] = "LastInclNull(Timestamp)";
+    valueFields[12] = null;
+
+    subjectFields[13] = "myInternetAddress";
+    aggregateTypes[13] = MemoryGroupByMeta.TYPE_GROUP_MAX;
+    aggregateFields[13] = "Max(InternetAddress)";
+    valueFields[13] = null;
+
+    subjectFields[14] = "myString";
+    aggregateTypes[14] = MemoryGroupByMeta.TYPE_GROUP_MAX;
+    aggregateFields[14] = "Max(String)";
+    valueFields[14] = null;
+
+    subjectFields[15] = "myInteger";
+    aggregateTypes[15] = MemoryGroupByMeta.TYPE_GROUP_MEDIAN; // Always returns Number
+    aggregateFields[15] = "Median(Integer)";
+    valueFields[15] = null;
+
+    subjectFields[16] = "myNumber";
+    aggregateTypes[16] = MemoryGroupByMeta.TYPE_GROUP_MIN;
+    aggregateFields[16] = "Min(Number)";
+    valueFields[16] = null;
+
+    subjectFields[17] = "myBigNumber";
+    aggregateTypes[17] = MemoryGroupByMeta.TYPE_GROUP_MIN;
+    aggregateFields[17] = "Min(BigNumber)";
+    valueFields[17] = null;
+
+    subjectFields[18] = "myBinary";
+    aggregateTypes[18] = MemoryGroupByMeta.TYPE_GROUP_PERCENTILE;
+    aggregateFields[18] = "Percentile(Binary)";
+    valueFields[18] = "0.5";
+
+    subjectFields[19] = "myBoolean";
+    aggregateTypes[19] = MemoryGroupByMeta.TYPE_GROUP_STANDARD_DEVIATION;
+    aggregateFields[19] = "StandardDeviation(Boolean)";
+    valueFields[19] = null;
+
+    subjectFields[20] = "myDate";
+    aggregateTypes[20] = MemoryGroupByMeta.TYPE_GROUP_SUM;
+    aggregateFields[20] = "Sum(Date)";
+    valueFields[20] = null;
+
+    subjectFields[21] = "myInteger";
+    aggregateTypes[21] = MemoryGroupByMeta.TYPE_GROUP_SUM;
+    aggregateFields[21] = "Sum(Integer)";
+    valueFields[21] = null;
+
+    subjectFields[22] = "myInteger";
+    aggregateTypes[22] = MemoryGroupByMeta.TYPE_GROUP_AVERAGE;
+    aggregateFields[22] = "Average(Integer)";
+    valueFields[22] = null;
+
+    subjectFields[23] = "myDate";
+    aggregateTypes[23] = MemoryGroupByMeta.TYPE_GROUP_AVERAGE;
+    aggregateFields[23] = "Average(Date)";
+    valueFields[23] = null;
+
+    meta.setGroupField( groupFields );
+    meta.setSubjectField( subjectFields );
+    meta.setAggregateType( aggregateTypes );
+    meta.setAggregateField( aggregateFields );
+    meta.setValueField( valueFields );
+
+    Variables vars = new Variables();
+    meta.getFields( rm, stepName, null, null, vars, null, null );
+    assertNotNull( rm );
+    assertEquals( 26, rm.size() );
+    assertTrue( rm.indexOfValue( "myGroupField1" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "myGroupField1" ) ).getType() );
+    assertTrue( rm.indexOfValue( "myGroupField2" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "myGroupField2" ) ).getType() );
+    assertTrue( rm.indexOfValue( "myGroupField2" ) > rm.indexOfValue( "myGroupField1" ) );
+    assertTrue( rm.indexOfValue( "ConcatComma" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "ConcatComma" ) ).getType() );
+    assertTrue( rm.indexOfValue( "ConcatString" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "ConcatString" ) ).getType() );
+    assertTrue( rm.indexOfValue( "CountAll" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "CountAll" ) ).getType() );
+    assertTrue( rm.indexOfValue( "CountAny" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "CountAny" ) ).getType() );
+    assertTrue( rm.indexOfValue( "CountDistinct" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "CountDistinct" ) ).getType() );
+    assertTrue( rm.indexOfValue( "First(String)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "First(String)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "First(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "First(Integer)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "FirstInclNull(Number)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "FirstInclNull(Number)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "FirstInclNull(BigNumber)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, rm.getValueMeta( rm.indexOfValue( "FirstInclNull(BigNumber)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Last(Binary)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_BINARY, rm.getValueMeta( rm.indexOfValue( "Last(Binary)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Last(Boolean)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, rm.getValueMeta( rm.indexOfValue( "Last(Boolean)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "LastInclNull(Date)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_DATE, rm.getValueMeta( rm.indexOfValue( "LastInclNull(Date)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "LastInclNull(Timestamp)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_TIMESTAMP, rm.getValueMeta( rm.indexOfValue( "LastInclNull(Timestamp)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Max(InternetAddress)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INET, rm.getValueMeta( rm.indexOfValue( "Max(InternetAddress)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Max(String)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_STRING, rm.getValueMeta( rm.indexOfValue( "Max(String)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Median(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Median(Integer)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Min(Number)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Min(Number)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Min(BigNumber)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, rm.getValueMeta( rm.indexOfValue( "Min(BigNumber)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Percentile(Binary)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Percentile(Binary)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "StandardDeviation(Boolean)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "StandardDeviation(Boolean)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Sum(Date)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Sum(Date)" ) ).getType() ); // Force changed to Numeric
+    assertTrue( rm.indexOfValue( "Sum(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "Sum(Integer)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Average(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, rm.getValueMeta( rm.indexOfValue( "Average(Integer)" ) ).getType() );
+    assertTrue( rm.indexOfValue( "Average(Date)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Average(Date)" ) ).getType() );
+
+    // Test Compatibility
+    rm = getInputRowMeta();
+    vars.setVariable( Const.KETTLE_COMPATIBILITY_MEMORY_GROUP_BY_SUM_AVERAGE_RETURN_NUMBER_TYPE, "Y" );
+    meta.getFields( rm, stepName, null, null, vars, null, null );
+    assertNotNull( rm );
+    assertEquals( 26, rm.size() );
+    assertTrue( rm.indexOfValue( "Average(Integer)" ) >= 0 );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, rm.getValueMeta( rm.indexOfValue( "Average(Integer)" ) ).getType() );
+  }
+}


### PR DESCRIPTION
SUM and Average should return the same type as they are aggregating, instead of always Numeric (w/ decimal) values.