### PR TITLE
[PDI-15858] - Fix for blank repository dialog in Windows

### DIFF
--- a/plugins/repositories/core/src/main/resources-filtered/web/index.html
+++ b/plugins/repositories/core/src/main/resources-filtered/web/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta http-equiv=”X-UA-Compatible” content=”IE=11” />
   <script src="/requirejs-manager/js/require-init.js"></script>
   <link href="css/style.css" rel="stylesheet">
   <script>


### PR DESCRIPTION
When Security_HKLM_only registry key set to DWORD 0x01, it forces the browser into IE7 compatibility mode. This change forces IE into IE11 mode which is what we need to work.