### PR TITLE
[SP-3150]

### DIFF
--- a/core/src/org/pentaho/di/core/row/ValueMetaAndData.java
+++ b/core/src/org/pentaho/di/core/row/ValueMetaAndData.java
@@ -183,6 +183,7 @@ public class ValueMetaAndData {
           originMeta.setGroupingSymbol( null );
           originMeta.setCurrencySymbol( null );
         }
+        originMeta.setConversionMask( ValueMetaBase.COMPATIBLE_DATE_FORMAT_PATTERN );
         valueData = Const.trim( text );
         valueData = valueMeta.convertData( originMeta, valueData );
       }

--- a/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -91,6 +91,7 @@ public class ValueMetaBase implements ValueMetaInterface {
 
   public static final String XML_META_TAG = "value-meta";
   public static final String XML_DATA_TAG = "value-data";
+  public static final String COMPATIBLE_DATE_FORMAT_PATTERN = "yyyy/MM/dd HH:mm:ss.SSS";
 
   public static final boolean EMPTY_STRING_AND_NULL_ARE_DIFFERENT = convertStringToBoolean( Const.NVL( System
       .getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
@@ -679,7 +680,7 @@ public class ValueMetaBase implements ValueMetaInterface {
     return getDateFormat().format( date );
   }
 
-  protected static SimpleDateFormat compatibleDateFormat = new SimpleDateFormat( "yyyy/MM/dd HH:mm:ss.SSS" );
+  protected static SimpleDateFormat compatibleDateFormat = new SimpleDateFormat( COMPATIBLE_DATE_FORMAT_PATTERN );
 
   protected synchronized String convertDateToCompatibleString( Date date ) {
     if ( date == null ) {

--- a/ui/src/org/pentaho/di/ui/core/dialog/EnterValueDialog.java
+++ b/ui/src/org/pentaho/di/ui/core/dialog/EnterValueDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,6 +24,8 @@ package org.pentaho.di.ui.core.dialog;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -279,11 +281,18 @@ public class EnterValueDialog extends Dialog {
     // If the user changes data type or if we type a text, we set the default mask for the type
     // We also set the list of possible masks in the wFormat
     //
-    wInputString.addModifyListener( new ModifyListener() {
-      public void modifyText( ModifyEvent event ) {
+    wInputString.addFocusListener( new FocusListener() {
+      @Override
+      public void focusGained( FocusEvent focusEvent ) {
+
+      }
+
+      @Override
+      public void focusLost( FocusEvent focusEvent ) {
         setFormats();
       }
     } );
+
     wValueType.addSelectionListener( new SelectionAdapter() {
       public void widgetSelected( SelectionEvent event ) {
         setFormats();


### PR DESCRIPTION
[PDI-14449] Filter Rows step and Kettle date variables,
[PDI-14417] Filter rows step behaviour with inputting dates - problem with EnterValueDialog,
[PDI-14418] Filter Rows step is not displaying date values after closing then re-opening a transformation

-added reading date in compatible format (how it was saved)
-replaced modify listener on focus lost listener
-added test
-added power mock dependency