### PR TITLE
[SP-2950] Backport of BISERVER-12713 - L10N - Error messages are not translated to different languages (6.1 Suite)

### DIFF
--- a/core/src/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/org/pentaho/di/core/database/DatabaseMeta.java
@@ -1564,18 +1564,18 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     ArrayList<String> remarks = new ArrayList<String>();
 
     if ( getDatabaseInterface() == null ) {
-      remarks.add( "No database type was choosen" );
+      remarks.add( BaseMessages.getString( PKG, "DatabaseMeta.BadInterface" ) );
     }
 
     if ( getName() == null || getName().length() == 0 ) {
-      remarks.add( "Please give this database connection a name" );
+      remarks.add( BaseMessages.getString( PKG, "DatabaseMeta.BadConnectionName" ) );
     }
 
     if ( !isPartitioned()
       && !( getDatabaseInterface() instanceof SAPR3DatabaseMeta
       || getDatabaseInterface() instanceof GenericDatabaseMeta ) ) {
       if ( getDatabaseName() == null || getDatabaseName().length() == 0 ) {
-        remarks.add( "Please specify the name of the database" );
+        remarks.add( BaseMessages.getString( PKG, "DatabaseMeta.BadDatabaseName" ) );
       }
     }
 

--- a/core/src/org/pentaho/di/core/database/messages/messages_en_US.properties
+++ b/core/src/org/pentaho/di/core/database/messages/messages_en_US.properties
@@ -52,3 +52,6 @@ DatabaseMeta.Error.LogTableNameNotFound=Log table name is undefined
 Database.Error.WriteLogTable=Unable to write log record to log table [{0}]
 DatabaseMeta.Error.UnableToObtainLastLogDate=Unable to obtain last log date from table [{0}]
 Database.Error.UnableToCommitToLogTable=Unable to commit log table [{0}]
+DatabaseMeta.BadInterface=No database type was choosen
+DatabaseMeta.BadConnectionName=Please give this database connection a name
+DatabaseMeta.BadDatabaseName=Please specify the name of the database


### PR DESCRIPTION
Backport of #2973