### PR TITLE
[PDI-14937] executors_output_step not cleared when a hop is deleted f…

### DIFF
--- a/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
@@ -1167,4 +1167,8 @@ public class BaseStepMeta implements Cloneable, StepAttributesInterface {
     RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
     Repository repository, IMetaStore metaStore ) {
   }
+
+  public boolean cleanAfterHopFromRemove() {
+    return false;
+  }
 }

--- a/engine/src/org/pentaho/di/trans/step/StepMetaInterface.java
+++ b/engine/src/org/pentaho/di/trans/step/StepMetaInterface.java
@@ -711,4 +711,9 @@ public interface StepMetaInterface {
    */
   public Object loadReferencedObject( int index, Repository rep, IMetaStore metaStore, VariableSpace space ) throws KettleException;
 
+  /**
+   * Action remove hop from this step
+   * @return step was changed
+   */
+  public boolean cleanAfterHopFromRemove();
 }

--- a/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
@@ -1486,4 +1486,12 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
     return metaStore;
   }
 
+  @Override
+  public boolean cleanAfterHopFromRemove() {
+    setExecutionResultTargetStepMeta( null );
+    setResultRowsTargetStepMeta( null );
+    setResultFilesTargetStepMeta( null );
+    return true;
+  }
+
 }

--- a/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMeta.java
@@ -1459,4 +1459,15 @@ public class TransExecutorMeta extends BaseStepMeta implements StepMetaInterface
   public void setExecutorsOutputStepMeta( StepMeta executorsOutputStepMeta ) {
     this.executorsOutputStepMeta = executorsOutputStepMeta;
   }
