### PR TITLE
[BACKLOG-15721] fix for Expand a folder that starts with same letter(…

### DIFF
--- a/plugins/file-open-save/core/src/main/javascript/app/components/folder/folder.component.js
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/folder/folder.component.js
@@ -147,7 +147,12 @@ define([
      * @private
      */
     function _isChild(folder, child) {
-      return child.path.indexOf(folder.path) === 0;
+      var childPath = child.path;
+      var depthDiff = child.depth - folder.depth;
+      for (var i = 0; i < depthDiff; i++) {
+        childPath = childPath.slice(0, childPath.lastIndexOf("/"));
+      }
+      return childPath === folder.path;
     }
 
     /**


### PR DESCRIPTION
…s) shows the subfolder(s) of folders below

@e-cuellar 