### PR TITLE
[BACKLOG-15249] Built-in empty lifecycle-listeners XML conflicting in…

### DIFF
--- a/engine/src/kettle-lifecycle-listeners.xml
+++ b/engine/src/kettle-lifecycle-listeners.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<listeners>
-</listeners>

--- a/engine/src/org/pentaho/di/core/plugins/KettleLifecyclePluginType.java
+++ b/engine/src/org/pentaho/di/core/plugins/KettleLifecyclePluginType.java
@@ -74,7 +74,7 @@ public class KettleLifecyclePluginType extends BasePluginType implements PluginT
         inputStream = getClass().getResourceAsStream( "/" + xmlFile );
       }
       if ( inputStream == null ) {
-        throw new KettlePluginException( "Unable to find native repository type definition file: " + xmlFile );
+        return;
       }
       Document document = XMLHandler.loadXMLFile( inputStream, null, true, false );
 


### PR DESCRIPTION
… Spark engine. Making the KettleLifecyclePluginType null safe with regard to the XML file.