### PR TITLE
[PDI-16337]-Spoon db dialog cache doesn't update value of database interface after changing db type

### DIFF
--- a/dbdialog/src/main/java/org/pentaho/ui/database/event/DataHandler.java
+++ b/dbdialog/src/main/java/org/pentaho/ui/database/event/DataHandler.java
@@ -121,7 +121,7 @@ public class DataHandler extends AbstractXulEventHandler {
 
   protected DatabaseMeta databaseMeta = null;
 
-  private DatabaseMeta cache = new DatabaseMeta();
+  protected DatabaseMeta cache = new DatabaseMeta();
 
   private XulDeck dialogDeck;
 
@@ -519,6 +519,13 @@ public class DataHandler extends AbstractXulEventHandler {
   }
 
   public void pushCache() {
+    // Database type:
+    if ( connectionBox != null ) {
+      Object connection = connectionBox.getSelectedItem();
+      if ( connection != null ) {
+        cache.setDatabaseType( (String) connection );
+      }
+    }
     getConnectionSpecificInfo( cache );
   }
 

--- a/dbdialog/src/test/java/org/pentaho/ui/database/event/DataHandlerTest.java
+++ b/dbdialog/src/test/java/org/pentaho/ui/database/event/DataHandlerTest.java
@@ -177,11 +177,13 @@ public class DataHandlerTest {
     when( accessBox.getSelectedItem() ).thenReturn( "ODBC" );
 
     DatabaseInterface dbInterface = mock( DatabaseInterface.class );
+    DatabaseMeta databaseMeta = mock( DatabaseMeta.class );
     when( dbInterface.getAccessTypeList() ).thenReturn(
       new int[]{ DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_ODBC } );
     when( dbInterface.getDefaultDatabasePort() ).thenReturn( 5309 );
     when( connectionBox.getSelectedItem() ).thenReturn( "myDb" );
     DataHandler.connectionMap.put( "myDb", dbInterface );
+    dataHandler.cache = databaseMeta;
     dataHandler.getData();
     dataHandler.loadAccessData();
   }
@@ -256,6 +258,17 @@ public class DataHandlerTest {
     dataHandler.pushCache();
     dataHandler.popCache();
     verify( webappName ).setValue( "pentaho" );
+  }
+
+  @Test
+  public void testPushCacheUpdatesDatabaseInterface() throws Exception {
+    DatabaseMeta databaseMeta = mock( DatabaseMeta.class );
+    when( connectionBox.getSelectedItem() ).thenReturn( "test" );
+    dataHandler.cache = databaseMeta;
+    dataHandler.getControls();
+    dataHandler.getData();
+    dataHandler.pushCache();
+    verify( databaseMeta ).setDatabaseType( "test" );
   }
 
   @Test


### PR DESCRIPTION
Now after selecting and changing database type, db cache will hold and update the correct value of database interface