### PR TITLE
[PDI-15922]-Missing data when using delimiters like "aa" in the CSV file

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
@@ -644,7 +644,7 @@ public class CsvInput extends BaseStep implements StepInterface {
             data.moveEndBufferPointer();
             i++;
           }
-          if ( data.newLineFound() ) {
+          if ( data.newLineFound() && outputIndex >= meta.getInputFields().length ) {
             data.moveEndBufferPointer();
           }
           if ( doubleLineEnd && data.encodingType.getLength() > 1 ) {

--- a/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvProcessRowInParallelTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvProcessRowInParallelTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -96,16 +96,16 @@ public class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
     final int totalNumberOfSteps = 2;
 
     final String fileContent =
-          "ab,111\r\n"
-        + "bc,222\r\n"
-        + "cd,333\r\n"
-        + "de,444\r\n"
-        + "ef,555\r"
-        + "fg,666\r\n"
-        + "gh,777\r\n"
-        + "hi,888\r\n"
-        + "ij,999\r"
-        + "jk,000\r";
+          "ab;111\r\n"
+        + "bc;222\r\n"
+        + "cd;333\r\n"
+        + "de;444\r\n"
+        + "ef;555\r"
+        + "fg;666\r\n"
+        + "gh;777\r\n"
+        + "hi;888\r\n"
+        + "ij;999\r"
+        + "jk;000\r";
 
     File sharedFile = createTestFile( "UTF-8", fileContent );
 
@@ -118,16 +118,16 @@ public class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
     final int totalNumberOfSteps = 2;
 
     final String fileContent =
-          "ab,111\r\n"
-        + "bc,222\r\n"
-        + "cd,333\r\n"
-        + "de,444\r\n"
-        + "ef,555\r"
-        + "fg,666\r\n"
-        + "gh,777\r\n"
-        + "hi,888\r\n"
-        + "ij,999\r"
-        + "jk,000";
+          "ab;111\r\n"
+        + "bc;222\r\n"
+        + "cd;333\r\n"
+        + "de;444\r\n"
+        + "ef;555\r"
+        + "fg;666\r\n"
+        + "gh;777\r\n"
+        + "hi;888\r\n"
+        + "ij;999\r"
+        + "jk;000";
 
     File sharedFile = createTestFile( "UTF-8", fileContent );
 


### PR DESCRIPTION
 - fix for regression BACKLOG-14781
 - fixed unittest