### PR TITLE
[PDI-15628] Results from jobs run in parallel should not be mixed in log files

### DIFF
--- a/core/src/org/pentaho/di/core/logging/LoggingObject.java
+++ b/core/src/org/pentaho/di/core/logging/LoggingObject.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,6 +25,7 @@ package org.pentaho.di.core.logging;
 import java.util.Date;
 
 import org.pentaho.di.core.Const;
+import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.ObjectRevision;
 import org.pentaho.di.repository.RepositoryDirectory;
@@ -92,7 +93,8 @@ public class LoggingObject implements LoggingObjectInterface {
 
       // If the filename is the same and parent is the same, it's the same object...
       if ( sameCarteFamily && !Const.isEmpty( loggingObject.getFilename() )
-          && loggingObject.getFilename().equals( getFilename() ) && sameParents ) {
+          && loggingObject.getFilename().equals( getFilename() ) && sameParents
+              && StringUtils.equals( loggingObject.getObjectName(), getObjectName() ) ) {
         return true;
       }
 

--- a/core/test-src/org/pentaho/di/core/logging/LoggingObjectTest.java
+++ b/core/test-src/org/pentaho/di/core/logging/LoggingObjectTest.java
@@ -1,0 +1,49 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+
+package org.pentaho.di.core.logging;
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class LoggingObjectTest {
+
+  @Test
+  public void testEquals() throws Exception {
+    LoggingObjectInterface parent = new LoggingObject( new SimpleLoggingObject( "parent", LoggingObjectType.JOB, null ) );
+
+    LoggingObject loggingObject1 = new LoggingObject( "test" );
+    loggingObject1.setFilename( "fileName" );
+    loggingObject1.setParent( parent );
+    loggingObject1.setObjectName( "job1" );
+
+
+    LoggingObject loggingObject2 = new LoggingObject( "test" );
+    loggingObject2.setFilename( "fileName" );
+    loggingObject2.setParent( parent );
+    loggingObject2.setObjectName( "job2" );
+
+    Assert.assertFalse( loggingObject1.equals( loggingObject2 ) );
+  }
+
+}


### PR DESCRIPTION
[PDI-15628] Results from jobs run in parallel should not be mixed in log files
-added checking object name in LoggingObject equals()

@mbatchelor Could you please review and merge it?