### PR TITLE
[PDI-15932] Use PluginRegistry.java to synchronise callExtensionPoint

### DIFF
--- a/core/src/org/pentaho/di/core/extension/ExtensionPointHandler.java
+++ b/core/src/org/pentaho/di/core/extension/ExtensionPointHandler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,6 +24,7 @@ package org.pentaho.di.core.extension;
 
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.plugins.PluginRegistry;
 
 public class ExtensionPointHandler {
 
@@ -42,8 +43,6 @@ public class ExtensionPointHandler {
    */
   public static void callExtensionPoint( final LogChannelInterface log, final String id, final Object object )
     throws KettleException {
-    for ( ExtensionPointInterface extensionPoint : ExtensionPointMap.getInstance().get( id ).values() ) {
-      extensionPoint.callExtensionPoint( log, object );
-    }
+    PluginRegistry.getInstance().callExtensionPoint( log, id, object );
   }
 }

--- a/core/src/org/pentaho/di/core/extension/ExtensionPointMap.java
+++ b/core/src/org/pentaho/di/core/extension/ExtensionPointMap.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -90,7 +90,10 @@ public class ExtensionPointMap {
 
   /**
    * Add the extension point plugin to the map
-   * 
+   *
+   * Warning: Do not call this method directly through ExtensionPointMap, it may lead to concurrency problems. Call
+   * PluginRegistry.getInstance().registerPlugin() instead.
+   *
    * @param extensionPointPlugin
    */
   public void addExtensionPoint( PluginInterface extensionPointPlugin ) {
@@ -101,6 +104,9 @@ public class ExtensionPointMap {
 
   /**
    * Remove the extension point plugin from the map
+   *
+   * Warning: Do not call this method directly through ExtensionPointMap, it may lead to concurrency problems. Call
+   * PluginRegistry.getInstance().registerPlugin() instead.
    * 
    * @param extensionPointPlugin
    */


### PR DESCRIPTION
Isolated callExtensionPoint for cycle through ExtensionPointMap's HashBasedTable to make use of lock already inside PluginRegistry, since it's already locking access to the ExtensionPointMap