### PR TITLE
PDI-15577 - XML Join saves output in random input fields

### DIFF
--- a/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xmljoin/XMLJoin.java
+++ b/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xmljoin/XMLJoin.java
@@ -113,7 +113,7 @@ public class XMLJoin extends BaseStep implements StepInterface {
 
       data.outputRowMeta = data.TargetRowSet.getRowMeta().clone();
       meta.getFields( data.outputRowMeta, getStepname(), new RowMetaInterface[] { data.TargetRowSet.getRowMeta() },
-          null, this, repository, metaStore );
+          null, getTransMeta(), repository, metaStore );
       data.outputRowData = rTarget.clone();
 
       // get the target xml structure and create a DOM

--- a/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xmljoin/XMLJoinMeta.java
+++ b/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xmljoin/XMLJoinMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.xmljoin;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.pentaho.di.core.annotations.Step;
@@ -153,7 +154,14 @@ public class XMLJoinMeta extends BaseStepMeta implements StepMetaInterface {
 
     ValueMetaInterface v = new ValueMeta( this.getValueXMLfield(), ValueMetaInterface.TYPE_STRING );
     v.setOrigin( name );
-    row.addValueMeta( v );
+
+    RowMetaInterface rowMeta = ( (TransMeta) space ) .getStepFields( getTargetXMLstep() ).clone();
+    if ( rowMeta != null ) {
+      rowMeta.addValueMeta( v );
+      row.setValueMetaList( rowMeta.getValueMetaList() );
+    } else {
+      row.setValueMetaList( Arrays.asList( v ) );
+    }
   }
 
   public String getXML() {

--- a/plugins/kettle-xml-plugin/test-src/org/pentaho/di/trans/steps/xmljoin/XmlJoinMetaGetFieldsTest.java
+++ b/plugins/kettle-xml-plugin/test-src/org/pentaho/di/trans/steps/xmljoin/XmlJoinMetaGetFieldsTest.java
@@ -1,0 +1,62 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2016-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.xmljoin;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.trans.TransMeta;
+
+
+public class XmlJoinMetaGetFieldsTest {
+
+  XMLJoinMeta xmlJoinMeta;
+  TransMeta transMeta;
+
+  @Before
+  public void setup() throws Exception {
+    xmlJoinMeta = new XMLJoinMeta();
+    transMeta = Mockito.mock( TransMeta.class );
+  }
+
+  @Test
+  public void testGetFieldsReturnTargetStepFieldsPlusResultXmlField() throws Exception {
+    String targetXmlStep = "target xml step name";
+    String targetStepField = "source field test name";
+    String resultXmlFieldName = "result xml field name";
+    RowMeta rowMetaPreviousSteps = new RowMeta();
+    rowMetaPreviousSteps.addValueMeta( new ValueMeta( targetStepField, ValueMetaInterface.TYPE_STRING ) );
+    xmlJoinMeta.setValueXMLfield( "result xml field name" );
+    xmlJoinMeta.setTargetXMLstep( targetXmlStep );
+    Mockito.when( transMeta.getStepFields( targetXmlStep ) ).thenReturn( rowMetaPreviousSteps );
+    RowMeta rowMeta = new RowMeta();
+    xmlJoinMeta.getFields( rowMeta, "testStepName", null, null, transMeta, null, null );
+    Assert.assertEquals( 2, rowMeta.size() );
+    String[] strings = rowMeta.getFieldNames();
+    Assert.assertEquals( targetStepField, strings[0] );
+    Assert.assertEquals( resultXmlFieldName, strings[1] );
+  }
+}


### PR DESCRIPTION
The problem was that previewing data called getFields method and got the wrong result -> which was which contained source step fields and target step's ones + result xml field. But XMLJoin step produces only  one row which will be produced containing the fields of the target step plus the result field of the join, 
therefore there was a field mismatch in preview data