### PR TITLE
[SP-3565] Backport of PDI-7090 - Only one user can make changes in a repository at any time. (Database Repository is locked) (6.1 Suite).

### DIFF
--- a/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConnectionDelegate.java
+++ b/engine/src/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConnectionDelegate.java
@@ -1827,6 +1827,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       if ( resultSet != null ) {
         database.closeQuery( resultSet );
       }
+      closeReadTransaction();
     }
   }
 


### PR DESCRIPTION
[SP-3565] Backport of PDI-7090 - Only one user can make changes in a repository at any time. (Database Repository is locked) (6.1 Suite).

Fixed an additional problem in 6.1. When user editing or create carte server it locks database (see steps in comments [SP-3565]).
This commit uses approach from base commit https://github.com/pentaho/pentaho-kettle/pull/3857/commits/befadee3293dd4f8f3c5999dd1e345f56b4cdabd
@mchen-len-son Could you please review and merge it?