### PR TITLE
[PDI-15721] When exporting/importing jobs as xml, variables used for …

### DIFF
--- a/core/src/org/pentaho/di/core/Const.java
+++ b/core/src/org/pentaho/di/core/Const.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1049,6 +1049,12 @@ public class Const {
    * Variable that is responsible for removing enclosure symbol after splitting the string
    */
   public static final String KETTLE_SPLIT_FIELDS_REMOVE_ENCLOSURE = "KETTLE_SPLIT_FIELDS_REMOVE_ENCLOSURE";
+
+  /**
+   * Set this variable to false to preserve global log variables defined in transformation / job Properties -> Log panel.
+   * Changing it to true will clear all global log variables when export transformation / job
+   */
+  public static final String KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT = "KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT";
 
   /**
    * Compatibility settings for {@link org.pentaho.di.core.row.ValueDataUtil#hourOfDay(ValueMetaInterface, Object)}.

--- a/engine/src/kettle-variables.xml
+++ b/engine/src/kettle-variables.xml
@@ -444,5 +444,11 @@
     <default-value>false</default-value>
   </kettle-variable>
 
+  <kettle-variable>
+    <description>Set this variable to false to preserve global log variables defined in transformation / job Properties -> Log panel. Changing it to true will clear it when export transformation / job.</description>
+    <variable>KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT</variable>
+    <default-value>false</default-value>
+  </kettle-variable>
+
 </kettle-variables>
 

--- a/engine/src/org/pentaho/di/core/logging/BaseLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/BaseLogTable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -530,10 +530,13 @@ public abstract class BaseLogTable {
   }
 
   public void setAllGlobalParametersToNull() {
-    schemaName = isGlobalParameter( schemaName ) ? null : schemaName;
-    connectionName = isGlobalParameter( connectionName ) ? null : connectionName;
-    tableName = isGlobalParameter( tableName ) ? null : tableName;
-    timeoutInDays = isGlobalParameter( timeoutInDays ) ? null : timeoutInDays;
+    boolean clearGlobalVariables = Boolean.valueOf( System.getProperties().getProperty( Const.KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT, "false" ) );
+    if ( clearGlobalVariables ) {
+      schemaName = isGlobalParameter( schemaName ) ? null : schemaName;
+      connectionName = isGlobalParameter( connectionName ) ? null : connectionName;
+      tableName = isGlobalParameter( tableName ) ? null : tableName;
+      timeoutInDays = isGlobalParameter( timeoutInDays ) ? null : timeoutInDays;
+    }
   }
 
   protected boolean isGlobalParameter( String parameter ) {

--- a/engine/src/org/pentaho/di/core/logging/JobLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/JobLogTable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -450,9 +450,12 @@ public class JobLogTable extends BaseLogTable implements Cloneable, LogTableInte
 
   @Override
   public void setAllGlobalParametersToNull() {
-    super.setAllGlobalParametersToNull();
+    boolean clearGlobalVariables = Boolean.valueOf( System.getProperties().getProperty( Const.KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT, "false" ) );
+    if ( clearGlobalVariables ) {
+      super.setAllGlobalParametersToNull();
 
-    logInterval = isGlobalParameter( logInterval ) ? null : logInterval;
-    logSizeLimit = isGlobalParameter( logSizeLimit ) ? null : logSizeLimit;
+      logInterval = isGlobalParameter( logInterval ) ? null : logInterval;
+      logSizeLimit = isGlobalParameter( logSizeLimit ) ? null : logSizeLimit;
+    }
   }
 }

--- a/engine/src/org/pentaho/di/core/logging/PerformanceLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/PerformanceLogTable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -297,8 +297,11 @@ public class PerformanceLogTable extends BaseLogTable implements Cloneable, LogT
 
   @Override
   public void setAllGlobalParametersToNull()  {
-    super.setAllGlobalParametersToNull();
+    boolean clearGlobalVariables = Boolean.valueOf( System.getProperties().getProperty( Const.KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT, "false" ) );
+    if ( clearGlobalVariables ) {
+      super.setAllGlobalParametersToNull();
 
-    logInterval = isGlobalParameter( logInterval ) ? null : logInterval;
+      logInterval = isGlobalParameter( logInterval ) ? null : logInterval;
+    }
   }
 }

--- a/engine/src/org/pentaho/di/core/logging/TransLogTable.java
+++ b/engine/src/org/pentaho/di/core/logging/TransLogTable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -512,9 +512,12 @@ public class TransLogTable extends BaseLogTable implements Cloneable, LogTableIn
 
   @Override
   public void setAllGlobalParametersToNull()  {
-    super.setAllGlobalParametersToNull();
+    boolean clearGlobalVariables = Boolean.valueOf( System.getProperties().getProperty( Const.KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT, "false" ) );
+    if ( clearGlobalVariables ) {
+      super.setAllGlobalParametersToNull();
 
-    logInterval = isGlobalParameter( logInterval ) ? null : logInterval;
-    logSizeLimit = isGlobalParameter( logSizeLimit ) ? null : logSizeLimit;
+      logInterval = isGlobalParameter( logInterval ) ? null : logInterval;
+      logSizeLimit = isGlobalParameter( logSizeLimit ) ? null : logSizeLimit;
+    }
   }
 }

--- a/engine/test-src/org/pentaho/di/core/logging/LogTableTest.java
+++ b/engine/test-src/org/pentaho/di/core/logging/LogTableTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+* Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ public class LogTableTest {
   @Before
   public void init() {
     System.setProperty( Const.KETTLE_STEP_LOG_DB, "KETTLE_STEP_LOG_DB_VALUE" );
+    System.setProperty( Const.KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT, "true" );
     mockedVariableSpace = mock( VariableSpace.class );
     mockedHasDbInterface = mock( HasDatabasesInterface.class );
   }
@@ -56,7 +57,11 @@ public class LogTableTest {
     tableFieldsChangedCorrectlyAfterNullingGlobalParams( GLOBAL_PARAM, null );
   }
 
-
+  @Test
+  public void globalParamsFieldsAreNotNulled() {
+    System.setProperty( Const.KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT, "false" );
+    tableFieldsChangedCorrectlyAfterNullingGlobalParams( GLOBAL_PARAM, GLOBAL_PARAM );
+  }
 
   public void tableFieldsChangedCorrectlyAfterNullingGlobalParams( String valueForAllFields,
                                                                    String expectedAfterNullingGlobalParams ) {

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryUnitTest.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/PurRepositoryUnitTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,20 +268,57 @@ public class PurRepositoryUnitTest extends RepositoryTestLazySupport {
 
   @Test
   public void onlyGlobalVariablesOfLogTablesSetToNull() {
+    try {
+      System.setProperty( Const.KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT, "true" );
+
+      PurRepositoryExporter purRepoExporter = new PurRepositoryExporter( mock( PurRepository.class ) );
+      String hardcodedString = "hardcoded";
+      String globalParam = "${" + Const.KETTLE_TRANS_LOG_TABLE + "}";
+
+      StepLogTable stepLogTable = StepLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+      stepLogTable.setConnectionName( hardcodedString );
+      stepLogTable.setSchemaName( hardcodedString );
+      stepLogTable.setTimeoutInDays( hardcodedString );
+      stepLogTable.setTableName( globalParam );
+
+      JobEntryLogTable jobEntryLogTable = JobEntryLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
+      jobEntryLogTable.setConnectionName( hardcodedString );
+      jobEntryLogTable.setSchemaName( hardcodedString );
+      jobEntryLogTable.setTimeoutInDays( hardcodedString );
+      jobEntryLogTable.setTableName( globalParam );
+
+      List<LogTableInterface> logTables = new ArrayList<>();
+      logTables.add( jobEntryLogTable );
+      logTables.add( stepLogTable );
+
+      purRepoExporter.setGlobalVariablesOfLogTablesNull( logTables );
+
+      for ( LogTableInterface logTable : logTables ) {
+        assertEquals( logTable.getConnectionName(), hardcodedString );
+        assertEquals( logTable.getSchemaName(), hardcodedString );
+        assertEquals( logTable.getTimeoutInDays(), hardcodedString );
+        assertEquals( logTable.getTableName(), null );
+      }
+    } finally {
+      System.setProperty( Const.KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT, "false" );
+    }
+  }
+
+  @Test
+  public void globalVariablesOfLogTablesNotSetToNull() {
     PurRepositoryExporter purRepoExporter = new PurRepositoryExporter( mock( PurRepository.class ) );
-    String hardcodedString = "hardcoded";
     String globalParam = "${" + Const.KETTLE_TRANS_LOG_TABLE + "}";
 
     StepLogTable stepLogTable = StepLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
-    stepLogTable.setConnectionName( hardcodedString );
-    stepLogTable.setSchemaName( hardcodedString );
-    stepLogTable.setTimeoutInDays( hardcodedString );
+    stepLogTable.setConnectionName( globalParam );
+    stepLogTable.setSchemaName( globalParam );
+    stepLogTable.setTimeoutInDays( globalParam );
     stepLogTable.setTableName( globalParam );
 
     JobEntryLogTable jobEntryLogTable = JobEntryLogTable.getDefault( mockedVariableSpace, mockedHasDbInterface );
-    jobEntryLogTable.setConnectionName( hardcodedString );
-    jobEntryLogTable.setSchemaName( hardcodedString );
-    jobEntryLogTable.setTimeoutInDays( hardcodedString );
+    jobEntryLogTable.setConnectionName( globalParam );
+    jobEntryLogTable.setSchemaName( globalParam );
+    jobEntryLogTable.setTimeoutInDays( globalParam );
     jobEntryLogTable.setTableName( globalParam );
 
     List<LogTableInterface> logTables = new ArrayList<>();
@@ -291,10 +328,10 @@ public class PurRepositoryUnitTest extends RepositoryTestLazySupport {
     purRepoExporter.setGlobalVariablesOfLogTablesNull( logTables );
 
     for ( LogTableInterface logTable : logTables ) {
-      assertEquals( logTable.getConnectionName(), hardcodedString );
-      assertEquals( logTable.getSchemaName(), hardcodedString );
-      assertEquals( logTable.getTimeoutInDays(), hardcodedString );
-      assertEquals( logTable.getTableName(), null );
+      assertEquals( logTable.getConnectionName(), globalParam );
+      assertEquals( logTable.getSchemaName(), globalParam );
+      assertEquals( logTable.getTimeoutInDays(), globalParam );
+      assertEquals( logTable.getTableName(), globalParam );
     }
   }
 


### PR DESCRIPTION
[PDI-15721] When exporting/importing jobs as xml, variables used forthe LOG Table and LOG Schema are not copied over

- add property to control log global params clear