### PR TITLE
[SP-2964][PDI-15070] Get rows from result" step does not pass rows when a transformation is executed on a remote carte server

### DIFF
--- a/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -3110,7 +3110,8 @@ public class ValueMetaBase implements ValueMetaInterface {
             // at all.
             //
             string = XMLHandler.addTagValue( "binary-string", (byte[]) object );
-            break;
+            xml.append( XMLHandler.openTag( XML_DATA_TAG ) ).append( string ).append( XMLHandler.closeTag( XML_DATA_TAG ) );
+            return xml.toString();
 
           case STORAGE_TYPE_INDEXED:
             // Just an index

--- a/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/test-src/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Encoder;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.database.NetezzaDatabaseMeta;
@@ -47,6 +48,7 @@ import org.pentaho.di.core.logging.LoggingRegistry;
 import org.pentaho.di.core.plugins.DatabasePluginType;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 
 import java.io.IOException;
@@ -220,6 +222,14 @@ public class ValueMetaBaseTest {
     assertEquals(
       "<value-data>" + encoder.encodeForXML( formater.format( timestamp ) ) + "</value-data>" + SystemUtils.LINE_SEPARATOR,
       valueMetaBaseTimeStamp.getDataXML( timestamp ) );
+
+    byte[] byteTestValues = { 0, 1, 2, 3 };
+    ValueMetaBase valueMetaBaseByteArray = new ValueMetaBase( byteTestValues.toString(), ValueMetaInterface.TYPE_STRING );
+    valueMetaBaseByteArray.setStorageType( ValueMetaInterface.STORAGE_TYPE_BINARY_STRING );
+    assertEquals(
+      "<value-data><binary-string>" + encoder.encodeForXML( XMLHandler.encodeBinaryData( byteTestValues ) )
+        + "</binary-string>" + Const.CR + "</value-data>",
+      valueMetaBaseByteArray.getDataXML( byteTestValues ) );
   }
 
   @Test


### PR DESCRIPTION
[SP-2964][PDI-15070] Get rows from result" step does not pass rows when a transformation is executed on a remote carte server

-fix using encoding XML tags for "binary-string" node