### PR TITLE
[BACKLOG-14239]Upgrade to rxjava2

### DIFF
--- a/pdi-execution-engine/api/pom.xml
+++ b/pdi-execution-engine/api/pom.xml
@@ -9,9 +9,10 @@
     <version>7.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <groupId>org.pentaho</groupId>
+
   <artifactId>pdi-execution-engine-api</artifactId>
   <version>7.1-SNAPSHOT</version>
+  <packaging>bundle</packaging>
 
   <dependencies>
     <dependency>
@@ -20,6 +21,7 @@
       <version>1.0.0</version>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -33,7 +35,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>${maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/pdi-execution-engine/impl/kettle-classic/pom.xml
+++ b/pdi-execution-engine/impl/kettle-classic/pom.xml
@@ -72,7 +72,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>${maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/pdi-execution-engine/impl/kettle-classic/pom.xml
+++ b/pdi-execution-engine/impl/kettle-classic/pom.xml
@@ -39,17 +39,10 @@
     </dependency>
 
     <dependency>
-      <groupId>io.reactivex</groupId>
+      <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
       <version>${rxjava.dependency.version}</version>
     </dependency>
-    <dependency>
-      <!-- https://mvnrepository.com/artifact/io.reactivex/rxjava-reactive-streams -->
-      <groupId>io.reactivex</groupId>
-      <artifactId>rxjava-reactive-streams</artifactId>
-      <version>1.2.1</version>
-    </dependency>
-
 
     <!-- Trans depends on servlet -->
     <dependency>

--- a/pdi-execution-engine/impl/kettle-classic/src/main/java/org/pentaho/di/engine/kettleclassic/ClassicKettleEngine.java
+++ b/pdi-execution-engine/impl/kettle-classic/src/main/java/org/pentaho/di/engine/kettleclassic/ClassicKettleEngine.java
@@ -1,6 +1,5 @@
 package org.pentaho.di.engine.kettleclassic;
 
-import com.google.common.base.Throwables;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.DefaultLogLevel;
@@ -18,8 +17,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadFactory;
-import java.util.function.Function;
 
 /**
  * Created by nbaker on 1/4/17.

--- a/pdi-execution-engine/impl/kettle-native/pom.xml
+++ b/pdi-execution-engine/impl/kettle-native/pom.xml
@@ -88,7 +88,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>${maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/pdi-execution-engine/impl/kettle-native/pom.xml
+++ b/pdi-execution-engine/impl/kettle-native/pom.xml
@@ -16,20 +16,9 @@
   <dependencies>
 
     <dependency>
-      <groupId>io.reactivex</groupId>
-      <artifactId>rxjava</artifactId>
-      <version>${rxjava.dependency.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams</artifactId>
       <version>1.0.0</version>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/io.reactivex/rxjava-reactive-streams -->
-    <dependency>
-      <groupId>io.reactivex</groupId>
-      <artifactId>rxjava-reactive-streams</artifactId>
-      <version>1.2.1</version>
     </dependency>
 
     <dependency>

--- a/pdi-execution-engine/impl/pom.xml
+++ b/pdi-execution-engine/impl/pom.xml
@@ -11,7 +11,6 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.pentaho</groupId>
   <artifactId>pdi-execution-engine-impl</artifactId>
   <version>7.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/pdi-execution-engine/pom.xml
+++ b/pdi-execution-engine/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <mockito.version>1.9.5</mockito.version>
-    <rxjava.dependency.version>1.2.5</rxjava.dependency.version>
+    <rxjava.dependency.version>2.0.4</rxjava.dependency.version>
     <guava.dependency.version>17.0</guava.dependency.version>
   </properties>
 

--- a/pdi-execution-engine/pom.xml
+++ b/pdi-execution-engine/pom.xml
@@ -15,6 +15,7 @@
     <mockito.version>1.9.5</mockito.version>
     <rxjava.dependency.version>2.0.4</rxjava.dependency.version>
     <guava.dependency.version>17.0</guava.dependency.version>
+    <maven-bundle-plugin.version>3.2.0</maven-bundle-plugin.version>
   </properties>
 
 


### PR DESCRIPTION
Newer rxjava2 provides native support for converting to/from reactive streams
Version 1 branches are also feature-frozen and approaching EOL

@CodeOnCoffee @ccaspanello @mkambol 