### PR TITLE
Revert "[BACKLOG-12892] In PUC & all the clients (PME, PRD, Spoon, PSW) when creating connection to Pentaho Data Services with empty Web App Name & reopening this connection Web App Name is reinserted as pentaho"

### DIFF
--- a/dbdialog/src/org/pentaho/ui/database/event/DataHandler.java
+++ b/dbdialog/src/org/pentaho/ui/database/event/DataHandler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -34,9 +34,11 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.swt.widgets.Display;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.BaseDatabaseMeta;
 import org.pentaho.di.core.database.DatabaseConnectionPoolParameter;
 import org.pentaho.di.core.database.DatabaseInterface;
@@ -1364,10 +1366,12 @@ public class DataHandler extends AbstractXulEventHandler {
       }
     }
 
-    if ( webAppName == null ) {
-      meta.getDatabaseInterface().setDatabaseName( "pentaho" );
-    } else {
-      webAppName.setValue( meta.getDatabaseName() );
+    if ( webAppName != null ) {
+      if ( Utils.isEmpty( meta.getDatabaseName() ) ) {
+        webAppName.setValue( "pentaho" );
+      } else {
+        webAppName.setValue( meta.getDatabaseName() );
+      }
     }
   }
 

--- a/dbdialog/test-src/org/pentaho/ui/database/event/DataHandlerTest.java
+++ b/dbdialog/test-src/org/pentaho/ui/database/event/DataHandlerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -255,7 +255,7 @@ public class DataHandlerTest {
     dataHandler.getData();
     dataHandler.pushCache();
     dataHandler.popCache();
-    verify( webappName ).setValue( "" );
+    verify( webappName ).setValue( "pentaho" );
   }
 
   @Test


### PR DESCRIPTION
Reverts pentaho/pentaho-kettle#3344

@hudak 