### PR TITLE
[SP-3247][PDI-13487]Excel Output field formats are ignored when "Split Every ... Rows" is used

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
@@ -682,7 +682,7 @@ public class ExcelOutput extends BaseStep implements StepInterface {
         }
 
       }
-      // data.formats.clear();
+      data.formats.clear();
       if ( log.isDebug() ) {
         logDebug( BaseMessages.getString( PKG, "ExcelOutput.Log.FileClosed", filename ) );
       }

--- a/engine/test-src/org/pentaho/di/trans/steps/exceloutput/ExcelOutputTemplateTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/exceloutput/ExcelOutputTemplateTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 
 import junit.framework.Assert;
 
@@ -63,6 +64,7 @@ public class ExcelOutputTemplateTest {
     ExcelOutputMeta meta = createStepMeta();
     excelOutput.init( meta, helper.initStepDataInterface );
     Assert.assertEquals( "Step init error.", 0, excelOutput.getErrors() );
+    helper.initStepDataInterface.formats = new HashMap<>();
     excelOutput.dispose( meta, helper.initStepDataInterface );
     Assert.assertEquals( "Step dispose error", 0, excelOutput.getErrors() );
   }


### PR DESCRIPTION
[SP-3247][PDI-13487]Excel Output field formats are ignored when "Split Every ... Rows" is used

-added clearing formats in closing file, so for next file format will be reinitialize and write in next file
-added test