### PR TITLE
[SP-2795] Backport of PDI-8927 - Trans.activeSubtransformations not threadsafe (5.4 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -424,7 +424,7 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     stepPerformanceSnapshotSeqNr = new AtomicInteger( 0 );
     lastWrittenStepPerformanceSequenceNr = 0;
 
-    activeSubtransformations = new HashMap<String, Trans>();
+    activeSubtransformations = new ConcurrentHashMap<String, Trans>();
     activeSubjobs = new HashMap<String, Job>();
 
     resultRows = new ArrayList<RowMetaAndData>();
@@ -5128,12 +5128,28 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
   }
 
   /**
-   * Gets the active sub-transformations.
+   *  Use:
+   *  {@link #addActiveSubTransformation(String, Trans),
+   *  {@link #getActiveSubTransformation(String)},
+   *  {@link #removeActiveSubTransformation(String)}
    *
-   * @return a map (by name) of the active sub-transformations
+   *  instead
    */
+  @Deprecated
   public Map<String, Trans> getActiveSubtransformations() {
     return activeSubtransformations;
+  }
+
+  public void addActiveSubTransformation( final String subTransName, Trans subTrans ) {
+    activeSubtransformations.put( subTransName, subTrans );
+  }
+
+  public Trans removeActiveSubTransformation( final String subTransName ) {
+    return activeSubtransformations.remove( subTransName );
+  }
+
+  public Trans getActiveSubTransformation( final String subTransName ) {
+    return activeSubtransformations.get( subTransName );
   }
 
   /**

--- a/engine/src/org/pentaho/di/trans/steps/mapping/Mapping.java
+++ b/engine/src/org/pentaho/di/trans/steps/mapping/Mapping.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -496,7 +496,7 @@ public class Mapping extends BaseStep implements StepInterface {
     // Finally, add the mapping transformation to the active sub-transformations
     // map in the parent transformation
     //
-    getTrans().getActiveSubtransformations().put( getStepname(), getData().getMappingTrans() );
+    getTrans().addActiveSubTransformation( getStepname(), getData().getMappingTrans() );
   }
 
   @VisibleForTesting StepInterface[] pickupTargetStepsFor( MappingIODefinition outputDefinition )
@@ -623,7 +623,7 @@ public class Mapping extends BaseStep implements StepInterface {
 
       // Remove it from the list of active sub-transformations...
       //
-      getTrans().getActiveSubtransformations().remove( getStepname() );
+      getTrans().removeActiveSubTransformation( getStepname() );
 
       // See if there was an error in the sub-transformation, in that case, flag error etc.
       if ( getData().getMappingTrans().getErrors() > 0 ) {

--- a/engine/src/org/pentaho/di/trans/steps/metainject/MetaInject.java
+++ b/engine/src/org/pentaho/di/trans/steps/metainject/MetaInject.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -269,7 +269,7 @@ public class MetaInject extends BaseStep implements StepInterface {
       // Finally, add the mapping transformation to the active sub-transformations
       // map in the parent transformation
       //
-      getTrans().getActiveSubtransformations().put( getStepname(), injectTrans );
+      getTrans().addActiveSubTransformation( getStepname(), injectTrans );
 
       if ( !Const.isEmpty( meta.getSourceStepName() ) ) {
         StepInterface stepInterface = injectTrans.getStepInterface( meta.getSourceStepName(), 0 );

--- a/engine/src/org/pentaho/di/trans/steps/simplemapping/SimpleMapping.java
+++ b/engine/src/org/pentaho/di/trans/steps/simplemapping/SimpleMapping.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -254,7 +254,7 @@ public class SimpleMapping extends BaseStep implements StepInterface {
     // Finally, add the mapping transformation to the active sub-transformations
     // map in the parent transformation
     //
-    getTrans().getActiveSubtransformations().put( getStepname(), simpleMappingData.mappingTrans );
+    getTrans().addActiveSubTransformation( getStepname(), simpleMappingData.mappingTrans );
   }
 
   void initServletConfig() {
@@ -313,7 +313,7 @@ public class SimpleMapping extends BaseStep implements StepInterface {
 
         // Remove it from the list of active sub-transformations...
         //
-        getTrans().getActiveSubtransformations().remove( getStepname() );
+        getTrans().removeActiveSubTransformation( getStepname() );
       }
 
       // See if there was an error in the sub-transformation, in that case, flag error etc.

--- a/engine/src/org/pentaho/di/trans/steps/singlethreader/SingleThreader.java
+++ b/engine/src/org/pentaho/di/trans/steps/singlethreader/SingleThreader.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -266,7 +266,7 @@ public class SingleThreader extends BaseStep implements StepInterface {
 
     // Add the mapping transformation to the active sub-transformations map in the parent transformation
     //
-    getTrans().getActiveSubtransformations().put( getStepname(), singleThreaderData.mappingTrans );
+    getTrans().addActiveSubTransformation( getStepname(), singleThreaderData.mappingTrans );
   }
 
   void initServletConfig() {

--- a/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
+++ b/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -196,7 +196,7 @@ public class TransExecutor extends BaseStep implements StepInterface {
     passParametersToTrans();
 
     // keep track for drill down in Spoon...
-    getTrans().getActiveSubtransformations().put( getStepname(), executorTrans );
+    getTrans().addActiveSubTransformation( getStepname(), executorTrans );
 
     Result result = new Result();
     result.setRows( transExecutorData.groupBuffer );

--- a/engine/test-src/org/pentaho/di/concurrency/ActiveSubTransformationsConcurrencyTest.java
+++ b/engine/test-src/org/pentaho/di/concurrency/ActiveSubTransformationsConcurrencyTest.java
@@ -1,0 +1,151 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.concurrency;
+
+import org.junit.Test;
+import org.pentaho.di.trans.Trans;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * In this test we add new elements to shared transformation concurrently
+ * and get added elements from this transformation concurrently.
+ *
+ * When working with {@link java.util.HashMap} with default loadFactor this test will fail
+ * when HashMap will try to rearrange it's elements (it will happen when number of elements in map will be equal to
+ * capacity/loadFactor).
+ *
+ * Map will be in inconsistent state, because in the same time, when rearrange happens other threads will be adding
+ * new elements to map.
+ * This will lead to unpredictable result of executing {@link java.util.HashMap#size()} method (as a result there
+ * would be an error in {@link Getter#call()} ).
+ *
+ */
+public class ActiveSubTransformationsConcurrencyTest {
+  private static final int NUMBER_OF_GETTERS = 10;
+  private static final int NUMBER_OF_CREATES = 10;
+  private static final int NUMBER_OF_CREATE_CYCLES = 20;
+  private static final int INITIAL_NUMBER_OF_TRANS = 100;
+
+
+  private static final String TRANS_NAME = "transformation";
+  private final Object lock = new Object();
+
+  @Test
+  public void getAndCreateConcurrently() throws Exception {
+    AtomicBoolean condition = new AtomicBoolean( true );
+    Trans trans = new Trans();
+    createSubTransformations( trans );
+
+    List<Getter> getters = generateGetters( trans, condition );
+    List<Creator> creators = generateCreators( trans, condition );
+
+    ConcurrencyTestRunner.runAndCheckNoExceptionRaised( creators, getters, condition );
+  }
+
+  private void createSubTransformations( Trans trans ) {
+    for ( int i = 0; i < INITIAL_NUMBER_OF_TRANS; i++ ) {
+      trans.addActiveSubTransformation( createTransName( i ), new Trans() );
+    }
+  }
+
+  private List<Getter> generateGetters( Trans trans, AtomicBoolean condition ) {
+    List<Getter> getters = new ArrayList<Getter>();
+    for ( int i = 0; i < NUMBER_OF_GETTERS; i++ ) {
+      getters.add( new Getter( trans, condition ) );
+    }
+
+    return getters;
+  }
+
+  private List<Creator> generateCreators( Trans trans, AtomicBoolean condition ) {
+    List<Creator> creators = new ArrayList<Creator>();
+    for ( int i = 0; i < NUMBER_OF_CREATES; i++ ) {
+      creators.add( new Creator( trans, condition ) );
+    }
+
+    return creators;
+  }
+
+
+  private class Getter extends StopOnErrorCallable<Object> {
+    private final Trans trans;
+    private final Random random;
+
+    Getter( Trans trans, AtomicBoolean condition ) {
+      super( condition );
+      this.trans = trans;
+      random = new Random();
+    }
+
+    @Override
+    Object doCall() throws Exception {
+      while ( condition.get() ) {
+        final String activeSubTransName = createTransName( random.nextInt( INITIAL_NUMBER_OF_TRANS ) );
+        Trans subTrans = trans.getActiveSubTransformation( activeSubTransName );
+
+        if ( subTrans == null ) {
+          throw new IllegalStateException(
+            String.format(
+              "Returned transformation must not be null. Transformation name = %s",
+              activeSubTransName ) );
+        }
+      }
+
+      return null;
+    }
+  }
+
+  private class Creator extends StopOnErrorCallable<Object> {
+    private final Trans trans;
+    private final Random random;
+
+    Creator( Trans trans, AtomicBoolean condition ) {
+      super( condition );
+      this.trans = trans;
+      random = new Random();
+    }
+
+    @Override
+    Object doCall() throws Exception {
+      for ( int i = 0; i < NUMBER_OF_CREATE_CYCLES; i++ ) {
+        synchronized ( lock ) {
+          String transName = createTransName( randomInt( INITIAL_NUMBER_OF_TRANS, Integer.MAX_VALUE ) );
+          trans.addActiveSubTransformation( transName, new Trans() );
+        }
+      }
+      return null;
+    }
+
+    private int randomInt( int min, int max ) {
+      return random.nextInt( max - min ) + min;
+    }
+  }
+
+  private String createTransName( int id ) {
+    return TRANS_NAME + " - " + id;
+  }
+}

