### PR TITLE
[BACKLOG-15550]  Stream status

### DIFF
--- a/engine/src/org/pentaho/di/trans/ael/adapters/StepInterfaceEngineAdapter.java
+++ b/engine/src/org/pentaho/di/trans/ael/adapters/StepInterfaceEngineAdapter.java
@@ -39,6 +39,8 @@ import org.pentaho.di.trans.step.RowListener;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepMeta;
 
+import java.util.Collections;
+
 import static org.pentaho.di.engine.api.model.Rows.TYPE.OUT;
 
 /**
@@ -56,6 +58,8 @@ public class StepInterfaceEngineAdapter extends BaseStep {
     super( stepMeta, dataInterface, 0, transMeta, trans );
     operation = op;
     this.executionContext = executionContext;
+    setInputRowSets( Collections.emptyList() );
+    setOutputRowSets( Collections.emptyList() );
     init();
   }
 


### PR DESCRIPTION
Addressing NPEs that occur when status is updated
due to rowsets not being present in the StepAdapter.