### PR TITLE
[BACKLOG-16179] Fix String to Numeric conversion behaviour that was…

### DIFF
--- a/assembly/package-res/samples/transformations/JavaScript - String to Number to String conversion.ktr
+++ b/assembly/package-res/samples/transformations/JavaScript - String to Number to String conversion.ktr
@@ -471,10 +471,10 @@
         <type>Number</type>
         <format/>
         <currency/>
-        <decimal/>
+        <decimal>,</decimal>
         <group/>
         <nullif>2345,67</nullif>
-        <length>7</length>
+        <length>6</length>
         <precision>2</precision>
         <set_empty_string>N</set_empty_string>
       </field>

--- a/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -996,7 +996,7 @@ public class ValueMetaBase implements ValueMetaInterface {
     }
 
     try {
-      DecimalFormat format = getDecimalFormat( false, TYPE_NUMBER );
+      DecimalFormat format = getDecimalFormat( false );
       Number number;
       if ( lenientStringToNumber ) {
         number = format.parse( string );
@@ -1073,10 +1073,6 @@ public class ValueMetaBase implements ValueMetaInterface {
 
   @Override
   public synchronized DecimalFormat getDecimalFormat( boolean useBigDecimal ) {
-    return getDecimalFormat( useBigDecimal, getType() );
-  }
-
-  private synchronized DecimalFormat getDecimalFormat( boolean useBigDecimal, int valueMetaType ) {
     // If we have an Integer that is represented as a String
     // In that case we can set the format of the original Integer on the String
     // value metadata in the form of a conversion metadata object.
@@ -1108,7 +1104,7 @@ public class ValueMetaBase implements ValueMetaInterface {
       }
       decimalFormat.setDecimalFormatSymbols( decimalFormatSymbols );
 
-      String decimalPattern = getMask( valueMetaType );
+      String decimalPattern = getMask( getType() );
       if ( !Utils.isEmpty( decimalPattern ) ) {
         decimalFormat.applyPattern( decimalPattern );
       }
@@ -1310,7 +1306,7 @@ public class ValueMetaBase implements ValueMetaInterface {
     try {
       Number number;
       if ( lenientStringToNumber ) {
-        number = new Long( getDecimalFormat( false, TYPE_INTEGER ).parse( string ).longValue() );
+        number = new Long( getDecimalFormat( false ).parse( string ).longValue() );
       } else {
         ParsePosition parsePosition = new ParsePosition( 0 );
         number = getDecimalFormat( false ).parse( string, parsePosition );
@@ -1350,7 +1346,7 @@ public class ValueMetaBase implements ValueMetaInterface {
     }
 
     try {
-      DecimalFormat format = getDecimalFormat( bigNumberFormatting, TYPE_BIGNUMBER );
+      DecimalFormat format = getDecimalFormat( bigNumberFormatting );
       Number number;
       if ( lenientStringToNumber ) {
         number = format.parse( string );


### PR DESCRIPTION
…causing it to throw a KettleException

@pentaho/millenniumfalcon please review

Converting from string to a numeric must rely on the Value metadata and not on the default mask of the numeric type we are converting to.

Also did a small tweak in the sample so that it gives the exact result after the conversion (fix works without this)