### PR TITLE
[BACKLOG-11303] - Missing word in the error message of the job entry "Columns exist in a table"

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/columnsexist/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/job/entries/columnsexist/messages/messages_en_US.properties
@@ -11,7 +11,7 @@ JobEntryColumnsExist.Schemaname.Tooltip=Schema name
 
 JobEntryColumnsExist.Log.TableExists=Table [{0}] exists.
 JobEntryColumnsExist.Log.TableNotExists=Table [{0}] doesn''t  exists.
-JobEntryColumnsExist.Log.ColumnNotExists=Column [{0}] doesn''t in table [{1}]
+JobEntryColumnsExist.Log.ColumnNotExists=Column [{0}] doesn''t exist in table [{1}]
 JobEntryColumnsExist.Log.ColumnExists=Column [{0}] exists in table [{1}]
 JobEntryColumnsExist.Error.UnexpectedError=An error occurred executing this job entry: {0}
 JobEntryColumnsExist.Error.NoDbConnection=No database connection is defined.


### PR DESCRIPTION
Simple mistypo