### PR TITLE
[SP-3559][PDI-16196]-Saving a transformation with a duplicate name makes PDI work inconsistently

### DIFF
--- a/ui/src/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegate.java
+++ b/ui/src/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegate.java
@@ -101,9 +101,9 @@ public class SpoonTransformationDelegate extends SpoonDelegate {
    * @return true if the transformation was added, false if it couldn't be added (already loaded)
    **/
   public boolean addTransformation( TransMeta transMeta ) {
-    int index = transformationMap.indexOf( transMeta );
+    int index = getTransformationList().indexOf( transMeta );
     if ( index < 0 ) {
-      transformationMap.add( transMeta );
+      getTransformationList().add( transMeta );
       return true;
     } else {
       /*
@@ -123,22 +123,27 @@ public class SpoonTransformationDelegate extends SpoonDelegate {
   public synchronized void closeTransformation( TransMeta transMeta ) {
     // Close the associated tabs...
     //
-    TabMapEntry entry = spoon.delegates.tabs.findTabMapEntry( transMeta );
+    TabMapEntry entry = getSpoon().delegates.tabs.findTabMapEntry( transMeta );
     if ( entry != null ) {
-      spoon.delegates.tabs.removeTab( entry );
+      getSpoon().delegates.tabs.removeTab( entry );
     }
 
     // Also remove it from the item from the transformationMap
     // Otherwise it keeps showing up in the objects tree
     // Look for the transformation, not the key (name might have changed)
     //
-    int index = transformationMap.indexOf( transMeta );
-    if ( index >= 0 ) {
-      transformationMap.remove( index );
+    int index = getTransformationList().indexOf( transMeta );
+    while ( index >= 0 ) {
+      getTransformationList().remove( index );
+      index = getTransformationList().indexOf( transMeta );
     }
 
-    spoon.refreshTree();
-    spoon.enableMenus();
+    getSpoon().refreshTree();
+    getSpoon().enableMenus();
+  }
+
+  public Spoon getSpoon() {
+    return this.spoon;
   }
 
   public void addTransGraph( TransMeta transMeta ) {

--- a/ui/src/org/pentaho/xul/swt/tab/TabSet.java
+++ b/ui/src/org/pentaho/xul/swt/tab/TabSet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -85,9 +85,11 @@ public class TabSet implements SelectionListener, CTabFolder2Listener {
 
 
   public void widgetSelected( SelectionEvent event ) {
-    TabItem deSelectedTabItem = tabList.get( selectedIndex );
-    if ( deSelectedTabItem != null ) {
-      notifyDeselectListeners( deSelectedTabItem );
+    if ( selectedIndex >= 0 && selectedIndex < tabList.size() ) {
+      TabItem deSelectedTabItem = tabList.get( selectedIndex );
+      if ( deSelectedTabItem != null ) {
+        notifyDeselectListeners( deSelectedTabItem );
+      }
     }
     for ( int i = 0; i < tabList.size(); i++ ) {
       TabItem item = tabList.get( i );

--- a/ui/test-src/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegateTest.java
+++ b/ui/test-src/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegateTest.java
@@ -33,16 +33,34 @@ import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.logging.TransLogTable;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.ui.spoon.Spoon;
+
+import java.util.ArrayList;
+import java.util.List;
+
 
 public class SpoonTransformationDelegateTest {
 
   private SpoonTransformationDelegate delegate;
+  private Spoon spoon;
 
   private TransLogTable transLogTable;
+  private TransMeta transMeta;
+  private List<TransMeta> transformationMap;
 
   @Before
   public void before() {
+    transformationMap = new ArrayList<TransMeta>();
+
+    transMeta = mock( TransMeta.class );
     delegate = mock( SpoonTransformationDelegate.class );
+    spoon = mock( Spoon.class );
+    spoon.delegates = mock( SpoonDelegates.class );
+    spoon.delegates.tabs = mock( SpoonTabsDelegate.class );
+
+    doReturn( transformationMap ).when( delegate ).getTransformationList();
+    doReturn( spoon ).when( delegate ).getSpoon();
     doCallRealMethod().when( delegate ).isLogTableDefined( any() );
     transLogTable = mock( TransLogTable.class );
   }
@@ -64,4 +82,13 @@ public class SpoonTransformationDelegateTest {
     assertFalse( delegate.isLogTableDefined( transLogTable ) );
   }
 
+  @Test
+  public void testAddAndCloseTransformation() {
+    doCallRealMethod().when( delegate ).closeTransformation( any() );
+    doCallRealMethod().when( delegate ).addTransformation( any() );
+    assertTrue( delegate.addTransformation( transMeta ) );
+    assertFalse( delegate.addTransformation( transMeta ) );
+    delegate.closeTransformation( transMeta );
+    assertTrue( delegate.addTransformation( transMeta ) );
+  }
 }

--- a/ui/test-src/org/pentaho/xul/swt/tab/TabSetTest.java
+++ b/ui/test-src/org/pentaho/xul/swt/tab/TabSetTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -85,6 +85,38 @@ public class TabSetTest {
 
     firstItem.dispose();
     assertEquals( "should select second", secondItem, tabSet.getSelected() );
+  }
+
+  /**
+   * PDI-16196 index out of bounds after closing tabs with the same name
+   */
+  @Test
+  public void testDuplicateNameCloseTab() {
+    final CTabFolder cTabFolder = mock( CTabFolder.class );
+    final TabSet tabSet = createTabSet( cTabFolder );
+
+    final CTabItem cTabItem1 = mock( CTabItem.class );
+    TabItem firstItem = createItem( tabSet, "equalName", "equals", cTabItem1 );
+    final CTabItem cTabItem2 = mock( CTabItem.class );
+    TabItem secondItem = createItem( tabSet, "equalName", "equals", cTabItem2 );
+    final CTabItem cTabItem3 = mock( CTabItem.class );
+    TabItem thirdItem = createItem( tabSet, "different", "different", cTabItem3 );
+
+    assertEquals( 0, tabSet.indexOf( firstItem ) );
+    assertEquals( 1, tabSet.indexOf( secondItem ) );
+
+    wireDisposalSelection( cTabFolder, tabSet, cTabItem1, cTabItem3 );
+    wireDisposalSelection( cTabFolder, tabSet, cTabItem2, cTabItem3 );
+    firstItem.dispose();
+    secondItem.dispose();
+
+    tabSet.setSelected( firstItem );
+    assertEquals( -1, tabSet.getSelectedIndex() );
+
+    Event evt = new Event();
+    evt.item = cTabItem1;
+    evt.widget = cTabFolder;
+    tabSet.widgetSelected( new SelectionEvent( evt ) );
   }
 
   @Test


### PR DESCRIPTION
 - Fix inconsistencies when closing tabs with the same name
 - Improve cobertura tests coverage