### PR TITLE
[SP-2754] Backport of PDI-14948 - Transformation with Metadata Injection runs endlessly if no input is received by Injection Step (6.1 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1434,6 +1434,10 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.TransformationStart.id, this );
 
     heartbeat = startHeartbeat( getHeartbeatIntervalInSeconds() );
+
+    if ( steps.isEmpty() ) {
+      fireTransFinishedListeners();
+    }
 
     if ( log.isDetailed() ) {
       log.logDetailed( BaseMessages.getString( PKG, "Trans.Log.TransformationHasAllocated", String.valueOf( steps

--- a/engine/test-src/org/pentaho/di/trans/TransTest.java
+++ b/engine/test-src/org/pentaho/di/trans/TransTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -82,6 +82,23 @@ public class TransTest {
     trans.setLog( Mockito.mock( LogChannelInterface.class ) );
     trans.prepareExecution( null );
     trans.startThreads();
+  }
+
+  /**
+   * PDI-14948 - Execution of trans with no steps never ends
+   */
+  @Test( timeout = 1000 )
+  public void transWithNoStepsIsNotEndless() throws Exception {
+    Trans transWithNoSteps = new Trans( new TransMeta() );
+    transWithNoSteps = spy( transWithNoSteps );
+
+    transWithNoSteps.prepareExecution( new String[] {} );
+
+    transWithNoSteps.startThreads();
+
+    // check trans lifecycle is not corrupted
+    verify( transWithNoSteps ).fireTransStartedListeners();
+    verify( transWithNoSteps ).fireTransFinishedListeners();
   }
 
   @Test


### PR DESCRIPTION
- When starting threads, check if transformation has any step to run, and finish it, if it has no steps.
- Test written
- Checkstyle applied

Backport of https://github.com/pentaho/pentaho-kettle/pull/2660