### PR TITLE
[PDI-16337] - Error reading from Oracle Number(38) column

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/OracleDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/OracleDatabaseMeta.java
@@ -38,6 +38,9 @@ import org.pentaho.di.core.variables.VariableSpace;
  */
 
 public class OracleDatabaseMeta extends BaseDatabaseMeta implements DatabaseInterface {
+
+  private static final String STRICT_BIGNUMBER_INTERPRETATION = "STRICT_NUMBER_38_INTERPRETATION";
+
   @Override
   public int[] getAccessTypeList() {
     return new int[] {
@@ -660,5 +663,19 @@ public class OracleDatabaseMeta extends BaseDatabaseMeta implements DatabaseInte
   @Override
   public SqlScriptParser createSqlScriptParser() {
     return new SqlScriptParser( false );
+  }
+
+  /**
+   * @return true if using strict number(38) interpretation
+   */
+  public boolean strictBigNumberInterpretation() {
+    return "Y".equalsIgnoreCase( getAttributes().getProperty( STRICT_BIGNUMBER_INTERPRETATION, "N" ) );
+  }
+
+  /**
+   * @param  strictBigNumberInterpretation true if use strict number(38) interpretation
+   */
+  public void setStrictBigNumberInterpretation( boolean strictBigNumberInterpretation ) {
+    getAttributes().setProperty( STRICT_BIGNUMBER_INTERPRETATION, strictBigNumberInterpretation ? "Y" : "N" );
   }
 }

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -4728,7 +4728,8 @@ public class ValueMetaBase implements ValueMetaInterface {
 
           if ( databaseMeta.getDatabaseInterface() instanceof OracleDatabaseMeta ) {
             if ( precision == 0 && length == 38 ) {
-              valtype = ValueMetaInterface.TYPE_INTEGER;
+              valtype = ( (OracleDatabaseMeta) databaseMeta.getDatabaseInterface() )
+                .strictBigNumberInterpretation() ? TYPE_BIGNUMBER : TYPE_INTEGER;
             }
             if ( precision <= 0 && length <= 0 ) {
               // undefined size: BIGNUMBER,

--- a/dbdialog/src/main/java/org/pentaho/ui/database/event/DataHandler.java
+++ b/dbdialog/src/main/java/org/pentaho/ui/database/event/DataHandler.java
@@ -43,6 +43,7 @@ import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.database.GenericDatabaseMeta;
 import org.pentaho.di.core.database.MSSQLServerNativeDatabaseMeta;
+import org.pentaho.di.core.database.OracleDatabaseMeta;
 import org.pentaho.di.core.database.PartitionDatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannel;
@@ -203,6 +204,8 @@ public class DataHandler extends AbstractXulEventHandler {
   XulCheckbox upperCaseIdentifiersCheck;
 
   XulCheckbox preserveReservedCaseCheck;
+
+  XulCheckbox strictBigNumberInterpretaion;
 
   XulCheckbox useIntegratedSecurityCheck;
 
@@ -690,6 +693,11 @@ public class DataHandler extends AbstractXulEventHandler {
       meta.setPreserveReservedCase( preserveReservedCaseCheck.isChecked() );
     }
 
+    if ( strictBigNumberInterpretaion != null && meta.getDatabaseInterface() instanceof OracleDatabaseMeta ) {
+      ( (OracleDatabaseMeta) meta.getDatabaseInterface() )
+        .setStrictBigNumberInterpretation( strictBigNumberInterpretaion.isChecked() );
+    }
+
     if ( preferredSchemaName != null ) {
       meta.setPreferredSchemaName( preferredSchemaName.getValue() );
     }
@@ -831,7 +839,6 @@ public class DataHandler extends AbstractXulEventHandler {
     setOptionsData( meta.getExtraOptions() );
 
     // Advanced panel settings:
-
     if ( supportBooleanDataType != null ) {
       supportBooleanDataType.setChecked( meta.supportsBooleanDataType() );
     }
@@ -854,6 +861,18 @@ public class DataHandler extends AbstractXulEventHandler {
 
     if ( preserveReservedCaseCheck != null ) {
       preserveReservedCaseCheck.setChecked( meta.preserveReservedCase() );
+    }
+
+    if ( strictBigNumberInterpretaion != null ) {
+      //check if Oracle
+      if ( meta.getDatabaseInterface() instanceof OracleDatabaseMeta ) {
+        strictBigNumberInterpretaion.setVisible( true );
+        strictBigNumberInterpretaion.setChecked( ( (OracleDatabaseMeta) meta.getDatabaseInterface() )
+          .strictBigNumberInterpretation() );
+      } else {
+        strictBigNumberInterpretaion.setVisible( false );
+        strictBigNumberInterpretaion.setChecked( false );
+      }
     }
 
     if ( preferredSchemaName != null ) {
@@ -1320,6 +1339,19 @@ public class DataHandler extends AbstractXulEventHandler {
       indexTablespaceBox.setValue( meta.getIndexTablespace() );
     }
 
+    // Strict Number(38) interpretation
+    if ( strictBigNumberInterpretaion != null ) {
+      // Check if oracle
+      if ( meta.getDatabaseInterface() instanceof OracleDatabaseMeta ) {
+        strictBigNumberInterpretaion.setVisible( true );
+        strictBigNumberInterpretaion.setChecked( ( (OracleDatabaseMeta) meta.getDatabaseInterface() )
+          .strictBigNumberInterpretation() );
+      } else {
+        strictBigNumberInterpretaion.setVisible( false );
+        strictBigNumberInterpretaion.setChecked( false );
+      }
+    }
+
     if ( serverInstanceBox != null ) {
       serverInstanceBox.setValue( meta.getSQLServerInstance() );
     }
@@ -1421,6 +1453,7 @@ public class DataHandler extends AbstractXulEventHandler {
     lowerCaseIdentifiersCheck = (XulCheckbox) document.getElementById( "force-lower-case-check" );
     upperCaseIdentifiersCheck = (XulCheckbox) document.getElementById( "force-upper-case-check" );
     preserveReservedCaseCheck = (XulCheckbox) document.getElementById( "preserve-reserved-case" );
+    strictBigNumberInterpretaion = (XulCheckbox) document.getElementById( "strict-bignum-interpretation" );
     preferredSchemaName = (XulTextbox) document.getElementById( "preferred-schema-name-text" );
     sqlBox = (XulTextbox) document.getElementById( "sql-text" );
     useIntegratedSecurityCheck = (XulCheckbox) document.getElementById( "use-integrated-security-check" );

--- a/dbdialog/src/main/resources/org/pentaho/ui/database/databasedialog.properties
+++ b/dbdialog/src/main/resources/org/pentaho/ui/database/databasedialog.properties
@@ -94,6 +94,7 @@ DatabaseDialog.label.AdvancedQuoteAllFields=Quote all in database
 DatabaseDialog.label.AdvancedForceIdentifiersLowerCase = Force all to lower case
 DatabaseDialog.label.AdvancedForceIdentifiersUpperCase = Force all to upper case
 DatabaseDialog.label.PreserveReservedCase = Preserve case of reserved words
+DatabaseDialog.label.StrictBigNumberInterpretation = Strict NUMBER(38) Interpretation ( For Oracle db only )
 
 DatabaseDialog.ExplorerNotImplemented.Title = Sorry
 DatabaseDialog.ExplorerNotImplemented.Message = Sorry, the explorer for this database was not yet implemented. 

--- a/dbdialog/src/main/resources/org/pentaho/ui/database/databasedialog.xul
+++ b/dbdialog/src/main/resources/org/pentaho/ui/database/databasedialog.xul
@@ -99,6 +99,7 @@
 					<checkbox id="force-lower-case-check" label="${DatabaseDialog.label.AdvancedForceIdentifiersLowerCase}" checked="false" />
 					<checkbox id="force-upper-case-check" label="${DatabaseDialog.label.AdvancedForceIdentifiersUpperCase}" checked="false" />
 					<checkbox id="preserve-reserved-case" label="${DatabaseDialog.label.PreserveReservedCase}" checked="false" />
+					<checkbox id="strict-bignum-interpretation" label="${DatabaseDialog.label.StrictBigNumberInterpretation}" checked="false" />
                     <label id="preferred-schema-name" value="${DatabaseDialog.label.PreferredSchemaName}" />
                         <textbox id="preferred-schema-name-text" pen:customclass="variabletextbox" />
 


### PR DESCRIPTION
Added new advanced database connection option "Strict number(38) interpretation (Oracle specific) ".

 If true Oracle NUMBER with 38 precision is interpreted as BigDecimal