### PR TITLE
SP-3019 - Backport of PDI-15707 - JSON Input is not processing HDFS files that come from a Field when connected to repository (7.0 Suite)

### DIFF
--- a/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/JsonInputMeta.java
+++ b/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/JsonInputMeta.java
@@ -854,7 +854,7 @@ public class JsonInputMeta extends
 
         getInputFields()[i] = field;
       }
-      inFields = rep.getStepAttributeBoolean( id_step, "IsInFields" );
+      setInFields( rep.getStepAttributeBoolean( id_step, "IsInFields" ) );
       isAFile = rep.getStepAttributeBoolean( id_step, "IsAFile" );
 
       valueField = rep.getStepAttributeString( id_step, "valueField" );

--- a/plugins/kettle-json-plugin/test-src/org/pentaho/di/trans/steps/jsoninput/JsonInputMetaTest.java
+++ b/plugins/kettle-json-plugin/test-src/org/pentaho/di/trans/steps/jsoninput/JsonInputMetaTest.java
@@ -27,15 +27,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.metastore.api.IMetaStore;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Created by bmorrise on 3/22/16.
@@ -135,11 +135,20 @@ public class JsonInputMetaTest {
     jsonInputMeta.setFieldValue( DATA );
     jsonInputMeta.setInFields( true );
 
-    when( rowMeta.indexOfValue( DATA ) ).thenReturn( 0 );
+    Mockito.when( rowMeta.indexOfValue( DATA ) ).thenReturn( 0 );
 
     jsonInputMeta.getFields( rowMeta, NAME, info, nextStep, space, repository, metaStore );
 
-    verify( rowMeta ).removeValueMeta( 0 );
+    Mockito.verify( rowMeta ).removeValueMeta( 0 );
+  }
+
+  @Test
+  public void verifyReadingRepoSetsAcceptFilenames() throws Exception {
+    ObjectId objectId = () -> "id";
+    Mockito.when( repository.getStepAttributeBoolean( objectId, "IsInFields" ) ).thenReturn( true );
+    jsonInputMeta.readRep( repository, null, objectId, null );
+    Assert.assertTrue( jsonInputMeta.isInFields() );
+    Assert.assertTrue( jsonInputMeta.inputFiles.acceptingFilenames );
   }
 
   @Test


### PR DESCRIPTION
Backport of PDI-15707 - JSON Input is not processing HDFS files that come from a Field when connected to repository 