### PR TITLE
[SP-2930][PDI-14278] Calculator step provides incorrect values when c…

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -1023,6 +1023,14 @@ public class Const {
   public static final String KETTLE_SPLIT_FIELDS_REMOVE_ENCLOSURE = "KETTLE_SPLIT_FIELDS_REMOVE_ENCLOSURE";
 
   /**
+   * Compatibility settings for {@link org.pentaho.di.core.row.ValueDataUtil#hourOfDay(ValueMetaInterface, Object)}.
+   *
+   * Switches off the fix for calculation of timezone decomposition.
+   */
+  public static final String KETTLE_COMPATIBILITY_CALCULATION_TIMEZONE_DECOMPOSITION =
+    "KETTLE_COMPATIBILITY_CALCULATION_TIMEZONE_DECOMPOSITION";
+
+  /**
    * Compatibility settings for setNrErrors
    */
   // see PDI-10270 for details.

--- a/core/src/org/pentaho/di/core/row/ValueDataUtil.java
+++ b/core/src/org/pentaho/di/core/row/ValueDataUtil.java
@@ -1376,6 +1376,13 @@ public class ValueDataUtil {
 
     Calendar calendar = Calendar.getInstance();
     calendar.setTime( metaA.getDate( dataA ) );
+
+    Boolean oldDateCalculation = Boolean.parseBoolean(
+      Const.getEnvironmentVariable( Const.KETTLE_COMPATIBILITY_CALCULATION_TIMEZONE_DECOMPOSITION, "false" ) );
+    if ( !oldDateCalculation ) {
+      calendar.setTimeZone( metaA.getDateFormatTimeZone() );
+    }
+
     return new Long( calendar.get( Calendar.HOUR_OF_DAY ) );
   }
 

--- a/core/test-src/org/pentaho/di/core/row/ValueDateUtilTest.java
+++ b/core/test-src/org/pentaho/di/core/row/ValueDateUtilTest.java
@@ -1,0 +1,70 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.row;
+
+import org.junit.After;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import org.junit.Assert;
+
+
+public class ValueDateUtilTest {
+
+  @After
+  public void tearDown() {
+    System.clearProperty( Const.KETTLE_COMPATIBILITY_CALCULATION_TIMEZONE_DECOMPOSITION );
+  }
+
+  @Test
+  public void shouldCalculateHourOfDayUsingValueMetasTimeZoneByDefault() throws KettleValueException {
+    Calendar date = Calendar.getInstance();
+    date.setTimeInMillis( 1454313600000L ); // 2016-07-01 08:00:00 UTC
+    ValueMetaInterface valueMetaDate = new ValueMetaDate();
+    valueMetaDate.setDateFormatTimeZone( TimeZone.getTimeZone( "CET" ) ); // UTC +1
+    long offsetCET = (long) TimeZone.getTimeZone( "CET" ).getRawOffset() / 3600000;
+
+    Object hourOfDayCET = ValueDataUtil.hourOfDay( valueMetaDate, date.getTime() );
+
+    Assert.assertEquals( 8L + offsetCET, hourOfDayCET );
+  }
+
+  @Test
+  public void shouldCalculateHourOfDayUsingLocalTimeZoneIfPropertyIsSet() throws KettleValueException {
+    Calendar date = Calendar.getInstance();
+    date.setTimeInMillis( 1454313600000L ); // 2016-07-01 08:00:00 UTC
+    ValueMetaInterface valueMetaDate = new ValueMetaDate();
+    valueMetaDate.setDateFormatTimeZone( TimeZone.getTimeZone( "CET" ) ); // UTC +1
+    long offsetLocal = (long) TimeZone.getDefault().getRawOffset() / 3600000;
+    System.setProperty( Const.KETTLE_COMPATIBILITY_CALCULATION_TIMEZONE_DECOMPOSITION, "true" );
+
+    Object hourOfDayLocal = ValueDataUtil.hourOfDay( valueMetaDate, date.getTime() );
+
+    Assert.assertEquals( 8L + offsetLocal, hourOfDayLocal );
+  }
+}


### PR DESCRIPTION
…onverting time zones

- hourOfDay calculation now considers valueMeta`s time zone
- added compatibilty property switching off the fix
- added unit test