### PR TITLE
[CLEANUP] Update Checkstyle Version

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -108,7 +108,7 @@ dependency.launcher.revision=7.0-SNAPSHOT
 
 # Checkstyle Properties
 checkstyle.version=6.12
-pentaho.coding.standards.version=1.0.3
+pentaho.coding.standards.version=1.0.4
 checkstyle.dir=${basedir}/checkstyle
 checkstyle.lib.dir=${checkstyle.dir}/lib
 checkstyle.reports.dir=${checkstyle.dir}/reports


### PR DESCRIPTION
Newer version ignores static imports of `org.junit.Assert.*`