### PR TITLE
[PDI-15691] Deprecated variable replaced by actual

### DIFF
--- a/ui/src/org/pentaho/di/ui/job/entries/trans/JobEntryTransDialog.java
+++ b/ui/src/org/pentaho/di/ui/job/entries/trans/JobEntryTransDialog.java
@@ -1294,10 +1294,7 @@ public class JobEntryTransDialog extends JobEntryDialog implements JobEntryDialo
         } else {
 
           if ( !prevName.endsWith( ".ktr" ) ) {
-            prevName =
-              "${"
-                + Const.INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY + "}/" + Const.trim( wFilename.getText() )
-                + ".ktr";
+            prevName = getEntryName( Const.trim( wFilename.getText() ) + ".ktr" );
           }
           if ( KettleVFS.fileExists( prevName ) ) {
             specificationMethod = ObjectLocationSpecificationMethod.FILENAME;
@@ -1340,12 +1337,17 @@ public class JobEntryTransDialog extends JobEntryDialog implements JobEntryDialo
       String parentFolderSelection = file.getParentFile().toString();
 
       if ( !Utils.isEmpty( parentFolder ) && parentFolder.equals( parentFolderSelection ) ) {
-        wFilename.setText( "${" + Const.INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY + "}/" + name );
+        wFilename.setText( getEntryName( name ) );
       } else {
         wFilename.setText( fname );
       }
 
     }
+  }
+
+  String getEntryName( String name ) {
+    return "${"
+      + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + name;
   }
 
   public void dispose() {

--- a/ui/test-src/org/pentaho/di/ui/job/entries/trans/JobEntryTransDialogTest.java
+++ b/ui/test-src/org/pentaho/di/ui/job/entries/trans/JobEntryTransDialogTest.java
@@ -1,0 +1,47 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.job.entries.trans;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Vadim_Polynkov
+ */
+public class JobEntryTransDialogTest {
+
+  private static final String FILE_NAME =  "TestTrans.ktr";
+
+  JobEntryTransDialog dialog;
+
+  @Test
+  public void testEntryName() {
+    dialog = mock( JobEntryTransDialog.class );
+    doCallRealMethod().when( dialog ).getEntryName( any() );
+    assertEquals( dialog.getEntryName( FILE_NAME ), "${Internal.Entry.Current.Directory}/" + FILE_NAME );
+  }
+}


### PR DESCRIPTION
@bmorrise , @wseyler , @e-cuellar , @mbatchelor please review.
PDI-15690 (http://jira.pentaho.com/browse/PDI-15691)
The idea of this fix is to replace the deprecated variable by actual variable in the JobEntryTransDialog class and to make the use of constant for file name testable.