### PR TITLE
[PDI-14058] Kettle Status page should show the history of jobs in a logical sequence

### DIFF
--- a/engine/src/org/pentaho/di/www/GetStatusServlet.java
+++ b/engine/src/org/pentaho/di/www/GetStatusServlet.java
@@ -29,6 +29,8 @@ import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
 import java.net.URLEncoder;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 
 import javax.servlet.ServletException;
@@ -252,7 +254,25 @@ public class GetStatusServlet extends BaseHttpServlet implements CartePluginInte
           + BaseMessages.getString( PKG, "GetStatusServlet.LastLogDate" ) + "</th> <th>"
           + BaseMessages.getString( PKG, "GetStatusServlet.Remove" ) + "</th> </tr>" );
 
-        Collections.sort( transEntries );
+        Comparator<CarteObjectEntry> transComparator = new Comparator<CarteObjectEntry>() {
+          @Override
+          public int compare( CarteObjectEntry o1, CarteObjectEntry o2 ) {
+            Trans t1 = getTransformationMap().getTransformation( o1 ); 
+            Trans t2 = getTransformationMap().getTransformation( o2 ); 
+            Date d1 = t1.getLogDate();
+            Date d2 = t2.getLogDate();
+            // if both transformations have last log date, desc sort by log date
+            if (d1 != null && d2 != null) {
+              int logDateCompare = d2.compareTo( d1 );
+              if ( logDateCompare != 0 ) {
+                return logDateCompare;
+              }
+            }
+            return o1.compareTo( o2 );
+          }
+        };
+
+        Collections.sort( transEntries, transComparator );
 
         for ( CarteObjectEntry entry : transEntries ) {
           String name = entry.getName();
@@ -290,7 +310,25 @@ public class GetStatusServlet extends BaseHttpServlet implements CartePluginInte
           + BaseMessages.getString( PKG, "GetStatusServlet.LastLogDate" ) + "</th> <th>"
           + BaseMessages.getString( PKG, "GetStatusServlet.Remove" ) + "</th> </tr>" );
 
-        Collections.sort( jobEntries );
+        Comparator<CarteObjectEntry> jobComparator = new Comparator<CarteObjectEntry>() {
+          @Override
+          public int compare( CarteObjectEntry o1, CarteObjectEntry o2 ) {
+            Job t1 = getJobMap().getJob( o1 ); 
+            Job t2 = getJobMap().getJob( o2 ); 
+            Date d1 = t1.getLogDate();
+            Date d2 = t2.getLogDate();
+            // if both jobs have last log date, desc sort by log date
+            if (d1 != null && d2 != null) {
+              int logDateCompare = d2.compareTo( d1 );
+              if ( logDateCompare != 0 ) {
+                return logDateCompare;
+              }
+            }
+            return o1.compareTo( o2 );
+          }
+        };
+
+        Collections.sort( jobEntries, jobComparator );
 
         for ( CarteObjectEntry entry : jobEntries ) {
           String name = entry.getName();


### PR DESCRIPTION
I added comparators for jobs and transformations in carte status lists so that jobs and transformations will be order this way:
1. firstly by last log date (desc)
2. if last log date is null in one of transformations/jobs or last log dates are equal, compare by name, then by guid