### PR TITLE
Revert "[SP-2994][PDI-14937] executors_output_step not cleared when a hop is deleted from the transformation executor step"

### DIFF
--- a/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
@@ -1118,8 +1118,4 @@ public class BaseStepMeta implements Cloneable, StepAttributesInterface {
     RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
     Repository repository, IMetaStore metaStore ) {
   }
-
-  public boolean cleanAfterHopFromRemove() {
-    return false;
-  }
 }

--- a/engine/src/org/pentaho/di/trans/step/StepMetaInterface.java
+++ b/engine/src/org/pentaho/di/trans/step/StepMetaInterface.java
@@ -710,9 +710,4 @@ public interface StepMetaInterface {
    */
   public Object loadReferencedObject( int index, Repository rep, IMetaStore metaStore, VariableSpace space ) throws KettleException;
 
-  /**
-   * Action remove hop from this step
-   * @return step was changed
-   */
-  public boolean cleanAfterHopFromRemove();
 }

--- a/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
@@ -1466,12 +1466,4 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
     return metaStore;
   }
 
-  @Override
-  public boolean cleanAfterHopFromRemove() {
-    setExecutionResultTargetStepMeta( null );
-    setResultRowsTargetStepMeta( null );
-    setResultFilesTargetStepMeta( null );
-    return true;
-  }
-
 }

--- a/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMeta.java
@@ -1458,15 +1458,4 @@ public class TransExecutorMeta extends BaseStepMeta implements StepMetaInterface
   public void setExecutorsOutputStepMeta( StepMeta executorsOutputStepMeta ) {
     this.executorsOutputStepMeta = executorsOutputStepMeta;
   }
