### PR TITLE
[BACKLOG-15718] File Open Save fixes for the following...

### DIFF
--- a/plugins/file-open-save/core/src/main/java/org/pentaho/repo/endpoint/RepositoryOpenSaveExtensionPoint.java
+++ b/plugins/file-open-save/core/src/main/java/org/pentaho/repo/endpoint/RepositoryOpenSaveExtensionPoint.java
@@ -54,7 +54,7 @@ public class RepositoryOpenSaveExtensionPoint implements ExtensionPointInterface
     }
 
     RepositoryOpenSaveDialog repositoryOpenSaveDialog =
-      new RepositoryOpenSaveDialog( spoonSupplier.get().getShell(), 930, 615 );
+      new RepositoryOpenSaveDialog( spoonSupplier.get().getShell(), 937, 616 );
     repositoryOpenSaveDialog
       .open( lastUsedFile != null ? lastUsedFile.getDirectory() : null,
         RepositoryOpenSaveDialog.STATE_SAVE.equals( o ) ? RepositoryOpenSaveDialog.STATE_SAVE : RepositoryOpenSaveDialog.STATE_OPEN );

--- a/plugins/file-open-save/core/src/main/javascript/app/app.component.js
+++ b/plugins/file-open-save/core/src/main/javascript/app/app.component.js
@@ -80,6 +80,7 @@ define([
     vm.setTooltip = setTooltip;
     vm.getOffsetTop = getOffsetTop;
     vm.getOffsetLeft = getOffsetLeft;
+    vm.recentsHasScrollBar = recentsHasScrollBar;
     vm.selectedFolder = "";
     vm.fileToSave = "";
     vm.searchString = "";
@@ -177,6 +178,11 @@ define([
         vm.wrapperClass = "save";
         vm.headerTitle = i18n.get("file-open-save-plugin.app.header.save.title");
       }
+    }
+
+    function recentsHasScrollBar() {
+      var recentsView = document.getElementsByClassName("recentsView");
+      return recentsView.scrollHeight > recentsView.clientHeight;
     }
 
     /**
@@ -297,7 +303,7 @@ define([
      */
     function highlightFile(file) {
       vm.file = file;
-      vm.fileToSave = file.type === "folder" ? "" : file.name;
+      vm.fileToSave = file.type === "folder" ? vm.fileToSave : file.name;
     }
 
     /**

--- a/plugins/file-open-save/core/src/main/javascript/app/app.css
+++ b/plugins/file-open-save/core/src/main/javascript/app/app.css
@@ -42,6 +42,7 @@ file-open-save-app input[type="text"] {
   font-size: 14px;
   line-height: 17px;
   height: 34px;
+  font-family: OpenSansRegular;
 }
 
 file-open-save-app input[type="text"]:focus,
@@ -230,23 +231,30 @@ file-open-save-app .fileArea {
   position: relative;
 }
 
-file-open-save-app .fileArea.overflow {
+file-open-save-app .fileArea.recentsView {
   overflow-y: auto;
   overflow-x: hidden;
   padding-right: 20px;
 }
 
+file-open-save-app .fileArea.recentsView.scrolling {
+  padding-right: 0;
+}
+
 file-open-save-app .bottom {
   padding: 20px 30px 30px;
+  height: 119px;
 }
 
 file-open-save-app .open .bottom {
   padding-top: 30px;
+  height: 36px;
 }
 
 file-open-save-app .fileNameEntry {
   width: 100%;
   margin-bottom: 30px;
+  line-height: 14px;
 }
 
 file-open-save-app .fileNameEntryLabel {
@@ -315,19 +323,24 @@ file-open-save-app .buttons button {
   float: right;
 }
 
-file-open-save-app .buttons {
-  float: right;
-}
-
 file-open-save-app .open .fileNameEntry {
   display: none;
 }
 
 file-open-save-app .fileAreaMessageView {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -100%);
+  width: 100%;
+  text-align: center;
+  height: 292px;
+  line-height: 292px;
+}
+
+file-open-save-app .open .fileAreaMessageView {
+  height: 368px;
+  line-height: 368px;
+}
+
+file-open-save-app .recentsView .fileAreaMessageView {
+  width: calc(100% + 20px);
 }
 
 .searchBoxExtra {

--- a/plugins/file-open-save/core/src/main/javascript/app/app.html
+++ b/plugins/file-open-save/core/src/main/javascript/app/app.html
@@ -56,7 +56,7 @@
               ng-class="{dark: vm.file !== null}"></folder>
     </div>
 
-    <div class="fileArea" ng-class="{overflow: vm.showRecents}">
+    <div class="fileArea" ng-class="{recentsView: vm.showRecents, scrolling: vm.recentsHasScrollBar}">
       <div class="fileAreaMessageView" ng-show="vm.showRecents && vm.recentFiles.length === 0">{{::vm.noRecentsMsg}}</div>
       <card ng-show="vm.showRecents && vm.recentFiles.length > 0"
             recent-files="vm.recentFiles"

--- a/plugins/file-open-save/core/src/main/javascript/app/components/card/card.css
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/card/card.css
@@ -47,10 +47,6 @@ card .card {
   user-select: none; /* Fallback */
 }
 
-card .card:last-child {
-  margin-bottom: 20px;
-}
-
 card .card:hover {
   background-color: #E6EFF6;
   border: 1px solid #E6EFF6;
@@ -90,14 +86,15 @@ card .cardTitleAndDate {
   float: left;
   width: 200px;
   max-width: 200px;
+  margin-top: -1px;
 }
 
 card .cardTitle {
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  line-height: 17px;
+  line-height: 20px;
 }
 
 card .cardDate {
@@ -110,4 +107,10 @@ card .cardAreaMessageView {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -100%);
+}
+
+card .bottomSpacer {
+  height: 20px;
+  width: calc(100% + 20px);
+  float: left;
 }

--- a/plugins/file-open-save/core/src/main/javascript/app/components/card/card.html
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/card/card.html
@@ -22,3 +22,4 @@
     <div class="cardTypeIcon"></div>
   </div>
 </div>
+<div class="bottomSpacer"></div>

--- a/plugins/file-open-save/core/src/main/javascript/app/components/files/files.css
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/files/files.css
@@ -62,6 +62,11 @@ files .bodyWrapper {
   max-height: 337px;
 }
 
+files .bodyWrapper .spacer {
+  height: 17px;
+  width: 100%;
+}
+
 files .headerWrapper table {
   background-color: #FAFAFA;
   text-align: left;
@@ -155,6 +160,9 @@ files tr .fileName .editing span {
 
 files tr .fileName .editing input {
   display: block;
+  border: 0 none;
+  outline: none;
+
 }
 
 files tr .fileTypeIcon {

--- a/plugins/file-open-save/core/src/main/javascript/app/components/files/files.html
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/files/files.html
@@ -35,7 +35,7 @@
   </div>
 
   <div class="bodyWrapper">
-    <table ng-class="{searchTable: vm.search, hasVertScroll: vm.getFileAreaWidth()}">
+    <table ng-class="{searchTable: vm.search}">
       <tbody>
       <tr ng-repeat="file in vm.getFiles(vm.folder.children) | orderBy:file:vm.sortReverse:vm.compareFiles "
           ng-click="vm.selectFile(file)"
@@ -63,6 +63,7 @@
         </td>
       </tr>
     </table>
+    <div class="spacer"></div>
   </div>
 </div>
 

--- a/plugins/file-open-save/core/src/main/resources/app/css/index.css
+++ b/plugins/file-open-save/core/src/main/resources/app/css/index.css
@@ -3,4 +3,5 @@ body {
   font-family: OpenSansRegular;
   color: #212121;
   margin: 0;
+  overflow: hidden;
 }


### PR DESCRIPTION
7 - Right now the text in the cards (name and date info) are not vertically aligned.
11 - Before vertical scrollbar appears, maintain 20px gutter to right, currently looks bigger than 20px.
12 - When vertical scrollbar appears, maintain 20px gutter to right of card between card edge and scrollbar (dev to see if thats possible).
14 - At the end of the 12 recent files, there is no 20px of space under the last row of cards. Right now they stick to the container edge.
22 - In the recents view, the cards are not displaying in 2 columns wide by default. They are stacking in one column
23 - "You haven't opened anything recently." not centered on Ubuntu
63 - When renaming a file/folder the styling of the row shifts
71 - in the save dialog, clicking a folder name in the right pane is populating the "File name" text box. It should only populate in that box when a file is selected.
90 - Scrolling bar is cutting the last file in the list view (see screen shot column)
109 - Search label should be using open sans regular, its using arial currently.
115 - The open dialog width should be 930px, it looks bigger
118 - Space in footer of dialog

@bmorrise 