### PR TITLE
Adding the ability to return more than one publisher for a given Even…

### DIFF
--- a/pdi-execution-engine/api/src/main/java/org/pentaho/di/engine/api/reporting/IMaterializedModelElement.java
+++ b/pdi-execution-engine/api/src/main/java/org/pentaho/di/engine/api/reporting/IMaterializedModelElement.java
@@ -4,14 +4,13 @@ import org.reactivestreams.Publisher;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Created by nbaker on 1/18/17.
  */
 public interface IMaterializedModelElement extends IModelElement  {
 
-  <D extends Serializable> Optional<Publisher> getPublisher( Class<D> type );
+  <D extends Serializable> List<Publisher<? extends IReportingEvent>> getPublisher( Class<D> type );
 
   <D extends Serializable> List<Serializable> getEventTypes();
 

--- a/pdi-execution-engine/impl/kettle-classic/src/test/java/org/pentaho/di/engine/kettleclassic/ClassicKettleEngineTest.java
+++ b/pdi-execution-engine/impl/kettle-classic/src/test/java/org/pentaho/di/engine/kettleclassic/ClassicKettleEngineTest.java
@@ -8,6 +8,7 @@ import org.pentaho.di.engine.api.Status;
 import org.pentaho.di.engine.api.reporting.Metrics;
 import org.pentaho.di.trans.TransMeta;
 
+import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -24,8 +25,13 @@ public class ClassicKettleEngineTest {
     ITransformation transformation = ClassicUtils.convert( meta );
     ClassicKettleExecutionContext context = (ClassicKettleExecutionContext) engine.prepare( transformation );
 
-    context.subscribe( transformation, Status.class,  d -> {
-      System.out.println( "Received Transformation Status event: " + d );
+    context.subscribe( transformation, Serializable.class, d -> {
+      System.out.println( "Received Transformation Event: " + d );
+    } );
+
+    // Receives both Status and Metrics
+    context.subscribe( transformation.getOperations().get( 0 ), Serializable.class, d -> {
+      System.out.println( "Received Operation Event: " + d );
     } );
 
     context.subscribe( transformation.getOperations().get( 0 ), Status.class,  d -> {
@@ -33,7 +39,7 @@ public class ClassicKettleEngineTest {
     } );
 
     context.subscribe( transformation.getOperations().get( 0 ), Metrics.class, d -> {
-      System.out.println( "Received Operation Status event: \n" + d );
+      System.out.println( "Received Operation Metrics event: \n" + d );
     } );
 
     IExecutionResult result = context.execute().get( 30, TimeUnit.SECONDS );


### PR DESCRIPTION
…t class. Querying for publishers now supports inheritance where Publishers for subclasses of the given event will be returned as well.

Multiple publishers for a subscription call are Merged together into one Publisher for the client.