### PR TITLE
[COMP-5831] Exclude drools-reteoo

### DIFF
--- a/plugins/kettle-drools5-plugin/kettle-drools5-core/pom.xml
+++ b/plugins/kettle-drools5-plugin/kettle-drools5-core/pom.xml
@@ -68,6 +68,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.drools</groupId>
+          <artifactId>drools-reteoo</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Exclude drools-reteoo. This is a legacy engine which is not used by default. There is no need for us to include it.