### PR TITLE
[PDI-15255] kitchen.sh/pan.sh cannot use relative paths to jobs/transformations stored on the filesystem

### DIFF
--- a/assembly/package-res/Kitchen.bat
+++ b/assembly/package-res/Kitchen.bat
@@ -1,7 +1,8 @@
 @echo off
 setlocal
+SET initialDir=%cd%
 pushd %~dp0
 SET STARTTITLE="Kitchen"
 SET SPOON_CONSOLE=1
-call Spoon.bat -main org.pentaho.di.kitchen.Kitchen %*
+call Spoon.bat -main org.pentaho.di.kitchen.Kitchen -initialDir "%initialDir%"\ %*
 popd

--- a/assembly/package-res/Pan.bat
+++ b/assembly/package-res/Pan.bat
@@ -1,7 +1,8 @@
 @echo off
 setlocal
+SET initialDir=%cd%
 pushd %~dp0
 SET STARTTITLE="Pan"
 SET SPOON_CONSOLE=1
-call Spoon.bat -main org.pentaho.di.pan.Pan %*
+call Spoon.bat -main org.pentaho.di.pan.Pan -initialDir "%initialDir%"\ %*
 popd

--- a/assembly/package-res/kitchen.sh
+++ b/assembly/package-res/kitchen.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+INITIALDIR="`pwd`"
 BASEDIR="`dirname $0`"
 cd "$BASEDIR"
 DIR="`pwd`"
@@ -14,4 +15,4 @@ fi
 
 export IS_KITCHEN="true"
 
-"$DIR/spoon.sh" -main org.pentaho.di.kitchen.Kitchen "$@"
+"$DIR/spoon.sh" -main org.pentaho.di.kitchen.Kitchen -initialDir "$INITIALDIR/" "$@"

--- a/assembly/package-res/pan.sh
+++ b/assembly/package-res/pan.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+INITIALDIR="`pwd`"
 BASEDIR="`dirname $0`"
 cd "$BASEDIR"
 DIR="`pwd`"
@@ -12,4 +13,4 @@ if [ "$1" = "-x" ]; then
   shift
 fi
 
-"$DIR/spoon.sh" -main org.pentaho.di.pan.Pan "$@"
+"$DIR/spoon.sh" -main org.pentaho.di.pan.Pan -initialDir "$INITIALDIR/" "$@"

--- a/engine/src/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/org/pentaho/di/kitchen/Kitchen.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.kitchen;
 
+import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -124,7 +125,7 @@ public class Kitchen {
     RepositoryMeta repositoryMeta = null;
     Job job = null;
 
-    StringBuilder optionRepname, optionUsername, optionPassword, optionJobname, optionDirname;
+    StringBuilder optionRepname, optionUsername, optionPassword, optionJobname, optionDirname, initialDir;
     StringBuilder optionFilename, optionLoglevel, optionLogfile, optionLogfileOld, optionListdir;
     StringBuilder optionListjobs, optionListrep, optionNorep, optionVersion, optionListParam, optionExport;
     NamedParams optionParams = new NamedParamsDefault();
@@ -187,10 +188,13 @@ public class Kitchen {
           "export", BaseMessages.getString( PKG, "Kitchen.ComdLine.Export" ), optionExport =
           new StringBuilder(), true, false ),
         new CommandLineOption(
+          "initialDir", null, initialDir =
+          new StringBuilder(), false, true ),
+        new CommandLineOption(
           "custom", BaseMessages.getString( PKG, "Kitchen.ComdLine.Custom" ), customOptions, false ),
         maxLogLinesOption, maxLogTimeoutOption, };
 
-    if ( args.size() == 0 ) {
+    if ( args.size() == 2 ) { // 2 internal hidden argument (flag and value)
       CommandLineOption.printUsage( options );
       exitJVM( 9 );
     }
@@ -378,7 +382,12 @@ public class Kitchen {
         // Try to load if from file anyway.
         if ( !Utils.isEmpty( optionFilename ) && job == null ) {
           blockAndThrow( kettleInitFuture );
-          jobMeta = new JobMeta( optionFilename.toString(), null, null );
+          String fileName = optionFilename.toString();
+          if ( !new File( fileName ).isAbsolute() ) {
+            fileName = initialDir.toString() + fileName;
+          }
+
+          jobMeta = new JobMeta( fileName, null, null );
           job = new Job( null, jobMeta );
         }
       } else if ( "Y".equalsIgnoreCase( optionListrep.toString() ) ) {

--- a/engine/src/org/pentaho/di/pan/Pan.java
+++ b/engine/src/org/pentaho/di/pan/Pan.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.pan;
 
+import java.io.File;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -88,7 +89,7 @@ public class Pan {
     StringBuilder optionRepname, optionUsername, optionPassword, optionTransname, optionDirname;
     StringBuilder optionFilename, optionLoglevel, optionLogfile, optionLogfileOld, optionListdir;
     StringBuilder optionListtrans, optionListrep, optionExprep, optionNorep, optionSafemode;
-    StringBuilder optionVersion, optionJarFilename, optionListParam, optionMetrics;
+    StringBuilder optionVersion, optionJarFilename, optionListParam, optionMetrics, initialDir;
 
     NamedParams optionParams = new NamedParamsDefault();
 
@@ -155,10 +156,13 @@ public class Pan {
           "listparam", BaseMessages.getString( PKG, "Pan.ComdLine.ListParam" ), optionListParam =
           new StringBuilder(), true, false ),
         new CommandLineOption(
+          "initialDir", null, initialDir =
+          new StringBuilder(), false, true ),
+        new CommandLineOption(
           "metrics", BaseMessages.getString( PKG, "Pan.ComdLine.Metrics" ), optionMetrics =
           new StringBuilder(), true, false ), maxLogLinesOption, maxLogTimeoutOption };
 
-    if ( args.size() == 0 ) {
+    if ( args.size() == 2 ) { // 2 internal hidden argument (flag and value)
       CommandLineOption.printUsage( options );
       exitJVM( 9 );
     }
@@ -377,10 +381,16 @@ public class Pan {
         // You could implement some fail-over mechanism this way.
         //
         if ( trans == null && !Utils.isEmpty( optionFilename ) ) {
-          if ( log.isDetailed() ) {
-            log.logDetailed( BaseMessages.getString( PKG, "Pan.Log.LoadingTransXML", "" + optionFilename ) );
+
+          String fileName = optionFilename.toString();
+          if ( !new File( fileName ).isAbsolute() ) {
+            fileName = initialDir.toString() + fileName;
           }
-          transMeta = new TransMeta( optionFilename.toString() );
+
+          if ( log.isDetailed() ) {
+            log.logDetailed( BaseMessages.getString( PKG, "Pan.Log.LoadingTransXML", "" + fileName ) );
+          }
+          transMeta = new TransMeta( fileName );
           trans = new Trans( transMeta );
         }
 


### PR DESCRIPTION
[PDI-15255] kitchen.sh/pan.sh cannot use relative paths to jobs/transformations stored on the filesystem

-calculate current (run) directory in scripts,
-sent current directory to kitchen and pan,
-calculate absolute path to file if used relative.