### PR TITLE
[BACKLOG-14309]  AEL API simplification.

### DIFF
--- a/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/converter/RowConversionManager.java
+++ b/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/converter/RowConversionManager.java
@@ -43,11 +43,8 @@ public final class RowConversionManager implements Serializable {
       .map( converter -> converter.convert( row, clazz ) )
       .filter( Optional::isPresent )
       .findFirst()
-      .orElseThrow( () -> new RuntimeException( "failed to convert IRow to " + clazz.toString() ) )
+      .orElseThrow( () -> new RuntimeException( "failed to convert Row to " + clazz.toString() ) )
       .get();
-
-
-
   }
 
 }

--- a/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/events/BaseEvent.java
+++ b/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/events/BaseEvent.java
@@ -22,26 +22,29 @@
  * *****************************************************************************
  */
 
-package org.pentaho.di.engine.api;
+package org.pentaho.di.engine.api.events;
 
-import org.pentaho.di.engine.api.converter.RowConversionManager;
-import org.pentaho.di.engine.api.model.Transformation;
-import org.pentaho.di.engine.api.reporting.SubscriptionManager;
 
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import org.pentaho.di.engine.api.model.LogicalModelElement;
 
-/**
- * Created by nbaker on 5/31/16.
- */
-public interface ExecutionContext extends SubscriptionManager {
-  Map<String, Object> getParameters();
+import java.io.Serializable;
 
-  Map<String, Object> getEnvironment();
+public abstract class BaseEvent<S extends LogicalModelElement, D extends Serializable>  implements PDIEvent<S, D> {
+  private final S source;
+  private final D data;
 
-  Transformation getTransformation();
+  public BaseEvent( S source, D data ) {
+    this.source = source;
+    this.data = data;
+  }
 
-  CompletableFuture<ExecutionResult> execute();
+  @Override public S getSource() {
+    return source;
+  }
 
-  RowConversionManager getConversionManager();
+  @Override public D getData() {
+    return data;
+  }
 }
+
+

--- a/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/events/DataEvent.java
+++ b/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/events/DataEvent.java
@@ -26,26 +26,20 @@ package org.pentaho.di.engine.api.events;
 
 import org.pentaho.di.engine.api.model.LogicalModelElement;
 import org.pentaho.di.engine.api.model.Row;
-
-import java.io.Serializable;
-import java.util.List;
+import org.pentaho.di.engine.api.model.Rows;
 
 /**
- * A {@link PDIEvent} associated with a list of {@link Row} elements. This event contains the data, the
- * {@link LogicalModelElement} source, as well as the flow information (TYPE) and STATE, indicating
- * whether the datastream is still ACTIVE, has no remaining rows (COMPLETE) or is EMPTY.
- *
+ * A {@link PDIEvent} associated with a list of {@link Row} elements.
  * <p>
  * Created by nbaker on 5/30/16.
  */
-public interface DataEvent<S extends LogicalModelElement, D extends Serializable & List<Row>> extends PDIEvent<S, D> {
-  enum TYPE { IN, OUT, ERROR }
+public class DataEvent<S extends LogicalModelElement> extends BaseEvent<S, Rows> {
 
-  enum STATE { ACTIVE, COMPLETE, EMPTY }
+  public DataEvent( S source, Rows rows ) {
+    super( source, rows );
+  }
 
-  TYPE getType();
 
-  STATE getState();
 
 
 

--- a/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/events/MetricsEvent.java
+++ b/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/events/MetricsEvent.java
@@ -30,20 +30,8 @@ import org.pentaho.di.engine.api.reporting.Metrics;
 /**
  * Created by nbaker on 1/20/17.
  */
-public class MetricsEvent<S extends LogicalModelElement> implements PDIEvent<S, Metrics> {
-  private final S source;
-  private final Metrics metrics;
-
-  public MetricsEvent( S source, Metrics metrics ) {
-    this.source = source;
-    this.metrics = metrics;
-  }
-
-  @Override public S getSource() {
-    return source;
-  }
-
-  @Override public Metrics getData() {
-    return metrics;
+public class MetricsEvent<S extends LogicalModelElement> extends BaseEvent<S, Metrics> {
+  public MetricsEvent( S source, Metrics status ) {
+    super( source, status );
   }
 }

--- a/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/events/StatusEvent.java
+++ b/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/events/StatusEvent.java
@@ -30,20 +30,8 @@ import org.pentaho.di.engine.api.reporting.Status;
 /**
  * Created by nbaker on 1/17/17.
  */
-public class StatusEvent<S extends LogicalModelElement> implements PDIEvent<S, Status> {
-  private final S source;
-  private final Status status;
-
+public class StatusEvent<S extends LogicalModelElement> extends BaseEvent<S, Status> {
   public StatusEvent( S source, Status status ) {
-    this.source = source;
-    this.status = status;
-  }
-
-  @Override public S getSource() {
-    return source;
-  }
-
-  @Override public Status getData() {
-    return status;
+    super( source, status );
   }
 }

--- a/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/model/Row.java
+++ b/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/model/Row.java
@@ -84,6 +84,5 @@ public interface Row extends Serializable {
 
   Optional<Object> getObject( String name ) throws RowException;
 
-
   Optional<Object[]> getObjects();
 }

--- a/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/model/Rows.java
+++ b/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/model/Rows.java
@@ -1,0 +1,163 @@
+/*
+ * ! ******************************************************************************
+ *
+ *  Pentaho Data Integration
+ *
+ *  Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * *****************************************************************************
+ */
+
+package org.pentaho.di.engine.api.model;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+
+/**
+ * A List of Rows, as well as the flow information (TYPE) and STATE, indicating
+ * whether the datastream is still ACTIVE, or has no remaining rows (COMPLETE).
+ */
+public class Rows implements List<Row>, Serializable {
+
+  public enum TYPE { IN, OUT, ERROR }
+
+  public enum STATE { ACTIVE, COMPLETE }
+
+  private final List<Row> rows;
+  private final STATE state;
+  private final TYPE type;
+
+  public Rows( List<Row> rowList, TYPE type, STATE state ) {
+    this.rows = rowList;
+    this.type = type;
+    this.state = state;
+  }
+
+  @Override public int size() {
+    return rows.size();
+  }
+
+  @Override public boolean isEmpty() {
+    return rows.isEmpty();
+  }
+
+  @Override public boolean contains( Object o ) {
+    return rows.contains( o );
+  }
+
+  @Override public Iterator<Row> iterator() {
+    return rows.iterator();
+  }
+
+  @Override public Object[] toArray() {
+    return rows.toArray();
+  }
+
+  @Override public <T> T[] toArray( T[] a ) {
+    return rows.toArray( a );
+  }
+
+  @Override public boolean add( Row row ) {
+    return rows.add( row );
+  }
+
+  @Override public boolean remove( Object o ) {
+    return rows.remove( o );
+  }
+
+  @Override public boolean containsAll( Collection<?> c ) {
+    return rows.containsAll( c );
+  }
+
+  @Override public boolean addAll( Collection<? extends Row> c ) {
+    return rows.addAll( c );
+  }
+
+  @Override public boolean addAll( int index, Collection<? extends Row> c ) {
+    return rows.addAll( index, c );
+  }
+
+  @Override public boolean removeAll( Collection<?> c ) {
+    return rows.removeAll( c );
+  }
+
+  @Override public boolean retainAll( Collection<?> c ) {
+    return rows.retainAll( c );
+  }
+
+  @Override public void clear() {
+    rows.clear();
+  }
+
+  @Override public boolean equals( Object o ) {
+    return rows.equals( o );
+  }
+
+  @Override public int hashCode() {
+    return rows.hashCode();
+  }
+
+  @Override public Row get( int index ) {
+    return rows.get( index );
+  }
+
+  @Override public Row set( int index, Row element ) {
+    return rows.set( index, element );
+  }
+
+  @Override public void add( int index, Row element ) {
+    rows.add( index, element );
+  }
+
+  @Override public Row remove( int index ) {
+    return rows.remove( index );
+  }
+
+  @Override public int indexOf( Object o ) {
+    return rows.indexOf( o );
+  }
+
+  @Override public int lastIndexOf( Object o ) {
+    return rows.lastIndexOf( o );
+  }
+
+  @Override public ListIterator<Row> listIterator() {
+    return rows.listIterator();
+  }
+
+  @Override public ListIterator<Row> listIterator( int index ) {
+    return rows.listIterator( index );
+  }
+
+  @Override public List<Row> subList( int fromIndex, int toIndex ) {
+    return rows.subList( fromIndex, toIndex );
+  }
+
+  public TYPE getType() {
+    return type;
+  }
+
+  public STATE getState() {
+    return state;
+  }
+
+
+}

--- a/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/model/Transformation.java
+++ b/pdi-engine-api/api/src/main/java/org/pentaho/di/engine/api/model/Transformation.java
@@ -31,7 +31,6 @@ import java.util.List;
 public interface Transformation extends LogicalModelElement, HasConfig {
   List<Operation> getOperations();
 
-
   List<Hop> getHops();
 
 }


### PR DESCRIPTION
Common base class for events.
Updated DataEvent to use Rows class as its data to
simplify subscription to events, and include TYPE and STATE

@hudak @CodeOnCoffee @ccaspanello 