### PR TITLE
[BACKLOG-15721] Fix for truncated breadcrumb extra item color per UX

### DIFF
--- a/plugins/file-open-save/core/src/main/javascript/app/components/breadcrumb/breadcrumb.css
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/breadcrumb/breadcrumb.css
@@ -61,6 +61,7 @@ breadcrumb .breadcrumbFolder.extra .breadcrumbExtraItem {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  color: #333;
 }
 
 breadcrumb .breadcrumbFolder.extra .breadcrumbExtraItem:hover {


### PR DESCRIPTION
Fix for #69 from https://docs.google.com/spreadsheets/d/17QboBxK0V064iFzd3GXdpYGZ5I2bg-yWP5OOCYyC9u0/edit#gid=1166424294

69: The breadcrumb truncated menu text color should be #333333

@bmorrise 