### PR TITLE
[SP-2766] Backport of PDI-6748 - Mondrian Input Step: pan.sh / kitche…

### DIFF
--- a/assembly/package-res/launcher/launcher.properties
+++ b/assembly/package-res/launcher/launcher.properties
@@ -1,5 +1,5 @@
 main=org.pentaho.di.ui.spoon.Spoon
 libraries=../test:../lib:../libswt
-classpath=../:../ui:../ui/images:../lib
+classpath=../classes:../:../ui:../ui/images:../lib
 
 system-property.pentaho.installed.licenses.file=${PENTAHO_INSTALLED_LICENSE_PATH}


### PR DESCRIPTION
…n.sh ignore mondrian.properties (5.4 Suite)

- added classes folder to classpath in order to make Kettle read mondrian.properties