### PR TITLE
[BACKLOG-11771] PDI - renaming a folder in the repository home folder…

### DIFF
--- a/engine/src/org/pentaho/di/repository/RepositoryExtended.java
+++ b/engine/src/org/pentaho/di/repository/RepositoryExtended.java
@@ -1,3 +1,25 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.di.repository;
 
 import org.pentaho.di.core.exception.KettleException;
@@ -17,4 +39,35 @@ public interface RepositoryExtended extends Repository {
    * @throws KettleException
    */
   RepositoryDirectoryInterface loadRepositoryDirectoryTree( boolean eager ) throws KettleException;
+
+  /**
+   * Move / rename a repository directory
+   *
+   * @param dirId
+   *          The ObjectId of the repository directory to move
+   * @param newParent
+   *          The RepositoryDirectoryInterface that will be the new parent of the repository directory (May be null if a
+   *          move is not desired)
+   * @param newName
+   *          The new name of the repository directory (May be null if a rename is not desired)
+   * @param renameHomeDirectories
+   *          true if this is an allowed action
+   * @return The ObjectId of the repository directory that was moved
+   * @throws KettleException
+   */
+  ObjectId renameRepositoryDirectory( final ObjectId dirId, final RepositoryDirectoryInterface newParent,
+                                             final String newName, final boolean renameHomeDirectories ) throws KettleException;
+
+
+  /**
+   * Delete a repository directory
+   *
+   * @param dir
+   *          The ObjectId of the repository directory to move
+   * @param deleteHomeDirectories
+   *          true if this is an allowed action
+   * @throws KettleException
+   */
+  void deleteRepositoryDirectory( final RepositoryDirectoryInterface dir, final boolean deleteHomeDirectories )
+          throws KettleException;
 }

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/PurRepository.java
@@ -482,6 +482,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
     deleteRepositoryDirectory( dir, false );
   }
 
+  @Override
   public void deleteRepositoryDirectory( final RepositoryDirectoryInterface dir, final boolean deleteHomeDirectories )
     throws KettleException {
     try {
@@ -515,6 +516,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
     return renameRepositoryDirectory( dirId, newParent, newName, false );
   }
 
+  @Override
   public ObjectId renameRepositoryDirectory( final ObjectId dirId, final RepositoryDirectoryInterface newParent,
                                              final String newName, final boolean renameHomeDirectories )
     throws KettleException {

--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/pur/repositoryexplorer/model/UIEERepositoryDirectory.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/ui/repository/pur/repositoryexplorer/model/UIEERepositoryDirectory.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
-import org.pentaho.di.repository.pur.PurRepository;
+import org.pentaho.di.repository.RepositoryExtended;
 import org.pentaho.di.ui.repository.pur.repositoryexplorer.IAclObject;
 import org.pentaho.di.ui.repository.pur.services.IAclService;
 import org.pentaho.di.ui.repository.repositoryexplorer.AccessDeniedException;
@@ -83,8 +83,8 @@ public class UIEERepositoryDirectory extends UIRepositoryDirectory implements IA
   }
 
   public void delete( boolean deleteHomeDirectories ) throws Exception {
-    if ( rep instanceof PurRepository ) {
-      ( (PurRepository) rep ).deleteRepositoryDirectory( getDirectory(), deleteHomeDirectories );
+    if ( rep instanceof RepositoryExtended ) {
+      ( (RepositoryExtended) rep ).deleteRepositoryDirectory( getDirectory(), deleteHomeDirectories );
     } else {
       rep.deleteRepositoryDirectory( getDirectory() );
     }
@@ -102,8 +102,8 @@ public class UIEERepositoryDirectory extends UIRepositoryDirectory implements IA
       return;
     }
 
-    if ( rep instanceof PurRepository ) {
-      ( (PurRepository) rep ).renameRepositoryDirectory( getDirectory().getObjectId(), null, name,
+    if ( rep instanceof RepositoryExtended ) {
+      ( (RepositoryExtended) rep ).renameRepositoryDirectory( getDirectory().getObjectId(), null, name,
           renameHomeDirectories );
     } else {
       rep.renameRepositoryDirectory( getDirectory().getObjectId(), null, name );


### PR DESCRIPTION
… gets an error

	- PurRepository lost the ability to rename/move/delete folder under /home because we now proxy-wrap it in a RepositorySessionTimeoutHandler
	- RepositoryExtended interface was created 8 months ago ( Feb 2016 ) to provide additional Repository methods on the next major release