### PR TITLE
[SP-2959][PDI-15296] Arguments (legacy) do not work in Spoon 6.1

### DIFF
--- a/engine/src/org/pentaho/di/job/JobExecutionConfiguration.java
+++ b/engine/src/org/pentaho/di/job/JobExecutionConfiguration.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -47,9 +47,13 @@ import org.pentaho.di.core.plugins.RepositoryPluginType;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.job.entries.trans.JobEntryTrans;
+import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.repository.RepositoriesMeta;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryMeta;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
 
 public class JobExecutionConfiguration implements ExecutionConfiguration {
@@ -673,5 +677,23 @@ public class JobExecutionConfiguration implements ExecutionConfiguration {
 
   public void setPassedBatchId( Long passedBatchId ) {
     this.passedBatchId = passedBatchId;
+  }
+
+  public void getUsedArguments( JobMeta jobMeta, String[] commandLineArguments, IMetaStore metaStore )
+    throws KettleException {
+
+    for ( JobEntryCopy jobEntryCopy : jobMeta.jobcopies ) {
+      if ( jobEntryCopy.isTransformation() ) {
+        JobEntryTrans jobEntryTrans = (JobEntryTrans) jobEntryCopy.getEntry();
+        TransMeta transMeta = jobEntryTrans.getTransMeta( repository, metaStore, jobMeta );
+        Map<String, String> map = transMeta.getUsedArguments( commandLineArguments );
+        for ( String key : map.keySet() ) {
+          String value = map.get( key );
+          if ( !arguments.containsKey( key ) ) {
+            arguments.put( key, value );
+          }
+        }
+      }
+    }
   }
 }

--- a/engine/test-src/org/pentaho/di/job/JobExecutionConfigurationTest.java
+++ b/engine/test-src/org/pentaho/di/job/JobExecutionConfigurationTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,9 +43,14 @@ import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.RepositoryPluginType;
 import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.job.entries.trans.JobEntryTrans;
+import org.pentaho.di.job.entry.JobEntryCopy;
+import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.repository.RepositoriesMeta;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryMeta;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -176,5 +182,62 @@ public class JobExecutionConfigurationTest {
       JobExecutionConfiguration jecCopy = new JobExecutionConfiguration( node );
       assertEquals( "xml-copy", jec.getPassedBatchId(), jecCopy.getPassedBatchId() );
     }
+  }
+
+  @Test
+  public void testGetUsedArguments() throws KettleException {
+    JobExecutionConfiguration executionConfiguration = new JobExecutionConfiguration();
+    JobMeta jobMeta = new JobMeta(  );
+    jobMeta.jobcopies = new ArrayList<>(  );
+    String[] commandLineArguments = new String[ 0 ];
+    IMetaStore metaStore = mock( IMetaStore.class );
+
+    JobEntryCopy jobEntryCopy0 = new JobEntryCopy(  );
+
+    TransMeta transMeta0 = mock( TransMeta.class );
+    Map<String, String> map0 = new HashMap<>(  );
+    map0.put( "arg0", "argument0" );
+    when( transMeta0.getUsedArguments( commandLineArguments ) ).thenReturn( map0 );
+
+    JobEntryInterface jobEntryInterface0 = mock( JobEntryInterface.class );
+    when( jobEntryInterface0.isTransformation() ).thenReturn( false );
+
+    jobEntryCopy0.setEntry( jobEntryInterface0 );
+    jobMeta.jobcopies.add( jobEntryCopy0 );
+
+
+    JobEntryCopy jobEntryCopy1 = new JobEntryCopy(  );
+
+    TransMeta transMeta1 = mock( TransMeta.class );
+    Map<String, String> map1 = new HashMap<>(  );
+    map1.put( "arg1", "argument1" );
+    when( transMeta1.getUsedArguments( commandLineArguments ) ).thenReturn( map1 );
+
+    JobEntryTrans jobEntryTrans1 = mock( JobEntryTrans.class );
+    when( jobEntryTrans1.isTransformation() ).thenReturn( true );
+    when( jobEntryTrans1.getTransMeta( executionConfiguration.getRepository(), metaStore, jobMeta ) ).thenReturn( transMeta1 );
+
+    jobEntryCopy1.setEntry( jobEntryTrans1 );
+    jobMeta.jobcopies.add( jobEntryCopy1 );
+
+
+    JobEntryCopy jobEntryCopy2 = new JobEntryCopy(  );
+
+    TransMeta transMeta2 = mock( TransMeta.class );
+    Map<String, String> map2 = new HashMap<>(  );
+    map2.put( "arg1", "argument1" );
+    map2.put( "arg2", "argument2" );
+    when( transMeta2.getUsedArguments( commandLineArguments ) ).thenReturn( map2 );
+
+    JobEntryTrans jobEntryTrans2 = mock( JobEntryTrans.class );
+    when( jobEntryTrans2.isTransformation() ).thenReturn( true );
+    when( jobEntryTrans2.getTransMeta( executionConfiguration.getRepository(), metaStore, jobMeta ) ).thenReturn( transMeta2 );
+
+    jobEntryCopy2.setEntry( jobEntryTrans2 );
+    jobMeta.jobcopies.add( jobEntryCopy2 );
+
+
+    executionConfiguration.getUsedArguments( jobMeta, commandLineArguments, metaStore );
+    assertEquals( 2, executionConfiguration.getArguments().size() );
   }
 }

--- a/ui/src/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
+++ b/ui/src/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1344,6 +1344,7 @@ public class SpoonJobDelegate extends SpoonDelegate {
     executionConfiguration.setStartCopyName( startCopyName );
     executionConfiguration.setStartCopyNr( startCopyNr );
 
+    executionConfiguration.getUsedArguments( jobMeta, spoon.getArguments(), spoon.getMetaStore() );
     executionConfiguration.setLogLevel( DefaultLogLevel.getLogLevel() );
 
     JobExecutionConfigurationDialog dialog =


### PR DESCRIPTION
[SP-2959][PDI-15296] Arguments (legacy) do not work in Spoon 6.1
-getting argument job as argument all transformation fo jobs
-test

@brosander @mchen-len-son Could you please reviewand merge?