### PR TITLE
PDI-15295 Merge Join step does not save input step names when exporte…

### DIFF
--- a/engine/src/org/pentaho/di/trans/step/errorhandling/Stream.java
+++ b/engine/src/org/pentaho/di/trans/step/errorhandling/Stream.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -46,6 +46,11 @@ public class Stream implements StreamInterface {
     this.description = description;
     this.streamIcon = streamIcon;
     this.subject = subject;
+  }
+
+  public Stream( StreamInterface stream ) {
+    this( stream.getStreamType(), stream.getStepMeta(), stream.getDescription(), stream.getStreamIcon(),
+      stream.getSubject() );
   }
 
   public String toString() {

--- a/engine/src/org/pentaho/di/trans/steps/mergejoin/MergeJoinMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/mergejoin/MergeJoinMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -147,6 +147,14 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
     retval.allocate( nrKeys1, nrKeys2 );
     System.arraycopy( keyFields1, 0, retval.keyFields1, 0, nrKeys1 );
     System.arraycopy( keyFields2, 0, retval.keyFields2, 0, nrKeys2 );
+
+    StepIOMetaInterface stepIOMeta = new StepIOMeta( true, true, false, false, false, false );
+    List<StreamInterface> infoStreams = getStepIOMeta().getInfoStreams();
+
+    for ( StreamInterface infoStream : infoStreams ) {
+      stepIOMeta.addStream( new Stream( infoStream ) );
+    }
+    retval.ioMeta = stepIOMeta;
 
     return retval;
   }

--- a/engine/test-src/org/pentaho/di/trans/steps/mergejoin/MergeJoinMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/mergejoin/MergeJoinMetaTest.java
@@ -31,6 +31,7 @@ import org.pentaho.di.core.row.value.ValueMetaInteger;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidatorFactory;
@@ -175,5 +176,16 @@ public class MergeJoinMetaTest {
     assertTrue( Arrays.equals( meta.getKeyFields1(), aClone.getKeyFields1() ) );
     assertTrue( Arrays.equals( meta.getKeyFields2(), aClone.getKeyFields2() ) );
     assertEquals( meta.getJoinType(), aClone.getJoinType() );
+
+    assertNotNull( aClone.getStepIOMeta() );
+    assertFalse( meta.getStepIOMeta() == aClone.getStepIOMeta() );
+    List<StreamInterface> infoStreams = meta.getStepIOMeta().getInfoStreams();
+    List<StreamInterface> cloneInfoStreams = aClone.getStepIOMeta().getInfoStreams();
+    assertFalse( infoStreams == cloneInfoStreams );
+    int streamSize = infoStreams.size();
+    assertTrue( streamSize == cloneInfoStreams.size() );
+    for ( int i = 0; i < streamSize; i++ ) {
+      assertFalse( infoStreams.get( i ) == cloneInfoStreams.get( i ) );
+    }
   }
 }


### PR DESCRIPTION
PDI-15295 Merge Join step does not save input step names when exported to XML from repository - preserve infostream steps after clone