### PR TITLE
[SP-2971] - Backport of PPP-3572 - Vulnerability CVE-2012-2098 - comm…

### DIFF
--- a/core/ivy.xml
+++ b/core/ivy.xml
@@ -31,7 +31,7 @@
 
     <dependency org="pentaho"             name="metastore"           rev="${dependency.pentaho-metastore.revision}"   changing="true" />
     
-    <dependency org="org.apache.commons"  name="commons-compress"    rev="1.4"              transitive="false"/>
+    <dependency org="org.apache.commons"  name="commons-compress"    rev="1.4.1"              transitive="false"/>
     <dependency org="dom4j"               name="dom4j"               rev="1.6.1"            transitive="false"/>
     <dependency org="org.eclipse.jetty" name="jetty-util" rev="8.1.15.v20140411" transitive="false"/>
     <dependency org="jug-lgpl"            name="jug-lgpl"            rev="2.0.0"            transitive="false"/>


### PR DESCRIPTION
…ons-compress-1.4.jar having implicit dependency on kettle-core-5.2.0.2-84.jar (6.1 Suite)

@graimundo, @mkambol, @pamval, here is backport of https://github.com/pentaho/pentaho-kettle/pull/3038/files to 6.1. Thanks. 