### PR TITLE
[SP-2993][PDI-14937] executors_output_step not cleared when a hop is deleted from the transformation executor step"

### DIFF
--- a/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStepMeta.java
@@ -1168,7 +1168,4 @@ public class BaseStepMeta implements Cloneable, StepAttributesInterface {
     Repository repository, IMetaStore metaStore ) {
   }
 
-  public boolean cleanAfterHopFromRemove() {
-    return false;
-  }
 }

--- a/engine/src/org/pentaho/di/trans/step/StepMetaInterface.java
+++ b/engine/src/org/pentaho/di/trans/step/StepMetaInterface.java
@@ -715,5 +715,7 @@ public interface StepMetaInterface {
    * Action remove hop from this step
    * @return step was changed
    */
-  public boolean cleanAfterHopFromRemove();
+  public default boolean cleanAfterHopFromRemove() {
+    return false;
+  }
 }


### PR DESCRIPTION
[SP-2993][PDI-14937] executors_output_step not cleared when a hop is deleted from the transformation executor step"
-added default implementation in interface