### PR TITLE
[SP-2994][PDI-14937] executors_output_step not cleared when a hop is deleted from the transformation executor step

### DIFF
--- a/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1117,5 +1117,9 @@ public class BaseStepMeta implements Cloneable, StepAttributesInterface {
   public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta,
     RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
     Repository repository, IMetaStore metaStore ) {
+  }
+
+  public boolean cleanAfterHopFromRemove() {
+    return false;
   }
 }

--- a/engine/src/org/pentaho/di/trans/step/StepMetaInterface.java
+++ b/engine/src/org/pentaho/di/trans/step/StepMetaInterface.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -710,4 +710,9 @@ public interface StepMetaInterface {
    */
   public Object loadReferencedObject( int index, Repository rep, IMetaStore metaStore, VariableSpace space ) throws KettleException;
 
+  /**
+   * Action remove hop from this step
+   * @return step was changed
+   */
+  public boolean cleanAfterHopFromRemove();
 }

--- a/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1464,6 +1464,14 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
 
   public IMetaStore getMetaStore() {
     return metaStore;
+  }
+
+  @Override
+  public boolean cleanAfterHopFromRemove() {
+    setExecutionResultTargetStepMeta( null );
+    setResultRowsTargetStepMeta( null );
+    setResultFilesTargetStepMeta( null );
+    return true;
   }
 
 }

--- a/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMeta.java
@@ -1458,4 +1458,15 @@ public class TransExecutorMeta extends BaseStepMeta implements StepMetaInterface
   public void setExecutorsOutputStepMeta( StepMeta executorsOutputStepMeta ) {
     this.executorsOutputStepMeta = executorsOutputStepMeta;
   }
+
+  @Override
+  public boolean cleanAfterHopFromRemove() {
+
+    setExecutionResultTargetStepMeta( null );
+    setOutputRowsSourceStepMeta( null );
+    setResultFilesTargetStepMeta( null );
+    setExecutorsOutputStepMeta( null );
+    return true;
+
+  }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,8 +30,11 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+
+import static org.junit.Assert.assertNull;
 
 /**
  * <p>
@@ -77,5 +80,19 @@ public class JobExecutorMetaTest {
   @Test
   public void testLoadSaveRepo() throws KettleException {
     loadSaveTester.testRepoRoundTrip();
+  }
+
+  @Test
+  public void testRemoveHopFrom() throws Exception {
+    JobExecutorMeta jobExecutorMeta = new JobExecutorMeta();
+    jobExecutorMeta.setExecutionResultTargetStepMeta( new StepMeta() );
+    jobExecutorMeta.setResultRowsTargetStepMeta( new StepMeta() );
+    jobExecutorMeta.setResultFilesTargetStepMeta( new StepMeta() );
+
+    jobExecutorMeta.cleanAfterHopFromRemove();
+
+    assertNull( jobExecutorMeta.getExecutionResultTargetStepMeta() );
+    assertNull( jobExecutorMeta.getResultRowsTargetStepMeta() );
+    assertNull( jobExecutorMeta.getResultFilesTargetStepMeta() );
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMetaTest.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.transexecutor;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -345,4 +346,22 @@ public class TransExecutorMetaTest {
     when( stream.getStepMeta() ).thenReturn( stepMeta );
     return stream;
   }
+
+
+  @Test
+  public void testRemoveHopFrom() throws Exception {
+    TransExecutorMeta transExecutorMeta = new TransExecutorMeta();
+    transExecutorMeta.setExecutionResultTargetStepMeta( new StepMeta() );
+    transExecutorMeta.setOutputRowsSourceStepMeta( new StepMeta() );
+    transExecutorMeta.setResultFilesTargetStepMeta( new StepMeta() );
+    transExecutorMeta.setExecutorsOutputStepMeta( new StepMeta() );
+
+    transExecutorMeta.cleanAfterHopFromRemove();
+
+    Assert.assertNull( transExecutorMeta.getExecutionResultTargetStepMeta() );
+    Assert.assertNull( transExecutorMeta.getOutputRowsSourceStepMeta() );
+    Assert.assertNull( transExecutorMeta.getResultFilesTargetStepMeta() );
+    Assert.assertNull( transExecutorMeta.getExecutorsOutputStepMeta() );
+  }
+
 }

--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -3562,25 +3562,29 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     addUndoDelete( transMeta, new Object[] { (TransHopMeta) transHopMeta.clone() }, new int[] { index } );
     transMeta.removeTransHop( index );
 
+    StepMeta fromStepMeta = transHopMeta.getFromStep();
+    StepMeta before = (StepMeta) fromStepMeta.clone();
+    index = transMeta.indexOfStep( fromStepMeta );
+
+    boolean stepFromNeedAddUndoChange = fromStepMeta.getStepMetaInterface().cleanAfterHopFromRemove();
     // If this is an error handling hop, disable it
     //
     if ( transHopMeta.getFromStep().isDoingErrorHandling() ) {
-      StepErrorMeta stepErrorMeta = transHopMeta.getFromStep().getStepErrorMeta();
+      StepErrorMeta stepErrorMeta = fromStepMeta.getStepErrorMeta();
 
       // We can only disable error handling if the target of the hop is the same as the target of the error handling.
       //
       if ( stepErrorMeta.getTargetStep() != null
         && stepErrorMeta.getTargetStep().equals( transHopMeta.getToStep() ) ) {
-        StepMeta stepMeta = transHopMeta.getFromStep();
+
         // Only if the target step is where the error handling is going to...
         //
-
-        StepMeta before = (StepMeta) stepMeta.clone();
         stepErrorMeta.setEnabled( false );
-
-        index = transMeta.indexOfStep( stepMeta );
-        addUndoChange( transMeta, new Object[] { before }, new Object[] { stepMeta }, new int[] { index } );
+        stepFromNeedAddUndoChange = true;
       }
+    }
+    if ( stepFromNeedAddUndoChange ) {
+      addUndoChange( transMeta, new Object[]{before}, new Object[]{fromStepMeta}, new int[]{index} );
     }
 
     refreshTree();


### PR DESCRIPTION
[SP-2994][PDI-14937] executors_output_step not cleared when a hop is deleted from the transformation executor step

-add method in StepMetaInterface for clean after removing hop
-add default implementation for BaseStep
-add implementation for Job and Transformation Executor
-add tests

@mbatchelor @mchen-len-son Could you please review and merge it?