### PR TITLE
[BACKLOG-14636] Enforcing serializable config items in ael HasConfig

### DIFF
--- a/engine/test-src/org/pentaho/di/trans/ael/adapters/TransMetaConverterTest.java
+++ b/engine/test-src/org/pentaho/di/trans/ael/adapters/TransMetaConverterTest.java
@@ -25,8 +25,12 @@
 package org.pentaho.di.trans.ael.adapters;
 
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.engine.api.model.Transformation;
 import org.pentaho.di.trans.TransHopMeta;
 import org.pentaho.di.trans.TransMeta;
@@ -35,17 +39,26 @@ import org.pentaho.di.trans.step.StepMetaInterface;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
 
-
+@RunWith ( MockitoJUnitRunner.class )
 public class TransMetaConverterTest {
 
   @Mock StepMetaInterface stepMetaInterface;
+
+  final String XML = "<xml></xml>";
+
+  @Before
+  public void before() throws KettleException {
+
+    when( stepMetaInterface.getXML() ).thenReturn( XML );
+  }
 
   @Test
   public void simpleConvert() {
     TransMeta meta = new TransMeta();
     meta.setName( "transName" );
-    meta.addStep( new StepMeta( "stepName", null ) );
+    meta.addStep( new StepMeta( "stepName", stepMetaInterface ) );
     Transformation trans = TransMetaConverter.convert( meta );
     assertThat( trans.getId(), is( meta.getName() ) );
     assertThat( trans.getOperations().size(), is( 1 ) );
@@ -56,9 +69,9 @@ public class TransMetaConverterTest {
   public void transWithHops() {
     TransMeta meta = new TransMeta();
     meta.setName( "transName" );
-    StepMeta from = new StepMeta( "step1", null );
+    StepMeta from = new StepMeta( "step1",  stepMetaInterface );
     meta.addStep( from );
-    StepMeta to = new StepMeta( "step2", null );
+    StepMeta to = new StepMeta( "step2",  stepMetaInterface );
     meta.addStep( to );
     meta.addTransHop( new TransHopMeta( from, to ) );
     Transformation trans = TransMetaConverter.convert( meta );

--- a/pdi-engine-api/src/main/java/org/pentaho/di/engine/api/HasConfig.java
+++ b/pdi-engine-api/src/main/java/org/pentaho/di/engine/api/HasConfig.java
@@ -33,9 +33,9 @@ import java.util.Optional;
  * Created by hudak on 1/17/17.
  */
 public interface HasConfig extends Serializable {
-  Map<String, Object> getConfig();
+  <T extends Serializable> Map<String, T> getConfig();
 
-  default Optional<Object> getConfig( String key ) {
+  default Optional<? extends Serializable> getConfig( String key ) {
     return Optional.ofNullable( getConfig().get( key ) );
   }
 

--- a/pdi-engine-api/src/main/java/org/pentaho/di/engine/model/Configurable.java
+++ b/pdi-engine-api/src/main/java/org/pentaho/di/engine/model/Configurable.java
@@ -3,6 +3,7 @@ package org.pentaho.di.engine.model;
 import com.google.common.collect.ImmutableMap;
 import org.pentaho.di.engine.api.HasConfig;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,17 +11,17 @@ import java.util.Map;
  * Created by hudak on 1/18/17.
  */
 abstract class Configurable implements HasConfig {
-  private final HashMap<String, Object> config = new HashMap<>();
+  private final HashMap<String, Serializable> config = new HashMap<>();
 
-  @Override public Map<String, Object> getConfig() {
+  @Override  public Map<String, Serializable> getConfig() {
     return ImmutableMap.copyOf( config );
   }
 
-  public void setConfig( String key, Object value ) {
+  public void setConfig( String key, Serializable value ) {
     this.config.put( key, value );
   }
 
-  public void setConfig( Map<String, Object> config ) {
+  public void setConfig( Map<String, Serializable> config ) {
     this.config.putAll( config );
   }
 }


### PR DESCRIPTION
Related: updated TransMetaConverter to pass the transmeta xml in config,
instead of TransMeta.

@hudak 