### PR TITLE
[PDI-15344] Date A - Date B (working days) Calculation returns incorrect

### DIFF
--- a/core/src/org/pentaho/di/core/row/ValueDataUtil.java
+++ b/core/src/org/pentaho/di/core/row/ValueDataUtil.java
@@ -1310,7 +1310,7 @@ public class ValueDataUtil {
           iNoOfWorkingDays += 1;
         }
         calFrom.add( Calendar.DATE, 1 );
-      } while ( calFrom.getTimeInMillis() < calTo.getTimeInMillis() );
+      } while ( calFrom.getTimeInMillis() <= calTo.getTimeInMillis() );
       return new Long( singminus ? -iNoOfWorkingDays : iNoOfWorkingDays );
     } else {
       return null;

--- a/core/test-src/org/pentaho/di/core/row/ValueDateUtilTest.java
+++ b/core/test-src/org/pentaho/di/core/row/ValueDateUtilTest.java
@@ -23,6 +23,7 @@
 package org.pentaho.di.core.row;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleValueException;
@@ -35,10 +36,21 @@ import static org.junit.Assert.assertEquals;
 
 
 public class ValueDateUtilTest {
+  private TimeZone defTimeZone;
+  private TimeZone defUserTimezone;
 
+  @Before
+  public void setUp() {
+    defUserTimezone = TimeZone.getTimeZone( System.getProperty( "user.timezone" ) );
+    defTimeZone = java.util.TimeZone.getDefault();
+    System.setProperty( "user.timezone", "UTC" );
+    TimeZone.setDefault( null );
+  }
   @After
   public void tearDown() {
     System.clearProperty( Const.KETTLE_COMPATIBILITY_CALCULATION_TIMEZONE_DECOMPOSITION );
+    System.setProperty( "user.timezone", defUserTimezone.getID() );
+    TimeZone.setDefault( defTimeZone );
   }
 
   @Test
@@ -67,4 +79,149 @@ public class ValueDateUtilTest {
 
     assertEquals( 8L + offsetLocal, hourOfDayLocal );
   }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_JAN() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1230768000000L ); // 2009-01-01 00:00:00
+    endDate.setTimeInMillis( 1233360000000L ); // 2009-01-31 00:00:00
+    Object workingDayOfJAN = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in JAN ", 22L, workingDayOfJAN );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_FEB() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1233446400000L ); // 2009-02-01 00:00:00
+    endDate.setTimeInMillis( 1235779200000L ); // 2009-02-28 00:00:00
+    Object workingDayOfFEB = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in FEB ", 20L, workingDayOfFEB );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_MAR() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1235865600000L ); // 2009-03-01 00:00:00
+    endDate.setTimeInMillis( 1238457600000L ); // 2009-03-31 00:00:00
+    Object workingDayOfMAR = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in MAR ", 22L, workingDayOfMAR );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_APR() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1238544000000L ); // 2009-04-01 00:00:00
+    endDate.setTimeInMillis( 1241049600000L ); // 2009-04-30 00:00:00
+    Object workingDayOfAPR = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in APR ", 22L, workingDayOfAPR );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_MAY() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1241136000000L ); // 2009-05-01 00:00:00
+    endDate.setTimeInMillis( 1243728000000L );     // 2009-05-31 00:00:00
+    Object workingDayOfMAY = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in MAY ", 21L, workingDayOfMAY );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_JUN() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1243814400000L ); // 2009-06-01 00:00:00
+    endDate.setTimeInMillis( 1246320000000L );     // 2009-06-30 00:00:00
+    Object workingDayOfJUN = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in JUN ", 22L, workingDayOfJUN );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_JUL() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1246406400000L ); // 2009-07-01 00:00:00
+    endDate.setTimeInMillis( 1248998400000L );     // 2009-07-31 00:00:00
+    Object workingDayOfJUL = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in JUL ", 23L, workingDayOfJUL );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_AUG() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1249084800000L ); // 2009-08-01 00:00:00
+    endDate.setTimeInMillis( 1251676800000L );     // 2009-08-31 00:00:00
+    Object workingDayOfAUG = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in AUG ", 21L, workingDayOfAUG );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_SEP() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1251763200000L ); // 2009-09-01 00:00:00
+    endDate.setTimeInMillis( 1254268800000L );     // 2009-09-30 00:00:00
+    Object workingDayOfSEP = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in SEP ", 22L, workingDayOfSEP );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_OCT() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1254355200000L ); // 2009-10-01 00:00:00
+    endDate.setTimeInMillis( 1256947200000L );     // 2009-10-31 00:00:00
+    Object workingDayOfOCT = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in OCT ", 22L, workingDayOfOCT );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_NOV() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1257033600000L ); // 2009-11-01 00:00:00
+    endDate.setTimeInMillis( 1259539200000L );     // 2009-11-30 00:00:00
+    Object workingDayOfNOV = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in NOV ", 21L, workingDayOfNOV );
+  }
+
+  @Test
+  public void shouldCalculateDateWorkingDiff_DEC() throws KettleValueException {
+    ValueMetaInterface metaA = new ValueMetaDate();
+    ValueMetaInterface metaB = new ValueMetaDate();
+    Calendar startDate = Calendar.getInstance();
+    Calendar endDate = Calendar.getInstance();
+    startDate.setTimeInMillis( 1259625600000L ); // 2009-12-01 00:00:00
+    endDate.setTimeInMillis( 1262217600000L );     // 2009-12-31 00:00:00
+    Object workingDayOfDEC = ValueDataUtil.DateWorkingDiff( metaA, endDate.getTime(), metaB, startDate.getTime() );
+    assertEquals( "Working days count in DEC ", 23L, workingDayOfDEC );
+  }
+
 }


### PR DESCRIPTION
values
 - DateWorkingDiff calculation now considers last day of month
 - added unit test (divided tests into separate ones by months since in case of errors some months are failing some not)