### PR TITLE
PDI-14840 - Having two syslog steps in transformation makes it running forever

### DIFF
--- a/engine/ivy.xml
+++ b/engine/ivy.xml
@@ -66,7 +66,7 @@
     <dependency org="net.sf.saxon"                     name="saxon-dom"            rev="9.1.0.8"         transitive="false"/>
     <dependency org="org.yaml"                         name="snakeyaml"            rev="1.7"             transitive="false"/>
     <dependency org="org.snmp4j"                       name="snmp4j"               rev="1.9.3d"          transitive="false"/>
-    <dependency org="org.syslog4j"                     name="syslog4j"             rev="0.9.34"          transitive="false"/>
+    <dependency org="org.syslog4j"                     name="syslog4j"             rev="0.9.46"          transitive="false"/>
     <dependency org="trilead-ssh2"                     name="trilead-ssh2"         rev="build213"        transitive="false"/>
     <dependency org="javax.xml"                        name="jaxrpc-api"           rev="1.1"             transitive="false"/>
     <dependency org="org.olap4j"                       name="olap4j"               rev="1.2.0"           transitive="false"/>

--- a/engine/src/org/pentaho/di/trans/steps/syslog/SyslogMessage.java
+++ b/engine/src/org/pentaho/di/trans/steps/syslog/SyslogMessage.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -34,8 +34,10 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
-import org.productivity.java.syslog4j.Syslog;
+import org.productivity.java.syslog4j.SyslogConstants;
 import org.productivity.java.syslog4j.SyslogIF;
+import org.productivity.java.syslog4j.impl.net.udp.UDPNetSyslog;
+import org.productivity.java.syslog4j.impl.net.udp.UDPNetSyslogConfig;
 
 /**
  * Write message to SyslogMessage *
@@ -163,7 +165,7 @@ public class SyslogMessage extends BaseStep implements StepInterface {
         data.syslog.getConfig().setFacility( meta.getFacility() );
         data.syslog.getConfig().setSendLocalName( false );
         data.syslog.getConfig().setSendLocalTimestamp( false );
-        data.syslog.initialize( SyslogDefs.DEFAULT_PROTOCOL_UDP, data.syslog.getConfig() );
+        data.syslog.initialize( SyslogConstants.UDP, new UDPNetSyslogConfig() );
       } catch ( Exception ex ) {
         logError( BaseMessages.getString( PKG, "SyslogMessage.UnknownHost", servername, ex.getMessage() ) );
         logError( Const.getStackTracker( ex ) );
@@ -175,7 +177,7 @@ public class SyslogMessage extends BaseStep implements StepInterface {
   }
 
   protected SyslogIF getSyslog() {
-    return Syslog.getInstance( SyslogDefs.DEFAULT_PROTOCOL_UDP );
+    return new UDPNetSyslog();
   }
 
   public void dispose( StepMetaInterface smi, StepDataInterface sdi ) {

--- a/engine/test-src/org/pentaho/di/trans/steps/syslog/SyslogMessageConcurrentTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/syslog/SyslogMessageConcurrentTest.java
@@ -1,0 +1,137 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.syslog;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleStepException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SyslogMessageConcurrentTest {
+
+  AtomicInteger numOfErrors = null;
+  CountDownLatch countDownLatch = null;
+  private String testMessage = "message value";
+  int numOfTasks = 5;
+
+  @Before
+   public void setUp() throws Exception {
+    numOfErrors = new AtomicInteger( 0 );
+    countDownLatch = new CountDownLatch( 1 );
+  }
+
+  @Test( timeout = 2000 )
+   public void concurrentSyslogMessageTest() throws Exception {
+    SyslogMessageTask syslogMessage = null;
+    ExecutorService service = Executors.newFixedThreadPool( numOfTasks );
+    for ( int i = 0; i < numOfTasks; i++ ) {
+      syslogMessage = createSyslogMessageTask();
+      service.execute( syslogMessage );
+    }
+    service.shutdown();
+    countDownLatch.countDown();
+    service.awaitTermination( Long.MAX_VALUE, TimeUnit.NANOSECONDS );
+    Assert.assertTrue( numOfErrors.get() == 0 );
+  }
+
+
+  private class SyslogMessageTask extends SyslogMessage implements Runnable {
+
+    SyslogMessageMeta syslogMessageMeta = null;
+
+    public SyslogMessageTask( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta, Trans trans, SyslogMessageMeta processRowsStepMetaInterface ) {
+      super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
+      syslogMessageMeta = processRowsStepMetaInterface;
+    }
+
+    @Override
+  public void run() {
+      try {
+        countDownLatch.await();
+        processRow( syslogMessageMeta, getStepDataInterface() );
+      } catch ( Exception e ) {
+        e.printStackTrace();
+        numOfErrors.getAndIncrement();
+      } finally {
+        try {
+          dispose( syslogMessageMeta, getStepDataInterface() );
+        } catch ( Exception e ) {
+          e.printStackTrace();
+          numOfErrors.getAndIncrement();
+        }
+      }
+    }
+
+    @Override
+    public void putRow( RowMetaInterface rowMeta, Object[] row ) throws KettleStepException {
+      Assert.assertNotNull( row );
+      Assert.assertTrue( row.length == 1 );
+      Assert.assertEquals( testMessage, row[0] );
+    }
+
+    @Override
+     public Object[] getRow() throws KettleException {
+      return new Object[]{ testMessage };
+    }
+  }
+
+  private SyslogMessageTask createSyslogMessageTask() throws Exception {
+    SyslogMessageData data = new SyslogMessageData();
+    StepMockHelper<SyslogMessageMeta, SyslogMessageData> stepMockHelper =
+             new StepMockHelper<SyslogMessageMeta, SyslogMessageData>( "SYSLOG_MESSAGE TEST", SyslogMessageMeta.class,
+                     SyslogMessageData.class );
+    when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+             stepMockHelper.logChannelInterface );
+    when( stepMockHelper.processRowsStepMetaInterface.getServerName() ).thenReturn( "localhost" );
+    when( stepMockHelper.processRowsStepMetaInterface.getMessageFieldName() ).thenReturn( "message field" );
+    when( stepMockHelper.processRowsStepMetaInterface.getPort() ).thenReturn( "9988" );
+    when( stepMockHelper.processRowsStepMetaInterface.getPriority() ).thenReturn( "ERROR" );
+    RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
+    when( inputRowMeta.indexOfValue( any() ) ).thenReturn( 0 );
+    when( inputRowMeta.getString( any(), eq( 0 ) ) ).thenReturn( testMessage );
+    SyslogMessageTask syslogMessage = new SyslogMessageTask( stepMockHelper.stepMeta, data, 0, stepMockHelper.transMeta,
+             stepMockHelper.trans, stepMockHelper.processRowsStepMetaInterface );
+    syslogMessage.init( stepMockHelper.processRowsStepMetaInterface, data );
+    syslogMessage.setInputRowMeta( inputRowMeta );
+    return syslogMessage;
+  }
+}


### PR DESCRIPTION
"running forever" was caused by an npe exception in dispose method in finally block which prevented transformation from proper finishing. Shutdown method in 0.9.34 in syslog api isnt thread safe and is not intended to be used multiple times . the method in 0.9.46 is also non fully thread safe. https://github.com/pentaho/pentaho-kettle/blob/master/engine/src/org/pentaho/di/trans/steps/syslog/SyslogMessage.java#L187 