### PR TITLE
[BACKLOG-15330] Explicit exclude for org.osgi.core

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -246,5 +246,6 @@
     <dependency org="javax.ws.rs" name="jsr311-api" rev="1.1.1" transitive="false"/>
 
     <exclude org="javax.servlet"/>
+    <exclude org="org.osgi" module="org.osgi.core"/>    
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
Version 4.2.0 was being resolved tinybundles->bndlib->org.osgi.core.