### PR TITLE
[BACKLOG-11444]  Pooled big-data connections fail in Spoon

### DIFF
--- a/core/src/org/pentaho/di/core/database/ConnectionPoolUtil.java
+++ b/core/src/org/pentaho/di/core/database/ConnectionPoolUtil.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.core.database;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
@@ -125,7 +126,8 @@ public class ConnectionPoolUtil {
     return properties;
   }
 
-  private static void configureDataSource( BasicDataSource ds, DatabaseMeta databaseMeta, String partitionId,
+  @VisibleForTesting
+  static void configureDataSource( BasicDataSource ds, DatabaseMeta databaseMeta, String partitionId,
       int initialSize, int maximumSize ) throws KettleDatabaseException {
     // substitute variables and populate pool properties; add credentials
     Properties connectionPoolProperties = new Properties( databaseMeta.getConnectionPoolingProperties() );
@@ -137,8 +139,10 @@ public class ConnectionPoolUtil {
     String url = databaseMeta.environmentSubstitute( databaseMeta.getURL( partitionId ) );
     ds.setUrl( url );
     String clazz = databaseMeta.getDriverClass();
+    if ( databaseMeta.getDatabaseInterface() != null ) {
+      ds.setDriverClassLoader( databaseMeta.getDatabaseInterface().getClass().getClassLoader() );
+    }
     ds.setDriverClassName( clazz );
-
   }
 
   private static void setCredentials( BasicDataSource ds, DatabaseMeta databaseMeta, String partitionId )

--- a/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -21,31 +21,6 @@
  ******************************************************************************/
 package org.pentaho.di.core.row.value;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.math.BigDecimal;
-import java.net.InetAddress;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.sql.Types;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.List;
-import java.util.TimeZone;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.junit.After;
@@ -74,6 +49,28 @@ import org.pentaho.di.core.plugins.DatabasePluginType;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.i18n.BaseMessages;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
+import java.net.InetAddress;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.junit.Assert.*;
 
 public class ValueMetaBaseTest {
 
@@ -660,7 +657,9 @@ public class ValueMetaBaseTest {
     double convertedNumberData = (double) base.convertDataUsingConversionMetaData( defaultNumberData );
     assertEquals( 1.999, convertedNumberData, DELTA );
 
-    base.setConversionMetadata( new ValueMetaDate( "DATE" ) );
+    ValueMetaInterface dateConversionMeta = new ValueMetaDate( "DATE" );
+    dateConversionMeta.setDateFormatTimeZone( TimeZone.getTimeZone( "CST" ) );
+    base.setConversionMetadata( dateConversionMeta );
     Object defaultDateData = "1990/02/18 00:00:00.000";
     Date date1 = new Date( 635320800000L );
     Date convertedDateData = (Date) base.convertDataUsingConversionMetaData( defaultDateData );


### PR DESCRIPTION
When configuring the DataSource, the call to setDriverClassname
would fail if the driver is not in the current thread's classpath.
Addressed by explicitly setting the BasicDataSource driver cp.

http://jira.pentaho.com/browse/BACKLOG-11444