### PR TITLE
[BACKLOG-11204] - Fix for: making sure the tablename gets set in the …

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/tableoutput/TableOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/tableoutput/TableOutput.java
@@ -540,6 +540,10 @@ public class TableOutput extends BaseStep implements StepInterface {
         }
         data.db.setCommit( data.commitSize );
 
+        if ( !meta.isPartitioningEnabled() && !meta.isTableNameInField() ) {
+          data.tableName = environmentSubstitute( meta.getTableName() );
+        }
+
         return true;
       } catch ( KettleException e ) {
         logError( "An error occurred intialising this step: " + e.getMessage() );
@@ -552,8 +556,6 @@ public class TableOutput extends BaseStep implements StepInterface {
 
   void truncateTable() throws KettleDatabaseException {
     if ( !meta.isPartitioningEnabled() && !meta.isTableNameInField() ) {
-      data.tableName = environmentSubstitute( meta.getTableName() );
-
       // Only the first one truncates in a non-partitioned step copy
       //
       if ( meta.truncateTable()


### PR DESCRIPTION
…init method as it did before this commit: https://github.com/pentaho/pentaho-kettle/pull/2996/commits/c82c5d8ed754efa50f68553ba608ab99fab2c4fe

That change caused an issue when the Truncate Tables option was not set, it wasn't setting the tablename, and everything failed.