### PR TITLE
[BACKLOG-9667] - ETL Metadata Injection step fails when we check the option 'Don't execute resulting transformation' for Synchronize after merge step

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/synchronizeaftermerge/SynchronizeAfterMergeMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/synchronizeaftermerge/SynchronizeAfterMergeMeta.java
@@ -364,9 +364,9 @@ public class SynchronizeAfterMergeMeta extends BaseStepMeta implements StepMetaI
   }
 
   public void normalizeAllocationFields() {
-    if ( keyLookup != null ) {
-      int keyGroupSize = keyLookup.length;
-      keyStream = normalizeAllocation( keyStream, keyGroupSize );
+    if ( keyStream != null ) {
+      int keyGroupSize = keyStream.length;
+      keyLookup = normalizeAllocation( keyLookup, keyGroupSize );
       keyCondition = normalizeAllocation( keyCondition, keyGroupSize );
       keyStream2 = normalizeAllocation( keyStream2, keyGroupSize );
     }
@@ -509,6 +509,7 @@ public class SynchronizeAfterMergeMeta extends BaseStepMeta implements StepMetaI
   }
 
   public String getXML() {
+    normalizeAllocationFields();
     StringBuilder retval = new StringBuilder( 200 );
 
     retval

--- a/engine/test-src/org/pentaho/di/trans/steps/synchronizeaftermerge/SynchronizeAfterMergeMetaInjectionTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/synchronizeaftermerge/SynchronizeAfterMergeMetaInjectionTest.java
@@ -22,8 +22,11 @@
 
 package org.pentaho.di.trans.steps.synchronizeaftermerge;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.injection.BaseMetadataInjectionTest;
 
 public class SynchronizeAfterMergeMetaInjectionTest extends BaseMetadataInjectionTest<SynchronizeAfterMergeMeta> {
@@ -151,4 +154,55 @@ public class SynchronizeAfterMergeMetaInjectionTest extends BaseMetadataInjectio
       }
     }, "My Connection" );
   }
+
+  @Test
+  public void getXML() throws KettleException {
+    skipProperties( "CONNECTION_NAME", "TABLE_NAME", "STREAM_FIELD2", "PERFORM_LOOKUP", "COMPARATOR",
+        "OPERATION_ORDER_FIELD", "ORDER_DELETE", "SHEMA_NAME", "TABLE_NAME_IN_FIELD", "ORDER_UPDATE", "ORDER_INSERT",
+        "USE_BATCH_UPDATE", "STREAM_FIELD", "TABLE_FIELD", "COMMIT_SIZE", "TABLE_NAME_FIELD" );
+    meta.setDefault();
+    check( "STREAM_FIELD1", new StringGetter() {
+      @Override
+      public String get() {
+        return meta.getKeyStream()[0];
+      }
+    } );
+    check( "UPDATE_TABLE_FIELD", new StringGetter() {
+      @Override
+      public String get() {
+        return meta.getUpdateLookup()[0];
+      }
+    } );
+    check( "UPDATE", new BooleanGetter() {
+      @Override
+      public boolean get() {
+        return meta.getUpdate()[0];
+      }
+    } );
+
+    meta.getXML();
+
+    String[] actualKeyLookup = meta.getKeyLookup();
+    assertNotNull( actualKeyLookup );
+    assertEquals( 1, actualKeyLookup.length );
+
+    String[] actualKeyCondition = meta.getKeyCondition();
+    assertNotNull( actualKeyCondition );
+    assertEquals( 1, actualKeyCondition.length );
+
+    String[] actualKeyStream2 = meta.getKeyCondition();
+    assertNotNull( actualKeyStream2 );
+    assertEquals( 1, actualKeyStream2.length );
+
+    String[] actualUpdateStream = meta.getUpdateStream();
+    assertNotNull( actualUpdateStream );
+    assertEquals( 1, actualUpdateStream.length );
+  }
+
+  private void skipProperties( String... propertyName ) {
+    for ( String property : propertyName ) {
+      skipPropertyTest( property );
+    }
+  }
+
 }


### PR DESCRIPTION
@bmorrise , @mdamour1976  please review.