### PR TITLE
[SP-2779] Backport of PDI-13918 - Get File Names throws ArrayIndexOutOfBoundsException when Filename is defined in a field option is checked (6.1 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/getfilenames/GetFileNamesMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/getfilenames/GetFileNamesMeta.java
@@ -374,10 +374,12 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
     return fileTypeFilter;
   }
 
+  @Override
   public void loadXML( Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore ) throws KettleXMLException {
     readData( stepnode );
   }
 
+  @Override
   public Object clone() {
     GetFileNamesMeta retval = (GetFileNamesMeta) super.clone();
 
@@ -403,6 +405,7 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
     includeSubFolders = new String[nrfiles];
   }
 
+  @Override
   public void setDefault() {
     int nrfiles = 0;
     doNotFailIfNoFile = false;
@@ -427,6 +430,7 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
     }
   }
 
+  @Override
   public void getFields( RowMetaInterface row, String name, RowMetaInterface[] info, StepMeta nextStep,
     VariableSpace space, Repository repository, IMetaStore metaStore ) throws KettleStepException {
 
@@ -512,6 +516,7 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
 
   }
 
+  @Override
   public String getXML() {
     StringBuffer retval = new StringBuffer( 300 );
 
@@ -586,6 +591,7 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
     }
   }
 
+  @Override
   public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases ) throws KettleException {
     try {
       int nrfiles = rep.countNrStepAttributes( id_step, "file_name" );
@@ -623,6 +629,7 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
     }
   }
 
+  @Override
   public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
     try {
       rep.saveStepAttribute( id_transformation, id_step, "filterfiletype", fileTypeFilter.toString() );
@@ -663,10 +670,10 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
     return includeSubFolders;
   }
 
-  private FileInputList.FileTypeFilter[] buildFileTypeFiltersArray() {
-    FileInputList.FileTypeFilter[] filters = new FileInputList.FileTypeFilter[fileName.length];
+  private FileInputList.FileTypeFilter[] buildFileTypeFiltersArray( String[] fileName ) {
+    FileInputList.FileTypeFilter[] filters = new FileInputList.FileTypeFilter[ fileName.length ];
     for ( int i = 0; i < fileName.length; i++ ) {
-      filters[i] = getFileTypeFilter();
+      filters[ i ] = getFileTypeFilter();
     }
     return filters;
   }
@@ -674,21 +681,24 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
   public String[] getFilePaths( VariableSpace space ) {
     return FileInputList.createFilePathList(
       space, fileName, fileMask, excludeFileMask, fileRequired, includeSubFolderBoolean(),
-      buildFileTypeFiltersArray() );
+      buildFileTypeFiltersArray( fileName ) );
   }
 
   public FileInputList getFileList( VariableSpace space ) {
     return FileInputList.createFileList(
       space, fileName, fileMask, excludeFileMask, fileRequired, includeSubFolderBoolean(),
-      buildFileTypeFiltersArray() );
+      buildFileTypeFiltersArray( fileName ) );
   }
 
   public FileInputList getDynamicFileList( VariableSpace space, String[] filename, String[] filemask,
-    String[] excludefilemask, String[] filerequired, boolean[] includesubfolders ) {
+                                           String[] excludefilemask, String[] filerequired,
+                                           boolean[] includesubfolders ) {
     return FileInputList.createFileList(
-      space, filename, filemask, excludefilemask, filerequired, includesubfolders, buildFileTypeFiltersArray() );
+      space, filename, filemask, excludefilemask, filerequired, includesubfolders,
+      buildFileTypeFiltersArray( fileName ) );
   }
 
+  @Override
   public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta,
     RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
     Repository repository, IMetaStore metaStore ) {
@@ -762,11 +772,13 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
     return references;
   }
 
+  @Override
   public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int cnr,
     TransMeta transMeta, Trans trans ) {
     return new GetFileNames( stepMeta, stepDataInterface, cnr, transMeta, trans );
   }
 
+  @Override
   public StepDataInterface getStepData() {
     return new GetFileNamesData();
   }
@@ -783,6 +795,7 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
    *
    * @return the filename of the exported resource
    */
+  @Override
   public String exportResources( VariableSpace space, Map<String, ResourceDefinition> definitions,
     ResourceNamingInterface resourceNamingInterface, Repository repository, IMetaStore metaStore ) throws KettleException {
     try {

--- a/engine/test-src/org/pentaho/di/trans/steps/getfilenames/GetFileNamesMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/getfilenames/GetFileNamesMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -98,9 +98,9 @@ public class GetFileNamesMetaTest {
     fieldLoadSaveValidatorAttributeMap.put( "file_required", fileRequiredArrayLoadSaveValidator );
     fieldLoadSaveValidatorAttributeMap.put( "include_subfolders", stringArrayLoadSaveValidator );
 
-    LoadSaveTester loadSaveTester =
-      new LoadSaveTester( GetFileNamesMeta.class, attributes, getterMap, setterMap,
-          fieldLoadSaveValidatorAttributeMap, new HashMap<String, FieldLoadSaveValidator<?>>() );
+    LoadSaveTester<GetFileNamesMeta> loadSaveTester =
+      new LoadSaveTester<>( GetFileNamesMeta.class, attributes, getterMap, setterMap,
+        fieldLoadSaveValidatorAttributeMap, new HashMap<String, FieldLoadSaveValidator<?>>() );
 
     loadSaveTester.testRepoRoundTrip();
     loadSaveTester.testXmlRoundTrip();
@@ -111,7 +111,7 @@ public class GetFileNamesMetaTest {
     @Override
     public FileInputList.FileTypeFilter getTestObject() {
       FileInputList.FileTypeFilter[] filters = FileInputList.FileTypeFilter.values();
-      return filters[new Random().nextInt( filters.length )];
+      return filters[ new Random().nextInt( filters.length ) ];
     }
 
     @Override
@@ -127,7 +127,7 @@ public class GetFileNamesMetaTest {
 
     @Override
     public String getTestObject() {
-      return GetFileNamesMeta.RequiredFilesCode[new Random().nextInt( GetFileNamesMeta.RequiredFilesCode.length )];
+      return GetFileNamesMeta.RequiredFilesCode[ new Random().nextInt( GetFileNamesMeta.RequiredFilesCode.length ) ];
     }
 
     @Override


### PR DESCRIPTION
Backport of https://github.com/pentaho/pentaho-kettle/pull/2655 + checkstyle