### PR TITLE
[PDI-14492] Copy Table Wizard_UI Issue

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -7761,9 +7761,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     }
 
     final CopyTableWizardPage1 page1 = new CopyTableWizardPage1( "1", databases );
-    page1.createControl( shell );
     final CopyTableWizardPage2 page2 = new CopyTableWizardPage2( "2" );
-    page2.createControl( shell );
 
     Wizard wizard = new Wizard() {
       @Override


### PR DESCRIPTION
This fixes the issue: [PDI-14492] Copy Table Wizard_UI Issue.
The `page.createControl( shell )` will be called in `Wizard.createPageControls(Composite)`, so should not be called in `Spoon.copyTableWizard()`.