### PR TITLE
[PDI-15156] Problem setting variables row-by-row when using Job Executor

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -818,6 +818,39 @@ public class Const {
   public static final String KETTLE_MAX_LOGGING_REGISTRY_SIZE = "KETTLE_MAX_LOGGING_REGISTRY_SIZE";
 
   /**
+   * A variable to configure the kettle log tab refresh delay.
+   */
+  public static final String KETTLE_LOG_TAB_REFRESH_DELAY = "KETTLE_LOG_TAB_REFRESH_DELAY";
+
+  /**
+   * A variable to configure the kettle log tab refresh period.
+   */
+  public static final String KETTLE_LOG_TAB_REFRESH_PERIOD = "KETTLE_LOG_TAB_REFRESH_PERIOD";
+
+  /**
+   * The kettle log tab refresh thread name to make LoggingBuffer able to determine it and save logs that have not been
+   * read by this thread.
+   */
+  public static final String KETTLE_LOG_TAB_REFRESH_THREAD = "KETTLE_LOG_TAB_REFRESH_THREAD";
+
+  /**
+   * The kettle trans executor discard lines thread name to make LoggingBuffer able to determine it and wait until log
+   * tab refresh thread reads a new logs
+   */
+  public static final String TRANS_EXECUTOR_DISCARD_LINES_THREAD = "TRANS_EXECUTOR_DISCARD_LINES_THREAD";
+
+  /**
+   * The kettle job executor discard lines thread name to make LoggingBuffer able to determine it and wait until log tab
+   * refresh thread reads a new logs
+   */
+  public static final String JOB_EXECUTOR_DISCARD_LINES_THREAD = "JOB_EXECUTOR_DISCARD_LINES_THREAD";
+
+  /**
+   * The kettle discard lines wait timeout.
+   */
+  public static final int KETTLE_DISCARD_LOG_LINES_WAIT_TIMEOUT = 10000;
+
+  /**
    * The name of the system wide variable that can contain the name of the SAP Connection factory for the test button in
    * the DB dialog. This defaults to
    */

--- a/engine/src/kettle-variables.xml
+++ b/engine/src/kettle-variables.xml
@@ -183,6 +183,18 @@
   </kettle-variable>
 
   <kettle-variable>
+    <description>The kettle log tab refresh delay.</description>
+    <variable>KETTLE_LOG_TAB_REFRESH_DELAY</variable>
+    <default-value>1000</default-value>
+  </kettle-variable>
+
+  <kettle-variable>
+    <description>The kettle log tab refresh period.</description>
+    <variable>KETTLE_LOG_TAB_REFRESH_PERIOD</variable>
+    <default-value>1000</default-value>
+  </kettle-variable>
+
+  <kettle-variable>
     <description>A comma delimited list of classes to scan for plugin annotations</description>
     <variable>KETTLE_PLUGIN_CLASSES</variable>
     <default-value/>

--- a/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
+++ b/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
@@ -355,8 +355,13 @@ public class JobExecutor extends BaseStep implements StepInterface {
     // Keep the strain on the logging back-end conservative.
     // TODO: make this optional/user-defined later
     if ( data.executorJob != null ) {
-      KettleLogStore.discardLines( data.executorJob.getLogChannelId(), false );
-      LoggingRegistry.getInstance().removeIncludingChildren( data.executorJob.getLogChannelId() );
+      final String logChannelId = data.executorJob.getLogChannelId();
+      new Thread( Const.JOB_EXECUTOR_DISCARD_LINES_THREAD ) {
+        @Override public void run() {
+          KettleLogStore.discardLines( logChannelId, false );
+          LoggingRegistry.getInstance().removeIncludingChildren( logChannelId );
+        }
+      }.start();
     }
   }
 

--- a/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
+++ b/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
@@ -239,8 +239,13 @@ public class TransExecutor extends BaseStep implements StepInterface {
     // TODO: make this optional/user-defined later
     Trans executorTrans = transExecutorData.getExecutorTrans();
     if ( executorTrans != null ) {
-      KettleLogStore.discardLines( executorTrans.getLogChannelId(), false );
-      LoggingRegistry.getInstance().removeIncludingChildren( executorTrans.getLogChannelId() );
+      final String logChannelId = executorTrans.getLogChannelId();
+      new Thread( Const.TRANS_EXECUTOR_DISCARD_LINES_THREAD ) {
+        @Override public void run() {
+          KettleLogStore.discardLines( logChannelId, false );
+          LoggingRegistry.getInstance().removeIncludingChildren( logChannelId );
+        }
+      }.start();
     }
   }
 

--- a/ui/src/org/pentaho/di/ui/spoon/trans/LogBrowser.java
+++ b/ui/src/org/pentaho/di/ui/spoon/trans/LogBrowser.java
@@ -42,6 +42,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.logging.HasLogChannelInterface;
@@ -96,9 +97,13 @@ public class LogBrowser {
 
         text.getDisplay().asyncExec( new Runnable() {
           public void run() {
+            // to make LoggingBuffer able to determine refresh tab thread
+            // and save logs that have not been read by this thread
+            Thread.currentThread().setName( Const.KETTLE_LOG_TAB_REFRESH_THREAD );
+
             HasLogChannelInterface provider = logProvider.getLogChannelProvider();
 
-            if ( provider != null && !text.isDisposed() && !busy.get() && !paused.get() && text.isVisible() ) {
+            if ( provider != null && !text.isDisposed() && !busy.get() && !paused.get() ) {
               busy.set( true );
 
               LogChannelInterface logChannel = provider.getLogChannel();
@@ -180,7 +185,9 @@ public class LogBrowser {
 
     // Refresh every often enough
     //
-    logRefreshTimer.schedule( timerTask, 1000, 1000 );
+    logRefreshTimer
+      .schedule( timerTask, Const.toInt( EnvUtil.getSystemProperty( Const.KETTLE_LOG_TAB_REFRESH_DELAY ), 1000 ),
+        Const.toInt( EnvUtil.getSystemProperty( Const.KETTLE_LOG_TAB_REFRESH_PERIOD ), 1000 ) );
 
     // Make sure the timer goes down when the widget is disposed
     //


### PR DESCRIPTION
Added waitLogTabSnifferBeforeRemovingIfSpoon() method to LoggingBuffer to make it able to determine refresh tab thread and save logs that have not been read by this thread.
