### PR TITLE
[SP-3112] Backport of PDI-14621 - JSON Output creates empty file when…

### DIFF
--- a/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsonoutput/JsonOutput.java
+++ b/plugins/kettle-json-plugin/src/org/pentaho/di/trans/steps/jsonoutput/JsonOutput.java
@@ -230,7 +230,7 @@ public class JsonOutput extends BaseStep implements StepInterface {
       putRow( data.outputRowMeta, outputRowData );
     }
 
-    if ( data.writeToFile ) {
+    if ( data.writeToFile && !data.ja.isEmpty() ) {
       // Open a file
       if ( !openNewFile() ) {
         throw new KettleStepException( BaseMessages.getString(
@@ -393,7 +393,7 @@ public class JsonOutput extends BaseStep implements StepInterface {
     return meta.buildFilename( environmentSubstitute( meta.getFileName() ), getCopy(), data.splitnr );
   }
 
-  private boolean closeFile() {
+  protected boolean closeFile() {
     if ( data.writer == null ) {
       return true;
     }


### PR DESCRIPTION
[SP-3112] Backport of PDI-14621 - JSON Output creates empty file when it receives empty stream (with option "Append" and "Do not create file...") (6.1 Suite)