### PR TITLE
PDI-15661 - Spoon Crashed when Logging is Removed. Since no one optio…

### DIFF
--- a/ui/src/org/pentaho/di/ui/core/widget/TableView.java
+++ b/ui/src/org/pentaho/di/ui/core/widget/TableView.java
@@ -1095,6 +1095,10 @@ public class TableView extends Composite {
               final TableItem item = table.getItem( index );
               for ( int i = 0; i < table.getColumnCount(); i++ ) {
                 Rectangle rect = item.getBounds( i );
+                if ( i == 0 ) {
+                  rect.width = rect.x;
+                  rect.x = 0;
+                }
                 if ( rect.contains( pt ) ) {
                   activeTableItem = item;
                   activeTableColumn = i;
@@ -2002,6 +2006,10 @@ public class TableView extends Composite {
     // up afterwards.
     table.showItem( row );
     table.setSelection( new TableItem[]{ row } );
+
+    if ( columns.length == 0 ) {
+      return;
+    }
 
     switch ( columns[colnr - 1].getType() ) {
       case ColumnInfo.COLUMN_TYPE_TEXT:


### PR DESCRIPTION
…n is selected it created a non-sized array(length == 0) for the options and trying to display it in table in "logging" tab in "executions resuts" caused  java.lang.ArrayIndexOutOfBoundsException as it tried to get the first element from the array. And also fixed unexpected additional row appending when you click on checkbox "Include?" in Transformation properties in "logging" tab 