### PR TITLE
[BACKLOG-14636]  Updates to support engine adapters

### DIFF
--- a/engine/src/org/pentaho/di/trans/ael/adapters/StepInterfaceEngineAdapter.java
+++ b/engine/src/org/pentaho/di/trans/ael/adapters/StepInterfaceEngineAdapter.java
@@ -110,6 +110,10 @@ public class StepInterfaceEngineAdapter extends BaseStep {
    **/
   private void putRow( Row row ) {
     try {
+      if ( executionContext.getConversionManager() == null ) {
+        // no way to convert this row to a RowMetaInterface.
+        return;
+      }
       synchronized ( rowListeners ) {
         for ( int i = 0; i < rowListeners.size(); i++ ) {
           RowListener rowListener = rowListeners.get( i );
@@ -119,7 +123,10 @@ public class StepInterfaceEngineAdapter extends BaseStep {
         }
       }
     } catch ( KettleStepException e ) {
-      throw new RuntimeException( e );
+      // log that we were unable to convert row.
+      // will probably want to throw when row conversion is more robust.  Right
+      // now this only means preview will not be populated for the current Engine impl.
+      logDebug( e.getMessage() );
     }
   }
 }

--- a/engine/src/org/pentaho/di/trans/ael/adapters/TransEngineAdapter.java
+++ b/engine/src/org/pentaho/di/trans/ael/adapters/TransEngineAdapter.java
@@ -121,8 +121,7 @@ public class TransEngineAdapter extends Trans {
       .collect( Collectors.toMap( Function.identity(),
         op -> {
           StepMetaDataCombi combi = new StepMetaDataCombi();
-          combi.stepMeta = (StepMeta) op.getConfig( TransMetaConverter.STEP_META_CONF_KEY )
-            .orElseThrow( () -> new IllegalStateException( "StepMeta not found in Operation" ) );
+          combi.stepMeta = StepMeta.fromXml( (String) op.getConfig().get( TransMetaConverter.STEP_META_CONF_KEY ) );
           combi.data = new StepDataInterfaceEngineAdapter( op, executionContext );
           combi.step = new StepInterfaceEngineAdapter( op, executionContext, combi.stepMeta, transMeta,
             combi.data, this );

--- a/engine/src/org/pentaho/di/trans/step/StepMeta.java
+++ b/engine/src/org/pentaho/di/trans/step/StepMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -63,6 +63,7 @@ import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.steps.missing.MissingTrans;
 import org.pentaho.metastore.api.IMetaStore;
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 /**
@@ -416,6 +417,18 @@ public class StepMeta extends SharedObjectBase implements Cloneable, Comparable<
       if ( look.getName().equals( clusterSchemaName ) ) {
         clusterSchema = look;
       }
+    }
+  }
+
+
+  public static StepMeta fromXml( String metaXml ) {
+    Document doc;
+    try {
+      doc = XMLHandler.loadXMLString( metaXml );
+      Node stepNode = XMLHandler.getSubNode( doc, "step" );
+      return new StepMeta( stepNode, Collections.emptyList(), (IMetaStore) null );
+    } catch ( KettleXMLException | KettlePluginLoaderException e ) {
+      throw new RuntimeException( e );
     }
   }
 


### PR DESCRIPTION
- config stored with Operations now has the string xml from the stepmeta,
TransEngineAdapter was still expecting the StepMeta object.
- short circuit .putRow in the adapter when no conversionManager is
available.