### PR TITLE
Enhance kettle gpload plugin to support unicode (non-printable ASCII …

### DIFF
--- a/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/GPLoad.java
+++ b/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/GPLoad.java
@@ -280,8 +280,11 @@ public class GPLoad extends BaseStep implements StepInterface {
     // See also page 155 for formatting information & escaping
     // delimiter validation should have been perfomed
     contents.append( GPLoad.INDENT ).append( "- FORMAT: TEXT" ).append( Const.CR );
-    contents.append( GPLoad.INDENT ).append( "- DELIMITER: " ).append( GPLoad.SINGLE_QUOTE ).append( delimiter )
-        .append( GPLoad.SINGLE_QUOTE ).append( Const.CR );
+    String delimiter_quote = GPLoad.SINGLE_QUOTE;
+    if(delimiter.startsWith("\\u")) //unicode delimiter should double quoted
+      delimiter_quote = GPLoad.DOUBLE_QUOTE;
+    contents.append( GPLoad.INDENT ).append( "- DELIMITER: " ).append( delimiter_quote ).append( delimiter )
+        .append( delimiter_quote ).append( Const.CR );
 //  if ( !Utils.isEmpty( meta.getNullAs() ) ) {
     if ( !Utils.isEmpty( meta.getNullAs() ) ) {
       contents.append( GPLoad.INDENT ).append( "- NULL_AS: " ).append( GPLoad.SINGLE_QUOTE ).append( meta.getNullAs() ).append( GPLoad.SINGLE_QUOTE ).append( Const.CR );

--- a/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/GPLoadDataOutput.java
+++ b/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/GPLoadDataOutput.java
@@ -151,6 +151,15 @@ public class GPLoadDataOutput {
         if ( Utils.isEmpty( delimiter ) ) {
           throw new KettleException( BaseMessages.getString( PKG, "GPload.Exception.DelimiterMissing" ) );
         }
+        if (delimiter.startsWith("\\u")) {
+          try {
+            int codepoint = Integer.parseInt(delimiter.substring(2), 16);
+            char[] ch = Character.toChars(codepoint);
+            delimiter = String.valueOf(ch);
+          } catch (Exception ex) {
+            throw new KettleException( BaseMessages.getString( PKG, "GPload.Exception.DelimiterInvalidUnicode" ), ex );
+          }
+        }
       }
 
       // Setup up the fields we need to take for each of the rows

--- a/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/messages/messages_en_US.properties
+++ b/plugins/kettle-gpload-plugin/src/org/pentaho/di/trans/steps/gpload/messages/messages_en_US.properties
@@ -114,6 +114,7 @@ GPload.Exception.DataFileMissing=A data file must be specified.
 GPLoadDialog.Port.Label=Port\:
 GPLoadDialog.TargetSchema.Label=Target schema
 GPload.Exception.DelimiterMissing=A delimiter must be specified.
+GPload.Exception.DelimiterInvalidUnicode=Delimiter is not a valid unicode.
 GPLoadDialog.SQL.Button=\ &SQL
 GPLoadDialog.Encoding.Tooltip=Which character set to use for the data (empty means default job encoding)
 GPLoadMeta.CheckResult.MissingFieldsToLoadInTargetTable=Missing fields to load in target table\:


### PR DESCRIPTION
# Enhance kettle gpload plugin to support unicode(non-printable ASCII) delimiter
Use case of non-printable ASCII character delimiter is very common. however the current gpload plugin doesn't support unicode (non-printable ASCII character) delimiter correctly, this enhancement will fix it. 

With this PR, unicode delimiter can be accepted in UI with prefix of **\u** , e,g, *\u001b*, as shown below:
![gpload_ui_unicode](https://user-images.githubusercontent.com/4687104/28243356-ee5a7870-69f8-11e7-913d-0672badaf052.png)

Later on running the plugin will produce gpload control file having a unicode 'DELIMITER' field, quoted with **double** quote (instead of single quote on common printable delimiter), as shown below:
![control0_better](https://user-images.githubusercontent.com/4687104/28243378-c3838000-69f9-11e7-9725-b453eb98ca22.png)

As GPLOAD command line utility usage stated below:
![gpload_cmd_gramma](https://user-images.githubusercontent.com/4687104/28243427-68c141f0-69fb-11e7-89ae-13440e082dcf.png)

A produced sample gpload load0.data file (with ESC(\u001b) delimiter):
![load0_unicode_delimiter](https://user-images.githubusercontent.com/4687104/28243430-a74235d8-69fb-11e7-992d-e8adc53dc7a3.png)

And the file shall be successfully imported into Greenplum database:
![db](https://user-images.githubusercontent.com/4687104/28243436-d08f8c6a-69fb-11e7-9a1a-f94e05e80186.png)
