### PR TITLE
[BAD-587] - PMR Mapper log is full of errors related to org.eclipse.jface.window.ApplicationWindow

### DIFF
--- a/plugins/meta-inject-plugin/src/main/java/org/pentaho/di/trans/steps/metainject/OpenMappingExtension.java
+++ b/plugins/meta-inject-plugin/src/main/java/org/pentaho/di/trans/steps/metainject/OpenMappingExtension.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,7 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
-import org.pentaho.di.trans.step.StepMetaInterface;
-import org.pentaho.di.ui.spoon.Spoon;
+import org.pentaho.di.ui.spoon.SpoonLifecycleListener;
 
 /**
  * Created by bmorrise on 7/26/16.
@@ -35,7 +34,8 @@ import org.pentaho.di.ui.spoon.Spoon;
   extensionPointId = "OpenMapping" )
 public class OpenMappingExtension implements ExtensionPointInterface {
 
-  private static Class<?> PKG = Spoon.class;
+  //spoon class without import of swt libraries, big-data pmr run doesn't have ui library and shouldn't
+  private static Class<?> PKG = SpoonLifecycleListener.class;
 
   @Override public void callExtensionPoint( LogChannelInterface log, Object object ) throws KettleException {
     StepMeta stepMeta = (StepMeta) ( (Object[]) object )[ 0 ];

--- a/plugins/meta-inject-plugin/src/test/java/org/pentaho/di/trans/steps/metainject/OpenMappingExtensionTest.java
+++ b/plugins/meta-inject-plugin/src/test/java/org/pentaho/di/trans/steps/metainject/OpenMappingExtensionTest.java
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.pentaho.di.trans.steps.metainject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
+import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.ui.spoon.SpoonLifecycleListener;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by Vasilina_Terehova on 3/31/2017.
+ */
+public class OpenMappingExtensionTest {
+
+  public static final String TRANS_META_NAME = "Test name";
+  private static LogChannelInterface logChannelInterface;
+  private TransMeta transMeta;
+  private StepMeta stepMeta;
+  private Object[] metaData;
+
+  @Before
+  public void setup() {
+    setKettleLogFactoryWithMock();
+    transMeta = spy( new TransMeta() );
+    stepMeta = mock( StepMeta.class );
+    metaData = new Object[] { stepMeta, transMeta };
+  }
+
+  @Test
+  public void testLocalizedMessage() throws KettleException {
+    OpenMappingExtension openMappingExtension = new OpenMappingExtension();
+    Class PKG = SpoonLifecycleListener.class;
+    String afterInjectionMessageAdded = BaseMessages.getString( PKG, "TransGraph.AfterInjection" );
+    transMeta.setName( TRANS_META_NAME );
+    doReturn( mock( MetaInjectMeta.class ) ).when( stepMeta ).getStepMetaInterface();
+    openMappingExtension.callExtensionPoint( logChannelInterface, metaData );
+    assert ( transMeta.getName().contains( afterInjectionMessageAdded ) );
+  }
+
+  private void setKettleLogFactoryWithMock() {
+    LogChannelInterfaceFactory logChannelInterfaceFactory = mock( LogChannelInterfaceFactory.class );
+    logChannelInterface = mock( LogChannelInterface.class );
+    when( logChannelInterfaceFactory.create( any() ) ).thenReturn( logChannelInterface );
+    KettleLogStore.setLogChannelInterfaceFactory( logChannelInterfaceFactory );
+  }
+}


### PR DESCRIPTION
pmr job log full of exceptions when some common step classes contains import to swt libraries 
localized needed for OpenMappingExtension is from spoon package, 
so to fix that situation and have correct localized message PKG is now SpoonLifecycleListener which doesn't have import for swt