### PR TITLE
[SP-2755] Backport of PDI-14948 - Transformation with Metadata Injection runs endlessly if no input is received by Injection Step (5.4 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/Trans.java
+++ b/engine/src/org/pentaho/di/trans/Trans.java
@@ -1439,6 +1439,10 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
 
     ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.TransformationStart.id, this );
 
+    if ( steps.isEmpty() ) {
+      fireTransFinishedListeners();
+    }
+
     if ( log.isDetailed() ) {
       log
         .logDetailed( BaseMessages
@@ -3728,8 +3732,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
       if ( executionConfiguration.isClusterPosting() ) {
         if ( executionConfiguration.isClusterPreparing() ) {
           // Prepare the master...
-          if ( masterSteps.size() > 0 ) // If there is something that needs to be done on the master...
-          {
+          if ( masterSteps.size() > 0 ) {
+            // If there is something that needs to be done on the master...
             String carteObjectId = carteObjectMap.get( master );
             String masterReply =
               masterServer.execService( PrepareExecutionTransServlet.CONTEXT_PATH
@@ -3763,8 +3767,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
 
         if ( executionConfiguration.isClusterStarting() ) {
           // Start the master...
-          if ( masterSteps.size() > 0 ) // If there is something that needs to be done on the master...
-          {
+          if ( masterSteps.size() > 0 ) {
+            // If there is something that needs to be done on the master...
             String carteObjectId = carteObjectMap.get( master );
             String masterReply =
               masterServer.execService( StartExecutionTransServlet.CONTEXT_PATH
@@ -4306,8 +4310,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
    *          the new internal kettle variables
    */
   public void setInternalKettleVariables( VariableSpace var ) {
-    if ( transMeta != null && !Const.isEmpty( transMeta.getFilename() ) ) // we have a finename that's defined.
-    {
+    if ( transMeta != null && !Const.isEmpty( transMeta.getFilename() ) ) {
+      // we have a finename that's defined.
       try {
         FileObject fileObject = KettleVFS.getFileObject( transMeta.getFilename(), var );
         FileName fileName = fileObject.getName();

--- a/engine/test-src/org/pentaho/di/trans/TransTest.java
+++ b/engine/test-src/org/pentaho/di/trans/TransTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,8 +25,7 @@ package org.pentaho.di.trans;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -253,6 +252,23 @@ public class TransTest {
     TransMeta.removeStep( 0 );
     assertEquals( TransMeta.nrSteps(), 2 );
 
+  }
+
+  /**
+   * PDI-14948 - Execution of trans with no steps never ends
+  **/
+   @Test( timeout = 1000 )
+  public void transWithNoStepsIsNotEndless() throws Exception {
+    Trans transWithNoSteps = new Trans( new TransMeta() );
+    transWithNoSteps = spy( transWithNoSteps );
+
+    transWithNoSteps.prepareExecution( new String[] {} );
+
+    transWithNoSteps.startThreads();
+
+    // check trans lifecycle is not corrupted
+    verify( transWithNoSteps ).fireTransStartedListeners();
+    verify( transWithNoSteps ).fireTransFinishedListeners();
   }
 
   private void startThreads( Runnable one, Runnable two, CountDownLatch start ) throws InterruptedException {


### PR DESCRIPTION
- When starting threads, check if transformation has any step to run, and finish it, if it has no steps.
- Test written
- Checkstyle applied

Backport of https://github.com/pentaho/pentaho-kettle/pull/2660

@mchen-len-son , could you please review this PR?