### PR TITLE
[BACKLOG-8388] - Upgrade Jersey to 1.19.1 across the suite for Java 8 compatibility

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -199,7 +199,9 @@
     <dependency org="org.codehaus.enunciate" name="enunciate-core-annotations" rev="1.27"   transitive="false" />
 
     <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.3" transitive="false"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.16" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.19.1" transitive="false"/>
+    <dependency org="org.jvnet.mimepull"  name="mimepull" rev="1.9.3" transitive="false"/>
+    <dependency org="javax.ws.rs" name="jsr311-api" rev="1.1.1" transitive="false"/>
 
     <exclude org="javax.servlet"   module="servlet-api"/>
   </dependencies>

--- a/engine/ivy.xml
+++ b/engine/ivy.xml
@@ -46,10 +46,10 @@
     <dependency org="jfree"                            name="jcommon"              rev="1.0.16"          transitive="false"/>
     <dependency org="com.googlecode.json-simple"       name="json-simple"          rev="1.1"             transitive="false"/>
     <dependency org="jsonpath"                         name="jsonpath"             rev="1.0"             transitive="false"/>
-    <dependency org="com.sun.jersey.contribs"          name="jersey-apache-client" rev="1.16"          transitive="false"/>
-    <dependency org="com.sun.jersey"                   name="jersey-bundle"        rev="1.16"          transitive="false"/>
-    <dependency org="com.sun.jersey"                   name="jersey-client"        rev="1.16"          transitive="false"/>
-    <dependency org="com.sun.jersey"                   name="jersey-core"          rev="1.16"          transitive="false"/>
+    <dependency org="com.sun.jersey.contribs"          name="jersey-apache-client" rev="1.19.1"          transitive="false"/>
+    <dependency org="com.sun.jersey"                   name="jersey-bundle"        rev="1.19.1"          transitive="false"/>
+    <dependency org="com.sun.jersey"                   name="jersey-client"        rev="1.19.1"          transitive="false"/>
+    <dependency org="com.sun.jersey"                   name="jersey-core"          rev="1.19.1"          transitive="false"/>
     <dependency org="jexcelapi"                        name="jxl"                  rev="2.6.12"          transitive="false"/>
     <dependency org="ldapjdk"                          name="ldapjdk"              rev="20000524"        transitive="false"/>
     <dependency org="monetdb"                          name="monetdb-jdbc"         rev="2.8"             transitive="false"/>

--- a/plugins/pdi-pur-plugin/ivy.xml
+++ b/plugins/pdi-pur-plugin/ivy.xml
@@ -117,9 +117,9 @@
     <dependency org="org.mortbay.jetty" name="jetty-util" rev="6.1.21" transitive="false" conf="test->default" />
 
     <!-- jersey -->
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart"     rev="1.16" transitive="false" conf="compile->default"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.16" transitive="false" conf="compile->default"/>
-    <dependency org="com.sun.jersey"          name="jersey-bundle"        rev="1.16" transitive="false" conf="compile->default"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart"     rev="1.19.1" transitive="false" conf="compile->default"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.19.1" transitive="false" conf="compile->default"/>
+    <dependency org="com.sun.jersey"          name="jersey-bundle"        rev="1.19.1" transitive="false" conf="compile->default"/>
 
     <!-- To support Enunciate Annotations in Resource classes 1.21.1 -->
     <dependency org="org.codehaus.enunciate" name="enunciate-core-annotations" rev="1.28"/>


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor