### PR TITLE
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnera…

### DIFF
--- a/core/build.properties
+++ b/core/build.properties
@@ -7,7 +7,7 @@ impl.productID=kettle-core
 impl.version=${project.revision}
 
 dependency.pentaho-metastore.revision=6.1-SNAPSHOT
-dependency.batik.revision=1.7
+dependency.batik.revision=1.7.1
 dependency.xml-apis-ext.revision=1.3.04
 dependency.spring.framework.revision=3.2.14.RELEASE
 

--- a/core/src/org/pentaho/di/core/svg/SvgSupport.java
+++ b/core/src/org/pentaho/di/core/svg/SvgSupport.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *


### PR DESCRIPTION
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes (6.1 Suite)