### PR TITLE
[BACKLOG-15034] - When creating a Database Repository, an 'Invalid user credentials' error is thrown to the logs - change log message

### DIFF
--- a/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepository.java
+++ b/engine/src/org/pentaho/di/repository/kdr/KettleDatabaseRepository.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -39,6 +39,7 @@ import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.Condition;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
+import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.core.NotePadMeta;
 import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.RowMetaAndData;
@@ -265,7 +266,8 @@ public class KettleDatabaseRepository extends KettleDatabaseRepositoryBase {
             disconnect();
             connect( "admin", pwd, true );
           } catch ( KettleException e ) {
-            log.logError( "Invalid user credentials" );
+            log.logError( BaseMessages.getString( KettleDatabaseRepository.class,
+                "KettleDatabaseRepository.ERROR_CONNECT_TO_REPOSITORY" ), e );
           }
         }
 

--- a/engine/src/org/pentaho/di/repository/kdr/messages/messages_en_US.properties
+++ b/engine/src/org/pentaho/di/repository/kdr/messages/messages_en_US.properties
@@ -1,2 +1,3 @@
 KettleDatabaseRepositorySecurityProvider.ERROR_0001_UNABLE_TO_CREATE_USER=Can''t Create User.
 KettleDatabaseRepositorySecurityProvider.ERROR_0001_USER_NAME_ALREADY_EXISTS=Someone already has that user name. Please try another.
+KettleDatabaseRepository.ERROR_CONNECT_TO_REPOSITORY=An error occurred while connecting to the repository


### PR DESCRIPTION
@bmorrise please review