### PR TITLE
[SP-3448][PDI-16045]-Rest Client step does not encode parameter list properly

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/rest/Rest.java
+++ b/engine/src/org/pentaho/di/trans/steps/rest/Rest.java
@@ -133,7 +133,7 @@ public class Rest extends BaseStep implements StepInterface {
           if ( isDebug() ) {
             logDebug( BaseMessages.getString( PKG, "Rest.Log.matrixParameterValue", data.matrixParamNames[i], value ) );
           }
-          builder = builder.matrixParam( data.matrixParamNames[i], value );
+          builder = builder.matrixParam( data.matrixParamNames[i], UriComponent.encode( value, UriComponent.Type.QUERY_PARAM ) );
         }
         webResource = client.resource( builder.build() );
       }


### PR DESCRIPTION
 - fix for case when parameters are defined in the "Matrix Parameters" tab