### PR TITLE
[PPP-3742]-Use of vulnerable component gwt-servlet-2.0.3.jar CVE-2012-4563

### DIFF
--- a/plugins/pdi-pur-plugin/ivy.xml
+++ b/plugins/pdi-pur-plugin/ivy.xml
@@ -72,7 +72,7 @@
     <dependency org="commons-httpclient" name="commons-httpclient" rev="3.0.1" conf="test->default" />
     <dependency org="ognl" name="ognl" rev="2.6.9" conf="test->default" />
 
-    <dependency org="com.google.gwt" name="gwt-servlet"  rev="2.0.3"/>
+    <dependency org="com.google.gwt" name="gwt-servlet"  rev="2.5.1"/>
 
       <!--Spring Framework--> 
     <dependency org="org.springframework" name="spring-test" rev="${dependency.spring.framework.revision}" conf="test->default" />


### PR DESCRIPTION
 - upgraded to 2.5.1