### PR TITLE
[BACKLOG-11693]Use default binary string conversion for Internet Address

### DIFF
--- a/core/src/org/pentaho/di/core/row/value/ValueMetaInternetAddress.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaInternetAddress.java
@@ -22,24 +22,23 @@
 
 package org.pentaho.di.core.row.value;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.Types;
-import java.util.Date;
-
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.database.PostgreSQLDatabaseMeta;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.Utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+import java.util.Date;
 
 public class ValueMetaInternetAddress extends ValueMetaDate {
 
@@ -228,18 +227,6 @@ public class ValueMetaInternetAddress extends ValueMetaDate {
           convertInternetAddressToString( (InetAddress) index[( (Integer) object )] ) );
       default:
         throw new KettleValueException( toString() + " : Unknown storage type " + storageType + " specified." );
-    }
-  }
-
-  @Override
-  public Object convertBinaryStringToNativeType( byte[] binary ) throws KettleValueException {
-    if ( binary == null || binary.length <= 0 ) {
-      return null;
-    }
-    try {
-      return InetAddress.getByAddress( binary );
-    } catch ( UnknownHostException e ) {
-      throw new KettleValueException( e );
     }
   }
 

--- a/core/test-src/org/pentaho/di/core/row/value/ValueMetaInternetAddressTest.java
+++ b/core/test-src/org/pentaho/di/core/row/value/ValueMetaInternetAddressTest.java
@@ -22,19 +22,14 @@
 
 package org.pentaho.di.core.row.value;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.ValueMetaInterface;
+
+import static org.junit.Assert.*;
 
 public class ValueMetaInternetAddressTest {
 
@@ -68,21 +63,27 @@ public class ValueMetaInternetAddressTest {
     // Test normal storage type
     ValueMetaInternetAddress vmInet = new ValueMetaInternetAddress();
     final ValueMetaString vmString = new ValueMetaString();
+    vmInet.setStorageMetadata( vmString );
     InetAddress inetAddress = InetAddress.getByName( "127.0.0.1" );
+
     byte[] output = vmInet.getBinaryString( inetAddress );
     assertNotNull( output );
     assertArrayEquals( vmString.getBinaryString( "127.0.0.1" ), output );
+    assertEquals( inetAddress, vmInet.convertBinaryStringToNativeType( output ) );
 
     // Test binary string storage type
     vmInet.setStorageType( ValueMetaInterface.STORAGE_TYPE_BINARY_STRING );
     output = vmInet.getBinaryString( vmString.getBinaryString( "127.0.0.1" ) );
     assertNotNull( output );
     assertArrayEquals( vmString.getBinaryString( "127.0.0.1" ), output );
+    assertEquals( inetAddress, vmInet.convertBinaryStringToNativeType( output ) );
 
     // Test indexed storage
     vmInet.setStorageType( ValueMetaInterface.STORAGE_TYPE_INDEXED );
     vmInet.setIndex( new InetAddress[] { inetAddress } );
     assertArrayEquals( vmString.getBinaryString( "127.0.0.1" ), vmInet.getBinaryString( 0 ) );
+    assertEquals( inetAddress, vmInet.convertBinaryStringToNativeType( output ) );
+
     try {
       vmInet.getBinaryString( 1 );
       fail();


### PR DESCRIPTION
Removed override for binary string converter.
`InetAddress.getByAddress` expects a byte array representing the IP Address value, not an encoded String.

@matthewtckr -- this override was added with https://github.com/pentaho/pentaho-kettle/pull/2766/commits/162d73be33164980f9a3dcc5d8b7239d902f6d1d
I added more unit testing and checked the related cases for regression, everything seems to be okay. Is there anything else that should be tested?