### PR TITLE
[BACKLOG-15186]: PMR and Hadoop Job Executor job entries fail because of they can not find "LogWriter" class (NoClassDefFoundError)

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -11,11 +11,11 @@
     <conf name="dataservice-jdbc" />
     <conf name="pentaho-system" />
   </configurations>
-  
+
   <publications>
     <artifact name="${ivy.artifact.id}" type="zip"/>
   </publications>
-  
+
   <dependencies defaultconf="default->default">
     <!-- Kettle module dependencies-->
     <dependency org="${ivy.artifact.group}" name="kettle-core"          rev="${project.revision}" changing="true" force="true"/>
@@ -29,7 +29,8 @@
       <exclude name="jaxen" module="jaxen"/>
       <exclude name="dom4j" module="dom4j"/>
     </dependency>
-    
+    <dependency org="${ivy.artifact.group}" name="kettle5-log4j-plugin" rev="${project.revision}" changing="true" force="true" transitive="false"/>
+
     <dependency org="pentaho" name="pdi-osgi-bridge-core" rev="${dependency.pdi-osgi-bridge.revision}" changing="true" />
 
     <!-- Data Service JDBC Driver -->
@@ -94,11 +95,11 @@
     </dependency>
     <dependency org="${ivy.artifact.group}" name="kettle-sap-plugin" rev="${project.revision}" changing="true" conf="plugins->default">
         <artifact name="kettle-sap-plugin" type="zip"/>
-    </dependency>    
+    </dependency>
     <dependency org="pentaho" name="pentaho-karaf-assembly" rev="${project.revision}" changing="true" conf="pentaho-system->default" m:classifier="client">
       <artifact name="pentaho-karaf-assembly" type="zip" m:classifier="client"/>
     </dependency>
-    
+
     <!-- Pentaho dependencies (non-Kettle), launcher, shim, etc. -->
     <dependency org="pentaho"               name="pentaho-application-launcher"  rev="${dependency.launcher.revision}" conf="launcher->default"/>
     <dependency org="pentaho" name="pentaho-big-data-plugin" rev="${dependency.pentaho-big-data-plugin.revision}" changing="true" transitive="false" conf="plugins->default">
@@ -161,7 +162,7 @@
     </dependency>
     <dependency org="org.apache.axis2" name="axis2-kernel" rev="1.5" transitive="false" />
     <dependency org="org.apache.axis2" name="axis2-adb" rev="1.5" transitive="false" />
-    
+
     <dependency org="${dependency.reporting-engine.group}" name="classic-extensions-reportdesigner-parser" rev="${dependency.pentaho-reporting.revision}" transitive="true" changing="true">
       <exclude org="pentaho-kettle"/>
     </dependency>
@@ -177,21 +178,21 @@
     <dependency org="pentaho" name="oss-licenses" rev="${dependency.oss-licenses.revision}" conf="oss-licenses->default">
       <artifact name="oss-licenses" type="zip" />
     </dependency>
-     
+
     <!-- The SWT OS-specific libraries -->
     <dependency org="org.eclipse.swt" name="org.eclipse.swt.gtk.linux.x86"       rev="${dependency.swt-linux.revision}" conf="swtlibs->default" transitive="false"/>
     <dependency org="org.eclipse.swt" name="org.eclipse.swt.gtk.linux.x86_64"    rev="${dependency.swt-linux.revision}" conf="swtlibs->default" transitive="false"/>
     <dependency org="org.eclipse.swt" name="org.eclipse.swt.win32.win32.x86"     rev="${dependency.swt-win.revision}"   conf="swtlibs->default" transitive="false"/>
     <dependency org="org.eclipse.swt" name="org.eclipse.swt.win32.win32.x86_64"  rev="${dependency.swt-win.revision}"   conf="swtlibs->default" transitive="false"/>
     <dependency org="org.eclipse.swt" name="org.eclipse.swt.cocoa.macosx.x86_64" rev="${dependency.swt-osx.revision}"   conf="swtlibs->default" transitive="false"/>
-      
+
 	    <!-- Karaf Dependencies -->
     <dependency org="org.apache.karaf" name="org.apache.karaf.main" rev="3.0.3"  transitive="false"/>
     <dependency org="org.apache.karaf" name="org.apache.karaf.util" rev="3.0.3"  transitive="false"/>
     <dependency org="org.apache.karaf.jaas" name="org.apache.karaf.jaas.boot" rev="2.4.2"  transitive="false"/>
     <dependency org="org.apache.felix" name="org.apache.felix.main" rev="4.2.1"  transitive="false"/>
 
-	
+
     <!-- Third-party JDBC dependencies -->
     <dependency org="org.apache.derby"     name="derby"                 rev="10.2.1.6"      transitive="false"/>
     <dependency org="org.apache.derby"     name="derbyclient"           rev="10.2.1.6"      transitive="false"/>
@@ -199,7 +200,7 @@
     <dependency org="org.hsqldb"           name="hsqldb"                rev="2.3.2"         transitive="false"/>
     <dependency org="infobright"           name="infobright-core"       rev="3.4"           transitive="false"/>
     <dependency org="org.firebirdsql.jdbc" name="jaybird"               rev="2.1.6"         transitive="false"/>
-    <dependency org="net.sf.jt400"         name="jt400"                 rev="6.1"           transitive="false"/>  
+    <dependency org="net.sf.jt400"         name="jt400"                 rev="6.1"           transitive="false"/>
     <dependency org="luciddb"              name="LucidDbClient-minimal" rev="0.9.4"         transitive="false"/>
     <dependency org="monetdb"              name="monetdb-jdbc"          rev="2.1"           transitive="false"/>
     <dependency org="org.postgresql"       name="postgresql"            rev="9.3-1102-jdbc4" transitive="false"/>


### PR DESCRIPTION
Hadoop Job Executor job entry uses org.pentaho.di.core.logging.LogWriter. This is located in kettle5-log4j-plugin-xxx.jar.
This jar was pulled into <PENTAHO>\data-integration\lib transitively from pentaho-reporting-engine-classic-extensions-kettle project.
After GAV changes for reporting projects (https://github.com/pentaho/pentaho-kettle/commit/8136fd585deb77007d06a89a0df369cae83285c1) this jar stopped to be pulling out transitively and disappeared from <PENTAHO>\data-integration\lib.

But we need to have it for big-data-project.
So the fix is to receive this dependency directly.