### PR TITLE
[SP-2819] - Backport of PDI-15523 - Select Values Step Throws Errors when multiple fields with same field name occur (6.1 Suite)

### DIFF
--- a/core/src/org/pentaho/di/core/row/RowMeta.java
+++ b/core/src/org/pentaho/di/core/row/RowMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -284,8 +284,17 @@ public class RowMeta implements RowMetaInterface {
       lock.writeLock().lock();
       try {
         ValueMetaInterface old = valueMetaList.get( index );
-        valueMetaList.set( index, valueMeta );
-        cache.replaceMapping( old.getName(), valueMeta.getName(), index );
+        ValueMetaInterface newMeta = valueMeta;
+
+        // try to check if a ValueMeta with the same name already exists 
+        int existsIndex = indexOfValue( valueMeta.getName() );
+        // if it exists and it's not in the requested position
+        // we need to take care of renaming
+        if ( existsIndex >= 0 && existsIndex != index ) {
+          newMeta = renameValueMetaIfInRow( valueMeta, null );
+        }
+        valueMetaList.set( index, newMeta );
+        cache.replaceMapping( old.getName(), newMeta.getName(), index );
       } finally {
         lock.writeLock().unlock();
       }

--- a/core/test-src/org/pentaho/di/core/row/RowMetaTest.java
+++ b/core/test-src/org/pentaho/di/core/row/RowMetaTest.java
@@ -53,6 +53,7 @@ public class RowMetaTest {
   ValueMetaInterface date;
 
   ValueMetaInterface charly;
+  ValueMetaInterface dup;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
@@ -73,6 +74,8 @@ public class RowMetaTest {
     rowMeta.addValueMeta( date );
 
     charly = ValueMetaFactory.createValueMeta( "charly", ValueMetaInterface.TYPE_SERIALIZABLE );
+
+    dup = ValueMetaFactory.createValueMeta( "dup", ValueMetaInterface.TYPE_SERIALIZABLE );
   }
 
   private List<ValueMetaInterface> generateVList( String[] names, int[] types ) throws KettlePluginException {
@@ -164,6 +167,23 @@ public class RowMetaTest {
     assertEquals( 1, rowMeta.getValueMetaList().indexOf( charly ) );
     assertEquals( "There is still 3 elements:", 3, rowMeta.size() );
     assertEquals( -1, rowMeta.indexOfValue( "integer" ) );
+  }
+
+  @Test
+  public void testSetValueMetaDup() throws KettlePluginException {
+    rowMeta.setValueMeta( 1, dup );
+    assertEquals( "There is still 3 elements:", 3, rowMeta.size() );
+    assertEquals( -1, rowMeta.indexOfValue( "integer" ) );
+
+    rowMeta.setValueMeta( 1, dup );
+    assertEquals( "There is still 3 elements:", 3, rowMeta.size() );
+    assertEquals( -1, rowMeta.indexOfValue( "integer" ) );
+
+    rowMeta.setValueMeta( 2, dup );
+    assertEquals( "There is still 3 elements:", 3, rowMeta.size() );
+    assertEquals( "Original is still the same (object)", 1, rowMeta.getValueMetaList().indexOf( dup ) );
+    assertEquals( "Original is still the same (name)", 1, rowMeta.indexOfValue( "dup" ) );
+    assertEquals( "Renaming happened", 2, rowMeta.indexOfValue( "dup_1" ) );
   }
 
   @Test

--- a/engine/test-src/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitterTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitterTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,13 +26,15 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
-import junit.framework.Assert;
+import java.util.Arrays;
 
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.QueueRowSet;
 import org.pentaho.di.core.RowSet;
+import org.pentaho.di.core.SingleRowRowSet;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
@@ -46,6 +48,8 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import org.pentaho.metastore.api.IMetaStore;
 
+import static org.junit.Assert.*;
+
 /**
  * Tests for FieldSplitter step
  *
@@ -54,6 +58,11 @@ import org.pentaho.metastore.api.IMetaStore;
  */
 public class FieldSplitterTest {
   StepMockHelper<FieldSplitterMeta, FieldSplitterData> smh;
+
+  @BeforeClass
+  public static void initKettle() throws Exception {
+    KettleEnvironment.init();
+  }
 
   @Before
   public void setUp() {
@@ -106,8 +115,6 @@ public class FieldSplitterTest {
 
   @Test
   public void testSplitFields() throws KettleException {
-    KettleEnvironment.init();
-
     FieldSplitter step = new FieldSplitter( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
     step.init( smh.initStepMetaInterface, smh.stepDataInterface );
     step.setInputRowMeta( getInputRowMeta() );
@@ -123,10 +130,47 @@ public class FieldSplitterTest {
     Object[] actualRow = outputRowSet.getRow();
     Object[] expectedRow = new Object[] { "before", null, "b=b", "after" };
 
-    Assert.assertEquals( "Output row is of an unexpected length", expectedRow.length, outputRowSet.getRowMeta().size() );
+    assertEquals( "Output row is of an unexpected length", expectedRow.length, outputRowSet.getRowMeta().size() );
 
     for ( int i = 0; i < expectedRow.length; i++ ) {
-      Assert.assertEquals( "Unexpected output value at index " + i, expectedRow[i], actualRow[i] );
+      assertEquals( "Unexpected output value at index " + i, expectedRow[i], actualRow[i] );
     }
+  }
+
+  @Test
+  public void testSplitFieldsDup() throws Exception {
+    FieldSplitterMeta meta = new FieldSplitterMeta();
+    meta.allocate( 2 );
+    meta.setDelimiter( " " );
+    meta.setEnclosure( "" );
+    meta.setSplitField( "split" );
+    meta.setFieldName( new String[] { "key", "val" } );
+    meta.setFieldType( new int[] { ValueMetaInterface.TYPE_STRING, ValueMetaInterface.TYPE_STRING } );
+
+    FieldSplitter step = new FieldSplitter( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    step.init( meta, smh.stepDataInterface );
+
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMetaString( "key" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "val" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "split" ) );
+
+    step.setInputRowMeta( rowMeta );
+    step.getInputRowSets().add( smh.getMockInputRowSet( new Object[] { "key", "string", "part1 part2" } ) );
+    step.getOutputRowSets().add( new SingleRowRowSet() );
+
+    assertTrue( step.processRow( meta, smh.stepDataInterface ) );
+
+    RowSet rs = step.getOutputRowSets().get( 0 );
+    Object[] row = rs.getRow();
+    RowMetaInterface rm = rs.getRowMeta();
+
+    assertArrayEquals(
+        new Object[] { "key", "string", "part1", "part2" },
+        Arrays.copyOf( row, 4 ) );
+
+    assertArrayEquals(
+        new Object[] { "key", "val", "key_1", "val_1" },
+        rm.getFieldNames() );
   }
 }


### PR DESCRIPTION
[PDI-15523] - Select Values Step Throws Errors when multiple fields with same field name occur

Earlier it used to work since RowMeta clone was implemented as sequential addValueMeta calls.
After reworking the RowMeta implementation this logic was eliminated, what is right:
cloning should replicate the state as is (w/o) taking care of fixing incosistencies.

Real inconsistancy (duplicated fields' names) were caused by the fact that setValueMeta method
did not process the case when duplicated field's name is introduced.
The fix is to incorporate deduplication to the setValueMeta() call logic.

license header