### PR TITLE
[PDI-15931] - Error "ERROR [org.pentaho.di.repository.pur.UserRoleDel…

### DIFF
--- a/plugins/pdi-pur-plugin/ivy.xml
+++ b/plugins/pdi-pur-plugin/ivy.xml
@@ -28,7 +28,7 @@
     <dependency org="pentaho" name="pentaho-platform-api" rev="${dependency.bi-platform.revision}"
       changing="true" transitive="false" conf="compile->default"/>
     <dependency org="pentaho" name="pentaho-platform-repository" rev="${dependency.bi-platform.revision}"
-      changing="true" transitive="false" />
+      changing="true" transitive="false" conf="compile->default"/>
     <dependency org="org.yaml" name="snakeyaml" rev="1.7" conf="default->default" transitive="false"/>
     <dependency org="pentaho" name="pentaho-platform-extensions" rev="${dependency.bi-platform.revision}"
       changing="true" transitive="false" conf="compile->default"/>


### PR DESCRIPTION
…egate] Unable to initialize UserRole web service" appears after logging into the kettle status page when the slave-server-config.xml has a repository defined with an admin user

@pamval, @mbatchelor, could you please take a look? This PR should be merged not earlier then:  
https://github.com/pentaho/pentaho-platform/pull/3499