--- a/engine/test-src/org/pentaho/di/concurrency/ConcurrencyTestRunner.java
+++ b/engine/test-src/org/pentaho/di/concurrency/ConcurrencyTestRunner.java
@@ -1,0 +1,225 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.concurrency;
+
+import com.google.common.base.Throwables;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * This class is aimed to be a general runner for concurrency tests. You need to follow a convention while using it. By
+ * it, there are two types of actors in multithreaded environment: monitored and background. The formers are active and
+ * are considered to do some mutations of class undergoing testing. The latter group is all about accessors, that
+ * normally should not change the state, but just ask for some information, e.g. invoke getters.
+ * <p/>
+ * There is a special condition flag, shared among all actors. Each of them must stop when it has found out the flag has
+ * been cleared. Also, in most cases it makes sense to clear the flag after any exception has raised (see {@linkplain
+ * StopOnErrorCallable}, because any actor can face with it in concurrency environment.
+ * <p/>
+ * The runner stores results of all actors, though in most cases this information is needless - what is important that
+ * is the fact the execution has completed with no errors.
+ *
+ * @author Andrey Khayrutdinov
+ */
+class ConcurrencyTestRunner<M, B> {
+
+  /**
+   * Runs all tasks and simply checks no exceptions were thrown during the execution. The timeout is 5 minutes.
+   *
+   * @param monitoredTasks  active actors
+   * @param backgroundTasks background actors
+   * @param condition       stop condition
+   * @throws Exception exception
+   */
+  @SuppressWarnings( "unchecked" )
+  static void runAndCheckNoExceptionRaised( List<? extends Callable<?>> monitoredTasks,
+                                            List<? extends Callable<?>> backgroundTasks,
+                                            AtomicBoolean condition ) throws Exception {
+    ConcurrencyTestRunner<?, ?> runner = new ConcurrencyTestRunner( monitoredTasks, backgroundTasks, condition );
+    runner.runConcurrentTest();
+    runner.checkNoExceptionRaised();
+  }
+
+
+  private final List<? extends Callable<? extends M>> monitoredTasks;
+  private final List<? extends Callable<? extends B>> backgroundTasks;
+  private final AtomicBoolean condition;
+
+  private final long timeout;
+
+  private final Map<Callable<? extends M>, ExecutionResult<M>> monitoredResults;
+  private final Map<Callable<? extends B>, ExecutionResult<B>> backgroundResults;
+
+  private Exception exception;
+
+  ConcurrencyTestRunner( List<? extends Callable<? extends M>> monitoredTasks,
+                         List<? extends Callable<? extends B>> backgroundTasks,
+                         AtomicBoolean condition ) {
+    this( monitoredTasks, backgroundTasks, condition, TimeUnit.MINUTES.toMillis( 5 ) );
+  }
+
+  ConcurrencyTestRunner( List<? extends Callable<? extends M>> monitoredTasks,
+                         List<? extends Callable<? extends B>> backgroundTasks,
+                         AtomicBoolean condition,
+                         long timeout ) {
+    this.monitoredTasks = monitoredTasks;
+    this.backgroundTasks = backgroundTasks;
+    this.condition = condition;
+    this.timeout = timeout;
+
+    this.monitoredResults = new HashMap<Callable<? extends M>, ExecutionResult<M>>( monitoredTasks.size() );
+    this.backgroundResults = new HashMap<Callable<? extends B>, ExecutionResult<B>>( backgroundTasks.size() );
+  }
+
+  void runConcurrentTest() throws Exception {
+    this.exception = null;
+
+    final int tasksAmount = monitoredTasks.size() + backgroundTasks.size();
+    final ExecutorService executors = Executors.newFixedThreadPool( tasksAmount );
+    try {
+      List<Future<? extends B>> background = new ArrayList<Future<? extends B>>( backgroundTasks.size() );
+      for ( Callable<? extends B> task : backgroundTasks ) {
+        background.add( executors.submit( task ) );
+      }
+
+      List<Future<? extends M>> monitored = new ArrayList<Future<? extends M>>( monitoredTasks.size() );
+      for ( Callable<? extends M> task : monitoredTasks ) {
+        monitored.add( executors.submit( task ) );
+      }
+
+      try {
+        final long start = System.currentTimeMillis();
+        while ( condition.get() && !isDone( monitored ) && checkTimeout( start ) ) {
+          Thread.sleep( 200 );
+        }
+      } catch ( Exception e ) {
+        exception = e;
+      }
+      condition.set( false );
+
+      for ( int i = 0; i < monitored.size(); i++ ) {
+        Future<? extends M> future = monitored.get( i );
+        monitoredResults.put( monitoredTasks.get( i ), ExecutionResult.from( future ) );
+      }
+
+      for ( int i = 0; i < background.size(); i++ ) {
+        Future<? extends B> future = background.get( i );
+        while ( !future.isDone() ) {
+          // wait: condition flag is cleared, thus background tasks must complete by convention
+        }
+        backgroundResults.put( backgroundTasks.get( i ), ExecutionResult.from( future ) );
+      }
+
+    } finally {
+      executors.shutdown();
+    }
+  }
+
+  private boolean isDone( List<? extends Future<?>> futures ) {
+    for ( Future<?> future : futures ) {
+      if ( !future.isDone() ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean checkTimeout( long start ) throws TimeoutException {
+    if ( this.timeout > 0 ) {
+      if ( System.currentTimeMillis() - start > timeout ) {
+        throw new TimeoutException( "Execution time limit is exceeded: " + timeout + " ms." );
+      }
+    }
+    return true;
+  }
+
+  Exception getException() {
+    return exception;
+  }
+
+  List<Throwable> getTasksErrors() {
+    List<Throwable> errors = new ArrayList<Throwable>();
+    errors.addAll( pickupErrors( monitoredResults.values() ) );
+    errors.addAll( pickupErrors( backgroundResults.values() ) );
+    return errors;
+  }
+
+  private List<Throwable> pickupErrors( Collection<? extends ExecutionResult<?>> collection ) {
+    List<Throwable> errors = new ArrayList<Throwable>( collection.size() );
+    for ( ExecutionResult<?> result : collection ) {
+      if ( result.isError() ) {
+        errors.add( result.getThrowable() );
+      }
+    }
+    return errors;
+  }
+
+
+  void checkNoExceptionRaised() {
+    List<Throwable> errors = getTasksErrors();
+    if ( !errors.isEmpty() ) {
+      StringBuilder message = new StringBuilder( 1024 );
+      message.append( "There are expected no exceptions during the test, but " )
+        .append( errors.size() ).append( " raised:" );
+
+      for ( Throwable throwable : errors ) {
+        String stacktrace = Throwables.getStackTraceAsString( throwable );
+        message.append( '\n' ).append( stacktrace );
+      }
+      Assert.fail( message.toString() );
+    }
+  }
+
+
+  List<M> getMonitoredTasksResults() {
+    return pickupResults( monitoredResults.values() );
+  }
+
+  private <T> List<T> pickupResults( Collection<? extends ExecutionResult<T>> collection ) {
+    List<T> errors = new ArrayList<T>( collection.size() );
+    for ( ExecutionResult<T> result : collection ) {
+      if ( !result.isError() ) {
+        errors.add( result.getResult() );
+      }
+    }
+    return errors;
+  }
+
+
+  Map<Callable<? extends M>, ExecutionResult<M>> getMonitoredResults() {
+    return Collections.unmodifiableMap( monitoredResults );
+  }
+}

--- a/engine/test-src/org/pentaho/di/concurrency/ExecutionResult.java
+++ b/engine/test-src/org/pentaho/di/concurrency/ExecutionResult.java
@@ -1,0 +1,64 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.concurrency;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+class ExecutionResult<T> {
+  static <T> ExecutionResult<T> from( Future<? extends T> future ) {
+    if ( !future.isDone() ) {
+      throw new IllegalArgumentException( "Future is not completed yet" );
+    }
+    try {
+      return new ExecutionResult<T>( future.get(), null );
+    } catch ( InterruptedException e ) {
+      throw new IllegalArgumentException( e );
+    } catch ( ExecutionException e ) {
+      return new ExecutionResult<T>( null, e.getCause() );
+    }
+  }
+
+  private final T result;
+  private final Throwable throwable;
+
+  ExecutionResult( T result, Throwable throwable ) {
+    this.result = result;
+    this.throwable = throwable;
+  }
+
+  boolean isError() {
+    return ( throwable != null );
+  }
+
+  T getResult() {
+    return result;
+  }
+
+  Throwable getThrowable() {
+    return throwable;
+  }
+}

--- a/engine/test-src/org/pentaho/di/concurrency/JobMapConcurrencyTest.java
+++ b/engine/test-src/org/pentaho/di/concurrency/JobMapConcurrencyTest.java
@@ -1,0 +1,186 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.concurrency;
+
+import org.apache.commons.collections.ListUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobConfiguration;
+import org.pentaho.di.www.CarteObjectEntry;
+import org.pentaho.di.www.JobMap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JobMapConcurrencyTest {
+  public static final String JOB_NAME_STRING = "job";
+  public static final String JOB_ID_STRING = "job";
+  public static final int INITIAL_JOB_MAP_SIZE = 100;
+
+  private static final int gettersAmount = 20;
+  private static final int replaceAmount = 20;
+  private static final int updatersAmount = 5;
+  private static final int updatersCycles = 10;
+
+  private static JobMap jobMap;
+
+  @BeforeClass
+  public static void init() {
+    jobMap = new JobMap();
+    for ( int i = 0; i < INITIAL_JOB_MAP_SIZE; i++ ) {
+      jobMap.addJob( JOB_NAME_STRING + i, JOB_ID_STRING + i, mockJob( i ), mock( JobConfiguration.class ) );
+    }
+  }
+
+  private static Job mockJob( int id ) {
+    Job job = mock( Job.class );
+    when( job.getContainerObjectId() ).thenReturn( JOB_NAME_STRING + id );
+    return job;
+  }
+
+  @Test
+  public void updateGetAndReplaceConcurrently() throws Exception {
+    AtomicBoolean condition = new AtomicBoolean( true );
+    AtomicInteger generator = new AtomicInteger( 10 );
+
+    List<Updater> updaters = new ArrayList<Updater>();
+    for ( int i = 0; i < updatersAmount; i++ ) {
+      Updater updater = new Updater( jobMap, generator, updatersCycles );
+      updaters.add( updater );
+    }
+
+    List<Getter> getters = new ArrayList<Getter>();
+    for ( int i = 0; i < gettersAmount; i++ ) {
+      getters.add( new Getter( jobMap, condition ) );
+    }
+
+    List<Replacer> replacers = new ArrayList<Replacer>();
+    for ( int i = 0; i < replaceAmount; i++ ) {
+      replacers.add( new Replacer( jobMap, condition ) );
+    }
+
+    //noinspection unchecked
+    ConcurrencyTestRunner.runAndCheckNoExceptionRaised( updaters, ListUtils.union( replacers, getters ), condition );
+
+  }
+
+  private static class Getter extends StopOnErrorCallable<Object> {
+    private final JobMap jobMap;
+    private final Random random;
+
+    public Getter( JobMap jobMap, AtomicBoolean condition ) {
+      super( condition );
+      this.jobMap = jobMap;
+      this.random = new Random();
+    }
+
+    @Override
+    public Object doCall() throws Exception {
+      while ( condition.get() ) {
+
+        int i = random.nextInt( INITIAL_JOB_MAP_SIZE );
+        CarteObjectEntry entry = jobMap.getJobObjects().get( i );
+
+        if ( entry == null ) {
+          throw new IllegalStateException(
+            String.format( "Returned CarteObjectEntry must not be null. EntryId = %d", i ) );
+        }
+        final String jobName = JOB_NAME_STRING + i;
+
+        Job job = jobMap.getJob( entry.getName() );
+        if ( job == null ) {
+          throw new IllegalStateException( String.format( "Returned job must not be null. Job name = %s", jobName ) );
+        }
+
+        JobConfiguration jobConfiguration = jobMap.getConfiguration( entry.getName() );
+        if ( jobConfiguration == null ) {
+          throw new IllegalStateException(
+            String.format( "Returned jobConfiguration must not be null. Job name = %s", jobName ) );
+        }
+      }
+
+      return null;
+    }
+  }
+
+
+  private static class Updater implements Callable<Exception> {
+    private final JobMap jobMap;
+    private final AtomicInteger generator;
+    private final int cycles;
+
+    public Updater( JobMap jobMap, AtomicInteger generator, int cycles ) {
+      this.jobMap = jobMap;
+      this.generator = generator;
+      this.cycles = cycles;
+    }
+
+    @Override
+    public Exception call() throws Exception {
+      Exception exception = null;
+      try {
+        for ( int i = 0; i < cycles; i++ ) {
+          int id = generator.get();
+          jobMap.addJob( JOB_NAME_STRING + id, JOB_ID_STRING + id, mockJob( id ), mock( JobConfiguration.class ) );
+        }
+      } catch ( Exception e ) {
+        exception = e;
+      }
+      return exception;
+    }
+  }
+
+  private static class Replacer extends StopOnErrorCallable<Object> {
+    private final JobMap jobMap;
+    private final Random random;
+
+    public Replacer( JobMap jobMap, AtomicBoolean condition ) {
+      super( condition );
+      this.jobMap = jobMap;
+      this.random = new Random();
+    }
+
+    @Override
+    public Object doCall() throws Exception {
+
+      int i = random.nextInt( INITIAL_JOB_MAP_SIZE );
+
+      final String jobName = JOB_NAME_STRING + i;
+      final String jobId = JOB_ID_STRING + i;
+
+      CarteObjectEntry entry = new CarteObjectEntry( jobName, jobId );
+
+      jobMap.replaceJob( entry, mockJob( i + 1 ), mock( JobConfiguration.class ) );
+
+      return null;
+    }
+  }
+}

--- a/engine/test-src/org/pentaho/di/concurrency/JobTrackerConcurrencyTest.java
+++ b/engine/test-src/org/pentaho/di/concurrency/JobTrackerConcurrencyTest.java
@@ -1,0 +1,215 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.concurrency;
+
+import org.apache.commons.collections.ListUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.pentaho.di.core.gui.JobTracker;
+import org.pentaho.di.job.JobEntryResult;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entry.JobEntryCopy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This test consists of two similar cases. There are three type of actors: getters, searchers and updaters. They work
+ * simultaneously within their own threads. Getters invoke {@linkplain JobTracker#getJobTracker(int)} with a random
+ * index, searchers call {@linkplain JobTracker#findJobTracker(JobEntryCopy)}, updaters add new children
+ * <tt>updatersCycles</tt> times. The difference between two cases is the second has a small limit of stored children,
+ * so the parent JobTracker will be forced to remove some of its elements.
+ *
+ * @author Andrey Khayrutdinov
+ */
+@RunWith( Parameterized.class )
+public class JobTrackerConcurrencyTest {
+
+  private static final int gettersAmount = 10;
+
+  private static final int searchersAmount = 20;
+
+  private static final int updatersAmount = 5;
+  private static final int updatersCycles = 10;
+
+  private static final int jobsLimit = 20;
+
+  @SuppressWarnings( "ConstantConditions" )
+  @BeforeClass
+  public static void setUp() {
+    // a guarding check for tests' parameters
+    int jobsToBeAdded = updatersAmount * updatersCycles;
+    assertTrue( "The limit of stored jobs must be less than the amount of children to be added",
+      jobsLimit < jobsToBeAdded );
+  }
+
+
+  @Parameterized.Parameters
+  public static List<Object[]> getData() {
+    return Arrays.asList(
+      new Object[] { new JobTracker( mockJobMeta( "parent" ) ) },
+      new Object[] { new JobTracker( mockJobMeta( "parent" ), jobsLimit ) }
+    );
+  }
+
+  private static JobMeta mockJobMeta( String name ) {
+    JobMeta meta = mock( JobMeta.class );
+    when( meta.getName() ).thenReturn( name );
+    return meta;
+  }
+
+
+  private final JobTracker tracker;
+
+  public JobTrackerConcurrencyTest( JobTracker tracker ) {
+    this.tracker = tracker;
+  }
+
+  @Test
+  public void readAndUpdateTrackerConcurrently() throws Exception {
+    final AtomicBoolean condition = new AtomicBoolean( true );
+
+    List<Getter> getters = new ArrayList<Getter>( gettersAmount );
+    for ( int i = 0; i < gettersAmount; i++ ) {
+      getters.add( new Getter( condition, tracker ) );
+    }
+
+    List<Searcher> searchers = new ArrayList<Searcher>( searchersAmount );
+    for ( int i = 0; i < searchersAmount; i++ ) {
+      int lookingFor = updatersAmount * updatersCycles / 2 + i;
+      assertTrue( "We are looking for reachable index", lookingFor < updatersAmount * updatersCycles );
+      searchers.add( new Searcher( condition, tracker, mockJobEntryCopy( "job-entry-" + lookingFor, lookingFor ) ) );
+    }
+
+    final AtomicInteger generator = new AtomicInteger( 0 );
+    List<Updater> updaters = new ArrayList<Updater>( updatersAmount );
+    for ( int i = 0; i < updatersAmount; i++ ) {
+      updaters.add( new Updater( tracker, updatersCycles, generator, "job-entry-%d" ) );
+    }
+
+    //noinspection unchecked
+    ConcurrencyTestRunner.runAndCheckNoExceptionRaised( updaters, ListUtils.union( getters, searchers ), condition );
+    assertEquals( updatersAmount * updatersCycles, generator.get() );
+  }
+
+  static JobEntryCopy mockJobEntryCopy( String name, int number ) {
+    JobEntryCopy copy = mock( JobEntryCopy.class );
+    when( copy.getName() ).thenReturn( name );
+    when( copy.getNr() ).thenReturn( number );
+    return copy;
+  }
+
+
+  private static class Getter extends StopOnErrorCallable<Object> {
+    private final JobTracker tracker;
+    private final Random random;
+
+    public Getter( AtomicBoolean condition, JobTracker tracker ) {
+      super( condition );
+      this.tracker = tracker;
+      this.random = new Random();
+    }
+
+    @Override
+    public Object doCall() throws Exception {
+      while ( condition.get() ) {
+        int amount = tracker.nrJobTrackers();
+        if ( amount == 0 ) {
+          continue;
+        }
+        int i = random.nextInt( amount );
+        JobTracker t = tracker.getJobTracker( i );
+        if ( t == null ) {
+          throw new IllegalStateException(
+            String.format( "Returned tracker must not be null. Index = %d, trackers' amount = %d", i, amount ) );
+        }
+      }
+      return null;
+    }
+  }
+
+
+  private static class Searcher extends StopOnErrorCallable<Object> {
+    private final JobTracker tracker;
+    private final JobEntryCopy copy;
+
+    public Searcher( AtomicBoolean condition, JobTracker tracker, JobEntryCopy copy ) {
+      super( condition );
+      this.tracker = tracker;
+      this.copy = copy;
+    }
+
+    @Override Object doCall() throws Exception {
+      while ( condition.get() ) {
+        // can be null, it is OK here
+        tracker.findJobTracker( copy );
+      }
+      return null;
+    }
+  }
+
+
+  private static class Updater implements Callable<Exception> {
+    private final JobTracker tracker;
+    private final int cycles;
+    private final AtomicInteger idGenerator;
+    private final String resultNameTemplate;
+
+    public Updater( JobTracker tracker, int cycles, AtomicInteger idGenerator, String resultNameTemplate ) {
+      this.tracker = tracker;
+      this.cycles = cycles;
+      this.idGenerator = idGenerator;
+      this.resultNameTemplate = resultNameTemplate;
+    }
+
+    @Override
+    public Exception call() throws Exception {
+      Exception exception = null;
+      try {
+        for ( int i = 0; i < cycles; i++ ) {
+          int id = idGenerator.getAndIncrement();
+          JobEntryResult result = new JobEntryResult();
+          result.setJobEntryName( String.format( resultNameTemplate, id ) );
+          result.setJobEntryNr( id );
+          JobTracker child = new JobTracker( mockJobMeta( "child-" + id ), result );
+          tracker.addJobTracker( child );
+        }
+      } catch ( Exception e ) {
+        exception = e;
+      }
+      return exception;
+    }
+  }
+}

--- a/engine/test-src/org/pentaho/di/concurrency/PluginRegistryConcurrencyTest.java
+++ b/engine/test-src/org/pentaho/di/concurrency/PluginRegistryConcurrencyTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -20,7 +20,7 @@
  *
  ******************************************************************************/
 
-package org.pentaho.di.core.plugins;
+package org.pentaho.di.concurrency;
 
 import org.junit.After;
 import org.junit.Before;
@@ -31,23 +31,18 @@ import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.encryption.TwoWayPasswordEncoderPluginType;
 import org.pentaho.di.core.extension.ExtensionPointPluginType;
+import org.pentaho.di.core.plugins.PluginInterface;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.plugins.PluginTypeInterface;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -101,22 +96,13 @@ public class PluginRegistryConcurrencyTest {
     List<Getter> getters = new ArrayList<Getter>( gettersAmount );
     for ( int i = 0; i < gettersAmount; i++ ) {
       Class<? extends PluginTypeInterface> type = ( i % 2 == 0 ) ? type1 : type2;
-      getters.add( new Getter( type, condition ) );
+      getters.add( new Getter( condition, type ) );
     }
 
     PluginTypeInterface type = mock( PluginTypeInterface.class );
 
-    TestRunner runner =
-      new TestRunner( Collections.singletonList( new Registrar( type.getClass(), 1, "" ) ), getters, condition );
-    runner.runConcurrentTest();
-
-    List<Exception> exceptions = runner.getExceptions();
-    if ( !exceptions.isEmpty() ) {
-      for ( Exception exception : exceptions ) {
-        exception.printStackTrace();
-      }
-      fail( "There is expected no exceptions during the test" );
-    }
+    ConcurrencyTestRunner.runAndCheckNoExceptionRaised(
+      singletonList( new Registrar( condition, type.getClass(), 1, "" ) ), getters, condition );
   }
 
 
@@ -129,41 +115,33 @@ public class PluginRegistryConcurrencyTest {
     List<Getter> getters = new ArrayList<Getter>( gettersAmount );
     for ( int i = 0; i < gettersAmount; i++ ) {
       Class<? extends PluginTypeInterface> type = ( i % 2 == 0 ) ? type1 : type2;
-      getters.add( new Getter( type, condition ) );
+      getters.add( new Getter( condition, type ) );
     }
 
-    List<Registrar> registrars = Arrays.asList(
-      new Registrar( type1, cycles, type1.getName() ),
-      new Registrar( type2, cycles, type2.getName() )
+    List<Registrar> registrars = asList(
+      new Registrar( condition, type1, cycles, type1.getName() ),
+      new Registrar( condition, type2, cycles, type2.getName() )
     );
 
-    TestRunner runner = new TestRunner( registrars, getters, condition );
-    runner.runConcurrentTest();
-
-    List<Exception> exceptions = runner.getExceptions();
-    if ( !exceptions.isEmpty() ) {
-      for ( Exception exception : exceptions ) {
-        exception.printStackTrace();
-      }
-      fail( "There is expected no exceptions during the test" );
-    }
+    ConcurrencyTestRunner.runAndCheckNoExceptionRaised( registrars, getters, condition );
   }
 
 
-  private class Registrar implements Callable<Exception> {
+  private class Registrar extends StopOnErrorCallable<Object> {
     private final Class<? extends PluginTypeInterface> type;
     private final int cycles;
     private final String nameSeed;
 
-    public Registrar( Class<? extends PluginTypeInterface> type, int cycles, String nameSeed ) {
+    public Registrar( AtomicBoolean condition, Class<? extends PluginTypeInterface> type, int cycles,
+                      String nameSeed ) {
+      super( condition );
       this.type = type;
       this.cycles = cycles;
       this.nameSeed = nameSeed;
     }
 
     @Override
-    public Exception call() throws Exception {
-      Exception exception = null;
+    Object doCall() throws Exception {
       List<PluginInterface> registered = new ArrayList<PluginInterface>( cycles );
       try {
         for ( int i = 0; i < cycles; i++ ) {
@@ -181,97 +159,28 @@ public class PluginRegistryConcurrencyTest {
 
           PluginRegistry.getInstance().registerPlugin( type, mock );
         }
-      } catch ( Exception e ) {
-        exception = e;
       } finally {
         // push up registered instances for future clean-up
         addUsedPlugins( type, registered );
       }
-      return exception;
+      return null;
     }
   }
 
-  private static class Getter implements Callable<Exception> {
+  private static class Getter extends StopOnErrorCallable<Object> {
     private final Class<? extends PluginTypeInterface> type;
-    private final AtomicBoolean condition;
 
-    public Getter( Class<? extends PluginTypeInterface> type, AtomicBoolean condition ) {
+    public Getter( AtomicBoolean condition, Class<? extends PluginTypeInterface> type ) {
+      super( condition );
       this.type = type;
-      this.condition = condition;
     }
 
     @Override
-    public Exception call() throws Exception {
-      Exception exception = null;
+    Object doCall() throws Exception {
       while ( condition.get() ) {
-        try {
-          PluginRegistry.getInstance().getPlugins( type );
-        } catch ( Exception e ) {
-          condition.set( false );
-          exception = e;
-          break;
-        }
+        PluginRegistry.getInstance().getPlugins( type );
       }
-      return exception;
-    }
-  }
-
-
-  private static class TestRunner {
-    private final List<? extends Callable<Exception>> monitoredTasks;
-    private final List<? extends Callable<Exception>> backgroundTasks;
-    private final AtomicBoolean condition;
-
-    private final List<Exception> exceptions;
-
-    public TestRunner( List<? extends Callable<Exception>> monitoredTasks,
-                       List<? extends Callable<Exception>> backgroundTasks, AtomicBoolean condition ) {
-      this.monitoredTasks = monitoredTasks;
-      this.backgroundTasks = backgroundTasks;
-      this.condition = condition;
-      this.exceptions = new ArrayList<Exception>();
-    }
-
-    public void runConcurrentTest() throws Exception {
-      final int tasksAmount = monitoredTasks.size() + backgroundTasks.size();
-      final ExecutorService executors = Executors.newFixedThreadPool( tasksAmount );
-      try {
-        CompletionService<Exception> service = new ExecutorCompletionService<Exception>( executors );
-        for ( Callable<Exception> task : backgroundTasks ) {
-          service.submit( task );
-        }
-        List<Future<Exception>> monitored = new ArrayList<Future<Exception>>( monitoredTasks.size() );
-        for ( Callable<Exception> task : monitoredTasks ) {
-          monitored.add( service.submit( task ) );
-        }
-
-        while ( condition.get() && !isDone( monitored ) ) {
-          // wait
-        }
-        condition.set( false );
-
-        for ( int i = 0; i < tasksAmount; i++ ) {
-          Exception exception = service.take().get();
-          if ( exception != null ) {
-            exceptions.add( exception );
-          }
-        }
-      } finally {
-        executors.shutdown();
-      }
-    }
-
-    private boolean isDone( List<Future<Exception>> futures ) {
-      for ( Future<Exception> future : futures ) {
-        if ( !future.isDone() ) {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    public List<Exception> getExceptions() {
-      return exceptions;
+      return null;
     }
   }
 }

--- a/engine/test-src/org/pentaho/di/concurrency/RowMetaConcurrencyTest.java
+++ b/engine/test-src/org/pentaho/di/concurrency/RowMetaConcurrencyTest.java
@@ -1,0 +1,317 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.concurrency;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RowMetaConcurrencyTest {
+
+  private static final int cycles = 50;
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleClientEnvironment.init();
+  }
+
+  @Test
+  public void fiveAddersAgainstTenReaders() throws Exception {
+    final int addersAmount = 5;
+    final int readersAmount = 10;
+
+    final AtomicBoolean condition = new AtomicBoolean( true );
+    final RowMeta rowMeta = new RowMeta();
+
+    List<Adder> adders = new ArrayList<Adder>( addersAmount );
+    for ( int i = 0; i < addersAmount; i++ ) {
+      adders.add( new Adder( condition, rowMeta, cycles, "adder" + i ) );
+    }
+
+    List<Getter> getters = new ArrayList<Getter>( readersAmount );
+    for ( int i = 0; i < readersAmount; i++ ) {
+      getters.add( new Getter( condition, rowMeta ) );
+    }
+
+    ConcurrencyTestRunner<List<ValueMetaInterface>, ?> runner =
+      new ConcurrencyTestRunner<List<ValueMetaInterface>, Object>( adders, getters, condition );
+    runner.runConcurrentTest();
+
+    runner.checkNoExceptionRaised();
+
+    Set<ValueMetaInterface> results = new HashSet<ValueMetaInterface>( cycles * addersAmount );
+    for ( List<ValueMetaInterface> list : runner.getMonitoredTasksResults() ) {
+      results.addAll( list );
+    }
+    List<ValueMetaInterface> metas = rowMeta.getValueMetaList();
+
+    assertEquals( cycles * addersAmount, metas.size() );
+    assertEquals( cycles * addersAmount, results.size() );
+    for ( ValueMetaInterface meta : metas ) {
+      assertTrue( meta.getName(), results.remove( meta ) );
+    }
+    assertTrue( results.isEmpty() );
+  }
+
+
+  @Test
+  public void fiveShufflersAgainstTenSearchers() throws Exception {
+    final int elementsAmount = 100;
+    final int shufflersAmount = 5;
+    final int searchersAmount = 10;
+
+    final RowMeta rowMeta = new RowMeta();
+    for ( int i = 0; i < elementsAmount; i++ ) {
+      rowMeta.addValueMeta( new ValueMetaString( "meta_" + i ) );
+    }
+
+    final AtomicBoolean condition = new AtomicBoolean( true );
+
+    List<Shuffler> shufflers = new ArrayList<Shuffler>( shufflersAmount );
+    for ( int i = 0; i < shufflersAmount; i++ ) {
+      shufflers.add( new Shuffler( condition, rowMeta, cycles ) );
+    }
+
+    List<Searcher> searchers = new ArrayList<Searcher>( searchersAmount );
+    for ( int i = 0; i < searchersAmount; i++ ) {
+      String name = "meta_" + ( new Random().nextInt( elementsAmount ) );
+      assertTrue( rowMeta.indexOfValue( name ) >= 0 );
+      searchers.add( new Searcher( condition, rowMeta, name ) );
+    }
+
+    ConcurrencyTestRunner.runAndCheckNoExceptionRaised( shufflers, searchers, condition );
+  }
+
+
+  @SuppressWarnings( "unchecked" )
+  @Test
+  public void addRemoveSearch() throws Exception {
+    final int addersAmount = 5;
+    final int removeAmount = 10;
+    final int searchersAmount = 10;
+
+    final RowMeta rowMeta = new RowMeta();
+    List<String> toRemove = new ArrayList<String>( removeAmount );
+    for ( int i = 0; i < removeAmount; i++ ) {
+      String name = "toBeRemoved_" + i;
+      toRemove.add( name );
+      rowMeta.addValueMeta( new ValueMetaString( name ) );
+    }
+
+    final AtomicBoolean condition = new AtomicBoolean( true );
+
+    List<Searcher> searchers = new ArrayList<Searcher>( searchersAmount );
+    for ( int i = 0; i < searchersAmount; i++ ) {
+      String name = "kept_" + i;
+      rowMeta.addValueMeta( new ValueMetaString( name ) );
+      searchers.add( new Searcher( condition, rowMeta, name ) );
+    }
+
+
+    List<Remover> removers = Collections.singletonList( new Remover( condition, rowMeta, toRemove ) );
+
+    List<Adder> adders = new ArrayList<Adder>( addersAmount );
+    for ( int i = 0; i < addersAmount; i++ ) {
+      adders.add( new Adder( condition, rowMeta, cycles, "adder" + i ) );
+    }
+
+    List<Callable<?>> monitored = new ArrayList<Callable<?>>();
+    monitored.addAll( adders );
+    monitored.addAll( removers );
+
+
+    ConcurrencyTestRunner<?, ?> runner =
+      new ConcurrencyTestRunner<Object, Object>( monitored, searchers, condition );
+    runner.runConcurrentTest();
+
+    runner.checkNoExceptionRaised();
+
+    Map<? extends Callable<?>, ? extends ExecutionResult<?>> results = runner.getMonitoredResults();
+
+    // removers should remove all elements
+    for ( Remover remover : removers ) {
+      ExecutionResult<List<String>> result = (ExecutionResult<List<String>>) results.get( remover );
+      assertTrue( result.getResult().isEmpty() );
+      for ( String name : remover.getToRemove() ) {
+        assertEquals( name, -1, rowMeta.indexOfValue( name ) );
+      }
+    }
+    // adders should add all elements
+    Set<ValueMetaInterface> metas = new HashSet<ValueMetaInterface>( rowMeta.getValueMetaList() );
+    for ( Adder adder : adders ) {
+      ExecutionResult<List<ValueMetaInterface>> result =
+        (ExecutionResult<List<ValueMetaInterface>>) results.get( adder );
+      for ( ValueMetaInterface meta : result.getResult() ) {
+        assertTrue( meta.getName(), metas.remove( meta ) );
+      }
+    }
+    assertEquals( searchersAmount, metas.size() );
+  }
+
+
+  private static class Getter extends StopOnErrorCallable<Object> {
+
+    private final RowMeta rowMeta;
+
+    public Getter( AtomicBoolean condition, RowMeta rowMeta ) {
+      super( condition );
+      this.rowMeta = rowMeta;
+    }
+
+    @Override
+    Object doCall() throws Exception {
+      Random random = new Random();
+      while ( condition.get() ) {
+        int acc = 0;
+        for ( ValueMetaInterface meta : rowMeta.getValueMetaList() ) {
+          // fake cycle to from eliminating this snippet by JIT
+          acc += meta.getType() / 10;
+        }
+        Thread.sleep( random.nextInt( Math.max( 100, acc ) ) );
+      }
+      return null;
+    }
+  }
+
+  private static class Adder extends StopOnErrorCallable<List<ValueMetaInterface>> {
+    private final RowMeta rowMeta;
+    private final int cycles;
+    private final String nameSeed;
+
+    public Adder( AtomicBoolean condition, RowMeta rowMeta, int cycles, String nameSeed ) {
+      super( condition );
+      this.rowMeta = rowMeta;
+      this.cycles = cycles;
+      this.nameSeed = nameSeed;
+    }
+
+    @Override
+    List<ValueMetaInterface> doCall() throws Exception {
+      Random random = new Random();
+      List<ValueMetaInterface> result = new ArrayList<ValueMetaInterface>( cycles );
+      for ( int i = 0; ( i < cycles ) && condition.get(); i++ ) {
+        ValueMetaInterface added = new ValueMetaString( nameSeed + '_' + i );
+        rowMeta.addValueMeta( added );
+        result.add( added );
+        Thread.sleep( random.nextInt( 100 ) );
+      }
+      return result;
+    }
+  }
+
+  private static class Searcher extends StopOnErrorCallable<Object> {
+    private final RowMeta rowMeta;
+    private final String name;
+
+    public Searcher( AtomicBoolean condition, RowMeta rowMeta, String name ) {
+      super( condition );
+      this.rowMeta = rowMeta;
+      this.name = name;
+    }
+
+    @Override
+    Object doCall() throws Exception {
+      Random random = new Random();
+      while ( condition.get() ) {
+        int index = rowMeta.indexOfValue( name );
+        if ( index < 0 ) {
+          throw new IllegalStateException( name + " was not found among " + rowMeta.getValueMetaList() );
+        }
+        Thread.sleep( random.nextInt( 100 ) );
+      }
+      return null;
+    }
+  }
+
+  private static class Shuffler extends StopOnErrorCallable<Object> {
+    private final RowMeta rowMeta;
+    private final int cycles;
+
+    public Shuffler( AtomicBoolean condition, RowMeta rowMeta, int cycles ) {
+      super( condition );
+      this.rowMeta = rowMeta;
+      this.cycles = cycles;
+    }
+
+    @Override
+    Object doCall() throws Exception {
+      Random random = new Random();
+      for ( int i = 0; ( i < cycles ) && condition.get(); i++ ) {
+        List<ValueMetaInterface> list = new ArrayList<ValueMetaInterface>( rowMeta.getValueMetaList() );
+        Collections.shuffle( list );
+        rowMeta.setValueMetaList( list );
+        Thread.sleep( random.nextInt( 100 ) );
+      }
+      return null;
+    }
+  }
+
+  private static class Remover extends StopOnErrorCallable<List<String>> {
+    private final RowMeta rowMeta;
+    private final List<String> toRemove;
+
+    public Remover( AtomicBoolean condition, RowMeta rowMeta, List<String> toRemove ) {
+      super( condition );
+      this.rowMeta = rowMeta;
+      this.toRemove = toRemove;
+    }
+
+    @Override
+    List<String> doCall() throws Exception {
+      Random random = new Random();
+      List<String> result = new LinkedList<String>( toRemove );
+      for ( Iterator<String> it = result.iterator(); it.hasNext() && condition.get(); ) {
+        String name = it.next();
+        rowMeta.removeValueMeta( name );
+        it.remove();
+        Thread.sleep( random.nextInt( 100 ) );
+      }
+      return result;
+    }
+
+    public List<String> getToRemove() {
+      return toRemove;
+    }
+  }
+}

--- a/engine/test-src/org/pentaho/di/concurrency/StopOnErrorCallable.java
+++ b/engine/test-src/org/pentaho/di/concurrency/StopOnErrorCallable.java
@@ -1,0 +1,52 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.concurrency;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A convenient class to derive from as it takes care of handling crashes during execution of callable
+ *
+ * @author Andrey Khayrutdinov
+ */
+abstract class StopOnErrorCallable<T> implements Callable<T> {
+
+  final AtomicBoolean condition;
+
+  StopOnErrorCallable( AtomicBoolean condition ) {
+    this.condition = condition;
+  }
+
+  @Override
+  public T call() throws Exception {
+    try {
+      return doCall();
+    } catch ( Exception e ) {
+      condition.set( false );
+      throw e;
+    }
+  }
+
+  abstract T doCall() throws Exception;
+}

--- a/engine/test-src/org/pentaho/di/trans/steps/simplemapping/SimpleMappingTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/simplemapping/SimpleMappingTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -139,7 +139,9 @@ public class SimpleMappingTest {
     smp.dispose( stepMockHelper.processRowsStepMetaInterface, simpleMpData );
     verify( stepMockHelper.trans, times( 1 ) ).isFinished();
     verify( stepMockHelper.trans, never() ).waitUntilFinished();
-    verify( stepMockHelper.trans, never() ).getActiveSubtransformations();
+    verify( stepMockHelper.trans, never() ).addActiveSubTransformation( anyString(), any( Trans.class ) );
+    verify( stepMockHelper.trans, never() ).removeActiveSubTransformation( anyString() );
+    verify( stepMockHelper.trans, never() ).getActiveSubTransformation( anyString() );
     verify( stepMockHelper.trans, times( 1 ) ).getErrors();
     assertTrue( "The step contains the errors", smp.getErrors() == errorCount );
 

--- a/ui/src/org/pentaho/di/ui/spoon/trans/TransGraph.java
+++ b/ui/src/org/pentaho/di/ui/spoon/trans/TransGraph.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -4295,7 +4295,7 @@ public class TransGraph extends AbstractGraph implements XulEventHandler, Redraw
    */
   private void attachActiveTrans( TransGraph transGraph, StepMeta stepMeta ) {
     if ( trans != null && transGraph != null ) {
-      Trans subTransformation = trans.getActiveSubtransformations().get( stepMeta.getName() );
+      Trans subTransformation = trans.getActiveSubTransformation( stepMeta.getName() );
       transGraph.setTrans( subTransformation );
       if ( !transGraph.isExecutionResultsPaneVisible() ) {
         transGraph.showExecutionResults();
@@ -4312,7 +4312,7 @@ public class TransGraph extends AbstractGraph implements XulEventHandler, Redraw
    */
   private Trans getActiveSubtransformation( TransGraph transGraph, StepMeta stepMeta ) {
     if ( trans != null && transGraph != null ) {
-      return trans.getActiveSubtransformations().get( stepMeta.getName() );
+      return trans.getActiveSubTransformation( stepMeta.getName() );
     }
     return null;
   }


### PR DESCRIPTION
- Changing HM to CHM for synchronization
- Separating add/remove/get methods, encapsulating map-implementation
- Test written
- Concurrent tests from kettle's core project are moved to engine, as they are not running on CI
- Checkstyle applied