### PR TITLE
[BACKLOG-10323] Standardizing on javassist version 3.20.0-GA

### DIFF
--- a/core/ivy.xml
+++ b/core/ivy.xml
@@ -41,7 +41,7 @@
     <dependency org="net.sf.scannotation" name="scannotation"        rev="1.0.2"            transitive="false"/>
     <dependency org="secondstring"        name="secondstring"        rev="20060615"         transitive="false"/>
     <dependency org="org.owasp.esapi"     name="esapi"               rev="2.0.1"            transitive="false"/>
-    <dependency org="javassist"           name="javassist"           rev="3.12.1.GA"        transitive="false" conf="runtime->default"/>
+    <dependency org="org.javassist"       name="javassist"           rev="3.20.0-GA"        transitive="false" conf="runtime->default"/>
     <dependency org="org.samba.jcifs"     name="jcifs"               rev="1.3.3"            transitive="false" conf="runtime->default"/>
 
     <dependency org="org.hamcrest"        name="java-hamcrest"       rev="2.0.0.0"          transitive="false" conf="test->default"/>

--- a/plugins/pdi-pur-plugin/ivy.xml
+++ b/plugins/pdi-pur-plugin/ivy.xml
@@ -104,7 +104,7 @@
         <artifact name="jackrabbit-data" type="jar"/>
     </dependency>
     <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.6.4" conf="test->default" />
-    <dependency org="javassist" name="javassist" rev="3.12.1.GA" conf="test->default" transitive="false" />
+    <dependency org="org.javassist" name="javassist" rev="3.20.0-GA" conf="test->default" transitive="false" />
     <dependency org="org.scannotation" name="scannotation" rev="1.0.2" conf="test->default" transitive="false"/>
     <dependency org="javax.jcr" name="jcr" rev="2.0" conf="test->default"/>
     <dependency org="org.owasp.esapi" name="esapi" rev="2.0.1" transitive="false" conf="test->default"/>


### PR DESCRIPTION
 - Changed the kettle-core and pdi-pur-plugin to use the newer version of
   javassist