### PR TITLE
[BACKLOG-8719] Updated laf.properties so that the add/edit/delete ico…

### DIFF
--- a/assembly/package-res/ui/laf.properties
+++ b/assembly/package-res/ui/laf.properties
@@ -91,12 +91,12 @@ Open_image=ui/images/open:16#16.svg
 Add_image=ui/images/Add.svg
 EditSmall_image=ui/images/generic-edit.svg
 
-New_image = ui/images/Add.svg
-Edit_image = ui/images/generic-edit.svg
-Delete_image = ui/images/generic-delete.svg
+New_image = ui/images/Add:16#16.svg
+Edit_image = ui/images/generic-edit:16#16.svg
+Delete_image = ui/images/generic-delete:16#16.svg
 Disabled_New_image = ui/images/disabled-add:16#16.svg
-Disabled_Edit_image = ui/images/disabled-generic-edit.svg
-Disabled_Delete_image = ui/images/disabled-generic-delete.svg
+Disabled_Edit_image = ui/images/disabled-generic-edit:16#16.svg
+Disabled_Delete_image = ui/images/disabled-generic-delete:16#16.svg
 Restore_image = ui/images/restore:16#16.svg
 
 Import_image = ui/images/import.svg


### PR DESCRIPTION
…ns are always 16x16 pixels for active/disabled states.

@hudak / @mkambol / @ddiroma 