### PR TITLE
[BACKLOG-15721] fix sorting icon per UX

### DIFF
--- a/plugins/file-open-save/core/src/main/javascript/app/components/files/files.css
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/files/files.css
@@ -226,7 +226,7 @@ files .sortWrapper {
 }
 
 files .sortWrapper .sort {
-  background: url("../../images/sort_none.svg") right center/10px 10px no-repeat;
+  background: url("../../images/sort_none.svg") center no-repeat;
   height: 17px;
   width: 10px;
   visibility: hidden;


### PR DESCRIPTION
Fix for #61 from https://docs.google.com/spreadsheets/d/17QboBxK0V064iFzd3GXdpYGZ5I2bg-yWP5OOCYyC9u0/edit#gid=1166424294

61: In the list view, sort icon looks incorrect in all operating systems. The icon doesn't look like what was provided by ux.Image is 7px x 11px *(see ux mockups)*

@bmorrise 