### PR TITLE
[BACKLOG-15721] Right container stroker missing on adding/renaming ne…

### DIFF
--- a/plugins/file-open-save/core/src/main/javascript/app/components/files/files.css
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/files/files.css
@@ -140,7 +140,7 @@ files tbody td div {
 
 files tbody td input {
   font-size: 14px;
-  width: 100%;
+  width: 98%;
 }
 
 files tr .fileName {


### PR DESCRIPTION
…w folder

Fix for #81 from https://docs.google.com/spreadsheets/d/17QboBxK0V064iFzd3GXdpYGZ5I2bg-yWP5OOCYyC9u0/edit#gid=1166424294

81: when adding or renaming a folder, the right container stroke is missing

@bmorrise 