### PR TITLE
SP-3069 - Backport of PDI-15196 - JSON Input Step does not ignore missing paths

### DIFF
--- a/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/exception/JsonInputException.java
+++ b/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/exception/JsonInputException.java
@@ -1,0 +1,43 @@
+ /*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2016-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.jsoninput.exception;
+
+import org.pentaho.di.core.exception.KettleException;
+
+public class JsonInputException extends KettleException {
+
+  public JsonInputException() {
+  }
+
+  public JsonInputException( String message ) {
+    super( message );
+  }
+
+  public JsonInputException( Throwable cause ) {
+    super( cause );
+  }
+
+  public JsonInputException( String message, Throwable cause ) {
+    super( message, cause );
+  }
+
+}

--- a/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/reader/FastJsonReader.java
+++ b/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsoninput/reader/FastJsonReader.java
@@ -24,6 +24,7 @@ package org.pentaho.di.trans.steps.jsoninput.reader;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import org.pentaho.di.core.RowSet;
@@ -39,6 +40,7 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.ReadContext;
+import org.pentaho.di.trans.steps.jsoninput.exception.JsonInputException;
 
 /**
  * @author Samatar
@@ -118,46 +120,32 @@ public class FastJsonReader implements IJsonReader {
   @Override
   public RowSet parse( InputStream in ) throws KettleException {
     readInput( in );
-    List<List<?>> results = evalCombinedResult();
+    List<Object[]> results = evalCombinedResult();
     if ( log.isDetailed() ) {
-      int len = results.isEmpty() ? 0 : results.get( 0 ).size();
-      log.logDetailed( BaseMessages.getString( PKG, "JsonInput.Log.NrRecords", len ) );
+      log.logDetailed( BaseMessages.getString( PKG, "JsonInput.Log.NrRecords", results.size() ) );
     }
     return new TransposedRowSet( results );
   }
 
   private static class TransposedRowSet extends SingleRowRowSet {
-    private List<List<?>> results;
-    int rowCount;
-    int rowNbr;
 
-    public TransposedRowSet( List<List<?>> results ) {
+    private List<Object[]> results;
+    public TransposedRowSet( List<Object[]> results ) {
       super();
       this.results = results;
-      this.rowCount = results.isEmpty() ? 0 : results.get( 0 ).size();
     }
 
     @Override
     public Object[] getRow() {
-      if ( rowNbr >= rowCount ) {
-        results.clear();
-        return null;
+      if ( !results.isEmpty() ) {
+        return results.remove( 0 );
       }
-      Object[] rowData = new Object[ results.size() ];
-      for ( int col = 0; col < results.size(); col++ ) {
-        if ( results.get( col ).size() == 0 ) {
-          rowData[ col ] = null;
-          continue;
-        }
-        rowData[ col ] = results.get( col ).get( rowNbr );
-      }
-      rowNbr++;
-      return rowData;
+      return null;
     }
 
     @Override
     public int size() {
-      return rowCount - rowNbr;
+      return results.size();
     }
 
     @Override
@@ -172,27 +160,122 @@ public class FastJsonReader implements IJsonReader {
     }
   }
 
-  private List<List<?>> evalCombinedResult() throws KettleException {
+  private List<Object[]> evalCombinedResult() throws JsonInputException {
     int lastSize = -1;
     String prevPath = null;
-    List<List<?>> results = new ArrayList<>( paths.length );
+    List<List<?>> inputs = new ArrayList<>( paths.length );
     int i = 0;
     for ( JsonPath path : paths ) {
-      List<Object> res = getReadContext().read( path );
-      if ( res.size() != lastSize && lastSize > 0  & res.size() != 0 ) {
-        throw new KettleException( BaseMessages.getString(
-            PKG, "JsonInput.Error.BadStructure", res.size(), fields[i].getPath(), prevPath, lastSize ) );
+      List<Object> input = getReadContext().read( path );
+      if ( input.size() != lastSize && lastSize > 0  & input.size() != 0 ) {
+        throw new JsonInputException( BaseMessages.getString(
+            PKG, "JsonInput.Error.BadStructure", input.size(), fields[i].getPath(), prevPath, lastSize ) );
       }
-      if ( ( isAllNull( res ) || res.size() == 0 ) && !isIgnoreMissingPath() ) {
-        throw new KettleException( BaseMessages.getString( PKG, "JsonReader.Error.CanNotFindPath", fields[i].getPath() ) );
+      if ( ( isAllNull( input ) || input.size() == 0 ) && !isIgnoreMissingPath() ) {
+        throw new JsonInputException( BaseMessages.getString( PKG, "JsonReader.Error.CanNotFindPath", fields[i].getPath() ) );
       }
-      results.add( res );
-      lastSize = res.size();
+      inputs.add( input );
+      lastSize = input.size();
       prevPath = fields[i].getPath();
       i++;
     }
-    return results;
+    List<Object[]> resultRows = convertInputsIntoResultRows( inputs );
+    filterOutExcessRows( resultRows );
+    if ( !ignoreMissingPath & paths.length != 0 ) {
+      raiseExceptionIfAnyMissingPath( resultRows );
+    }
+    return resultRows;
   }
+
+  private List<Object[]> convertInputsIntoResultRows( List<List<?>> inputs ) {
+
+    List<Object[]> resultRows = null;
+
+    if ( inputs.isEmpty() ) {
+      resultRows = new ArrayList<>( 1 );
+      resultRows.add( new Object[]{} );
+      return resultRows;
+    }
+    int rowCount = 0;
+    for ( List<?> list: inputs ) {
+      if ( list.size() > rowCount ) {
+        rowCount = list.size();
+      }
+    }
+
+    resultRows = new ArrayList<>( rowCount );
+
+    Object[] resultRow = null;
+    for ( int rownum = 0; rownum < rowCount; rownum++ ) {
+      resultRow = new Object[ inputs.size() ];
+      for ( int col = 0; col < inputs.size(); col++ ) {
+        if ( inputs.get( col ).size() == 0 ) {
+          resultRow[col] = null;
+          continue;
+        }
+        resultRow[col] = inputs.get( col ).get( rownum );
+      }
+      resultRows.add( resultRow );
+    }
+
+    return resultRows;
+  }
+
+  private void filterOutExcessRows( List<Object[]> resultRows ) {
+    boolean atLeastOneNonNull = atLeastOneNonNull( resultRows );
+
+    if ( !atLeastOneNonNull ) {
+      resultRows.clear();
+      resultRows.add( new Object[]{} );
+      return;
+    }
+
+    deleteEmptyRows( resultRows );
+
+  }
+
+  private void deleteEmptyRows( List<Object[]> resultRows ) {
+    Iterator<Object[]> iterator = resultRows.iterator();
+    while ( iterator.hasNext() ) {
+      if ( !atLeastOneNonNull( iterator.next() ) ) {
+        iterator.remove();
+      }
+    }
+  }
+
+  private void raiseExceptionIfAnyMissingPath( List<Object[]> resultRows ) throws JsonInputException {
+    for ( Object[] resultRow : resultRows ) {
+      for ( int i = 0; i < resultRow.length; i++ ) {
+        if ( resultRow[i] == null ) {
+          throw new JsonInputException( BaseMessages.getString( PKG, "JsonReader.Error.CanNotFindPath", fields[i].getPath() ) );
+        }
+      }
+    }
+  }
+
+  private boolean atLeastOneNonNull( Object[] objects ) {
+    for ( Object obj : objects ) {
+      if ( obj != null ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean atLeastOneNonNull( List<Object[]> resultRows ) {
+    for ( Object[] result : resultRows ) {
+      for ( Object obj : result ) {
+        if ( obj != null ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+
+
+
 
   public static boolean isAllNull( Iterable<?> list ) {
     for ( Object obj : list ) {

--- a/plugins/kettle-json-plugin/test-src/org/pentaho/di/trans/steps/jsoninput/JsonInputTest.java
+++ b/plugins/kettle-json-plugin/test-src/org/pentaho/di/trans/steps/jsoninput/JsonInputTest.java
@@ -286,8 +286,13 @@ public class JsonInputTest {
     helper.redirectLog( out, LogLevel.ERROR );
 
     try ( LocaleChange enUS = new LocaleChange( Locale.US ) ) {
-      JsonInput jsonInput = createBasicTestJsonInput( "$..fail", new ValueMetaString( "result" ), "json",
-          new Object[] { getBasicTestJson() } );
+      ValueMetaString outputMeta = new ValueMetaString( "result" );
+      JsonInputField jpath = new JsonInputField( outputMeta.getName() );
+      jpath.setPath( "$..fail" );
+      jpath.setType( outputMeta.getType() );
+      JsonInputMeta jsonInputMeta = createSimpleMeta( "json", jpath );
+      jsonInputMeta.setIgnoreMissingPath( false );
+      JsonInput jsonInput = createJsonInput( "json", jsonInputMeta, new Object[] { getBasicTestJson() } );
       processRows( jsonInput, 2 );
       Assert.assertEquals( "errors", 1, jsonInput.getErrors() );
       Assert.assertEquals( "rows written", 0, jsonInput.getLinesWritten() );
@@ -420,6 +425,7 @@ public class JsonInputTest {
     bField.setRepeated( true );
 
     JsonInputMeta meta = createSimpleMeta( inCol, aField, bField );
+    meta.setIgnoreMissingPath( true );
     JsonInput step = createJsonInput( inCol, meta, new Object[] { input } );
     step.addRowListener(
         new RowComparatorListener(
@@ -447,21 +453,43 @@ public class JsonInputTest {
   }
 
   @Test
-   public void testDoNotSkipRowIfInputIsNull() throws Exception {
-    JsonInputField field = new JsonInputField( "foo" );
-    field.setPath( "$.foo" );
-    field.setType( ValueMetaInterface.TYPE_STRING );
-    JsonInputMeta meta = createSimpleMeta( "json", field );
-    JsonInput jsonInput = new JsonInput( helper.stepMeta, helper.stepDataInterface, 0, helper.transMeta, helper.trans );
-    JsonInputData data = new JsonInputData();
-    RowSet input = helper.getMockInputRowSet( new Object[] { null, "something" } );
-    RowMetaInterface rowMeta = createRowMeta( new ValueMetaString( "json" ), new ValueMetaString( "json1" ) );
-    input.setRowMeta( rowMeta );
-    jsonInput.getInputRowSets().add( input );
-    jsonInput.setInputRowMeta( rowMeta );
-    jsonInput.init( meta, data );
-    processRows( jsonInput, 1 );
-    Assert.assertEquals( 1, jsonInput.getLinesWritten() );
+  public void testIfIgnorePathDoNotSkipRowIfInputIsNullOrFieldNotFound() throws Exception {
+    final String input1 = "{ \"value1\": \"1\",\n"
+            + "  \"value2\": \"2\",\n"
+            + "}";
+    final String input2 = "{ \"value1\": \"3\""
+            + "}";
+    final String input3 = "{ \"value2\": \"4\""
+            + "}";
+    final String input4 = "{ \"value1\": null,\n"
+            + "  \"value2\": null,\n"
+            + "}";
+    final String input5 = "{}";
+    final String input6 = null;
+
+    final String inCol = "input";
+    JsonInputField aField = new JsonInputField();
+    aField.setName( "a" );
+    aField.setPath( "$.value1" );
+    aField.setType( ValueMetaInterface.TYPE_STRING );
+    JsonInputField bField = new JsonInputField();
+    bField.setName( "b" );
+    bField.setPath( "$.value2" );
+    bField.setType( ValueMetaInterface.TYPE_STRING );
+    JsonInputMeta meta = createSimpleMeta( inCol, aField, bField );
+    meta.setIgnoreMissingPath( true );
+    JsonInput step = createJsonInput( inCol, meta, new Object[] { input1 },
+            new Object[] { input2 },
+            new Object[] { input3 },
+            new Object[] { input4 },
+            new Object[] { input5 },
+            new Object[] { input6 }
+    );
+    step.addRowListener(
+            new RowComparatorListener(
+                    new Object[]{ input1, "1", "2" }, new Object[]{ input2, "3", null }, new Object[]{ input3, null, "4" },
+                    new Object[]{ input4, null, null }, new Object[]{ input5, null, null }, new Object[]{ input6, null, null }   ) );
+    processRows( step, 5 );
   }
 
 
@@ -492,6 +520,7 @@ public class JsonInputTest {
     price.setType( ValueMetaInterface.TYPE_NUMBER );
 
     JsonInputMeta meta = createSimpleMeta( "json", isbn, price );
+    meta.setIgnoreMissingPath( true );
     meta.setRemoveSourceField( true );
 
     JsonInput jsonInput = createJsonInput( "json", meta, new Object[] { getBasicTestJson() } );
@@ -606,8 +635,11 @@ public class JsonInputTest {
           new Object[] { jsonInputField },
           new Object[] { null } },
         new Object[][] {
+          new Object[] { null, null },
           new Object[] { jsonInputField, "Herman Melville" },
-          new Object[] { jsonInputField, "J. R. R. Tolkien" } } );
+          new Object[] { jsonInputField, "J. R. R. Tolkien" },
+          new Object[] { null, null }
+          } );
   }
 
   /**
@@ -956,7 +988,7 @@ public class JsonInputTest {
     jsonInputMeta.setInFields( true );
     jsonInputMeta.setFieldValue( inputColumn );
     jsonInputMeta.setInputFields( jsonPathFields );
-    jsonInputMeta.setIgnoreMissingPath( false );
+    jsonInputMeta.setIgnoreMissingPath( true );
     return jsonInputMeta;
   }
 


### PR DESCRIPTION
Fixed skipping rows if json field is null, empty or if there are no matches with json fields and at the same time there are no additional not null row fields. Corrected filtering out rows