### PR TITLE
[PDI-15070] Get rows from result" step does not pass rows when a transformation is executed on a remote carte server

### DIFF
--- a/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -3220,7 +3220,8 @@ public class ValueMetaBase implements ValueMetaInterface {
             // at all.
             //
             string = XMLHandler.addTagValue( "binary-string", (byte[]) object );
-            break;
+            xml.append( XMLHandler.openTag( XML_DATA_TAG ) ).append( string ).append( XMLHandler.closeTag( XML_DATA_TAG ) );
+            return xml.toString();
 
           case STORAGE_TYPE_INDEXED:
             // Just an index

--- a/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -72,6 +72,7 @@ import org.pentaho.di.core.logging.LoggingRegistry;
 import org.pentaho.di.core.plugins.DatabasePluginType;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 
 public class ValueMetaBaseTest {
@@ -218,6 +219,14 @@ public class ValueMetaBaseTest {
     assertEquals(
       "<value-data>" + encoder.encodeForXML( formater.format( timestamp ) ) + "</value-data>" + SystemUtils.LINE_SEPARATOR,
       valueMetaBaseTimeStamp.getDataXML( timestamp ) );
+
+    byte[] byteTestValues = { 0, 1, 2, 3 };
+    ValueMetaBase valueMetaBaseByteArray = new ValueMetaBase( byteTestValues.toString(), ValueMetaInterface.TYPE_STRING );
+    valueMetaBaseByteArray.setStorageType( ValueMetaInterface.STORAGE_TYPE_BINARY_STRING );
+    assertEquals(
+      "<value-data><binary-string>" + encoder.encodeForXML( XMLHandler.encodeBinaryData( byteTestValues ) )
+        + "</binary-string>" + Const.CR + "</value-data>",
+      valueMetaBaseByteArray.getDataXML( byteTestValues ) );
   }
 
   @Test


### PR DESCRIPTION
[PDI-15070] Get rows from result" step does not pass rows when a transformation is executed on a remote carte server
-fix using encode XML tags for "binary-string" node

I saw that the same issue is available for STORAGE_TYPE_INDEXED (tag "index-value") but I codln't find using this storage type (except junit tests).
@mbatchelor @mchen-len-son Could you please review and merge it?