### PR TITLE
[BACKLOG-7056] Dataservices: Min() is not ignoring null values (same …

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupBy.java
+++ b/engine/src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupBy.java
@@ -326,10 +326,12 @@ public class MemoryGroupBy extends BaseStep implements StepInterface {
           aggregate.counts[i]++;
           break;
         case MemoryGroupByMeta.TYPE_GROUP_MIN:
-          if ( minNullIsValued || ( subj != null && value != null ) ) {
+          boolean subjIsNull = subjMeta.isNull( subj );
+          boolean valueIsNull = valueMeta.isNull( value );
+          if ( minNullIsValued || ( !subjIsNull && !valueIsNull ) ) {
             // PDI-11530 do not compare null
             aggregate.agg[i] = subjMeta.compare( subj, valueMeta, value ) < 0 ? subj : value;
-          } else if ( value == null && subj != null ) {
+          } else if ( valueIsNull && !subjIsNull ) {
             // By default set aggregate to first not null value
             aggregate.agg[i] = subj;
           }

--- a/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByAggregationNullsTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/memgroupby/MemoryGroupByAggregationNullsTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -39,6 +39,7 @@ import org.pentaho.di.core.logging.LoggingObjectInterface;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.trans.steps.memgroupby.MemoryGroupByData.HashEntry;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 
@@ -52,6 +53,8 @@ public class MemoryGroupByAggregationNullsTest {
   static int def = 113;
 
   Aggregate aggregate;
+  private ValueMetaInterface vmi;
+  private RowMetaInterface rmi;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
@@ -70,9 +73,9 @@ public class MemoryGroupByAggregationNullsTest {
     MemoryGroupByMeta meta = new MemoryGroupByMeta();
     meta.setAggregateType( new int[] { 5 } );
     meta.setAggregateField( new String[] { "x" } );
-    ValueMetaInterface vmi = new ValueMetaInteger();
+    vmi = new ValueMetaInteger();
     when( mockHelper.stepMeta.getStepMetaInterface() ).thenReturn( meta );
-    RowMetaInterface rmi = Mockito.mock( RowMetaInterface.class );
+    rmi = Mockito.mock( RowMetaInterface.class );
     data.inputRowMeta = rmi;
     data.outputRowMeta = rmi;
     data.groupMeta = rmi;
@@ -155,5 +158,16 @@ public class MemoryGroupByAggregationNullsTest {
     step.setAllNullsAreZero( false );
     Object[] row = step.getAggregateResult( aggregate );
     Assert.assertNull( "Returns null if aggregation is null", row[0] );
+  }
+
+  @Test
+  public void addToAggregateLazyConversionMinTest() throws Exception {
+    vmi.setStorageType( ValueMetaInterface.STORAGE_TYPE_BINARY_STRING );
+    vmi.setStorageMetadata( new ValueMetaString() );
+    aggregate.agg = new Object[] { new byte[0] };
+    byte[] bytes = { 51 };
+    step.addToAggregate( new Object[] { bytes } );
+    Aggregate result = data.map.get( getHashEntry() );
+    Assert.assertEquals( "Returns non-null value", bytes, result.agg[0] );
   }
 }


### PR DESCRIPTION
…for max)

* switch off lazy conversion by default
* use valuemeta to check if value is null when lazy conversion is on