### PR TITLE
[BACKLOG-15514] - [Web Service Lookup] Improve the Fatal Error message that is thrown to the logs

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/webservices/wsdl/Wsdl.java
+++ b/engine/src/org/pentaho/di/trans/steps/webservices/wsdl/Wsdl.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -367,11 +367,7 @@ public final class Wsdl implements java.io.Serializable {
   private Definition parse( URI wsdlURI, String username, String password ) throws WSDLException, KettleException,
     AuthenticationException {
     WSDLReader wsdlReader = getReader();
-    try {
-      return wsdlReader.readWSDL( wsdlURI.toString() );
-    } catch ( WSDLException we ) {
-      return readWsdl( wsdlReader, wsdlURI.toString(), username, password );
-    }
+    return readWsdl( wsdlReader, wsdlURI.toString(), username, password );
   }
 
   private Definition readWsdl( WSDLReader wsdlReader, String uri, String username, String password ) throws WSDLException, KettleException, AuthenticationException {


### PR DESCRIPTION
@bmorrise , @mdamour1976  please review.

The error occurred inside WSDLReader#readWSDL(String wsdlURI) method call and we can not change the way how WSDLReader reads WSDL document from the defined URI. We also can not improve/remove its error message as logging part also happens inside readWSDL call. However in WebService we have a fallback for WSDL retriving: readWsdl method, that uses HTTPProtocol utility to load  WSDL content. This utility works well while getting WDSL from the same server. So I decided to remove WSDLReader#readWSDL and use the fallback as only approach for getting WSDL.