### PR TITLE
[PDI-14390] Text file input throws NPE if skipping error rows and passing through incoming fieds

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -813,16 +813,17 @@ public class TextFileInput extends BaseStep implements StepInterface {
           r[index] = rooturi;
           index++;
         }
+
+        if ( passThruFields != null ) {
+          // Simply add all fields from source files step
+          for ( int i = 0; i < nrPassThruFields; i++ ) {
+            r[i] = passThruFields[i];
+          }
+        }
+
       } // End if r != null
     } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( PKG, "TextFileInput.Log.Error.ErrorConvertingLineText" ), e );
-    }
-
-    if ( passThruFields != null ) {
-      // Simply add all fields from source files step
-      for ( int i = 0; i < nrPassThruFields; i++ ) {
-        r[i] = passThruFields[i];
-      }
     }
 
     return r;


### PR DESCRIPTION
[PDI-14390] Text file input throws NPE if skipping error rows and passing through incoming fieds

- fixed NPE
- added test