### PR TITLE
[TEST] Ignoring some old concurrent tests as they are running with different results on different JDK build versions.

### DIFF
--- a/engine/test-src/org/pentaho/di/concurrency/JobTrackerConcurrencyTest.java
+++ b/engine/test-src/org/pentaho/di/concurrency/JobTrackerConcurrencyTest.java
@@ -24,6 +24,7 @@ package org.pentaho.di.concurrency;
 
 import org.apache.commons.collections.ListUtils;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -55,6 +56,7 @@ import static org.mockito.Mockito.when;
  * @author Andrey Khayrutdinov
  */
 @RunWith( Parameterized.class )
+@Ignore
 public class JobTrackerConcurrencyTest {
 
   private static final int gettersAmount = 10;

--- a/engine/test-src/org/pentaho/di/concurrency/PluginRegistryConcurrencyTest.java
+++ b/engine/test-src/org/pentaho/di/concurrency/PluginRegistryConcurrencyTest.java
@@ -25,6 +25,7 @@ package org.pentaho.di.concurrency;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -49,6 +50,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Andrey Khayrutdinov
  */
+@Ignore
 public class PluginRegistryConcurrencyTest {
 
   private static final Class<? extends PluginTypeInterface> type1 = TwoWayPasswordEncoderPluginType.class;


### PR DESCRIPTION
Ignoring some old concurrent tests as they are running with different results on different JDK build versions.
Before doing this made sure that test itself is correct and it is an issue with JDK (not in test).

Test:
- runs fine on OpenJDK
- runs fine but very long on Oracle JDK 8 92 build
- runs with OutOfMemoryError on Oracle JDK 8 77 build

@mchen-len-son , could you please review this PR?