### PR TITLE
BACKLOG-17562: Upgrade jackrabbit library to 2.14.2

### DIFF
--- a/plugins/pur/core/pom.xml
+++ b/plugins/pur/core/pom.xml
@@ -46,7 +46,7 @@
     <spring.webflow.version>2.4.4.RELEASE</spring.webflow.version>
     <se-jcr.version>0.9</se-jcr.version>
     <jcr.version>2.0</jcr.version>
-    <jackrabbit-core.version>2.10.0</jackrabbit-core.version>
+    <jackrabbit-core.version>2.14.2</jackrabbit-core.version>
 
     <!-- Wadl2Java Settings -->
     <wadl2java.generated-class-name>Localhost_PentahoPlugin</wadl2java.generated-class-name>


### PR DESCRIPTION
Upgrading jackrabbit version to 2.14.2
Refer to BACKLOG-17562 and PPP-3714 for details. 
Related PRs being opened to upgrade other projects that depend on jackrabbit.
pentaho-platform : https://github.com/pentaho/pentaho-platform/pull/3708
pdi-ee-plugin: pentaho/pdi-ee-plugin#340
data-access: pentaho/data-access#917
@pentaho/rogueone @pentaho/rebelalliance 