### PR TITLE
[SP-3244][PDI-13487]Excel Output field formats are ignored when "Split Every ... Rows" is used

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
@@ -681,7 +681,7 @@ public class ExcelOutput extends BaseStep implements StepInterface {
         }
 
       }
-      // data.formats.clear();
+      data.formats.clear();
       if ( log.isDebug() ) {
         logDebug( BaseMessages.getString( PKG, "ExcelOutput.Log.FileClosed", filename ) );
       }

--- a/engine/test-src/org/pentaho/di/trans/steps/exceloutput/ExcelOutputTemplateTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/exceloutput/ExcelOutputTemplateTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,16 +22,15 @@
 
 package org.pentaho.di.trans.steps.exceloutput;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
-
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 
 import junit.framework.Assert;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
@@ -51,9 +50,9 @@ public class ExcelOutputTemplateTest {
     helper =
         new StepMockHelper<ExcelOutputMeta, ExcelOutputData>( "ExcelOutputTest", ExcelOutputMeta.class,
             ExcelOutputData.class );
-    when( helper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+    Mockito.when( helper.logChannelInterfaceFactory.create( Matchers.any(), Matchers.any( LoggingObjectInterface.class ) ) ).thenReturn(
         helper.logChannelInterface );
-    when( helper.trans.isRunning() ).thenReturn( true );
+    Mockito.when( helper.trans.isRunning() ).thenReturn( true );
   }
 
   @Test
@@ -63,6 +62,7 @@ public class ExcelOutputTemplateTest {
     ExcelOutputMeta meta = createStepMeta();
     excelOutput.init( meta, helper.initStepDataInterface );
     Assert.assertEquals( "Step init error.", 0, excelOutput.getErrors() );
+    helper.initStepDataInterface.formats = new HashMap<>();
     excelOutput.dispose( meta, helper.initStepDataInterface );
     Assert.assertEquals( "Step dispose error", 0, excelOutput.getErrors() );
   }

--- a/engine/test-src/org/pentaho/di/trans/steps/exceloutput/ExcelOutputTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/exceloutput/ExcelOutputTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,10 +24,12 @@ package org.pentaho.di.trans.steps.exceloutput;
 
 import jxl.Sheet;
 import jxl.Workbook;
+import jxl.write.WritableCellFormat;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
@@ -40,10 +42,6 @@ import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
 
 /**
  * Created by Yury_Bakhmutski on 12/12/2016.
@@ -68,9 +66,9 @@ public class ExcelOutputTest {
     helper =
       new StepMockHelper<ExcelOutputMeta, ExcelOutputData>( "ExcelOutputTest", ExcelOutputMeta.class,
         ExcelOutputData.class );
-    when( helper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+    Mockito.when( helper.logChannelInterfaceFactory.create( Matchers.any(), Matchers.any( LoggingObjectInterface.class ) ) ).thenReturn(
       helper.logChannelInterface );
-    when( helper.trans.isRunning() ).thenReturn( true );
+    Mockito.when( helper.trans.isRunning() ).thenReturn( true );
   }
 
   @Test
@@ -93,8 +91,8 @@ public class ExcelOutputTest {
     excelOutput.first = false;
 
     Object[] row = { new Date() };
-    doReturn( row ).when( excelOutput ).getRow();
-    doReturn( rowMetaToBeReturned ).when( excelOutput ).getInputRowMeta();
+    Mockito.doReturn( row ).when( excelOutput ).getRow();
+    Mockito.doReturn( rowMetaToBeReturned ).when( excelOutput ).getInputRowMeta();
 
     ExcelOutputMeta meta = createStepMeta();
 
@@ -110,6 +108,41 @@ public class ExcelOutputTest {
     Sheet sheet = workbook.getSheet( 0 );
     int rows = sheet.getRows();
     Assert.assertSame( rows, 2 );
+
+  }
+
+  @Test
+  /**
+   * Tests http://jira.pentaho.com/browse/PDI-13487 issue
+   */
+  public void testClosingFile() throws Exception {
+
+    ValueMetaInterface vmi = new ValueMetaString( "new_row" );
+
+    ExcelOutputData data = new ExcelOutputData();
+    int[] ints = { 0 };
+    data.fieldnrs = ints;
+    String testColumnName = "testColumnName";
+    data.formats.put( testColumnName, new WritableCellFormat() );
+    RowMeta rowMetaToBeReturned = Mockito.spy( new RowMeta() );
+    rowMetaToBeReturned.addValueMeta( 0, vmi );
+
+    data.previousMeta = rowMetaToBeReturned;
+    ExcelOutput excelOutput =
+            Mockito.spy( new ExcelOutput( helper.stepMeta, data, 0, helper.transMeta, helper.trans ) );
+    excelOutput.first = false;
+
+    Object[] row = { new Date() };
+    Mockito.doReturn( row ).when( excelOutput ).getRow();
+    Mockito.doReturn( rowMetaToBeReturned ).when( excelOutput ).getInputRowMeta();
+    Mockito.doReturn( 1L ).when( excelOutput ).getLinesOutput();
+
+    ExcelOutputMeta meta = createStepMeta();
+    meta.setSplitEvery( 1 );
+
+    excelOutput.init( meta, data );
+    excelOutput.processRow( meta, data );
+    Assert.assertNull( data.formats.get( testColumnName ) );
 
   }
 


### PR DESCRIPTION
[SP-3244][PDI-13487]Excel Output field formats are ignored when "Split Every ... Rows" is used

-added clearing formats in closing file, so for next file format will be reinitialize and write in next file
-added test