### PR TITLE
PDI-15196 - Fixed skipping rows if json field is null, empty or if th…

### DIFF
--- a/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/JsonInput.java
+++ b/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/JsonInput.java
@@ -22,11 +22,11 @@
 
 package org.pentaho.di.trans.steps.jsoninput;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Objects;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.vfs2.FileObject;
@@ -52,6 +52,7 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.steps.fileinput.BaseFileInputStep;
 import org.pentaho.di.trans.steps.fileinput.IBaseFileInputReader;
+import org.pentaho.di.trans.steps.jsoninput.exception.JsonInputException;
 import org.pentaho.di.trans.steps.jsoninput.reader.FastJsonReader;
 import org.pentaho.di.trans.steps.jsoninput.reader.InputsReader;
 import org.pentaho.di.trans.steps.jsoninput.reader.RowOutputConverter;
@@ -68,6 +69,8 @@ public class JsonInput extends BaseFileInputStep<JsonInputMeta, JsonInputData> i
   private static Class<?> PKG = JsonInputMeta.class; // for i18n purposes, needed by Translator2!!
 
   private RowOutputConverter rowOutputConverter;
+
+  private static final byte[] EMPTY_JSON = "{}".getBytes(); // for replacing null inputs
 
   public JsonInput( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
                     Trans trans ) {
@@ -113,22 +116,6 @@ public class JsonInput extends BaseFileInputStep<JsonInputMeta, JsonInputData> i
         return false; // end of data or error.
       }
 
-      // filter out rows that only contain null
-      int start = 0;
-      if ( meta.isInFields() && !meta.isRemoveSourceField() ) {
-        start = 1;
-      }
-      boolean hasValues = false;
-      for ( int i = start; i < outRow.length; i++ ) {
-        if ( outRow[ i ] != null ) {
-          hasValues = true;
-          break;
-        }
-      }
-      if ( !hasValues ) {
-        return true;
-      }
-
       if ( log.isRowLevel() ) {
         logRowlevel( BaseMessages.getString( PKG, "JsonInput.Log.ReadRow", data.outputRowMeta.getString( outRow ) ) );
       }
@@ -143,18 +130,27 @@ public class JsonInput extends BaseFileInputStep<JsonInputMeta, JsonInputData> i
         return false;
       }
 
+    } catch ( JsonInputException e ) {
+      if ( !getStepMeta().isDoingErrorHandling() ) {
+        stopErrorExecution( e );
+        return false;
+      }
     } catch ( Exception e ) {
+      logError( BaseMessages.getString( PKG, "JsonInput.ErrorInStepRunning", e.getMessage() ) );
       if ( getStepMeta().isDoingErrorHandling() ) {
         sendErrorRow( e.toString() );
       } else {
-        logError( BaseMessages.getString( PKG, "JsonInput.ErrorInStepRunning", e.getMessage() ) );
-        setErrors( getErrors() + 1 );
-        stopAll();
-        setOutputDone(); // signal end to receiver(s)
+        incrementErrors();
+        stopErrorExecution( e );
         return false;
       }
     }
     return true;
+  }
+
+  private void stopErrorExecution( Exception e ) {
+    stopAll();
+    setOutputDone();
   }
 
   @Override
@@ -262,19 +258,17 @@ public class JsonInput extends BaseFileInputStep<JsonInputMeta, JsonInputData> i
     addFileToResultFilesname( file );
   }
 
