### PR TITLE
[BACKLOG-11621] Removes JTDS driver dependency

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -177,7 +177,6 @@
     <dependency org="infobright"           name="infobright-core"       rev="3.4"           transitive="false"/>
     <dependency org="org.firebirdsql.jdbc" name="jaybird"               rev="2.1.6"         transitive="false"/>
     <dependency org="net.sf.jt400"         name="jt400"                 rev="6.1"           transitive="false"/>  
-    <dependency org="jtds"                 name="jtds"                  rev="1.2.5"         transitive="false"/>
     <dependency org="luciddb"              name="LucidDbClient-minimal" rev="0.9.4"         transitive="false"/>
     <dependency org="monetdb"              name="monetdb-jdbc"          rev="2.1"           transitive="false"/>
     <dependency org="org.postgresql"       name="postgresql"            rev="9.3-1102-jdbc4" transitive="false"/>


### PR DESCRIPTION
@CodeOnCoffee @rmansoor @mbatchelor @pentaho/rogueone Devci looked good for master, doing 7.0 now. Please review

Related PRs:
https://github.com/pentaho/pentaho-platform/pull/3212
https://github.com/pentaho/pentaho-kettle/pull/3104
https://github.com/pentaho/pentaho-reporting/pull/871
https://github.com/pentaho/pentaho-reportdesigner-ee/pull/54