### PR TITLE
[BACKLOG-10068] When Lazy Conversion is enabled aggregations cannot b…

### DIFF
--- a/core/src/org/pentaho/di/core/row/ValueDataUtil.java
+++ b/core/src/org/pentaho/di/core/row/ValueDataUtil.java
@@ -547,7 +547,9 @@ public class ValueDataUtil {
       return null;
     }
     if ( dataA == null && dataB != null ) {
-      return metaA.convertData( metaB, dataB );
+      Object value = metaA.convertData( metaB, dataB );
+      metaA.setStorageType( ValueMetaInterface.STORAGE_TYPE_NORMAL );
+      return value;
     }
     if ( dataA != null && dataB == null ) {
       return dataA;


### PR DESCRIPTION
…e calculated since the aggregrated value is converted to a numeric even though the meta type is still set to Binary String. Converting the aggregation meta type from binary string to normal when a convert call is made.