### PR TITLE
[PDI-16378] Add cause to exception thrown in KettleVFS#getFileObject

### DIFF
--- a/core/src/org/pentaho/di/core/vfs/KettleVFS.java
+++ b/core/src/org/pentaho/di/core/vfs/KettleVFS.java
@@ -161,7 +161,7 @@ public class KettleVFS {
       return fileObject;
     } catch ( IOException e ) {
       throw new KettleFileException( "Unable to get VFS File object for filename '"
-        + cleanseFilename( vfsFilename ) + "' : " + e.getMessage() );
+        + cleanseFilename( vfsFilename ) + "' : " + e.getMessage(), e );
     }
   }
 


### PR DESCRIPTION
Proposed change for [PDI-16378](http://jira.pentaho.com/browse/PDI-16378)