### PR TITLE
PDI-15681- Fixed removing row when parsing a null field

### DIFF
--- a/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/JsonInput.java
+++ b/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/JsonInput.java
@@ -335,8 +335,8 @@ public class JsonInput extends BaseFileInputStep<JsonInputMeta, JsonInputData> i
     while ( ( rawReaderRow = data.readerRowSet.getRow() ) == null ) {
       if ( data.inputs.hasNext() && data.readerRowSet.isDone() ) {
         try ( InputStream nextIn = data.inputs.next() ) {
-          boolean parsed = parseNextInputToRowSet( nextIn );
-          if ( parsed && shouldOutputEmpty() ) {
+          parseNextInputToRowSet( nextIn );
+          if ( shouldOutputEmpty() ) {
             return buildBaseOutputRow();
           }
         } catch ( IOException e ) {
@@ -355,6 +355,8 @@ public class JsonInput extends BaseFileInputStep<JsonInputMeta, JsonInputData> i
     if ( rowContainsData ) {
       outputRow = rowOutputConverter.getRow( buildBaseOutputRow(), rawReaderRow, data );
       addExtraFields( outputRow, data );
+    } else {
+      outputRow = buildBaseOutputRow();
     }
     return outputRow;
   }

--- a/plugins/kettle-json-plugin/test-src/org/pentaho/di/trans/steps/jsoninput/JsonInputTest.java
+++ b/plugins/kettle-json-plugin/test-src/org/pentaho/di/trans/steps/jsoninput/JsonInputTest.java
@@ -356,13 +356,30 @@ public class JsonInputTest {
     meta.setRemoveSourceField( true );
     final String input = getBasicTestJson();
 
-    JsonInput jsonInput = createJsonInput( "json", meta, new Object[] { input }, new Object[] { input } );
+    JsonInput jsonInput = createJsonInput( "json", meta, new Object[] { input } );
     processRows( jsonInput, 8 );
     disposeJsonInput( jsonInput );
 
     Assert.assertEquals( 5, jsonInput.getLinesWritten() );
   }
 
+  @Test
+  public void testDoNotSkipRowIfInputIsNull() throws Exception {
+    JsonInputField field = new JsonInputField( "foo" );
+    field.setPath( "$.foo" );
+    field.setType( ValueMetaInterface.TYPE_STRING );
+    JsonInputMeta meta = createSimpleMeta( "json", field );
+    JsonInput jsonInput = new JsonInput( helper.stepMeta, helper.stepDataInterface, 0, helper.transMeta, helper.trans );
+    JsonInputData data = new JsonInputData();
+    RowSet input = helper.getMockInputRowSet( new Object[] { null, "something" } );
+    RowMetaInterface rowMeta = createRowMeta( new ValueMetaString( "json" ), new ValueMetaString( "json1" ) );
+    input.setRowMeta( rowMeta );
+    jsonInput.getInputRowSets().add( input );
+    jsonInput.setInputRowMeta( rowMeta );
+    jsonInput.init( meta, data );
+    processRows( jsonInput, 1 );
+    Assert.assertEquals( 1, jsonInput.getLinesWritten() );
+  }
 
   @Test
   public void testBfsMatchOrder() throws Exception {


### PR DESCRIPTION
Fixed removing row when parsing a null field using JSON Input step. Now if the json field is null and the row has another input fields then Json Input step wont skip the row and will set the missed value to null