### PR TITLE
[BACKLOG-11126][BACKLOG-11425] - Updated ExpandedContentManger for OSX

### DIFF
--- a/ui/src/org/pentaho/di/ui/spoon/ExpandedContentManager.java
+++ b/ui/src/org/pentaho/di/ui/spoon/ExpandedContentManager.java
@@ -33,6 +33,7 @@ import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.widgets.Control;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.ui.spoon.trans.TransGraph;
 
 import java.util.function.Consumer;
@@ -160,6 +161,9 @@ public final class ExpandedContentManager {
     if ( !isVisible( graph ) ) {
       maximizeExpandedContent( browser );
     }
+    if ( Const.isOSX() && graph.isExecutionResultsPaneVisible() ) {
+      graph.extraViewComposite.setVisible( false );
+    }
     browser.moveAbove( null );
     browser.getParent().layout( true );
     browser.getParent().redraw();
@@ -207,8 +211,11 @@ public final class ExpandedContentManager {
    */
   public static void hideExpandedContent( TransGraph graph ) {
     doToExpandedContent( graph, browser -> {
+      if ( Const.isOSX() && graph.isExecutionResultsPaneVisible() ) {
+        graph.extraViewComposite.setVisible( true );
+      }
       browser.moveBelow( null );
-      browser.getParent().layout( true );
+      browser.getParent().layout( true, true );
       browser.getParent().redraw();
     } );
   }

--- a/ui/test-src/org/pentaho/di/ui/spoon/ExpandedContentManagerTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/ExpandedContentManagerTest.java
@@ -87,7 +87,7 @@ public class ExpandedContentManagerTest {
     Composite parent = setupExpandedContentMocks( transGraph, browser, sashForm );
     ExpandedContentManager.hideExpandedContent( transGraph );
     verify( browser ).moveBelow( null );
-    verify( parent ).layout( true );
+    verify( parent ).layout( true, true );
     verify( parent ).redraw();
     verify( sashForm ).setWeights( new int[] { 3, 2, 1 } );
   }


### PR DESCRIPTION
This fixes an SWT browser issue on the Mac.  Now when you on the mac when the user goes into DET if there is an existing execution panel open it is hidden so that artifacts from it won't "come through" to the DET screen.  When leaving DET it is set visible again.  The additional code is only active on OS X. @mdamour1976 @bmorrise 