### PR TITLE
[PDI-14598] When creating roles with the existing names but with lowercase letters the roles are added but they cannot be removed

### DIFF
--- a/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/UserRoleDelegate.java
+++ b/plugins/pdi-pur-plugin/src/org/pentaho/di/repository/pur/UserRoleDelegate.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -307,7 +307,7 @@ public class UserRoleDelegate implements java.io.Serializable {
     if ( existing != null ) {
       String name = role.getName();
       for ( ProxyPentahoRole pentahoRole : existing ) {
-        if ( name.equals( pentahoRole.getName() ) ) {
+        if ( name.equalsIgnoreCase( pentahoRole.getName() ) ) {
           return true;
         }
       }

--- a/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/UserRoleDelegateTest.java
+++ b/plugins/pdi-pur-plugin/test/org/pentaho/di/repository/pur/UserRoleDelegateTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import org.pentaho.platform.security.userroledao.ws.ProxyPentahoRole;
 import org.pentaho.platform.security.userroledao.ws.ProxyPentahoUser;
 import org.pentaho.platform.security.userroledao.ws.UserRoleSecurityInfo;
 
-import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -119,7 +118,7 @@ public class UserRoleDelegateTest {
     verify( roleWebService ).createRole( any( ProxyPentahoRole.class ) );
   }
 
-  @Test
+  @Test( expected = KettleException.class )
   public void createRole_CreatesSuccessfully_WhenNameDiffersInCase() throws Exception {
     final String name = "role";
     final String upperCased = name.toUpperCase();


### PR DESCRIPTION
- fixed role creation - now users cannot create roles with the same name but with different case.