### PR TITLE
[PDI-15932]: Use ReentrantReadWriteLock to protect ExtensionPointMap

### DIFF
--- a/core/src/org/pentaho/di/core/extension/ExtensionPointHandler.java
+++ b/core/src/org/pentaho/di/core/extension/ExtensionPointHandler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -42,8 +42,6 @@ public class ExtensionPointHandler {
    */
   public static void callExtensionPoint( final LogChannelInterface log, final String id, final Object object )
     throws KettleException {
-    for ( ExtensionPointInterface extensionPoint : ExtensionPointMap.getInstance().get( id ).values() ) {
-      extensionPoint.callExtensionPoint( log, object );
-    }
+    ExtensionPointMap.getInstance().callExtensionPoint( log, id, object );
   }
 }

--- a/core/src/org/pentaho/di/core/plugins/PluginRegistry.java
+++ b/core/src/org/pentaho/di/core/plugins/PluginRegistry.java
@@ -1077,4 +1077,8 @@ public class PluginRegistry {
     }
     return result;
   }
+
+  public ReentrantReadWriteLock getLock() {
+    return lock;
+  }
 }

--- a/core/test-src/org/pentaho/di/core/extension/ExtensionPointIntegrationTest.java
+++ b/core/test-src/org/pentaho/di/core/extension/ExtensionPointIntegrationTest.java
@@ -1,7 +1,7 @@
 /*
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  * **************************************************************************
  *
@@ -30,8 +30,16 @@ import javassist.NotFoundException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.*;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -61,7 +69,7 @@ public class ExtensionPointIntegrationTest {
     // check that all extension points are executed
     final LogChannelInterface log = mock( LogChannelInterface.class );
     for ( KettleExtensionPoint ep : KettleExtensionPoint.values() ) {
-      final ExtensionPointInterface currentEP = ExtensionPointMap.getInstance().get( ep.id ).get( "id" + ep.id );
+      final ExtensionPointInterface currentEP = ExtensionPointMap.getInstance().getMap().get( ep.id ).get( "id" + ep.id ).get();
       assertFalse( currentEP.getClass().getField( EXECUTED_FIELD_NAME ).getBoolean( currentEP ) );
       ExtensionPointHandler.callExtensionPoint( log, ep.id, null );
       assertTrue( currentEP.getClass().getField( EXECUTED_FIELD_NAME ).getBoolean( currentEP ) );
@@ -69,17 +77,17 @@ public class ExtensionPointIntegrationTest {
 
     // check modification of extension point
     final KettleExtensionPoint jobAfterOpen = KettleExtensionPoint.JobAfterOpen;
-    final ExtensionPointInterface int1 = ExtensionPointMap.getInstance().get( jobAfterOpen.id ).get( "id" + jobAfterOpen.id );
+    final ExtensionPointInterface int1 = ExtensionPointMap.getInstance().getMap().get( jobAfterOpen.id ).get( "id" + jobAfterOpen.id ).get();
     ExtensionPointPluginType.getInstance().registerCustom( createClassRuntime( jobAfterOpen, "Edited" ), "custom", "id"
             + jobAfterOpen.id, jobAfterOpen.id,
         "no description", null );
-    assertNotSame( int1, ExtensionPointMap.getInstance().get( jobAfterOpen.id ) );
+    assertNotSame( int1, ExtensionPointMap.getInstance().getMap().get( jobAfterOpen.id ) );
     assertEquals( KettleExtensionPoint.values().length, ExtensionPointMap.getInstance().getMap().size() );
 
     // check removal of extension point
     PluginRegistry.getInstance().removePlugin( ExtensionPointPluginType.class, PluginRegistry.getInstance().getPlugin(
         ExtensionPointPluginType.class, "id" + jobAfterOpen.id ) );
-    assertTrue( ExtensionPointMap.getInstance().get( jobAfterOpen.id ).isEmpty() );
+    assertTrue( ExtensionPointMap.getInstance().getMap().get( jobAfterOpen.id ) == null );
     assertEquals( KettleExtensionPoint.values().length - 1, ExtensionPointMap.getInstance().getMap().size() );
   }
 
@@ -107,4 +115,130 @@ public class ExtensionPointIntegrationTest {
         ctClass ) );
     return ctClass.toClass();
   }
+
+  @Test
+  public void testExtensionPointMapConcurrency() throws InterruptedException {
+    final int totalThreadsToRun = 2000;
+    final int maxTimeoutSeconds = 60;
+
+    List<Runnable> parallelTasksList = new ArrayList<>( totalThreadsToRun );
+    List<Runnable> tasksList = getTasksList();
+
+    for ( int i = 0; i < totalThreadsToRun; i++ ) {
+      parallelTasksList.add( tasksList.get( i % 3 ) );
+    }
+
+    assertConcurrent( "serviceCall must be ThreadSafe", parallelTasksList, maxTimeoutSeconds );
+  }
+
+  private static KettleExtensionPoint getRandomKettleExtensionPoint() {
+    KettleExtensionPoint[] kettleExtensionPoints = KettleExtensionPoint.values();
+    int randomInd = ThreadLocalRandom.current().nextInt( 0, kettleExtensionPoints.length );
+    return kettleExtensionPoints[randomInd];
+  }
+
+  private static void assertConcurrent( final String message, final List<? extends Runnable> runnables,
+                                       final int maxTimeoutSeconds )  throws InterruptedException {
+    final int numThreads = runnables.size();
+    final List<Throwable> exceptions = Collections.synchronizedList( new ArrayList<>() );
+    final ExecutorService threadPool = Executors.newFixedThreadPool( numThreads );
+
+    try {
+      final CountDownLatch allExecutorThreadsReady = new CountDownLatch( numThreads );
+      final CountDownLatch afterInitBlocker = new CountDownLatch( 1 );
+      final CountDownLatch allDone = new CountDownLatch( numThreads );
+      for ( final Runnable submittedTestRunnable : runnables ) {
+        threadPool.submit( new Runnable() {
+          public void run() {
+            allExecutorThreadsReady.countDown();
+            try {
+              afterInitBlocker.await();
+              submittedTestRunnable.run();
+            } catch ( final Throwable e ) {
+              exceptions.add( e );
+            } finally {
+              allDone.countDown();
+            }
+          }
+        } );
+      }
+      // wait until all threads are ready
+      assertTrue(
+              "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent",
+              allExecutorThreadsReady.await( 10L * runnables.size(), TimeUnit.MILLISECONDS ) );
+      // start all test runners
+      afterInitBlocker.countDown();
+      assertTrue( message + " timeout! More than " + maxTimeoutSeconds + " seconds",
+              allDone.await( maxTimeoutSeconds, TimeUnit.SECONDS ) );
+    } finally {
+      threadPool.shutdownNow();
+    }
+    assertTrue( message + "failed with exception(s)" + exceptions, exceptions.isEmpty() );
+  }
+
+  List<Runnable> getTasksList() {
+    List<Runnable> runnableList = new ArrayList<Runnable>();
+
+    //Remove ExtensionPoint
+    runnableList.add( new Runnable() {
+      public void run() {
+        KettleExtensionPoint kettleExtensionPoint = getRandomKettleExtensionPoint();
+        PluginInterface pluginInterface = PluginRegistry.getInstance().getPlugin( ExtensionPointPluginType.class, "id" + kettleExtensionPoint.id );
+
+        try {
+          PluginRegistry.getInstance().removePlugin( ExtensionPointPluginType.class, pluginInterface );
+          PluginRegistry.getInstance().getLock().writeLock().lock();
+          try {
+            ExtensionPointMap.getInstance().removeExtensionPoint( pluginInterface );
+          } finally {
+            PluginRegistry.getInstance().getLock().writeLock().unlock();
+          }
+        } catch ( NullPointerException e ) { //Need because when doesn't exist already, throws NullPointerException
+
+        }
+      }
+    } );
+
+    //Add ExtensionPoint
+    runnableList.add( new Runnable() {
+      public void run() {
+        KettleExtensionPoint kettleExtensionPoint = getRandomKettleExtensionPoint();
+        PluginInterface pluginInterface = PluginRegistry.getInstance().getPlugin( ExtensionPointPluginType.class, "id" + kettleExtensionPoint.id );
+
+        try {
+          PluginRegistry.getInstance().registerPlugin( ExtensionPointPluginType.class, pluginInterface );
+          PluginRegistry.getInstance().getLock().writeLock().lock();
+          try {
+            ExtensionPointMap.getInstance().addExtensionPoint( pluginInterface );
+          } finally {
+            PluginRegistry.getInstance().getLock().writeLock().unlock();
+          }
+        } catch ( NullPointerException e ) { //Need because when already exists, throws NullPointerException
+
+        } catch ( KettlePluginException e ) {
+          e.printStackTrace();
+        }
+
+      }
+    } );
+
+    //Call extension point
+    runnableList.add( new Runnable() {
+      public void run() {
+        final LogChannelInterface log = mock( LogChannelInterface.class );
+
+        KettleExtensionPoint kettleExtensionPoint = getRandomKettleExtensionPoint();
+
+        try {
+          ExtensionPointHandler.callExtensionPoint( log, kettleExtensionPoint.id, new Object() );
+        } catch ( KettleException e ) {
+          e.printStackTrace();
+        }
+
+      }
+    } );
+
+    return runnableList;
+  }
+
 }

--- a/core/test-src/org/pentaho/di/core/extension/ExtensionPointMapTest.java
+++ b/core/test-src/org/pentaho/di/core/extension/ExtensionPointMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  * **************************************************************************
  *
@@ -67,10 +67,10 @@ public class ExtensionPointMapTest {
   @Test
   public void addExtensionPointTest() throws KettlePluginException {
     ExtensionPointMap.getInstance().addExtensionPoint( pluginInterface );
-    assertEquals( ExtensionPointMap.getInstance().get( TEST_NAME ).get( "testID" ), extensionPoint );
+    assertEquals( ExtensionPointMap.getInstance().getMap().get( TEST_NAME ).get( "testID" ).get(), extensionPoint );
 
     // Verify cached instance
-    assertEquals( ExtensionPointMap.getInstance().get( TEST_NAME ).get( "testID" ), extensionPoint );
+    assertEquals( ExtensionPointMap.getInstance().getMap().get( TEST_NAME ).get( "testID" ).get(), extensionPoint );
     verify( pluginInterface, times( 1 ) ).loadClass( any( Class.class ) );
   }
 }


### PR DESCRIPTION
Use ReentrantReadWriteLock to protect ExtensionPointMap against concurrent access. Add concurrency UT to ExtensionPointIntegrationTest.java