### PR TITLE
[BACKLOG-11620] Update product App icons and splash screens

### DIFF
--- a/ui/package-res/ui/images/kettle_logo_small.svg
+++ b/ui/package-res/ui/images/kettle_logo_small.svg
@@ -1,1 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#005da6;}.cls-2{fill:#fff;}</style></defs><title>PDI_16x16</title><g id="Layer_2" data-name="Layer 2"><g id="Layer_1-2" data-name="Layer 1"><rect id="img_background" class="cls-1" width="16" height="16" rx="2" ry="2"/><path class="cls-2" d="M13,8.11a.94.94,0,0,0-.82.48L8.83,8s0-.07,0-.11a1.68,1.68,0,0,0-.11-.59L12,4.95a1.13,1.13,0,1,0-.36-.51L8.41,6.77a1.69,1.69,0,0,0-.64-.45l.19-1.08a1,1,0,1,0-.62-.06l-.18,1A1.68,1.68,0,0,0,6,6.62L4.43,5.13A1.25,1.25,0,1,0,4,5.59L5.65,7.11a1.69,1.69,0,0,0,0,1.54l-1,.71A.94.94,0,1,0,5,9.88L6,9.15a1.69,1.69,0,0,0,1.64.35L8.81,11a1.26,1.26,0,1,0,.51-.37L8.22,9.2a1.69,1.69,0,0,0,.46-.59l3.38.59A.94.94,0,1,0,13,8.11Z"/></g></g></svg>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<g id="Layer_2">
+	<g id="Layer_2_1_">
+		<rect fill="none" width="16" height="16"/>
+	</g>
+</g>
+<g id="art">
+	<g>
+		<rect fill="#005CA7" class="cls-1" width="16" height="16" rx="2" ry="2"/>
+		<path fill="#FFFFFF" d="M13,8.11a.94.94,0,0,0-.82.48L8.83,8s0-.07,0-.11a1.68,1.68,0,0,0-.11-.59L12,4.95a1.13,1.13,0,1,0-.36-.51L8.41,6.77a1.69,1.69,0,0,0-.64-.45l.19-1.08a1,1,0,1,0-.62-.06l-.18,1A1.68,1.68,0,0,0,6,6.62L4.43,5.13A1.25,1.25,0,1,0,4,5.59L5.65,7.11a1.69,1.69,0,0,0,0,1.54l-1,.71A.94.94,0,1,0,5,9.88L6,9.15a1.69,1.69,0,0,0,1.64.35L8.81,11a1.26,1.26,0,1,0,.51-.37L8.22,9.2a1.69,1.69,0,0,0,.46-.59l3.38.59A.94.94,0,1,0,13,8.11Z"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
[CHERRY-PICK] https://github.com/pentaho/pentaho-kettle/pull/3068/commits/7aa391755e44a27b13d0ae4e5627badda6cb2782

	- fixed kettle_logo_small.svg icon