### PR TITLE
[SP-2931][PDI-14278] Calculator step provides incorrect values when c…

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -989,6 +989,14 @@ public class Const {
   public static final String KETTLE_SPLIT_FIELDS_REMOVE_ENCLOSURE = "KETTLE_SPLIT_FIELDS_REMOVE_ENCLOSURE";
 
   /**
+   * Compatibility settings for {@link org.pentaho.di.core.row.ValueDataUtil#hourOfDay(ValueMetaInterface, Object)}.
+   *
+   * Switches off the fix for calculation of timezone decomposition.
+   */
+  public static final String KETTLE_COMPATIBILITY_CALCULATION_TIMEZONE_DECOMPOSITION =
+    "KETTLE_COMPATIBILITY_CALCULATION_TIMEZONE_DECOMPOSITION";
+
+  /**
    * Compatibility settings for setNrErrors
    */
   // see PDI-10270 for details.

--- a/core/src/org/pentaho/di/core/row/ValueDataUtil.java
+++ b/core/src/org/pentaho/di/core/row/ValueDataUtil.java
@@ -1376,6 +1376,13 @@ public class ValueDataUtil {
 
     Calendar calendar = Calendar.getInstance();
     calendar.setTime( metaA.getDate( dataA ) );
+
+    Boolean oldDateCalculation = Boolean.parseBoolean(
+      Const.getEnvironmentVariable( Const.KETTLE_COMPATIBILITY_CALCULATION_TIMEZONE_DECOMPOSITION, "false" ) );
+    if ( !oldDateCalculation ) {
+      calendar.setTimeZone( metaA.getDateFormatTimeZone() );
+    }
+
     return new Long( calendar.get( Calendar.HOUR_OF_DAY ) );
   }
 


### PR DESCRIPTION
…onverting time zones

- hourOfDay calculation now considers valueMeta`s time zone
- added compatibilty property switching off the fix
- added unit test
- fix static import