### PR TITLE
[BACKLOG-15718] Fixes for the following:

### DIFF
--- a/plugins/file-open-save/core/src/main/javascript/app/app.css
+++ b/plugins/file-open-save/core/src/main/javascript/app/app.css
@@ -224,6 +224,7 @@ file-open-save-app .fileArea {
 file-open-save-app .fileArea.overflow {
   overflow-y: auto;
   overflow-x: hidden;
+  padding-right: 20px;
 }
 
 file-open-save-app .bottom {

--- a/plugins/file-open-save/core/src/main/javascript/app/app.html
+++ b/plugins/file-open-save/core/src/main/javascript/app/app.html
@@ -80,7 +80,7 @@
     </div>
     <div class="buttons">
       <button class="secondary" ng-click="vm.cancel()">{{::vm.cancelButton}}</button>
-      <button class="primary" ng-show="vm.wrapperClass === 'open'" ng-click="vm.openClicked()">{{::vm.openButton}}</button>
+      <button class="primary" ng-show="vm.wrapperClass === 'open'" ng-click="vm.openClicked()" ng-disabled="!vm.file">{{::vm.openButton}}</button>
       <button class="primary" ng-show="vm.wrapperClass === 'save'" ng-click="vm.saveClicked()" ng-disabled="vm.fileToSave === ''">{{::vm.saveButton}}</button>
     </div>
   </div>

--- a/plugins/file-open-save/core/src/main/javascript/app/components/card/card.css
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/card/card.css
@@ -22,7 +22,7 @@
 
 /* CARDS */
 card .card {
-  background-color: #FFF;
+  background-color: #FDFDFD;
   border: 1px solid #E4E4E4;
   border-radius: 4px;
   -moz-border-radius: 4px;
@@ -97,6 +97,7 @@ card .cardTitle {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  line-height: 14px;
 }
 
 card .cardDate {

--- a/plugins/file-open-save/core/src/main/javascript/app/components/card/card.html
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/card/card.html
@@ -1,3 +1,4 @@
+<div class="cardAreaMessageView" ng-show="!vm.hasResults()">{{::vm.noResult}}</div>
 <!--
   Classes for main div
      1. cardTrans:  Transformation
@@ -21,4 +22,3 @@
     <div class="cardTypeIcon"></div>
   </div>
 </div>
-<div class="cardAreaMessageView" ng-show="!vm.hasResults()">{{::vm.noResult}}</div>

--- a/plugins/file-open-save/core/src/main/resources/i18n/file-open-save/messages_en.properties
+++ b/plugins/file-open-save/core/src/main/resources/i18n/file-open-save/messages_en.properties
@@ -8,7 +8,7 @@ file-open-save-plugin.app.open.button=Open
 file-open-save-plugin.app.save.button=Save
 file-open-save-plugin.app.cancel.button=Cancel
 file-open-save-plugin.app.save.file-name.label=File name
-file-open-save-plugin.app.middle.no-recents.message=You haven't opened anything recently
+file-open-save-plugin.app.middle.no-recents.message=You haven't opened anything recently.
 file-open-save-plugin.app.middle.no-results.message=No results
 
 ## error component


### PR DESCRIPTION
Fixes for #'s 6, 7, 8, 10, 11, 12, and 13 for https://docs.google.com/spreadsheets/d/17QboBxK0V064iFzd3GXdpYGZ5I2bg-yWP5OOCYyC9u0/edit#gid=1166424294

6: Normal card background color should be #FDFDFD. (this was my bad - PJ)
7: Right now the text in the cards (name and date info) are not vertically aligned. Adding a line height of 14 pix to the Card title should fix this.
8: When there are no recent files the message "You haven't opened anything recently." is missing a period.
10: Before the user selects a recent file, the open button should be disabled.
11: Before vertical scrollbar appears, maintain 20px gutter to right, currently looks bigger than 20px.
12: When vertical scrollbar appears, maintain 20px gutter to right of card between card edge and scrollbar (dev to see if thats possible).
13: At the end of the 12 recent files, there is no 20px of space under the last row of cards. Right now they stick to the container edge.

@bmorrise 
@e-cuellar 