### PR TITLE
[BACKLOG-11621] Removes JTDS driver dependency

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -177,7 +177,6 @@
     <dependency org="infobright"           name="infobright-core"       rev="3.4"           transitive="false"/>
     <dependency org="org.firebirdsql.jdbc" name="jaybird"               rev="2.1.6"         transitive="false"/>
     <dependency org="net.sf.jt400"         name="jt400"                 rev="6.1"           transitive="false"/>  
-    <dependency org="jtds"                 name="jtds"                  rev="1.2.5"         transitive="false"/>
     <dependency org="luciddb"              name="LucidDbClient-minimal" rev="0.9.4"         transitive="false"/>
     <dependency org="monetdb"              name="monetdb-jdbc"          rev="2.1"           transitive="false"/>
     <dependency org="org.postgresql"       name="postgresql"            rev="9.3-1102-jdbc4" transitive="false"/>


### PR DESCRIPTION
@dkincade @kcruzada @pamval 7.0-SNAPSHOT looked good. Please review

CC: @CodeOnCoffee @mbatchelor @rmansoor @pentaho/rogueone 

Related PRs:
https://github.com/pentaho/pentaho-platform/pull/3216
https://github.com/pentaho/pentaho-kettle/pull/3105
https://github.com/pentaho/pentaho-reporting/pull/873
https://github.com/pentaho/pentaho-reportdesigner-ee/pull/55