+
+  @Override
+  public boolean cleanAfterHopFromRemove() {
+
+    setExecutionResultTargetStepMeta( null );
+    setOutputRowsSourceStepMeta( null );
+    setResultFilesTargetStepMeta( null );
+    setExecutorsOutputStepMeta( null );
+    return true;
+
+  }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
@@ -30,8 +30,11 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+
+import static org.junit.Assert.assertNull;
 
 /**
  * <p>
@@ -72,5 +75,19 @@ public class JobExecutorMetaTest {
   @Test
   public void testSerialization() throws KettleException {
     loadSaveTester.testSerialization();
+  }
+
+  @Test
+  public void testRemoveHopFrom() throws Exception {
+    JobExecutorMeta jobExecutorMeta = new JobExecutorMeta();
+    jobExecutorMeta.setExecutionResultTargetStepMeta( new StepMeta() );
+    jobExecutorMeta.setResultRowsTargetStepMeta( new StepMeta() );
+    jobExecutorMeta.setResultFilesTargetStepMeta( new StepMeta() );
+
+    jobExecutorMeta.cleanAfterHopFromRemove();
+
+    assertNull( jobExecutorMeta.getExecutionResultTargetStepMeta() );
+    assertNull( jobExecutorMeta.getResultRowsTargetStepMeta() );
+    assertNull( jobExecutorMeta.getResultFilesTargetStepMeta() );
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMetaTest.java
@@ -316,4 +316,22 @@ public class TransExecutorMetaTest {
     when( stream.getStepMeta() ).thenReturn( stepMeta );
     return stream;
   }
+
+
+  @Test
+  public void testRemoveHopFrom() throws Exception {
+    TransExecutorMeta transExecutorMeta = new TransExecutorMeta();
+    transExecutorMeta.setExecutionResultTargetStepMeta( new StepMeta() );
+    transExecutorMeta.setOutputRowsSourceStepMeta( new StepMeta() );
+    transExecutorMeta.setResultFilesTargetStepMeta( new StepMeta() );
+    transExecutorMeta.setExecutorsOutputStepMeta( new StepMeta() );
+
+    transExecutorMeta.cleanAfterHopFromRemove();
+
+    assertNull( transExecutorMeta.getExecutionResultTargetStepMeta() );
+    assertNull( transExecutorMeta.getOutputRowsSourceStepMeta() );
+    assertNull( transExecutorMeta.getResultFilesTargetStepMeta() );
+    assertNull( transExecutorMeta.getExecutorsOutputStepMeta() );
+  }
+
 }

--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -3566,25 +3566,29 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     addUndoDelete( transMeta, new Object[] { (TransHopMeta) transHopMeta.clone() }, new int[] { index } );
     transMeta.removeTransHop( index );
 
+    StepMeta fromStepMeta = transHopMeta.getFromStep();
+    StepMeta before = (StepMeta) fromStepMeta.clone();
+    index = transMeta.indexOfStep( fromStepMeta );
+
+    boolean stepFromNeedAddUndoChange = fromStepMeta.getStepMetaInterface().cleanAfterHopFromRemove();
     // If this is an error handling hop, disable it
     //
     if ( transHopMeta.getFromStep().isDoingErrorHandling() ) {
-      StepErrorMeta stepErrorMeta = transHopMeta.getFromStep().getStepErrorMeta();
+      StepErrorMeta stepErrorMeta = fromStepMeta.getStepErrorMeta();
 
       // We can only disable error handling if the target of the hop is the same as the target of the error handling.
       //
       if ( stepErrorMeta.getTargetStep() != null
         && stepErrorMeta.getTargetStep().equals( transHopMeta.getToStep() ) ) {
-        StepMeta stepMeta = transHopMeta.getFromStep();
+
         // Only if the target step is where the error handling is going to...
         //
-
-        StepMeta before = (StepMeta) stepMeta.clone();
         stepErrorMeta.setEnabled( false );
-
-        index = transMeta.indexOfStep( stepMeta );
-        addUndoChange( transMeta, new Object[] { before }, new Object[] { stepMeta }, new int[] { index } );
+        stepFromNeedAddUndoChange = true;
       }
+    }
+    if ( stepFromNeedAddUndoChange ) {
+      addUndoChange( transMeta, new Object[]{before}, new Object[]{fromStepMeta}, new int[]{index} );
     }
 
     refreshTree();

--- a/ui/test-src/org/pentaho/di/ui/spoon/SpoonTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/SpoonTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.base.AbstractMeta;
@@ -47,9 +48,11 @@ import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryObjectType;
 import org.pentaho.di.repository.RepositorySecurityProvider;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.TransHopMeta;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepErrorMeta;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.steps.csvinput.CsvInputMeta;
 import org.pentaho.di.trans.steps.dummytrans.DummyTransMeta;
 import org.pentaho.di.ui.spoon.delegates.SpoonDelegates;
@@ -70,7 +73,7 @@ public class SpoonTest {
     doCallRealMethod().when( spoon ).copySelected( any( TransMeta.class ), anyListOf( StepMeta.class ),
         anyListOf( NotePadMeta.class ) );
     doCallRealMethod().when( spoon ).pasteXML( any( TransMeta.class ), anyString(), any( Point.class ) );
-
+    doCallRealMethod().when( spoon ).delHop( any( TransMeta.class ), any( TransHopMeta.class ) );
     LogChannelInterface log = mock( LogChannelInterface.class );
     when( spoon.getLog() ).thenReturn( log );
 
@@ -370,4 +373,22 @@ public class SpoonTest {
     doReturn( isTransformation ? RepositoryObjectType.TRANSFORMATION : RepositoryObjectType.JOB ).when( mockObjMeta )
         .getRepositoryElementType();
   }
+
+  @Test
+  public void testDelHop() throws Exception {
+
+    StepMetaInterface stepMetaInterface = Mockito.mock( StepMetaInterface.class );
+    StepMeta step = new StepMeta();
+    step.setStepMetaInterface( stepMetaInterface );
+
+    TransHopMeta transHopMeta = new TransHopMeta();
+    transHopMeta.setFromStep( step );
+
+    TransMeta transMeta = Mockito.mock( TransMeta.class );
+
+    spoon.delHop( transMeta, transHopMeta );
+    Mockito.verify( stepMetaInterface, times( 1 ) ).cleanAfterHopFromRemove( );
+
+  }
+
 }


### PR DESCRIPTION
…rom the transformation executor step

-add method in StepMetaInterface for clean after removing hop
-add default implementation for BaseStep
-add implementation for Job and Transformation Executor
-add tests 

@mbatchelor @mchen-len-son Could you please review and merge it?
My changes improved unit test coverage in my changes files.
