### PR TITLE
[PDI-16048] LDAP Input protocol not substituted

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/ldapinput/LdapProtocolFactory.java
+++ b/engine/src/org/pentaho/di/trans/steps/ldapinput/LdapProtocolFactory.java
@@ -89,7 +89,7 @@ public class LdapProtocolFactory {
    */
   public LdapProtocol createLdapProtocol( VariableSpace variableSpace, LdapMeta meta,
     Collection<String> binaryAttributes ) throws KettleException {
-    String connectionType = meta.getProtocol();
+    String connectionType = environmentSubstitute( meta.getProtocol() );
 
     synchronized ( protocols ) {
       for ( Class<? extends LdapProtocol> protocol : protocols ) {


### PR DESCRIPTION
untested. should fix the problem to substitute variables on the protocol field.