### PR TITLE
[SP-2779] Backport of PDI-13918 - Get File Names throws ArrayIndexOutOfBoundsException when Filename is defined in a field option is checked (6.1 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/getfilenames/GetFileNamesMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/getfilenames/GetFileNamesMeta.java
@@ -695,7 +695,7 @@ public class GetFileNamesMeta extends BaseStepMeta implements StepMetaInterface 
                                            boolean[] includesubfolders ) {
     return FileInputList.createFileList(
       space, filename, filemask, excludefilemask, filerequired, includesubfolders,
-      buildFileTypeFiltersArray( fileName ) );
+      buildFileTypeFiltersArray( filename ) );
   }
 
   @Override


### PR DESCRIPTION
Backport of https://github.com/pentaho/pentaho-kettle/pull/2655.
In https://github.com/pentaho/pentaho-kettle/pull/2721 there was a typo: file**N**ame instead of file**n**ame

@mchen-len-son , review this PR please
