### PR TITLE
PDI-15877 - Enclosure character is not removed from output stream

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -533,7 +533,7 @@ public class CsvInput extends BaseStep implements StepInterface {
           } else if ( data.enclosureFound() && !ignoreEnclosuresInField ) {
             int enclosurePosition = data.getEndBuffer();
             int fieldFirstBytePosition = data.getStartBuffer();
-            if ( fieldFirstBytePosition == enclosurePosition ) {
+            if ( fieldFirstBytePosition == enclosurePosition - ( data.enclosure.length - 1 )  ) {
               // Perhaps we need to skip over an enclosed part?
               // We always expect exactly one enclosure character
               // If we find the enclosure doubled, we consider it escaped.

--- a/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputUnicodeTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputUnicodeTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -50,8 +50,11 @@ public class CsvInputUnicodeTest extends CsvInputUnitTestBase {
   private static final String ONE_CHAR_DELIM = "\t";
   private static final String MULTI_CHAR_DELIM = "|||";
   private static final String TEXT = "Header1%1$sHeader2\nValue%1$sValue\nValue%1$sValue\n";
+  private static final String TEXT_WITH_ENCLOSURES = "Header1%1$sHeader2\n\"Value\"%1$s\"Value\"\n\"Value\"%1$s\"Value\"\n";
   private static final String TEST_DATA = String.format( TEXT, ONE_CHAR_DELIM );
   private static final String TEST_DATA1 = String.format( TEXT, MULTI_CHAR_DELIM );
+  private static final String TEST_DATA2 = String.format( TEXT_WITH_ENCLOSURES, ONE_CHAR_DELIM );
+  private static final String TEST_DATA3 = String.format( TEXT_WITH_ENCLOSURES, MULTI_CHAR_DELIM );
 
   private static StepMockHelper<?, ?> stepMockHelper;
 
@@ -92,6 +95,36 @@ public class CsvInputUnicodeTest extends CsvInputUnitTestBase {
   @Test
   public void testUTF8_multiDelim() throws Exception {
     doTest( UTF8, UTF8, TEST_DATA1, MULTI_CHAR_DELIM );
+  }
+
+  @Test
+  public void testUTF16LEDataWithEnclosures() throws Exception {
+    doTest( UTF16LE, UTF16LE, TEST_DATA2, ONE_CHAR_DELIM );
+  }
+
+  @Test
+  public void testUTF16BEDataWithEnclosures() throws Exception {
+    doTest( UTF16BE, UTF16BE, TEST_DATA2, ONE_CHAR_DELIM );
+  }
+
+  @Test
+  public void testUTF16LEBOMDataWithEnclosures() throws Exception {
+    doTest( UTF16LEBOM, UTF16LE, TEST_DATA2, ONE_CHAR_DELIM );
+  }
+
+  @Test
+  public void testUTF16BE_multiDelim_DataWithEnclosures() throws Exception {
+    doTest( UTF16BE, UTF16BE, TEST_DATA3, MULTI_CHAR_DELIM );
+  }
+
+  @Test
+  public void testUTF16LE_multiDelim_DataWithEnclosures() throws Exception {
+    doTest( UTF16LE, UTF16LE, TEST_DATA3, MULTI_CHAR_DELIM );
+  }
+
+  @Test
+  public void testUTF8_multiDelim_DataWithEnclosures() throws Exception {
+    doTest( UTF8, UTF8, TEST_DATA3, MULTI_CHAR_DELIM );
   }
 
   private void doTest( final String fileEncoding, final String stepEncoding, final String testData,


### PR DESCRIPTION
https://github.com/pentaho/pentaho-kettle/blob/master/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java#L536 Here the facts that enclosure character(s) may be represented not only as 1 byte and that enclosure can consist of more than one character weren't taken into account