### PR TITLE
[PDI-11194] - Formula now treating empty strings as null

### DIFF
--- a/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -3831,12 +3831,19 @@ public class ValueMetaBase implements ValueMetaInterface {
 
     // See if the polled value is empty
     // In that case, we have a null value on our hands...
-    //
-    Object emptyValue = ( outValueType == Value.VALUE_TYPE_STRING ) ? Const.NULL_STRING : null;
+    boolean isStringValue = outValueType == Value.VALUE_TYPE_STRING;
+    Object emptyValue = isStringValue ? Const.NULL_STRING : null;
+
+    Boolean isEmptyAndNullDiffer = convertStringToBoolean(
+        Const.NVL( System.getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
+
+    if ( pol == null && isStringValue && isEmptyAndNullDiffer ) {
+      pol = Const.NULL_STRING;
+    }
 
     if ( pol == null ) {
       return null;
-    } else if ( Const.isEmpty( pol ) && outValueType != Value.VALUE_TYPE_STRING ) {
+    } else if ( Const.isEmpty( pol ) && !isStringValue ) {
       return null;
     } else {
       // if the null_value is specified, we try to match with that.

--- a/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -55,6 +55,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Encoder;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.database.NetezzaDatabaseMeta;
@@ -331,13 +332,27 @@ public class ValueMetaBaseTest {
     int trim_type = 0;
     Object result;
 
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
     result =
       outValueMetaString.convertDataFromString( inputValueEmptyString, inValueMetaString, nullIf, ifNull, trim_type );
-    assertEquals( "Conversion from empty string to string must return empty string", result, StringUtils.EMPTY );
+    assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = N: "
+        + "Conversion from empty string to string must return empty string", StringUtils.EMPTY, result );
 
     result =
       outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
-    assertEquals( "Conversion from null string must return null", result, null );
+    assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = N: "
+        + "Conversion from null string must return null", null, result );
+
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
+    result =
+        outValueMetaString.convertDataFromString( inputValueEmptyString, inValueMetaString, nullIf, ifNull, trim_type );
+    assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y: "
+        + "Conversion from empty string to string must return empty string", StringUtils.EMPTY, result );
+
+    result =
+        outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
+    assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y: "
+        + "Conversion from null string must return empty string", StringUtils.EMPTY, result );
   }
 
   @Test


### PR DESCRIPTION
@CodeOnCoffee, @pamval could you please take a look?

Current behavior is following: if KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL=Y then null is retrieved as empty string like it was in old product versions ( 4.4.0 ).

when KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL=N we have null as returned value.