### PR TITLE
[PDI-13987] “Text file output” step writes field to the file with different encoding (binary data with different encoding, lazy conversion)

### DIFF
--- a/engine/src/org/pentaho/di/trans/step/BaseStep.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStep.java
@@ -1924,8 +1924,8 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
     }
 
     // Also set the meta data on the first occurrence.
-    //
-    if ( inputRowMeta == null ) {
+    // or if prevSteps.length > 1 inputRowMeta can be changed
+    if ( inputRowMeta == null || prevSteps.length > 1 ) {
       inputRowMeta = inputRowSet.getRowMeta();
     }
 

--- a/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -96,10 +96,11 @@ public class TextFileOutput extends BaseStep implements StepInterface {
     boolean bEndedLineWrote = false;
     boolean fileExist;
     Object[] r = getRow(); // This also waits for a row to be finished.
-
+    if ( r != null ) {
+      data.outputRowMeta = getInputRowMeta().clone();
+    }
     if ( r != null && first ) {
       first = false;
-      data.outputRowMeta = getInputRowMeta().clone();
       meta.getFields( data.outputRowMeta, getStepname(), null, null, this, repository, metaStore );
 
       // if file name in field is enabled then set field name and open file
@@ -348,11 +349,11 @@ public class TextFileOutput extends BaseStep implements StepInterface {
       }
     } else {
       byte[] text;
-      if ( Utils.isEmpty( v.getStringEncoding() ) ) {
+      if ( Utils.isEmpty( meta.getEncoding() ) ) {
         text = string.getBytes();
       } else {
         try {
-          text = string.getBytes( v.getStringEncoding() );
+          text = string.getBytes( meta.getEncoding() );
         } catch ( UnsupportedEncodingException e ) {
           throw new KettleValueException( "Unable to convert String to Binary with specified string encoding ["
               + v.getStringEncoding() + "]", e );

--- a/engine/test-src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputTest.java
@@ -22,10 +22,13 @@
 
 package org.pentaho.di.trans.steps.textfileoutput;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -51,6 +54,7 @@ import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.trans.Trans;
@@ -479,7 +483,7 @@ public class TextFileOutputTest {
    * @throws KettleException
    */
   @Test
-  public void testProcessRule_2() throws KettleException {
+  public void testProcessRule_2() throws Exception {
 
     TextFileField tfFieldMock = Mockito.mock( TextFileField.class );
     TextFileField[] textFileFields = { tfFieldMock };
@@ -526,7 +530,7 @@ public class TextFileOutputTest {
 
     textFileOutputSpy.processRow( stepMockHelper.processRowsStepMetaInterface, stepMockHelper.initStepDataInterface );
     Mockito.verify( textFileOutputSpy, Mockito.times( 1 ) ).writeHeader(  );
-
+    Files.deleteIfExists( new File( TEXT_FILE_OUTPUT_PREFIX + TEXT_FILE_OUTPUT_EXTENSION ).toPath() );
   }
 
 
@@ -584,6 +588,44 @@ public class TextFileOutputTest {
 
     textFileOutputSpy.processRow( stepMockHelper.processRowsStepMetaInterface, stepMockHelper.initStepDataInterface );
     Mockito.verify( textFileOutputSpy, Mockito.times( 1 ) ).writeHeader(  );
+  }
+
+  /**
+   * Test for PDI-13987
+   * @throws Exception
+   */
+  @Test
+  public void testFastDumpDisableStreamEncodeTest() throws Exception {
+
+    textFileOutput =
+            new TextFileOutputTestHandler( stepMockHelper.stepMeta, stepMockHelper.stepDataInterface, 0, stepMockHelper.transMeta,
+                    stepMockHelper.trans );
+    textFileOutput.meta = stepMockHelper.processRowsStepMetaInterface;
+
+    String testString = "ÖÜä";
+    String inputEncode = "UTF-8";
+    String outputEncode = "Windows-1252";
+    Object[] rows = {testString.getBytes( inputEncode )};
+
+    ValueMetaBase valueMetaInterface = new ValueMetaBase( "test", ValueMetaInterface.TYPE_STRING );
+    valueMetaInterface.setStringEncoding( inputEncode );
+    valueMetaInterface.setStorageType( ValueMetaInterface.STORAGE_TYPE_BINARY_STRING );
+    valueMetaInterface.setStorageMetadata( new ValueMetaString() );
+
+    TextFileOutputData data = new TextFileOutputData();
+    data.binarySeparator = " ".getBytes();
+    data.binaryEnclosure = "\"".getBytes();
+    data.binaryNewline = "\n".getBytes();
+    textFileOutput.data = data;
+
+    RowMeta rowMeta = new RowMeta();
+    rowMeta.addValueMeta( valueMetaInterface );
+
+    Mockito.doReturn( outputEncode ).when( stepMockHelper.processRowsStepMetaInterface ).getEncoding();
+    textFileOutput.data.writer = Mockito.mock( BufferedOutputStream.class );
+
+    textFileOutput.writeRowToFile( rowMeta, rows );
+    Mockito.verify( textFileOutput.data.writer, Mockito.times( 1 ) ).write( testString.getBytes( outputEncode ) );
   }
 
 }


### PR DESCRIPTION
- update output Row and input Row meta for 2 and more sources
- fixed writing encode for "fast data dump" off
@mbatchelor Could you please review and merge it?