### PR TITLE
PDI-14994 - Rowlevel Logging causes NPE in Join rows step. Fixed usin…

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/joinrows/JoinRows.java
+++ b/engine/src/org/pentaho/di/trans/steps/joinrows/JoinRows.java
@@ -198,7 +198,7 @@ public class JoinRows extends BaseStep implements StepInterface {
         }
         if ( log.isRowLevel() ) {
           logRowlevel( BaseMessages.getString( PKG, "JoinRows.Log.ReadRowFromFile" )
-            + filenr + " : " + getInputRowMeta().getString( rowData ) );
+            + filenr + " : " + data.fileRowMeta[filenr].getString( rowData ) );
         }
 
         data.position[filenr]++;


### PR DESCRIPTION
…g wrong inputRowMeta(which is null) for a logging data. The correct input row meta for a data in this place is available as data.fileRowMeta[filenr(index of a file the data was taken)].