### PR TITLE
[PDI-15929] Salesforce Input step throws a Incompatible class exception when run on server in 7.0

### DIFF
--- a/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceinput/SalesforceInput.java
+++ b/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceinput/SalesforceInput.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -74,7 +74,7 @@ public class SalesforceInput extends SalesforceStep {
       data.convertRowMeta = data.outputRowMeta.cloneToType( ValueMetaInterface.TYPE_STRING );
 
       // Let's query Salesforce
-      data.connection.query( meta.isSpecifyQuery() );
+      runQueryInPluginClassLoader();
 
       data.limitReached = true;
       data.recordcount = data.connection.getQueryResultSize();
@@ -131,6 +131,22 @@ public class SalesforceInput extends SalesforceStep {
       }
     }
     return true;
+  }
+
+  /**
+   * Class loader for current thread have to be the same with plugin (the same current class)
+   *
+   * @throws KettleException
+   */
+  private void runQueryInPluginClassLoader() throws KettleException {
+    ClassLoader orig = Thread.currentThread().getContextClassLoader();
+    ClassLoader loader = getClass().getClassLoader();
+    Thread.currentThread().setContextClassLoader( loader );
+    try {
+      data.connection.query( meta.isSpecifyQuery() );
+    } finally {
+      Thread.currentThread().setContextClassLoader( orig );
+    }
   }
 
   private Object[] getOneRow() throws KettleException {


### PR DESCRIPTION
-set classloader for current thread when lib force-wsc.jar was called.

Library force-wsc.jar ( method com.sforce.ws.bind.TypeMapper#load ) loads class with  classloader of thread. The thread for server case has web class loader but Salesforce classes are loaded by plugin class loader. So we have a problem here com.sforce.ws.bind.TypeMapper#readSingle.
For fixing I used pentaho standart approach like here https://github.com/pentaho/pentaho-hadoop-shims/blob/master/common/hadoop-shim/src/main/java/org/pentaho/hadoop/shim/common/HadoopShimImpl.java#L72-L82. When SalesforceInput calls force-wsc.jar we set classloader for thread what SalesforceInput was loaded.
