### PR TITLE
[SP-2823][PDI-8942] RowMetaAndData - inconsistent synchronization

### DIFF
--- a/core/src/org/pentaho/di/core/RowMetaAndData.java
+++ b/core/src/org/pentaho/di/core/RowMetaAndData.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -289,7 +289,7 @@ public class RowMetaAndData implements Cloneable {
     removeValue( index );
   }
 
-  public synchronized void removeValue( int index ) {
+  public void removeValue( int index ) {
     rowMeta.removeValueMeta( index );
     data = RowDataUtil.removeItem( data, index );
   }


### PR DESCRIPTION
From my investigation RowMetaAndData class is not used in concurrent environment, so synchronization is redundant here.
@mchen-len-son , @mbatchelor, could you please review and merge this PR?