### PR TITLE
[SP-2766] - Backport of PDI-6748 - Mondrian Input Step: pan.sh / kitc…

### DIFF
--- a/assembly/package-res/classes/mondrian.properties
+++ b/assembly/package-res/classes/mondrian.properties
@@ -1,0 +1,1092 @@
+# This software is subject to the terms of the Eclipse Public License v1.0
+# Agreement, available at the following URL:
+# http://www.eclipse.org/legal/epl-v10.html.
+# You must accept the terms of that agreement to use this software.
+#
+# Copyright (C) 2001-2005 Julian Hyde
+# Copyright (C) 2005-2011 Pentaho and others
+# All Rights Reserved.
+
+###############################################################################
+# String property that is the AggRule element's tag value.
+#
+# Normally, this property is not set by a user.
+#
+#mondrian.rolap.aggregates.rule.tag=default
+
+###############################################################################
+# String property containing the name of the file which defines the
+# rules for recognizing an aggregate table. Can be either a resource in
+# the Mondrian jar or a URL.
+#
+# The default value is "/DefaultRules.xml", which is in the
+# mondrian.rolap.aggmatcher package in Mondrian.jar.
+#
+# Normally, this property is not set by a user.
+#
+#mondrian.rolap.aggregates.rules=/DefaultRules.xml
+
+###############################################################################
+# Alerting action to take in case native evaluation of a function is
+# enabled but not supported for that function's usage in a particular
+# query.  (No alert is ever raised in cases where native evaluation would
+# definitely have been wasted effort.)
+#
+# Recognized actions:
+#
+#
+# * OFF:  do nothing (default action, also used if
+# unrecognized action is specified)
+# * WARN:  log a warning to RolapUtil logger
+# * ERROR:  throw an instance of
+# NativeEvaluationUnsupportedException
+#
+#mondrian.native.unsupported.alert=OFF
+
+###############################################################################
+# Boolean property that controls whether the MDX parser resolves uses
+# case-sensitive matching when looking up identifiers. The default is
+# false.
+#
+#mondrian.olap.case.sensitive=false
+
+###############################################################################
+# Property that contains the URL of the catalog to be used by
+# mondrian.tui.CmdRunner and XML/A Test.
+#
+#mondrian.catalogURL=
+
+###############################################################################
+# Integer property that, if set to a value greater than zero, sets a hard limit on the
+# number of cells that are batched together when building segments.
+#
+#mondrian.rolap.cellBatchSize=-1
+
+###############################################################################
+# Positive integer property that determines loop iterations number between checks for whether the current mdx query has been cancelled or timeout was exceeded.
+# Setting the interval too small may result in a performance degradation when reading large result sets;
+# setting it too high can cause a big delay between the query being marked as cancelled or timeout was exceeded and system resources associated to it being released.
+#
+#mondrian.util.checkCancelOrTimeoutInterval=1000
+
+###############################################################################
+# Boolean property that controls whether aggregate tables
+# are ordered by their volume or row count.
+#
+# If true, Mondrian uses the aggregate table with the smallest volume
+# (number of rows multiplied by number of columns); if false, Mondrian
+# uses the aggregate table with the fewest rows.
+#
+#mondrian.rolap.aggregates.ChooseByVolume=false
+
+###############################################################################
+# Boolean property that controls whether sibling members are
+# compared according to order key value fetched from their ordinal
+# expression.  The default is false (only database ORDER BY is used).
+#
+#mondrian.rolap.compareSiblingsByOrderKey=false
+
+###############################################################################
+# Property that defines
+# when to apply the crossjoin optimization algorithm.
+#
+# If a crossjoin input list's size is larger than this property's
+# value and the axis has the "NON EMPTY" qualifier, then
+# the crossjoin non-empty optimizer is applied.
+# Setting this value to '0' means that for all crossjoin
+# input lists in non-empty axes will have the optimizer applied.
+# On the other hand, if the value is set larger than any possible
+# list, say Integer.MAX_VALUE, then the optimizer
+# will never be applied.
+#
+#mondrian.olap.fun.crossjoin.optimizer.size=0
+
+###############################################################################
+# Property that defines
+# the name of the plugin class that resolves data source names to
+# javax.sql.DataSource objects. The class must implement the
+# mondrian.spi.DataSourceResolver interface. If not specified,
+# the default implementation uses JNDI to perform resolution.
+#
+# Example:
+# mondrian.spi.dataSourceResolverClass=mondrian.spi.impl.JndiDataSourceResolver
+#
+#mondrian.spi.dataSourceResolverClass=
+
+###############################################################################
+# Boolean property that controls whether a RolapStar's
+# aggregate data cache is cleared after each query.
+# If true, no RolapStar will cache aggregate data from one
+# query to the next (the cache is cleared after each query).
+#
+#mondrian.rolap.star.disableCaching=false
+
+###############################################################################
+# Boolean property that controls whether the data from segments
+# is cached locally. To create custom caches, look for the
+# SegmentCache SPI.
+#
+#mondrian.rolap.star.disableLocalSegmentCache=false
+
+###############################################################################
+# Property that controls whether aggregation cache hit / miss
+# counters will be enabled.
+#
+# Note that this will affect performance due to existence of sync
+# blocks.
+#
+# @deprecated This property is no longer used, and will be removed in
+# mondrian-4.0.
+#
+#mondrian.rolap.agg.enableCacheHitCounters=false
+
+###############################################################################
+# If disabled, Mondrian will throw an exception if someone attempts to
+# perform a drillthrough of any kind.
+#
+#mondrian.drillthrough.enable=true
+
+###############################################################################
+# Boolean property that controls whether to use a cache for frequently
+# evaluated expressions. With the cache disabled, an expression like
+# Rank([Product].CurrentMember,
+# Order([Product].MEMBERS, [Measures].[Unit Sales])) would perform
+# many redundant sorts. The default is true.
+#
+#mondrian.expCache.enable=true
+
+###############################################################################
+# Property that defines
+# whether to generate SQL queries using the GROUPING SETS
+# construct for rollup. By default it is not enabled.
+#
+# Ignored on databases which do not support the
+# GROUPING SETS construct (see
+# mondrian.spi.Dialect#supportsGroupingSets).
+#
+#mondrian.rolap.groupingsets.enable=false
+
+###############################################################################
+# Property which turns on or off the in-memory rollup
+# of segment data. Defaults to true.
+#
+#mondrian.rolap.EnableInMemoryRollup=true
+
+###############################################################################
+# If enabled some NON EMPTY CrossJoin will be computed in SQL.
+#
+#mondrian.native.crossjoin.enable=true
+
+###############################################################################
+# If enabled some Filter() will be computed in SQL.
+#
+#mondrian.native.filter.enable=true
+
+###############################################################################
+# If enabled some NON EMPTY set operations like member.children,
+# level.members and member descendants will be computed in SQL.
+#
+#mondrian.native.nonempty.enable=true
+
+###############################################################################
+# If enabled some TopCount will be computed in SQL.
+#
+#mondrian.native.topcount.enable=true
+
+###############################################################################
+# Boolean property that controls whether each query axis implicit has the
+# NON EMPTY option set. The default is false.
+#
+#mondrian.rolap.nonempty=false
+
+###############################################################################
+# Property that determines whether to cache RolapCubeMember objects,
+# each of which associates a member of a shared hierarchy with a
+# particular cube in which it is being used.
+#
+# The default is true, that is, use a cache. If you wish to use
+# the member cache control aspects of mondrian.olap.CacheControl,
+# you must set this property to false.
+#
+# RolapCubeMember has recently become more lightweight to
+# construct, and we may obsolete this cache and this
+# property.
+#
+#mondrian.rolap.EnableRolapCubeMemberCache=true
+
+###############################################################################
+# If enabled, first row in the result of an XML/A drill-through request
+# will be filled with the total count of rows in underlying database.
+#
+#mondrian.xmla.drillthroughTotalCount.enable=true
+
+###############################################################################
+# Boolean property that controls whether to notify the Mondrian system
+# when a MondrianProperties property value changes.
+#
+# This allows objects dependent on Mondrian properties to react (that
+# is, reload), when a given property changes via, say,
+# MondrianProperties.instance().populate(null) or
+# MondrianProperties.instance().QueryLimit.set(50).
+#
+#mondrian.olap.triggers.enable=true
+
+###############################################################################
+# Property that defines how many previous execution instances the
+# Monitor keeps in its history so that it can send the events
+# which happen after the fact. Setting this property too high will make the
+# JVM run out of memory. Setting it too low might prevent some events from
+# reaching the listeners of the monitor.
+# This property is for internal use only and should not be changed
+# unless required. Defaults to 1,000.
+#
+#mondrian.server.monitor.executionHistorySize=1000
+
+###############################################################################
+# Property that defines
+# the name of the class used to compile scalar expressions.
+#
+# If the value is
+# non-null, it is used by the ExpCompiler.Factory
+# to create the implementation.
+#
+# To test that for all test MDX queries that all functions can
+# handle requests for ITERABLE, LIST and MUTABLE_LIST evaluation
+# results, use the following:
+#
+# mondrian.calc.ExpCompiler.class=mondrian.olap.fun.ResultStyleCompiler
+#
+#mondrian.calc.ExpCompiler.class=
+
+###############################################################################
+# If this property is true, when looking for native evaluation of an
+# expression, Mondrian will expand non-native sub-expressions into
+# lists of members.
+#
+#mondrian.native.ExpandNonNative=false
+
+###############################################################################
+# Property that defines
+# whether to generate joins to filter out members in a snowflake
+# dimension that do not have any children.
+#
+# If true (the default), some queries to query members of high
+# levels snowflake dimensions will be more expensive. If false, and if
+# there are rows in an outer snowflake table that are not referenced by
+# a row in an inner snowflake table, then some queries will return members
+# that have no children.
+#
+# Our recommendation, for best performance, is to remove rows outer
+# snowflake tables are not referenced by any row in an inner snowflake
+# table, during your ETL process, and to set this property to
+# false.
+#
+#mondrian.rolap.FilterChildlessSnowflakeMembers=true
+
+###############################################################################
+# Property containing the JDBC URL of the FoodMart database.
+# The default value is to connect to an ODBC data source called
+# "MondrianFoodMart".
+#
+# To run the test suite, first load the FoodMart data set into the
+# database of your choice. Then set the driver.classpath,
+# mondrian.foodmart.jdbcURL and mondrian.jdbcDrivers properties, by
+# un-commenting and modifying one of the sections below.
+# Put the JDBC driver jar into mondrian/testlib.
+#
+# Here are example property settings for various databases.
+#
+# ### Derby: needs user and password ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:derby:demo/derby/foodmart
+# mondrian.foodmart.jdbcUser=sa
+# mondrian.foodmart.jdbcPassword=sa
+# mondrian.jdbcDrivers=org.apache.derby.jdbc.EmbeddedDriver
+# driver.classpath=testlib/derby.jar
+#
+# ### FireBirdSQL ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:firebirdsql:localhost/3050:/mondrian/foodmart.gdb
+# mondrian.jdbcDrivers=org.firebirdsql.jdbc.FBDriver
+# driver.classpath=/jdbc/fb/firebirdsql-full.jar
+#
+# ### Greenplum (similar to Postgres) ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:postgresql://localhost/foodmart?user=gpadmin&password=xxxx
+# mondrian.foodmart.jdbcUser=foodmart
+# mondrian.foodmart.jdbcPassword=foodmart
+# mondrian.jdbcDrivers=org.postgresql.Driver
+# driver.classpath=lib/postgresql-8.2-504.jdbc3.jar
+#
+# ### LucidDB (see <a>instructions</a>) ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:luciddb:http://localhost
+# mondrian.foodmart.jdbcUser=foodmart
+# mondrian.jdbcDrivers=org.luciddb.jdbc.LucidDbClientDriver
+# driver.classpath=/path/to/luciddb/plugin/LucidDbClient.jar
+#
+# ### Oracle (needs user and password) ###
+#
+# oracle.home=G:/oracle/product/10.1.0/Db_1
+# mondrian.foodmart.jdbcURL.oracle=jdbc:oracle:thin:@//host:port/service_name
+# mondrian.foodmart.jdbcURL=jdbc:oracle:thin:foodmart/foodmart@//stilton:1521/orcl
+# mondrian.foodmart.jdbcURL=jdbc:oracle:oci8:foodmart/foodmart@orcl
+# mondrian.foodmart.jdbcUser=FOODMART
+# mondrian.foodmart.jdbcPassword=oracle
+# mondrian.jdbcDrivers=oracle.jdbc.OracleDriver
+# driver.classpath=/home/jhyde/open/mondrian/lib/ojdbc14.jar
+#
+# ### ODBC (Microsoft Access) ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:odbc:MondrianFoodMart
+# mondrian.jdbcDrivers=sun.jdbc.odbc.JdbcOdbcDriver
+# driver.classpath=
+#
+# ###  Hypersonic ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:hsqldb:demo/hsql/FoodMart
+# mondrian.jdbcDrivers=org.hsqldb.jdbcDriver
+# driver.classpath=xx
+#
+# ###  MySQL: can have user and password set in JDBC URL ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:mysql://localhost/foodmart?user=foodmart&password=foodmart
+# mondrian.foodmart.jdbcURL=jdbc:mysql://localhost/foodmart
+# mondrian.foodmart.jdbcUser=foodmart
+# mondrian.foodmart.jdbcPassword=foodmart
+# mondrian.jdbcDrivers=com.mysql.jdbc.Driver
+# driver.classpath=D:/mysql-connector-3.1.12
+#
+# ###  NuoDB ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:com.nuodb://localhost/foodmart?schema=mondrian
+# mondrian.foodmart.jdbcUser=foodmart
+# mondrian.foodmart.jdbcPassword=foodmart
+# mondrian.jdbcDrivers=com.nuodb.jdbc.Driver
+# mondrian.foodmart.jdbcSchema=mondrian
+# driver.classpath=/opt/nuodb/jar/nuodbjdbc.jar
+#
+# ### Infobright ###
+# As MySQL. (Infobright uses a MySQL driver, version 5.1 and later.)
+#
+# ### Ingres ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:ingres://192.168.200.129:II7/MondrianFoodMart;LOOP=on;AUTO=multi;UID=ingres;PWD=sergni
+# mondrian.jdbcDrivers=com.ingres.jdbc.IngresDriver
+# driver.classpath=c:/ingres2006/ingres/lib/iijdbc.jar
+#
+# ### Postgres: needs user and password ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:postgresql://localhost/FM3
+# mondrian.foodmart.jdbcUser=postgres
+# mondrian.foodmart.jdbcPassword=pgAdmin
+# mondrian.jdbcDrivers=org.postgresql.Driver
+#
+# ### Neoview ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:hpt4jdbc://localhost:18650/:schema=PENTAHO;serverDataSource=PENTAHO_DataSource
+# mondrian.foodmart.jdbcUser=user
+# mondrian.foodmart.jdbcPassword=password
+# mondrian.jdbcDrivers=com.hp.t4jdbc.HPT4Driver
+# driver.classpath=/some/path/hpt4jdbc.jar
+#
+# ### Netezza: mimics Postgres ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:netezza://127.0.1.10/foodmart
+# mondrian.foodmart.jdbcUser=user
+# mondrian.foodmart.jdbcPassword=password
+# mondrian.jdbcDrivers=org.netezza.Driver
+# driver.classpath=/some/path/nzjdbc.jar
+#
+# ### Sybase ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:jtds:sybase://xxx.xxx.xxx.xxx:port/dbName
+# mondrian.foodmart.jdbcUser=user
+# mondrian.foodmart.jdbcPassword=password
+# mondrian.jdbcDrivers=net.sourceforge.jtds.jdbc.Driver
+# driver.classpath=/some/path/jtds-1.2.jar
+#
+# ### Teradata ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:teradata://DatabaseServerName/DATABASE=FoodMart
+# mondrian.foodmart.jdbcUser=user
+# mondrian.foodmart.jdbcPassword=password
+# mondrian.jdbcDrivers=com.ncr.teradata.TeraDriver
+# driver.classpath=/some/path/terajdbc/classes/terajdbc4.jar
+#
+# ### Vertica ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:vertica://xxx.xxx.xxx.xxx:port/dbName
+# mondrian.foodmart.jdbcUser=user
+# mondrian.foodmart.jdbcPassword=password
+# mondrian.jdbcDrivers=com.vertica.Driver
+# driver.classpath=/some/path/vertica.jar
+#
+# ### Vectorwise ###
+#
+# mondrian.foodmart.jdbcURL=jdbc:ingres://xxx.xxx.xxx.xxxport/dbName
+# mondrian.foodmart.jdbcUser=user
+# mondrian.foodmart.jdbcPassword=password
+# mondrian.jdbcDrivers=com.ingres.jdbc.IngresDriver 
+# driver.classpath=/some/path/iijdbc.jar
+#
+#mondrian.foodmart.jdbcURL=jdbc:odbc:MondrianFoodMart
+
+###############################################################################
+# Boolean property that controls whether to print the SQL code
+# generated for aggregate tables.
+#
+# If set, then as each aggregate request is processed, both the lost
+# and collapsed dimension create and insert sql code is printed.
+# This is for use in the CmdRunner allowing one to create aggregate table
+# generation sql.
+#
+#mondrian.rolap.aggregates.generateSql=false
+
+###############################################################################
+# Boolean property that controls pretty-print mode.
+#
+# If true, the all SqlQuery SQL strings will be generated in
+# pretty-print mode, formatted for ease of reading.
+#
+#mondrian.rolap.generate.formatted.sql=false
+
+###############################################################################
+# Property that establishes the amount of chunks for querying cells
+# involving high-cardinality dimensions.
+# Should prime with #ResultLimit mondrian.result.limit.
+#
+#mondrian.result.highCardChunkSize=1
+
+###############################################################################
+# Property that defines whether non-existent member errors should be
+# ignored during schema load. If so, the non-existent member is treated
+# as a null member.
+#
+#mondrian.rolap.ignoreInvalidMembers=false
+
+###############################################################################
+# Property that defines whether non-existent member errors should be
+# ignored during query validation. If so, the non-existent member is
+# treated as a null member.
+#
+#mondrian.rolap.ignoreInvalidMembersDuringQuery=false
+
+###############################################################################
+# Property that defines whether to ignore measure when non joining
+# dimension is in the tuple during aggregation.
+#
+# If there are unrelated dimensions to a measure in context during
+# aggregation, the measure is ignored in the evaluation context. This
+# behaviour kicks in only if the CubeUsage for this measure has
+# IgnoreUnrelatedDimensions attribute set to false.
+#
+# For example, Gender doesn't join with [Warehouse Sales] measure.
+#
+# With mondrian.olap.agg.IgnoreMeasureForNonJoiningDimension=true
+# Warehouse Sales gets eliminated and is ignored in the aggregate
+# value.
+#
+#                                     [Store Sales] + [Warehouse Sales]
+# SUM({Product.members * Gender.members})    7,913,333.82
+#
+# With mondrian.olap.agg.IgnoreMeasureForNonJoiningDimension=false
+# Warehouse Sales with Gender All level member contributes to the aggregate
+# value.
+#
+#                                      [Store Sales] + [Warehouse Sales]
+# SUM({Product.members * Gender.members})    9,290,730.03
+#
+# On a report where Gender M, F and All members exist a user will see a
+# large aggregated value compared to the aggregated value that can be
+# arrived at by summing up values against Gender M and F. This can be
+# confusing to the user. This feature can be used to eliminate such a
+# situation.
+#
+#mondrian.olap.agg.IgnoreMeasureForNonJoiningDimension=false
+
+###############################################################################
+# Integer property indicating the maximum number of iterations
+# allowed when iterating over members to compute aggregates.  A value of
+# 0 (the default) indicates no limit.
+#
+#mondrian.rolap.iterationLimit=0
+
+###############################################################################
+# Not documented.
+#
+#mondrian.test.Iterations=1
+
+###############################################################################
+# Property containing a list of JDBC drivers to load automatically.
+# Must be a comma-separated list of class names, and the classes must be
+# on the class path.
+#
+#mondrian.jdbcDrivers=sun.jdbc.odbc.JdbcOdbcDriver,org.hsqldb.jdbcDriver,oracle.jdbc.OracleDriver,com.mysql.jdbc.Driver
+
+###############################################################################
+# Property that defines the JdbcSchema factory class which
+# determines the list of tables and columns of a specific datasource.
+#
+# @see mondrian.rolap.aggmatcher.JdbcSchema
+#
+#mondrian.rolap.aggregates.jdbcFactoryClass=
+
+###############################################################################
+# Property which governs whether child members or members of a level are precached
+#                 when child or level members are requested within a
+#                 query expression.  For example,
+#                 if an expression references two child members in the store dimension,
+#                 like { [Store].[USA].[CA], [Store].[USA].[OR] }, precaching will
+#                 load *all* children under [USA] rather than just the 2 requested.
+#                 The threshold value is
+#                 compared against the cardinality of the level to determine
+#                 whether or not precaching should be performed.  If cardinality is
+#                 lower than the threshold value Mondrian will precache.  Setting
+#                 this property to 0 effectively disables precaching.
+#
+#mondrian.rolap.precache.threshold=300
+
+###############################################################################
+# String property that holds the
+# name of the class whose resource bundle is to be used to for this
+# schema. For example, if the class is com.acme.MyResource,
+# mondrian will look for a resource bundle called
+# com/acme/MyResource_locale.properties on the class path.
+# (This property has a confusing name because in a previous release it
+# actually held a file name.)
+#
+# Used for the mondrian.i18n.LocalizingDynamicSchemaProcessor;
+# see <a>Internationalization</a>
+# for more details.
+#
+# Default value is null.
+#
+#mondrian.rolap.localePropFile=
+
+###############################################################################
+# Set mondrian logging information if not provided by containing application.
+#
+# Examples:
+#
+#
+# log4j.configuration=file://full/path/log4j.xml
+# log4j.configuration=file:log4j.properties
+#
+#log4j.configuration=
+
+###############################################################################
+# Max number of constraints in a single 'IN' SQL clause.
+#
+# This value may be variant among database products and their runtime
+# settings. Oracle, for example, gives the error "ORA-01795: maximum
+# number of expressions in a list is 1000".
+#
+# Recommended values:
+#
+# * Oracle: 1,000
+# * DB2: 2,500
+# * Other: 10,000
+#
+#mondrian.rolap.maxConstraints=1000
+
+###############################################################################
+# Boolean property that defines the maximum number of passes
+# allowable while evaluating an MDX expression.
+#
+# If evaluation exceeds this depth (for example, while evaluating a
+# very complex calculated member), Mondrian will throw an error.
+#
+#mondrian.rolap.evaluate.MaxEvalDepth=10
+
+###############################################################################
+# Property that defines
+# limit on the number of rows returned by XML/A drill through request.
+#
+#mondrian.xmla.drillthroughMaxRows=1000
+
+###############################################################################
+# Property that defines whether the MemoryMonitor should
+# be enabled. By default it is disabled; memory monitor is not available
+# before Java version 1.5.
+#
+#mondrian.util.memoryMonitor.enable=false
+
+###############################################################################
+# Property that defines
+# the name of the class used as a memory monitor.
+#
+# If the value is
+# non-null, it is used by the MemoryMonitorFactory
+# to create the implementation.
+#
+#mondrian.util.MemoryMonitor.class=
+
+###############################################################################
+# Property that defines the default MemoryMonitor
+# percentage threshold. If enabled, when Java's memory monitor detects
+# that post-garbage collection is above this value, notifications are
+# generated.
+#
+#mondrian.util.memoryMonitor.percentage.threshold=90
+
+###############################################################################
+# Property that controls the maximum number of results contained in a
+# NativizeSet result set.
+#
+# If the number of tuples contained in the result set exceeds this
+# value Mondrian throws a LimitExceededDuringCrossjoin error.
+#
+#mondrian.native.NativizeMaxResults=150000
+
+###############################################################################
+# Property that controls minimum expected cardinality required in
+# order for NativizeSet to natively evaluate a query.
+#
+# If the expected cardinality falls below this level the query is
+# executed non-natively.
+#
+# It is possible for the actual cardinality to fall below this
+# threshold even though the expected cardinality falls above this
+# threshold.  In this case the query will be natively evaluated.
+#
+#mondrian.native.NativizeMinThreshold=100000
+
+###############################################################################
+# Property determines if elements of dimension (levels, hierarchies,
+# members) need to be prefixed with dimension name in MDX query.
+#
+# For example when the property is true, the following queries
+# will error out. The same queries will work when this property
+# is set to false.
+#
+# select {[M]} on 0 from sales
+# select {[USA]} on 0 from sales
+# select {[USA].[CA].[Santa Monica]}  on 0 from sales
+#
+# When the property is set to true, any query where elements are
+# prefixed with dimension name as below will work
+#
+# select {[Gender].[F]} on 0 from sales
+# select {[Customers].[Santa Monica]} on 0 from sales
+#
+# Please note that this property does not govern the behaviour
+# wherein
+#
+# [Gender].[M]
+#
+# is resolved into a fully qualified
+#
+# [Gender].[M]
+#
+#  In a scenario where the schema is very large and dimensions have
+# large number of members a MDX query that has a invalid member in it will
+# cause mondrian to to go through all the dimensions, levels, hierarchies,
+# members and properties trying to resolve the element name. This behavior
+# consumes considerable time and resources on the server. Setting this
+# property to true will make it fail fast in a scenario where it is
+# desirable.
+#
+#mondrian.olap.elements.NeedDimensionPrefix=false
+
+###############################################################################
+# Property that defines
+# the behavior of division if the denominator evaluates to zero.
+#
+# If false (the default), if a division has a non-null numerator and
+# a null denominator, it evaluates to "Infinity", which conforms to SSAS
+# behavior.
+#
+# If true, the result is null if the denominator is null. Setting to
+# true enables the old semantics of evaluating this to null; this does
+# not conform to SSAS, but is useful in some applications.
+#
+#mondrian.olap.NullDenominatorProducesNull=false
+
+###############################################################################
+# Property that determines how a null member value is represented in the
+# result output.
+# AS 2000 shows this as empty value
+# AS 2005 shows this as "(null)" value
+#
+#mondrian.olap.NullMemberRepresentation=#null
+
+###############################################################################
+# Boolean property that determines whether Mondrian optimizes predicates.
+#
+# If true, Mondrian may retrieve a little more data than specified in
+# MDX query and cache it for future use.  For example, if you ask for
+# data on 48 states of the United States for 3 quarters of 2011,
+# Mondrian will round out to all 50 states and all 4 quarters.  If
+# false, Mondrian still optimizes queries that involve all members of a
+# dimension.
+#
+#mondrian.rolap.aggregates.optimizePredicates=true
+
+###############################################################################
+# Property that defines the name of the factory class used
+# to create maps of member properties to their respective values.
+#
+# If the value is
+# non-null, it is used by the PropertyValueFactory
+# to create the implementation.  If unset,
+# mondrian.rolap.RolapMemberBase.DefaultPropertyValueMapFactory
+# will be used.
+#
+#mondrian.rolap.RolapMember.PropertyValueMapFactory.class=
+
+###############################################################################
+# Property defining
+# where the test XML files are.
+#
+#mondrian.test.QueryFileDirectory=
+
+###############################################################################
+# Property that defines
+# a pattern for which test XML files to run.  Pattern has to
+# match a file name of the form:
+# querywhatever.xml in the directory.
+#
+# Example:
+#
+#
+# mondrian.test.QueryFilePattern=queryTest_fec[A-Za-z0-9_]*.xml
+#
+#mondrian.test.QueryFilePattern=
+
+###############################################################################
+# Maximum number of simultaneous queries the system will allow.
+#
+# Oracle fails if you try to run more than the 'processes' parameter in
+# init.ora, typically 150. The throughput of Oracle and other databases
+# will probably reduce long before you get to their limit.
+#
+#mondrian.query.limit=40
+
+###############################################################################
+# Property that defines the timeout value (in seconds) for queries. A
+# value of 0 (the default) indicates no timeout.
+#
+#mondrian.rolap.queryTimeout=0
+
+###############################################################################
+# Boolean property that determines whether Mondrian should read
+# aggregate tables.
+#
+# If set to true, then Mondrian scans the database for aggregate tables.
+# Unless mondrian.rolap.aggregates.Use is set to true, the aggregates
+# found will not be used.
+#
+#mondrian.rolap.aggregates.Read=false
+
+###############################################################################
+# Integer property that, if set to a value greater than zero, limits the
+# maximum size of a result set.
+#
+#mondrian.result.limit=0
+
+###############################################################################
+# Maximum number of MDX query threads per Mondrian server instance.
+# Defaults to 20.
+#
+#mondrian.rolap.maxQueryThreads=20
+
+###############################################################################
+# Property that defines the interval value between
+# polling operations performed by the RolapConnection shepherd thread.
+# This controls query timeouts and cancellation, so a small value
+# (a few milliseconds) is best. Setting this to a value higher than
+# mondrian.rolap.queryTimeout will result the timeout not being enforced
+# as expected.
+#
+# Default value is "1000ms". Default time unit is "ms".
+#
+#mondrian.rolap.shepherdThreadPollingInterval=1000ms
+
+###############################################################################
+# Property which defines which SegmentCache implementation to use.
+# Specify the value as a fully qualified class name, such as
+# org.example.SegmentCacheImpl where SegmentCacheImpl
+# is an implementation of mondrian.spi.SegmentCache.
+#
+#mondrian.rolap.SegmentCache=
+
+###############################################################################
+# Maximum number of threads per Mondrian server instance that
+# are used to run perform operations on the external caches.
+# Defaults to 100.
+#
+#mondrian.rolap.maxCacheThreads=100
+
+###############################################################################
+# Maximum number of threads per Mondrian server instance that
+# are used to run SQL queries when populating segments.
+# Defaults to 100.
+#
+#mondrian.rolap.maxSqlThreads=100
+
+###############################################################################
+# Property that controls the behavior of
+# Property#SOLVE_ORDER solve order of calculated members and sets.
+#
+# Valid values are "scoped" and "absolute" (the default). See
+# mondrian.olap.SolveOrderMode for details.
+#
+#mondrian.rolap.SolveOrderMode=ABSOLUTE
+
+###############################################################################
+# Property that, with #SparseSegmentDensityThreshold, determines
+# whether to choose a sparse or dense representation when storing
+# collections of cell values in memory.
+#
+# When storing collections of cell values, Mondrian has to choose
+# between a sparse and a dense representation, based upon the
+# possible and actual number of values.
+# The density is actual / possible.
+#
+# We use a sparse representation if
+# (possible -
+# #SparseSegmentCountThreshold countThreshold) *
+# #SparseSegmentDensityThreshold densityThreshold >
+# actual
+#
+# For example, at the default values
+# (#SparseSegmentCountThreshold countThreshold = 1000,
+# #SparseSegmentDensityThreshold = 0.5),
+# we use a dense representation for
+#
+#
+# * (1000 possible, 0 actual), or
+# * (2000 possible, 500 actual), or
+# * (3000 possible, 1000 actual).
+#
+#
+# Any fewer actual values, or any more
+# possible values, and Mondrian will use a sparse representation.
+#
+#mondrian.rolap.SparseSegmentValueThreshold=1000
+
+###############################################################################
+# Property that, with #SparseSegmentCountThreshold,
+# determines whether to choose a sparse or dense representation when
+# storing collections of cell values in memory.
+#
+#mondrian.rolap.SparseSegmentDensityThreshold=0.5
+
+###############################################################################
+# Property that defines the name of the class used in SqlMemberSource
+# to pool common values.
+#
+# If the value is non-null, it is used by the
+# SqlMemberSource.ValueMapFactory
+# to create the implementation.  If it is not set, then
+# mondrian.rolap.SqlMemberSource.NullValuePoolFactory
+# will be used, meaning common values will not be pooled.
+#
+#mondrian.rolap.SqlMemberSource.ValuePoolFactory.class=
+
+###############################################################################
+# Property that defines
+# whether to enable new naming behavior.
+#
+# If true, hierarchies are named [Dimension].[Hierarchy]; if false,
+# [Dimension.Hierarchy].
+#
+#mondrian.olap.SsasCompatibleNaming=false
+
+###############################################################################
+# Comma-separated list of classes to be used to get statistics about the
+# number of rows in a table, or the number of distinct values in a column.
+#
+# If there is a value for mondrian.statistics.providers.DATABASE, where
+# DAtABASE is the current database name (e.g. MYSQL or ORACLE), then that
+# property overrides.
+#
+# Example:
+#
+#
+# mondrian.statistics.providers=mondrian.spi.impl.JdbcStatisticsProvider
+# mondrian.statistics.providers.MYSQL=mondrian.spi.impl.JdbcStatisticsProvider,mondrian.spi.impl.JdbcStatisticsProvider
+#
+# This would use JDBC's statistics (via the
+# java.sql.DatabaseMetaData.getIndexInfo method) for most
+# databases, but for connections to a MySQL database, would use
+# external statistics first, and fall back to JDBC statistics
+# only if external statistics were not available.
+#
+#mondrian.statistics.providers=
+
+###############################################################################
+# String property that determines which test class to run.
+#
+# This is the name of the class. It must either implement
+# junit.framework.Test or have a method
+# public [static] junit.framework.Test suite().
+#
+# Example:
+#
+# mondrian.test.Class=mondrian.test.FoodMartTestCase
+#
+# @see #TestName
+#
+#mondrian.test.Class=
+
+###############################################################################
+# Property containing the connect string which regression tests should
+# use to connect to the database.
+#
+# Format is specified in Util#parseConnectString(String).
+#
+#mondrian.test.connectString=
+
+###############################################################################
+# Integer property that controls whether to test operators'
+# dependencies, and how much time to spend doing it.
+#
+# If this property is positive, Mondrian's test framework allocates an
+# expression evaluator which evaluates each expression several times, and
+# makes sure that the results of the expression are independent of
+# dimensions which the expression claims to be independent of.
+#
+# The default is 0.
+#
+#mondrian.test.ExpDependencies=0
+
+###############################################################################
+# Property containing a list of dimensions in the Sales cube that should
+# be treated as high-cardinality dimensions by the testing infrastructure.
+# This allows us to run the full suite of tests with high-cardinality
+# functionality enabled.
+#
+#mondrian.test.highCardDimensions=
+
+###############################################################################
+# Property containing the JDBC password of a test database.
+# The default value is null, to cope with DBMSs that don't need this.
+#
+#mondrian.foodmart.jdbcPassword=
+
+###############################################################################
+# Property containing the JDBC user of a test database.
+# The default value is null, to cope with DBMSs that don't need this.
+#
+#mondrian.foodmart.jdbcUser=
+
+###############################################################################
+# String property that determines which tests are run.
+#
+# This is a regular expression as defined by
+# java.util.regex.Pattern.
+# If this property is specified, only tests whose names match the pattern
+# in its entirety will be run.
+#
+# @see #TestClass
+#
+#mondrian.test.Name=
+
+###############################################################################
+# Seed for random number generator used by some of the tests.
+#
+# Any value besides 0 or -1 gives deterministic behavior.
+# The default value is 1234: most users should use this.
+# Setting the seed to a different value can increase coverage, and
+# therefore may uncover new bugs.
+#
+# If you set the value to 0, the system will generate its own
+# pseudo-random seed.
+#
+# If you set the value to -1, Mondrian uses the next seed from an
+# internal random-number generator. This is a little more deterministic
+# than setting the value to 0.
+#
+#mondrian.test.random.seed=1234
+
+###############################################################################
+# Property that returns the time limit for the test run in seconds.
+# If the test is running after that time, it is terminated.
+#
+#mondrian.test.TimeLimit=0
+
+###############################################################################
+# Boolean property that controls whether Mondrian uses aggregate
+# tables.
+#
+# If true, then Mondrian uses aggregate tables. This property is
+# queried prior to each aggregate query so that changing the value of this
+# property dynamically (not just at startup) is meaningful.
+#
+# Aggregates can be read from the database using the
+# #ReadAggregates property but will not be used unless this
+# property is set to true.
+#
+#mondrian.rolap.aggregates.Use=false
+
+###############################################################################
+# Not documented.
+#
+#mondrian.test.VUsers=1
+
+###############################################################################
+# Property that indicates whether this is a "warmup test".
+#
+#mondrian.test.Warmup=false
+
+###############################################################################
+# Property that controls whether warning messages should be printed if a SQL
+# comparison test does not contain expected SQL statements for the specified
+# dialect. The tests are skipped if no expected SQL statements are
+# found for the current dialect.
+#
+# Possible values are the following:
+#
+#
+# * "NONE": no warning (default)
+# * "ANY": any dialect
+# * "ACCESS"
+# * "DERBY"
+# * "LUCIDDB"
+# * "MYSQL"
+# * ... and any Dialect enum in SqlPattern.Dialect
+#
+#
+# Specific tests can overwrite the default setting. The priority is:
+# * Settings besides "ANY" in mondrian.properties file
+# * < Any setting in the test
+# * < "ANY"
+#
+#mondrian.test.WarnIfNoPatternForDialect=NONE
+
+###############################################################################
+# Connect string for the webapp. (Used by the webapp only.)
+#
+# To achieve access control, append say ;Role='California
+# manager' to the connect string.
+#
+#mondrian.webapp.connectString=Provider=mondrian;Jdbc=jdbc:odbc:MondrianFoodMart;Catalog=/WEB-INF/queries/FoodMart.xml;JdbcDrivers=sun.jdbc.odbc.JdbcOdbcDriver
+
+###############################################################################
+# Where mondrian.war will be deployed to. (Used by mondrian's build.xml ant file only.)
+#
+# Example: mondrian.webapp.deploy=C:/jboss-4.0.2/server/default/deploy
+#
+#mondrian.webapp.deploy=
+
+###############################################################################
+# Interval at which to refresh the
+# list of XML/A catalogs. (Usually known as the
+# datasources.xml file.)
+#
+# It is not an active process; no threads will be created. It only
+# serves as a rate limiter. The refresh process is triggered by requests
+# to the doPost() servlet method.
+#
+# Values may have time unit suffixes such as 's' (second) or 'ms'
+# (milliseconds). Default value is 3000 milliseconds (3 seconds).
+# Default time unit is milliseconds.
+#
+# See also
+# mondrian.xmla.impl.DynamicDatasourceXmlaServlet.
+#
+#mondrian.xmla.SchemaRefreshInterval=3000ms
+
+# End mondrian.properties.template


### PR DESCRIPTION
…hen.sh ignore mondrian.properties (5.4 Suite)

- was added actual mondrian.properties according to mondrian.properties.template under mondrian project.

@pamval, here is the backport of #2647 and #2664 to 5.4. Thanks. 