### PR TITLE
Fixed Content-Length miscalculation

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/httppost/HTTPPOST.java
+++ b/engine/src/org/pentaho/di/trans/steps/httppost/HTTPPOST.java
@@ -186,13 +186,10 @@ public class HTTPPOST extends BaseStep implements StepInterface {
           fis = new FileInputStream( input );
           post.setRequestEntity( new InputStreamRequestEntity( fis, input.length() ) );
         } else {
-          if ( ( data.realEncoding != null ) && ( data.realEncoding.length() > 0 ) ) {
-            post.setRequestEntity( new InputStreamRequestEntity( new ByteArrayInputStream( tmp
-                .getBytes( data.realEncoding ) ), tmp.length() ) );
-          } else {
-            post.setRequestEntity( new InputStreamRequestEntity( new ByteArrayInputStream( tmp.getBytes() ), tmp
-                .length() ) );
-          }
+          byte[] bytes = ( data.realEncoding != null ) && ( data.realEncoding.length() > 0 ) ?
+                  tmp.getBytes( data.realEncoding ) :
+                  tmp.getBytes();
+          post.setRequestEntity( new InputStreamRequestEntity( new ByteArrayInputStream( bytes ), bytes.length ) );
         }
       }
 


### PR DESCRIPTION
The second parameter of InputStreamRequestEntity expects the Content-Length in bytes, which is not necessarily the same as the length of the Java String. For example, the following code:

`        String s = "©";
        System.out.println(s.length());
        System.out.println(s.getBytes(StandardCharsets.UTF_8).length);`

outputs:

> 1
> 2
> 

because the copyright-sign character has a 2-byte encoding in UTF-8, but requires only 1 Java char.