### PR TITLE
[PDI-16318] REST Client Step: Http Method DELETE results in 401 where GET, PUT succeed. Postman works fine with OK/200

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
@@ -169,10 +169,10 @@ public class Rest extends BaseStep implements StepInterface {
       }
 
       ClientResponse response = null;
-      String entityString = "";
+      String entityString = null;
       if ( data.useBody ) {
         // Set Http request entity
-        entityString = Const.NVL( data.inputRowMeta.getString( rowData, data.indexOfBodyField ), "" );
+        entityString = Const.NVL( data.inputRowMeta.getString( rowData, data.indexOfBodyField ), null );
         if ( isDebug() ) {
           logDebug( BaseMessages.getString( PKG, "Rest.Log.BodyValue", entityString ) );
         }


### PR DESCRIPTION
- if the entity is an empty string, the DefaultApacheHttpMethodExecutor will not set headers due to the null com.sun.jersey.client.property.chunkedEncodingSize property.