### PR TITLE
[PDI-15932] Protect extensionPointPluginMap against ConcurrentModificationException...

### DIFF
--- a/core/src/org/pentaho/di/core/extension/ExtensionPointHandler.java
+++ b/core/src/org/pentaho/di/core/extension/ExtensionPointHandler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -42,8 +42,6 @@ public class ExtensionPointHandler {
    */
   public static void callExtensionPoint( final LogChannelInterface log, final String id, final Object object )
     throws KettleException {
-    for ( ExtensionPointInterface extensionPoint : ExtensionPointMap.getInstance().get( id ).values() ) {
-      extensionPoint.callExtensionPoint( log, object );
-    }
+    ExtensionPointMap.getInstance().callExtensionPoint( log, id, object );
   }
 }

--- a/core/src/org/pentaho/di/core/plugins/PluginRegistry.java
+++ b/core/src/org/pentaho/di/core/plugins/PluginRegistry.java
@@ -143,15 +143,14 @@ public class PluginRegistry {
         //
         classLoaderGroupsMap.remove( plugin.getClassLoaderGroup() );
       }
-
+    } finally {
+      lock.writeLock().unlock();
       List<PluginTypeListener> listeners = this.listeners.get( pluginType );
       if ( listeners != null ) {
         for ( PluginTypeListener listener : listeners ) {
           listener.pluginRemoved( plugin );
         }
       }
-    } finally {
-      lock.writeLock().unlock();
       synchronized ( this ) {
         notifyAll();
       }
@@ -169,12 +168,9 @@ public class PluginRegistry {
 
   public void registerPlugin( Class<? extends PluginTypeInterface> pluginType, PluginInterface plugin )
       throws KettlePluginException {
-
+    boolean changed = false; // Is this an add or an update?
     lock.writeLock().lock();
     try {
-
-      boolean changed = false; // Is this an add or an update?
-
       if ( plugin.getIds()[0] == null ) {
         throw new KettlePluginException( "Not a valid id specified in plugin :" + plugin );
       }
@@ -241,6 +237,8 @@ public class PluginRegistry {
           }
         }
       }
+    } finally {
+      lock.writeLock().unlock();
       List<PluginTypeListener> listeners = this.listeners.get( pluginType );
       if ( listeners != null ) {
         for ( PluginTypeListener listener : listeners ) {
@@ -252,8 +250,6 @@ public class PluginRegistry {
           }
         }
       }
-    } finally {
-      lock.writeLock().unlock();
       synchronized ( this ) {
         notifyAll();
       }

--- a/core/test-src/org/pentaho/di/core/extension/ExtensionPointIntegrationTest.java
+++ b/core/test-src/org/pentaho/di/core/extension/ExtensionPointIntegrationTest.java
@@ -1,7 +1,7 @@
 /*
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  * **************************************************************************
  *
@@ -30,8 +30,20 @@ import javassist.NotFoundException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -39,6 +51,8 @@ import static org.mockito.Mockito.mock;
 
 public class ExtensionPointIntegrationTest {
   public static final String EXECUTED_FIELD_NAME = "executed";
+  private static final int TOTAL_THREADS_TO_RUN = 2000;
+  private static final int MAX_TIMEOUT_SECONDS = 60;
   private static ClassPool pool;
 
   @BeforeClass
@@ -56,12 +70,12 @@ public class ExtensionPointIntegrationTest {
   @Test
   public void test() throws Exception {
     // check that all extension points are added to the map
-    assertEquals( KettleExtensionPoint.values().length, ExtensionPointMap.getInstance().getMap().size() );
+    assertEquals( KettleExtensionPoint.values().length, ExtensionPointMap.getInstance().getNumberOfRows() );
 
     // check that all extension points are executed
     final LogChannelInterface log = mock( LogChannelInterface.class );
     for ( KettleExtensionPoint ep : KettleExtensionPoint.values() ) {
-      final ExtensionPointInterface currentEP = ExtensionPointMap.getInstance().get( ep.id ).get( "id" + ep.id );
+      final ExtensionPointInterface currentEP = ExtensionPointMap.getInstance().getTableValue( ep.id, "id" + ep.id );
       assertFalse( currentEP.getClass().getField( EXECUTED_FIELD_NAME ).getBoolean( currentEP ) );
       ExtensionPointHandler.callExtensionPoint( log, ep.id, null );
       assertTrue( currentEP.getClass().getField( EXECUTED_FIELD_NAME ).getBoolean( currentEP ) );
@@ -69,18 +83,18 @@ public class ExtensionPointIntegrationTest {
 
     // check modification of extension point
     final KettleExtensionPoint jobAfterOpen = KettleExtensionPoint.JobAfterOpen;
-    final ExtensionPointInterface int1 = ExtensionPointMap.getInstance().get( jobAfterOpen.id ).get( "id" + jobAfterOpen.id );
+    final ExtensionPointInterface int1 = ExtensionPointMap.getInstance().getTableValue( jobAfterOpen.id, "id" + jobAfterOpen.id );
     ExtensionPointPluginType.getInstance().registerCustom( createClassRuntime( jobAfterOpen, "Edited" ), "custom", "id"
             + jobAfterOpen.id, jobAfterOpen.id,
         "no description", null );
-    assertNotSame( int1, ExtensionPointMap.getInstance().get( jobAfterOpen.id ) );
-    assertEquals( KettleExtensionPoint.values().length, ExtensionPointMap.getInstance().getMap().size() );
+    assertNotSame( int1, ExtensionPointMap.getInstance().getTableValue( jobAfterOpen.id, "id" + jobAfterOpen.id ) );
+    assertEquals( KettleExtensionPoint.values().length, ExtensionPointMap.getInstance().getNumberOfRows() );
 
     // check removal of extension point
     PluginRegistry.getInstance().removePlugin( ExtensionPointPluginType.class, PluginRegistry.getInstance().getPlugin(
         ExtensionPointPluginType.class, "id" + jobAfterOpen.id ) );
-    assertTrue( ExtensionPointMap.getInstance().get( jobAfterOpen.id ).isEmpty() );
-    assertEquals( KettleExtensionPoint.values().length - 1, ExtensionPointMap.getInstance().getMap().size() );
+    assertTrue( ExtensionPointMap.getInstance().getTableValue( jobAfterOpen.id, "id" + jobAfterOpen.id ) == null );
+    assertEquals( KettleExtensionPoint.values().length - 1, ExtensionPointMap.getInstance().getNumberOfRows() );
   }
 
   private static Class createClassRuntime( KettleExtensionPoint ep ) throws NotFoundException, CannotCompileException {
@@ -106,5 +120,80 @@ public class ExtensionPointIntegrationTest {
             + "throws org.pentaho.di.core.exception.KettleException { " + EXECUTED_FIELD_NAME + " = true; }",
         ctClass ) );
     return ctClass.toClass();
+  }
+
+  @Test
+  public void testExtensionPointMapConcurrency() throws InterruptedException {
+    final LogChannelInterface log = mock( LogChannelInterface.class );
+
+    List<Runnable> parallelTasksList = new ArrayList<>( TOTAL_THREADS_TO_RUN );
+    for ( int i = 0; i < TOTAL_THREADS_TO_RUN; i++ ) {
+      parallelTasksList.add( () -> {
+        KettleExtensionPoint kettleExtensionPoint = getRandomKettleExtensionPoint();
+        PluginInterface pluginInterface = PluginRegistry.getInstance().getPlugin( ExtensionPointPluginType.class,
+          "id" + kettleExtensionPoint.id );
+
+        try {
+          PluginRegistry.getInstance().removePlugin( ExtensionPointPluginType.class, pluginInterface );
+          PluginRegistry.getInstance().registerPlugin( ExtensionPointPluginType.class, pluginInterface );
+        } catch ( KettlePluginException e ) {
+          e.printStackTrace();
+        } catch ( NullPointerException e ) {
+          //NullPointerException can be thrown if trying to remove a plugin that doesn't exit, discarding occurence
+        }
+
+        ExtensionPointMap.getInstance().reInitialize();
+
+        try {
+          ExtensionPointMap.getInstance().callExtensionPoint( log, kettleExtensionPoint.id, null );
+        } catch ( KettleException e ) {
+          e.printStackTrace();
+        }
+      } );
+    }
+
+    assertConcurrent( parallelTasksList );
+  }
+
+  private static KettleExtensionPoint getRandomKettleExtensionPoint() {
+    KettleExtensionPoint[] kettleExtensionPoints = KettleExtensionPoint.values();
+    int randomInd = ThreadLocalRandom.current().nextInt( 0, kettleExtensionPoints.length );
+    return kettleExtensionPoints[randomInd];
+  }
+
+  private static void assertConcurrent( final List<? extends Runnable> runnables )  throws InterruptedException {
+    final int numThreads = runnables.size();
+    final List<Throwable> exceptions = Collections.synchronizedList( new ArrayList<>() );
+    final ExecutorService threadPool = Executors.newFixedThreadPool( numThreads );
+
+    try {
+      final CountDownLatch allExecutorThreadsReady = new CountDownLatch( numThreads );
+      final CountDownLatch afterInitBlocker = new CountDownLatch( 1 );
+      final CountDownLatch allDone = new CountDownLatch( numThreads );
+      for ( final Runnable submittedTestRunnable : runnables ) {
+        threadPool.submit( () -> {
+          allExecutorThreadsReady.countDown();
+          try {
+            afterInitBlocker.await();
+            submittedTestRunnable.run();
+          } catch ( final Throwable e ) {
+            exceptions.add( e );
+          } finally {
+            allDone.countDown();
+          }
+        } );
+      }
+      // wait until all threads are ready
+      assertTrue(
+        "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent",
+        allExecutorThreadsReady.await( 10L * runnables.size(), TimeUnit.MILLISECONDS ) );
+      // start all test runners
+      afterInitBlocker.countDown();
+      assertTrue( String.format( "Timeout! Run took more than %s seconds", MAX_TIMEOUT_SECONDS ),
+        allDone.await( MAX_TIMEOUT_SECONDS, TimeUnit.SECONDS ) );
+    } finally {
+      threadPool.shutdownNow();
+    }
+    assertTrue( String.format( " Run failed with exception(s): %s", exceptions ), exceptions.isEmpty() );
   }
 }

--- a/core/test-src/org/pentaho/di/core/extension/ExtensionPointMapTest.java
+++ b/core/test-src/org/pentaho/di/core/extension/ExtensionPointMapTest.java
@@ -1,7 +1,7 @@
 /*
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  * **************************************************************************
  *
@@ -52,13 +52,13 @@ public class ExtensionPointMapTest {
   @Test
   public void constructorTest() throws Exception {
     PluginRegistry.getInstance().registerPlugin( ExtensionPointPluginType.class, pluginInterface );
-    assertEquals( 1, ExtensionPointMap.getInstance().getMap().size() );
+    assertEquals( 1, ExtensionPointMap.getInstance().getNumberOfRows() );
 
     PluginRegistry.getInstance().registerPlugin( ExtensionPointPluginType.class, pluginInterface );
-    assertEquals( 1, ExtensionPointMap.getInstance().getMap().size() );
+    assertEquals( 1, ExtensionPointMap.getInstance().getNumberOfRows() );
 
     PluginRegistry.getInstance().removePlugin( ExtensionPointPluginType.class, pluginInterface );
-    assertEquals( 0, ExtensionPointMap.getInstance().getMap().size() );
+    assertEquals( 0, ExtensionPointMap.getInstance().getNumberOfRows() );
 
     // Verify lazy loading
     verify( pluginInterface, never() ).loadClass( any( Class.class ) );
@@ -67,10 +67,10 @@ public class ExtensionPointMapTest {
   @Test
   public void addExtensionPointTest() throws KettlePluginException {
     ExtensionPointMap.getInstance().addExtensionPoint( pluginInterface );
-    assertEquals( ExtensionPointMap.getInstance().get( TEST_NAME ).get( "testID" ), extensionPoint );
+    assertEquals( ExtensionPointMap.getInstance().getTableValue( TEST_NAME, "testID" ), extensionPoint );
 
     // Verify cached instance
-    assertEquals( ExtensionPointMap.getInstance().get( TEST_NAME ).get( "testID" ), extensionPoint );
+    assertEquals( ExtensionPointMap.getInstance().getTableValue( TEST_NAME, "testID" ), extensionPoint );
     verify( pluginInterface, times( 1 ) ).loadClass( any( Class.class ) );
   }
 }


### PR DESCRIPTION
… with reentrant lock and isolate the ExtensionPointHandler iteration inside ExtensionPointMap.callExtensionPoint()

Based on the solution proposed by @mbatchelor:

- [x] Remove the get( id ) method from the map: 
\- Having grepped all the code we ship, the only classes that use ExtensionPointMap are in the same package.
\- It's not a public API nor does it implement an interface
> Removed getMap() as well to prevent any iteration of the map from the outside that may lead to a similar problem


- [x] Create a new package-protected method called callExtensionPoint that receives a log channel, id, and object (like the method in ExtensionPointHandler only not public static)
- [x] In ExtensionPointMap do the iteration

- [x] Fix the couple of tests that use the map directly (if there are any)
> Had to create two new methods that expose just the needed values for validation in UTs: getTableValue() and getNumberOfRows()

**Extra steps:** 
- In PluginRegistry class I had to remove the blocks that make calls to ExtentionPointMap via PluginTypeListener from the blocks that are locked. The reason for this was the possibility of having dangerous concurrency issues, like dead locks.
- Added new UT, testExtensionPointMapConcurrency(), to check concurrency access in ExtensionPointMap