### PR TITLE
[SP-3564][PDI-7090] - Only one user can make changes in a repository at any time. (Database Repository is locked)

### DIFF
--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConnectionDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConnectionDelegate.java
@@ -1831,6 +1831,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       if ( resultSet != null ) {
         database.closeQuery( resultSet );
       }
+      closeReadTransaction();
     }
   }
 


### PR DESCRIPTION
[SP-3564][PDI-7090] - Only one user can make changes in a repository at any time. (Database Repository is locked)

Fixed an additional problem. When user editing or create slave server via toolbar it locks database.
This commit uses approach from base commit https://github.com/pentaho/pentaho-kettle/pull/3857/commits/befadee3293dd4f8f3c5999dd1e345f56b4cdabd

@mbatchelor @mchen-len-son Could you please review and merge it?