### PR TITLE
[BACKLOG-14876] Making TextFileOutput.writeRowToFile public

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -265,7 +265,7 @@ public class TextFileOutput extends BaseStep implements StepInterface {
     }
   }
 
-  protected void writeRowToFile( RowMetaInterface rowMeta, Object[] r ) throws KettleStepException {
+  public void writeRowToFile( RowMetaInterface rowMeta, Object[] r ) throws KettleStepException {
     try {
       if ( meta.getOutputFields() == null || meta.getOutputFields().length == 0 ) {
         /*


### PR DESCRIPTION
So content conversion logic can be accessible within AEL functions.