-  private boolean parseNextInputToRowSet( InputStream input ) throws KettleException {
-    if ( input != null ) {
-      try {
-        data.readerRowSet = data.reader.parse( input );
-        input.close();
-        return true;
-      } catch ( KettleException ke ) {
-        logInputError( ke );
-      } catch ( Exception e ) {
-        logInputError( e );
-      }
+  private void parseNextInputToRowSet( InputStream input ) throws KettleException {
+    try {
+      data.readerRowSet = data.reader.parse( input );
+      input.close();
+    } catch ( KettleException ke ) {
+      logInputError( ke );
+      throw new JsonInputException( ke );
+    } catch ( Exception e ) {
+      logInputError( e );
+      throw new JsonInputException( e );
     }
-    return false;
   }
 
   private void logInputError( KettleException e ) {
@@ -335,10 +329,13 @@ public class JsonInput extends BaseFileInputStep<JsonInputMeta, JsonInputData> i
     while ( ( rawReaderRow = data.readerRowSet.getRow() ) == null ) {
       if ( data.inputs.hasNext() && data.readerRowSet.isDone() ) {
         try ( InputStream nextIn = data.inputs.next() ) {
-          parseNextInputToRowSet( nextIn );
-          if ( shouldOutputEmpty() ) {
-            return buildBaseOutputRow();
+
+          if ( nextIn != null ) {
+            parseNextInputToRowSet( nextIn );
+          } else {
+            parseNextInputToRowSet( new ByteArrayInputStream( EMPTY_JSON ) );
           }
+
         } catch ( IOException e ) {
           logError( BaseMessages.getString( PKG, "JsonInput.Log.UnexpectedError", e.toString() ), e );
           incrementErrors();
@@ -350,14 +347,14 @@ public class JsonInput extends BaseFileInputStep<JsonInputMeta, JsonInputData> i
         return null;
       }
     }
-    Object[] outputRow = {};
-    boolean rowContainsData = Arrays.stream( rawReaderRow ).filter( Objects::nonNull ).findAny().isPresent();
+    boolean rowContainsData = Arrays.stream( rawReaderRow ).anyMatch( el -> el != null );
+    Object[] outputRow;
     if ( rowContainsData ) {
       outputRow = rowOutputConverter.getRow( buildBaseOutputRow(), rawReaderRow, data );
-      addExtraFields( outputRow, data );
     } else {
       outputRow = buildBaseOutputRow();
     }
+    addExtraFields( outputRow, data );
     return outputRow;
   }
 
@@ -374,10 +371,6 @@ public class JsonInput extends BaseFileInputStep<JsonInputMeta, JsonInputData> i
     } catch ( KettleStepException e ) {
       logError( e.getLocalizedMessage(), e );
     }
-  }
-
-  private boolean shouldOutputEmpty() {
-    return meta.isInFields() && isEmpty( data.readerRowSet );
   }
 
   private boolean hasAdditionalFileFields() {

--- a/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/exception/JsonInputException.java
+++ b/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/exception/JsonInputException.java
@@ -1,0 +1,43 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2016-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.jsoninput.exception;
+
+import org.pentaho.di.core.exception.KettleException;
+
+public class JsonInputException extends KettleException {
+
+  public JsonInputException() {
+  }
+
+  public JsonInputException( String message ) {
+    super( message );
+  }
+
+  public JsonInputException( Throwable cause ) {
+    super( cause );
+  }
+
+  public JsonInputException( String message, Throwable cause ) {
+    super( message, cause );
+  }
+
+}

--- a/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/reader/FastJsonReader.java
+++ b/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/reader/FastJsonReader.java
@@ -24,6 +24,8 @@ package org.pentaho.di.trans.steps.jsoninput.reader;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import org.pentaho.di.core.RowSet;
@@ -39,6 +41,7 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.ReadContext;
+import org.pentaho.di.trans.steps.jsoninput.exception.JsonInputException;
 
 /**
  * @author Samatar
@@ -118,46 +121,33 @@ public class FastJsonReader implements IJsonReader {
   @Override
   public RowSet parse( InputStream in ) throws KettleException {
     readInput( in );
-    List<List<?>> results = evalCombinedResult();
+    List<Object[]> results = evalCombinedResult();
     if ( log.isDetailed() ) {
-      int len = results.isEmpty() ? 0 : results.get( 0 ).size();
-      log.logDetailed( BaseMessages.getString( PKG, "JsonInput.Log.NrRecords", len ) );
+      log.logDetailed( BaseMessages.getString( PKG, "JsonInput.Log.NrRecords", results.size() ) );
     }
     return new TransposedRowSet( results );
   }
 
   private static class TransposedRowSet extends SingleRowRowSet {
-    private List<List<?>> results;
-    int rowCount;
-    int rowNbr;
+    private List<Object[]> results;
 
-    public TransposedRowSet( List<List<?>> results ) {
+    public TransposedRowSet( List<Object[]> results ) {
       super();
       this.results = results;
-      this.rowCount = results.isEmpty() ? 0 : results.get( 0 ).size();
     }
 
     @Override
     public Object[] getRow() {
-      if ( rowNbr >= rowCount ) {
-        results.clear();
-        return null;
+      if ( !results.isEmpty() ) {
+        return results.remove( 0 );
       }
-      Object[] rowData = new Object[ results.size() ];
-      for ( int col = 0; col < results.size(); col++ ) {
-        if ( results.get( col ).size() == 0 ) {
-          rowData[ col ] = null;
-          continue;
-        }
-        rowData[ col ] = results.get( col ).get( rowNbr );
-      }
-      rowNbr++;
-      return rowData;
+
+      return null;
     }
 
     @Override
     public int size() {
-      return rowCount - rowNbr;
+      return results.size();
     }
 
     @Override
@@ -172,26 +162,88 @@ public class FastJsonReader implements IJsonReader {
     }
   }
 
-  private List<List<?>> evalCombinedResult() throws KettleException {
+  private List<Object[]> evalCombinedResult() throws JsonInputException {
     int lastSize = -1;
     String prevPath = null;
-    List<List<?>> results = new ArrayList<>( paths.length );
+    List<List<?>> inputs = new ArrayList<>( paths.length );
     int i = 0;
     for ( JsonPath path : paths ) {
-      List<Object> res = getReadContext().read( path );
-      if ( res.size() != lastSize && lastSize > 0 & res.size() != 0 ) {
-        throw new KettleException( BaseMessages.getString(
-            PKG, "JsonInput.Error.BadStructure", res.size(), fields[i].getPath(), prevPath, lastSize ) );
+      List<Object> input = getReadContext().read( path );
+      if ( input.size() != lastSize && lastSize > 0 & input.size() != 0 ) {
+        throw new JsonInputException( BaseMessages.getString(
+            PKG, "JsonInput.Error.BadStructure", input.size(), fields[i].getPath(), prevPath, lastSize ) );
       }
-      if ( ( isAllNull( res ) || res.size() == 0 ) && !isIgnoreMissingPath() ) {
-        throw new KettleException( BaseMessages.getString( PKG, "JsonReader.Error.CanNotFindPath", fields[i].getPath() ) );
+      if ( ( isAllNull( input ) || input.size() == 0 ) && !isIgnoreMissingPath() ) {
+        throw new JsonInputException( BaseMessages.getString( PKG, "JsonReader.Error.CanNotFindPath", fields[i].getPath() ) );
       }
-      results.add( res );
-      lastSize = res.size();
+      inputs.add( input );
+      lastSize = input.size();
       prevPath = fields[i].getPath();
       i++;
     }
-    return results;
+
+    List<Object[]> resultRows = convertInputsIntoResultRows( inputs );
+
+    filterOutExcessRows( resultRows );
+
+    if ( !ignoreMissingPath & paths.length != 0 ) {
+      raiseExceptionIfAnyMissingPath( resultRows );
+    }
+
+    return resultRows;
+  }
+
+  private List<Object[]> convertInputsIntoResultRows( List<List<?>> inputs ) {
+
+    List<Object[]> resultRows = null;
+
+    if ( inputs.isEmpty() ) {
+      resultRows = new ArrayList<>( 1 );
+      resultRows.add( new Object[]{} );
+      return resultRows;
+    }
+
+    int rowCount = inputs.stream().max( Comparator.comparingInt( List::size ) ).get().size();
+
+    resultRows = new ArrayList<>( rowCount );
+
+    Object[] resultRow = null;
+    for ( int rownum = 0; rownum < rowCount; rownum++ ) {
+      resultRow = new Object[ inputs.size() ];
+      for ( int col = 0; col < inputs.size(); col++ ) {
+        if ( inputs.get( col ).size() == 0 ) {
+          resultRow[ col ] = null;
+          continue;
+        }
+        resultRow[ col ] = inputs.get( col ).get( rownum );
+      }
+      resultRows.add( resultRow );
+    }
+
+    return resultRows;
+  }
+
+  private void filterOutExcessRows( List<Object[]> resultRows ) {
+    boolean atLeastOneNonNull = resultRows.stream().anyMatch( el -> Arrays.stream( el ).anyMatch( in -> in != null ) );
+
+    if ( !atLeastOneNonNull ) {
+      resultRows.clear();
+      resultRows.add( new Object[]{} );
+      return;
+    }
+
+    resultRows.removeIf( el -> Arrays.stream( el ).allMatch( in -> in == null ) );
+
+  }
+
+  private void raiseExceptionIfAnyMissingPath( List<Object[]> resultRows ) throws JsonInputException {
+    for ( Object[] resultRow : resultRows ) {
+      for ( int i = 0; i < resultRow.length; i++ ) {
+        if ( resultRow[i] == null ) {
+          throw new JsonInputException( BaseMessages.getString( PKG, "JsonReader.Error.CanNotFindPath", fields[i].getPath() ) );
+        }
+      }
+    }
   }
 
   public static boolean isAllNull( Iterable<?> list ) {


### PR DESCRIPTION
- Fixed skipping rows if json field is null, empty or if there are no matches with json fields and at the same time there are no additional not null row fields
- Corrected filtering out rows and avoiding excess processRow calls.

- Reworked process of result rows' storage and converting.


-  Changed 'Ignore Missing Path' behavior. Now it is unchecked it will throw an exception if there are at least one null json value in output row after parsing. Previously it failed only if  all the rows misses the same path.