-
-  @Override
-  public boolean cleanAfterHopFromRemove() {
-
-    setExecutionResultTargetStepMeta( null );
-    setOutputRowsSourceStepMeta( null );
-    setResultFilesTargetStepMeta( null );
-    setExecutorsOutputStepMeta( null );
-    return true;
-
-  }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
@@ -30,11 +30,8 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
-
-import static org.junit.Assert.assertNull;
 
 /**
  * <p>
@@ -80,19 +77,5 @@ public class JobExecutorMetaTest {
   @Test
   public void testLoadSaveRepo() throws KettleException {
     loadSaveTester.testRepoRoundTrip();
-  }
-
-  @Test
-  public void testRemoveHopFrom() throws Exception {
-    JobExecutorMeta jobExecutorMeta = new JobExecutorMeta();
-    jobExecutorMeta.setExecutionResultTargetStepMeta( new StepMeta() );
-    jobExecutorMeta.setResultRowsTargetStepMeta( new StepMeta() );
-    jobExecutorMeta.setResultFilesTargetStepMeta( new StepMeta() );
-
-    jobExecutorMeta.cleanAfterHopFromRemove();
-
-    assertNull( jobExecutorMeta.getExecutionResultTargetStepMeta() );
-    assertNull( jobExecutorMeta.getResultRowsTargetStepMeta() );
-    assertNull( jobExecutorMeta.getResultFilesTargetStepMeta() );
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/transexecutor/TransExecutorMetaTest.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.di.trans.steps.transexecutor;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -346,22 +345,4 @@ public class TransExecutorMetaTest {
     when( stream.getStepMeta() ).thenReturn( stepMeta );
     return stream;
   }
-
-
-  @Test
-  public void testRemoveHopFrom() throws Exception {
-    TransExecutorMeta transExecutorMeta = new TransExecutorMeta();
-    transExecutorMeta.setExecutionResultTargetStepMeta( new StepMeta() );
-    transExecutorMeta.setOutputRowsSourceStepMeta( new StepMeta() );
-    transExecutorMeta.setResultFilesTargetStepMeta( new StepMeta() );
-    transExecutorMeta.setExecutorsOutputStepMeta( new StepMeta() );
-
-    transExecutorMeta.cleanAfterHopFromRemove();
-
-    Assert.assertNull( transExecutorMeta.getExecutionResultTargetStepMeta() );
-    Assert.assertNull( transExecutorMeta.getOutputRowsSourceStepMeta() );
-    Assert.assertNull( transExecutorMeta.getResultFilesTargetStepMeta() );
-    Assert.assertNull( transExecutorMeta.getExecutorsOutputStepMeta() );
-  }
-
 }

--- a/ui/src/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/org/pentaho/di/ui/spoon/Spoon.java
@@ -3562,29 +3562,25 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     addUndoDelete( transMeta, new Object[] { (TransHopMeta) transHopMeta.clone() }, new int[] { index } );
     transMeta.removeTransHop( index );
 
-    StepMeta fromStepMeta = transHopMeta.getFromStep();
-    StepMeta before = (StepMeta) fromStepMeta.clone();
-    index = transMeta.indexOfStep( fromStepMeta );
-
-    boolean stepFromNeedAddUndoChange = fromStepMeta.getStepMetaInterface().cleanAfterHopFromRemove();
     // If this is an error handling hop, disable it
     //
     if ( transHopMeta.getFromStep().isDoingErrorHandling() ) {
-      StepErrorMeta stepErrorMeta = fromStepMeta.getStepErrorMeta();
+      StepErrorMeta stepErrorMeta = transHopMeta.getFromStep().getStepErrorMeta();
 
       // We can only disable error handling if the target of the hop is the same as the target of the error handling.
       //
       if ( stepErrorMeta.getTargetStep() != null
         && stepErrorMeta.getTargetStep().equals( transHopMeta.getToStep() ) ) {
-
+        StepMeta stepMeta = transHopMeta.getFromStep();
         // Only if the target step is where the error handling is going to...
         //
+
+        StepMeta before = (StepMeta) stepMeta.clone();
         stepErrorMeta.setEnabled( false );
-        stepFromNeedAddUndoChange = true;
+
+        index = transMeta.indexOfStep( stepMeta );
+        addUndoChange( transMeta, new Object[] { before }, new Object[] { stepMeta }, new int[] { index } );
       }
-    }
-    if ( stepFromNeedAddUndoChange ) {
-      addUndoChange( transMeta, new Object[]{before}, new Object[]{fromStepMeta}, new int[]{index} );
     }
 
     refreshTree();

--- a/ui/test-src/org/pentaho/di/ui/spoon/SpoonTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/SpoonTest.java
@@ -38,11 +38,9 @@ import org.pentaho.di.core.NotePadMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.gui.Point;
 import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.trans.TransHopMeta;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepErrorMeta;
 import org.pentaho.di.trans.step.StepMeta;
-import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.steps.csvinput.CsvInputMeta;
 import org.pentaho.di.trans.steps.dummytrans.DummyTransMeta;
 
@@ -61,7 +59,7 @@ public class SpoonTest {
     Mockito.doCallRealMethod().when( spoon ).copySelected( Mockito.any( TransMeta.class ), Mockito.anyListOf( StepMeta.class ),
             Mockito.anyListOf( NotePadMeta.class ) );
     Mockito.doCallRealMethod().when( spoon ).pasteXML( Mockito.any( TransMeta.class ), anyString(), Mockito.any( Point.class ) );
-    Mockito.doCallRealMethod().when( spoon ).delHop( Mockito.any( TransMeta.class ), Mockito.any( TransHopMeta.class ) );
+
     LogChannelInterface log = Mockito.mock( LogChannelInterface.class );
     Mockito.when( spoon.getLog() ).thenReturn( log );
 
@@ -154,22 +152,4 @@ public class SpoonTest {
 
     spoon.copySelected( transMeta, transMeta.getSelectedSteps(), Collections.<NotePadMeta>emptyList() );
   }
-
-  @Test
-  public void testDelHop() throws Exception {
-
-    StepMetaInterface stepMetaInterface = Mockito.mock( StepMetaInterface.class );
-    StepMeta step = new StepMeta();
-    step.setStepMetaInterface( stepMetaInterface );
-
-    TransHopMeta transHopMeta = new TransHopMeta();
-    transHopMeta.setFromStep( step );
-
-    TransMeta transMeta = Mockito.mock( TransMeta.class );
-
-    spoon.delHop( transMeta, transHopMeta );
-    Mockito.verify( stepMetaInterface, Mockito.times( 1 ) ).cleanAfterHopFromRemove( );
-
-  }
-
 }


### PR DESCRIPTION
Revert "[SP-2994][PDI-14937] executors_output_step not cleared when a hop is deleted from the transformation executor step"

This reverts commit f3f7ab00200c04138c454cf9ee7bec82c553dd74.