### PR TITLE
[PDI-15922]-Missing data when using delimiters like "aa" in the CSV file

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInput.java
@@ -644,7 +644,7 @@ public class CsvInput extends BaseStep implements StepInterface {
             data.moveEndBufferPointer();
             i++;
           }
-          if ( data.newLineFound() ) {
+          if ( data.newLineFound() && outputIndex >= meta.getInputFields().length ) {
             data.moveEndBufferPointer();
           }
           if ( doubleLineEnd && data.encodingType.getLength() > 1 ) {

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
@@ -235,22 +235,18 @@ public class CsvInputData extends BaseStepData implements StepDataInterface {
 
   byte[] getField( boolean delimiterFound, boolean enclosureFound, boolean newLineFound, boolean endOfBuffer ) {
     int fieldStart = startBuffer;
-
-    int length = endBuffer - fieldStart;
+    int fieldEnd = endBuffer;
 
     if ( newLineFound && !endOfBuffer ) {
-      length -= encodingType.getLength();
+      fieldEnd -= encodingType.getLength();
     }
 
     if ( enclosureFound ) {
       fieldStart += enclosure.length;
-      length = endBuffer - fieldStart - enclosure.length;
-      if ( length > 1 ) {
-        if ( newLineFound ) {
-          length -= enclosure.length;
-        }
-      }
+      fieldEnd -= enclosure.length;
     }
+
+    int length = fieldEnd - fieldStart;
 
     if ( length <= 0 ) {
       length = 0;

--- a/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputEnclosureTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputEnclosureTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -55,31 +55,65 @@ public class CsvInputEnclosureTest extends CsvInputUnitTestBase {
 
   @Test
   public void hasEnclosures_HasNewLine() throws Exception {
-    doTest( "\"value1\";\"value2\"\n" );
+    doTest( "\"value1\";\"value2\"\n", "\"" );
   }
 
   @Test
   public void hasEnclosures_HasNotNewLine() throws Exception {
-    doTest( "\"value1\";\"value2\"" );
+    doTest( "\"value1\";\"value2\"", "\"" );
   }
 
   @Test
   public void hasNotEnclosures_HasNewLine() throws Exception {
-    doTest( "value1;value2\n" );
+    doTest( "value1;value2\n", "\"" );
   }
 
   @Test
   public void hasNotEnclosures_HasNotNewLine() throws Exception {
-    doTest( "value1;value2" );
+    doTest( "value1;value2", "\"" );
   }
 
+  @Test
+  public void hasMultiSymbolsEnclosureWithoutEnclosureAndEndFile() throws Exception {
+    doTest( "value1;value2", "\"!" );
+  }
 
-  public void doTest( String content ) throws Exception {
+  @Test
+  public void hasMultiSymbolsEnclosureWithEnclosureAndWithoutEndFile() throws Exception {
+    doTest( "\"!value1\"!;value2", "\"!" );
+  }
+
+  @Test
+  public void hasMultiSymbolsEnclosurewithEnclosureInBothfield() throws Exception {
+    doTest( "\"!value1\"!;\"!value2\"!", "\"!" );
+  }
+
+  @Test
+  public void hasMultiSymbolsEnclosureWithoutEnclosureAndWithEndfileRN() throws Exception {
+    doTest( "value1;value2\r\n", "\"!" );
+  }
+
+  @Test
+  public void hasMultiSymbolsEnclosureWithEnclosureAndWithEndfileRN() throws Exception {
+    doTest( "value1;\"!value2\"!\r\n", "\"!" );
+  }
+
+  @Test
+  public void hasMultiSymbolsEnclosureWithoutEnclosureAndWithEndfileN() throws Exception {
+    doTest( "value1;value2\n", "\"!" );
+  }
+
+  @Test
+  public void hasMultiSymbolsEnclosureWithEnclosureAndWithEndfileN() throws Exception {
+    doTest( "value1;\"!value2\"!\n", "\"!" );
+  }
+
+  public void doTest( String content, String enclosure ) throws Exception {
     RowSet output = new QueueRowSet();
 
     File tmp = createTestFile( "utf-8", content );
     try {
-      CsvInputMeta meta = createMeta( tmp, createInputFileFields( "f1", "f2" ) );
+      CsvInputMeta meta = createMeta( tmp, createInputFileFields( "f1", "f2" ), enclosure );
       CsvInputData data = new CsvInputData();
       csvInput.init( meta, data );
 
@@ -103,12 +137,12 @@ public class CsvInputEnclosureTest extends CsvInputUnitTestBase {
     assertNull( output.getRowImmediate() );
   }
 
-  private CsvInputMeta createMeta( File file, TextFileInputField[] fields ) {
+  private CsvInputMeta createMeta( File file, TextFileInputField[] fields, String enclosure ) {
     CsvInputMeta meta = new CsvInputMeta();
     meta.setFilename( file.getAbsolutePath() );
     meta.setDelimiter( ";" );
     meta.setEncoding( "utf-8" );
-    meta.setEnclosure( "\"" );
+    meta.setEnclosure( enclosure );
     meta.setBufferSize( "1024" );
     meta.setInputFields( fields );
     meta.setHeaderPresent( false );

--- a/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputUnicodeTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvInputUnicodeTest.java
@@ -22,9 +22,9 @@
 
 package org.pentaho.di.trans.steps.csvinput;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
+import org.junit.Assert;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,9 +62,9 @@ public class CsvInputUnicodeTest extends CsvInputUnitTestBase {
   public static void setUp() throws KettleException {
     stepMockHelper =
       new StepMockHelper<CsvInputMeta, CsvInputData>( "CsvInputTest", CsvInputMeta.class, CsvInputData.class );
-    when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) )
+    Mockito.when( stepMockHelper.logChannelInterfaceFactory.create( Matchers.any(), Matchers.any( LoggingObjectInterface.class ) ) )
       .thenReturn( stepMockHelper.logChannelInterface );
-    when( stepMockHelper.trans.isRunning() ).thenReturn( true );
+    Mockito.when( stepMockHelper.trans.isRunning() ).thenReturn( true );
   }
 
   @Test
@@ -144,7 +144,7 @@ public class CsvInputUnicodeTest extends CsvInputUnitTestBase {
       @Override
       public void rowWrittenEvent( RowMetaInterface rowMeta, Object[] row ) throws KettleStepException {
         for ( int i = 0; i < rowMeta.size(); i++ ) {
-          assertEquals( "Value", row[ i ] );
+          Assert.assertEquals( "Value", row[ i ] );
         }
       }
     } );
@@ -155,7 +155,7 @@ public class CsvInputUnicodeTest extends CsvInputUnitTestBase {
     } while ( !haveRowsToRead );
 
     csvInput.dispose( meta, data );
-    assertEquals( 2, csvInput.getLinesWritten() );
+    Assert.assertEquals( 2, csvInput.getLinesWritten() );
   }
 
   private CsvInputMeta createStepMeta( final String testFilePath, final String encoding, final String delimiter ) {

--- a/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvProcessRowInParallelTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/csvinput/CsvProcessRowInParallelTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -96,16 +96,16 @@ public class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
     final int totalNumberOfSteps = 2;
 
     final String fileContent =
-          "ab,111\r\n"
-        + "bc,222\r\n"
-        + "cd,333\r\n"
-        + "de,444\r\n"
-        + "ef,555\r"
-        + "fg,666\r\n"
-        + "gh,777\r\n"
-        + "hi,888\r\n"
-        + "ij,999\r"
-        + "jk,000\r";
+          "ab;111\r\n"
+        + "bc;222\r\n"
+        + "cd;333\r\n"
+        + "de;444\r\n"
+        + "ef;555\r"
+        + "fg;666\r\n"
+        + "gh;777\r\n"
+        + "hi;888\r\n"
+        + "ij;999\r"
+        + "jk;000\r";
 
     File sharedFile = createTestFile( "UTF-8", fileContent );
 
@@ -118,16 +118,16 @@ public class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
     final int totalNumberOfSteps = 2;
 
     final String fileContent =
-          "ab,111\r\n"
-        + "bc,222\r\n"
-        + "cd,333\r\n"
-        + "de,444\r\n"
-        + "ef,555\r"
-        + "fg,666\r\n"
-        + "gh,777\r\n"
-        + "hi,888\r\n"
-        + "ij,999\r"
-        + "jk,000";
+          "ab;111\r\n"
+        + "bc;222\r\n"
+        + "cd;333\r\n"
+        + "de;444\r\n"
+        + "ef;555\r"
+        + "fg;666\r\n"
+        + "gh;777\r\n"
+        + "hi;888\r\n"
+        + "ij;999\r"
+        + "jk;000";
 
     File sharedFile = createTestFile( "UTF-8", fileContent );
 


### PR DESCRIPTION
 - fix for regression BACKLOG-14781
 - fix case for multichars enclosure
 - fixed unittest

