### PR TITLE
[SP-3431][PDI-13987] “Text file output” step writes field to the file with different encoding (binary data with different encoding, lazy conversion)

### DIFF
--- a/engine/src/org/pentaho/di/trans/step/BaseStep.java
+++ b/engine/src/org/pentaho/di/trans/step/BaseStep.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1867,8 +1867,8 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
     }
 
     // Also set the meta data on the first occurrence.
-    //
-    if ( inputRowMeta == null ) {
+    // or if prevSteps.length > 1 inputRowMeta can be changed
+    if ( inputRowMeta == null || prevSteps.length > 1 ) {
       inputRowMeta = inputRowSet.getRowMeta();
     }
 

--- a/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -95,10 +95,11 @@ public class TextFileOutput extends BaseStep implements StepInterface {
     boolean bEndedLineWrote = false;
     boolean fileExist;
     Object[] r = getRow(); // This also waits for a row to be finished.
-
+    if ( r != null ) {
+      data.outputRowMeta = getInputRowMeta().clone();
+    }
     if ( r != null && first ) {
       first = false;
-      data.outputRowMeta = getInputRowMeta().clone();
       meta.getFields( data.outputRowMeta, getStepname(), null, null, this, repository, metaStore );
 
       // if file name in field is enabled then set field name and open file
@@ -347,11 +348,11 @@ public class TextFileOutput extends BaseStep implements StepInterface {
       }
     } else {
       byte[] text;
-      if ( Const.isEmpty( v.getStringEncoding() ) ) {
+      if ( Const.isEmpty( meta.getEncoding() ) ) {
         text = string.getBytes();
       } else {
         try {
-          text = string.getBytes( v.getStringEncoding() );
+          text = string.getBytes( meta.getEncoding() );
         } catch ( UnsupportedEncodingException e ) {
           throw new KettleValueException( "Unable to convert String to Binary with specified string encoding ["
               + v.getStringEncoding() + "]", e );


### PR DESCRIPTION
- update output Row and input Row meta for 2 and more sources
- fixed writing encode for "fast data dump" off