### PR TITLE
[BACKLOG-13069] Fixes to the version.properties in gp-bulkloader-plugin

### DIFF
--- a/plugins/gp-bulk-loader/gp-bulk-loader-core/pom.xml
+++ b/plugins/gp-bulk-loader/gp-bulk-loader-core/pom.xml
@@ -18,7 +18,7 @@
     <build.revision>${project.version}</build.revision>
     <timestamp>${maven.build.timestamp}</timestamp>
     <build.description>${project.description}</build.description>
-    <maven.build.timestamp.format>yyyy/MM/dd hh:mm</maven.build.timestamp.format>
+    <maven.build.timestamp.format>yyyy/MM/dd hh\:mm</maven.build.timestamp.format>
   </properties>
   <dependencies>
     <dependency>

--- a/plugins/gp-bulk-loader/gp-bulk-loader-core/src/main/resources/version.properties
+++ b/plugins/gp-bulk-loader/gp-bulk-loader-core/src/main/resources/version.properties
@@ -1,4 +1,4 @@
-${build.description} build information
+#${build.description} build information
 
 version=${build.revision}
 builddate=${timestamp}


### PR DESCRIPTION
@pminutillo Now the version.properties content is produced like this:

#GP Bulk Loader Plugin build information

version=8.0-SNAPSHOT
builddate=2017/05/01 07\:21