### PR TITLE
Revert "[SP-3273][PDI-15922]-Missing data when using delimiters like "aa" in the CSV file"

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
@@ -550,12 +550,10 @@ public class CsvInput extends BaseStep implements StepInterface {
                 if ( !keepGoing ) {
                   // We found an enclosure character.
                   // Read another byte...
-                  if ( !data.endOfBuffer() && data.moveEndBufferPointer() ) {
+                  if ( data.moveEndBufferPointer() ) {
                     break;
                   }
-                  if ( data.enclosure.length > 1 ) {
-                    data.moveEndBufferPointer();
-                  }
+
                   // If this character is also an enclosure, we can consider the enclosure "escaped".
                   // As such, if this is an enclosure, we keep going...
                   //
@@ -639,20 +637,15 @@ public class CsvInput extends BaseStep implements StepInterface {
         // do-while loop below) and possibly skipping a newline character. This can occur if there is an
         // empty column at the end of the row (see the Jira case for details)
         if ( ( !newLineFound && outputIndex < meta.getInputFields().length ) || ( newLineFound && doubleLineEnd ) ) {
-          int i = 0;
-          while ( ( !data.newLineFound() && ( i < data.delimiter.length ) ) ) {
-            data.moveEndBufferPointer();
-            i++;
-          }
-          if ( data.newLineFound() && outputIndex >= meta.getInputFields().length ) {
-            data.moveEndBufferPointer();
-          }
-          if ( doubleLineEnd && data.encodingType.getLength() > 1 ) {
-            data.moveEndBufferPointer();
-          }
+          data.moveEndBufferPointer();
         }
 
-        data.setStartBuffer( data.getEndBuffer() );
+        if ( newLineFound && !doubleLineEnd ) {
+          // Consider bytes skipped checking for double line end
+          data.setStartBuffer( data.getEndBuffer() - ( data.encodingType.getLength() - 1 ) );
+        } else {
+          data.setStartBuffer( data.getEndBuffer() );
+        }
       }
 
       // See if we reached the end of the line.

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
@@ -239,16 +239,31 @@ public class CsvInputData extends BaseStepData implements StepDataInterface {
     int length = endBuffer - fieldStart;
 
     if ( newLineFound && !endOfBuffer ) {
-      length -= encodingType.getLength();
+      length -= encodingType.getLength() * 2 - 1;
     }
 
     if ( enclosureFound ) {
-      fieldStart += enclosure.length;
-      length = endBuffer - fieldStart - enclosure.length;
       if ( length > 1 ) {
-        if ( newLineFound ) {
-          length -= enclosure.length;
+        if ( delimiterFound ) {
+          length -= delimiter.length;
         }
+        if ( endOfBuffer || newLineFound ) {
+          length--;
+        }
+      }
+
+      fieldStart += enclosure.length;
+      length -= enclosure.length;
+
+      // Lets get rid of the delimiter, if it is still in the range and spaces between it and the enclosure.
+      while ( ( byteBuffer[fieldStart + length] == 32 ) || ( byteBuffer[fieldStart + length] == delimiter[0] ) ) {
+        length -= 1;
+      }
+
+      length -= enclosure.length - 1;
+    } else {
+      if ( delimiterFound ) {
+        length -= delimiter.length - 1;
       }
     }
 

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/MultiByteBigCrLfMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/MultiByteBigCrLfMatcher.java
@@ -27,7 +27,7 @@ public class MultiByteBigCrLfMatcher implements CrLfMatcherInterface {
   @Override
   public boolean isLineFeed( byte[] source, int location ) {
     if ( location >= 1 ) {
-      return source[location] == 0 && source[location + 1] == 0x0a;
+      return source[location - 1] == 0 && source[location] == 0x0a;
     } else {
       return false;
     }
@@ -36,7 +36,7 @@ public class MultiByteBigCrLfMatcher implements CrLfMatcherInterface {
   @Override
   public boolean isReturn( byte[] source, int location ) {
     if ( location >= 1 ) {
-      return source[location] == 0 && source[location + 1] == 0x0d;
+      return source[location - 1] == 0 && source[location] == 0x0d;
     } else {
       return false;
     }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/MultiByteLittleCrLfMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/MultiByteLittleCrLfMatcher.java
@@ -27,7 +27,7 @@ public class MultiByteLittleCrLfMatcher implements CrLfMatcherInterface {
   @Override
   public boolean isReturn( byte[] source, int location ) {
     if ( location >= 1 ) {
-      return source[location] == 0x0d && source[location + 1] == 0x00;
+      return source[location - 1] == 0x0d && source[location] == 0x00;
     } else {
       return false;
     }
@@ -36,7 +36,7 @@ public class MultiByteLittleCrLfMatcher implements CrLfMatcherInterface {
   @Override
   public boolean isLineFeed( byte[] source, int location ) {
     if ( location >= 1 ) {
-      return source[location] == 0x0a && source[location + 1] == 0x00;
+      return source[location - 1] == 0x0a && source[location] == 0x00;
     } else {
       return false;
     }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/MultiBytePatternMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/MultiBytePatternMatcher.java
@@ -25,13 +25,17 @@ package org.pentaho.di.trans.steps.csvinput;
 public class MultiBytePatternMatcher implements PatternMatcherInterface {
 
   public boolean matchesPattern( byte[] source, int location, byte[] pattern ) {
-    int start = location;
-    for ( int i = 0; i < pattern.length; i++ ) {
-      if ( source[start + i] != pattern[i] ) {
-        return false;
+    if ( location >= pattern.length - 1 ) {
+      int start = location - pattern.length + 1;
+      for ( int i = 0; i < pattern.length; i++ ) {
+        if ( source[start + i] != pattern[i] ) {
+          return false;
+        }
       }
+      return true;
+    } else {
+      return false;
     }
-    return true;
   }
 
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputDoubleLineEndTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputDoubleLineEndTest.java
@@ -46,7 +46,7 @@ public class CsvInputDoubleLineEndTest extends CsvInputUnitTestBase {
   private static final String ASCII = "windows-1252";
   private static final String UTF8 = "UTF-8";
   private static final String UTF16LE = "UTF-16LE";
-  private static final String UTF16BE = "UTF-16BE";
+  private static final String UTF16BE = "UTF-16LE";
   private static final String TEST_DATA = "Header1\tHeader2\r\nValue\tValue\r\nValue\tValue\r\n";
 
   private static StepMockHelper<?, ?> stepMockHelper;

--- a/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputUnicodeTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputUnicodeTest.java
@@ -46,7 +46,7 @@ public class CsvInputUnicodeTest extends CsvInputUnitTestBase {
   private static final String UTF8 = "UTF-8";
   private static final String UTF16LE = "UTF-16LE";
   private static final String UTF16LEBOM = "x-UTF-16LE-BOM";
-  private static final String UTF16BE = "UTF-16BE";
+  private static final String UTF16BE = "UTF-16LE";
   private static final String ONE_CHAR_DELIM = "\t";
   private static final String MULTI_CHAR_DELIM = "|||";
   private static final String TEXT = "Header1%1$sHeader2\nValue%1$sValue\nValue%1$sValue\n";

--- a/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvProcessRowInParallelTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvProcessRowInParallelTest.java
@@ -96,16 +96,16 @@ public class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
     final int totalNumberOfSteps = 2;
 
     final String fileContent =
-          "ab;111\r\n"
-        + "bc;222\r\n"
-        + "cd;333\r\n"
-        + "de;444\r\n"
-        + "ef;555\r"
-        + "fg;666\r\n"
-        + "gh;777\r\n"
-        + "hi;888\r\n"
-        + "ij;999\r"
-        + "jk;000\r";
+          "ab,111\r\n"
+        + "bc,222\r\n"
+        + "cd,333\r\n"
+        + "de,444\r\n"
+        + "ef,555\r"
+        + "fg,666\r\n"
+        + "gh,777\r\n"
+        + "hi,888\r\n"
+        + "ij,999\r"
+        + "jk,000\r";
 
     File sharedFile = createTestFile( "UTF-8", fileContent );
 
@@ -118,16 +118,16 @@ public class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
     final int totalNumberOfSteps = 2;
 
     final String fileContent =
-          "ab;111\r\n"
-        + "bc;222\r\n"
-        + "cd;333\r\n"
-        + "de;444\r\n"
-        + "ef;555\r"
-        + "fg;666\r\n"
-        + "gh;777\r\n"
-        + "hi;888\r\n"
-        + "ij;999\r"
-        + "jk;000";
+          "ab,111\r\n"
+        + "bc,222\r\n"
+        + "cd,333\r\n"
+        + "de,444\r\n"
+        + "ef,555\r"
+        + "fg,666\r\n"
+        + "gh,777\r\n"
+        + "hi,888\r\n"
+        + "ij,999\r"
+        + "jk,000";
 
     File sharedFile = createTestFile( "UTF-8", fileContent );
 


### PR DESCRIPTION
This reverts commit 173c7306b6d1ae3f93929695b721abe355d1327c.
This reverts commit 42ac888b31e1b3593c37a33da5c6fa339ff0fb2f.