### PR TITLE
[BACKLOG-11769] PDI - Pan is unable to run a zip File exported as

### DIFF
--- a/core/src/org/pentaho/di/core/vfs/KettleVFS.java
+++ b/core/src/org/pentaho/di/core/vfs/KettleVFS.java
@@ -429,4 +429,25 @@ public class KettleVFS {
     return new FileInputStream( fileObject.getName().getPathDecoded() );
   }
 
+  /**
+   * Check if filename starts with one of the known protocols like file: zip: ram: smb: jar: etc.
+   * If yes, return true otherwise return false
+   * @param vfsFileName
+   * @return boolean
+   */
+  public static boolean startsWithScheme( String vfsFileName ) {
+    FileSystemManager fsManager = getInstance().getFileSystemManager();
+
+    boolean found = false;
+    String[] schemes = fsManager.getSchemes();
+    for ( int i = 0; i < schemes.length; i++ ) {
+      if ( vfsFileName.startsWith( schemes[i] + ":" ) ) {
+        found = true;
+        break;
+      }
+    }
+
+    return found;
+  }
+
 }

--- a/core/test-src/org/pentaho/di/core/vfs/KettleVFSTest.java
+++ b/core/test-src/org/pentaho/di/core/vfs/KettleVFSTest.java
@@ -1,0 +1,44 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.vfs;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import org.junit.Test;
+
+public class KettleVFSTest {
+
+  /**
+   * Test to validate that startsWitScheme() returns true if the fileName starts with
+   * known protocol like zip: jar: then it returns true else returns false
+   * @param fileName
+   */
+  @Test
+  public void testStartsWithScheme() {
+    String fileName = "zip:file:///SavedLinkedres.zip!Calculate median and percentiles using the group by steps.ktr";
+    assertTrue( KettleVFS.startsWithScheme( fileName ) );
+
+    fileName = "SavedLinkedres.zip!Calculate median and percentiles using the group by steps.ktr";
+    assertFalse( KettleVFS.startsWithScheme( fileName ) );
+  }
+}

--- a/engine/src/org/pentaho/di/pan/Pan.java
+++ b/engine/src/org/pentaho/di/pan/Pan.java
@@ -46,6 +46,7 @@ import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.RepositoryPluginType;
 import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.kitchen.Kitchen;
 import org.pentaho.di.metastore.MetaStoreConst;
@@ -383,7 +384,10 @@ public class Pan {
         if ( trans == null && !Utils.isEmpty( optionFilename ) ) {
 
           String fileName = optionFilename.toString();
-          if ( !new File( fileName ).isAbsolute() && !fileName.matches( "^zip:file:[/].*" ) ) {
+          // If the filename starts with scheme like zip:, then isAbsolute() will return false even though the
+          // the path following the zip is absolute path. Check for isAbsolute only if the fileName does not
+          // start with scheme
+          if ( !KettleVFS.startsWithScheme( fileName ) && !new File( fileName ).isAbsolute() ) {
             fileName = initialDir.toString() + fileName;
           }
 


### PR DESCRIPTION
"File>Export>Linked Resources to XML" returns [error: can't open file]
    Currently the code uses the regular expression to identify if there is
    "zip" in the name. Now we check to see if the fileName starts with
    protocol like "Zip". If is does not, checks to see if the path is relative
    -Added a utility method in KettleVFS
    -Added test case for new method in KettleVFS