### PR TITLE
[BACKLOG-11582]-Escaping variable to correctly work with spaces

### DIFF
--- a/assembly/package-res/spoon.sh
+++ b/assembly/package-res/spoon.sh
@@ -230,6 +230,6 @@ fi
 EXIT_CODE=$?
 
 # return to the catalog from which spoon.sh has been started
-cd $INITIALDIR
+cd "$INITIALDIR"
 
 exit $EXIT_CODE


### PR DESCRIPTION
* To be able to return to folder which contains spaces in name