### PR TITLE
[PDI-2301]-Slave server monitor refresh freezes Spoon

### DIFF
--- a/core/src/main/java/org/pentaho/di/cluster/HttpUtil.java
+++ b/core/src/main/java/org/pentaho/di/cluster/HttpUtil.java
@@ -23,6 +23,7 @@
 package org.pentaho.di.cluster;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Base64OutputStream;
 import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
@@ -145,11 +146,11 @@ public class HttpUtil {
 
   public static String encodeBase64ZippedString( String in ) throws IOException {
     Charset charset = Charset.forName( Const.XML_ENCODING );
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    GZIPOutputStream gzos = new GZIPOutputStream( baos );
-    gzos.write( in.getBytes( charset ) );
-    gzos.close();
-
-    return new String( Base64.encodeBase64( baos.toByteArray() ) );
+    ByteArrayOutputStream baos = new ByteArrayOutputStream( 1024 );
+    try ( Base64OutputStream base64OutputStream = new Base64OutputStream( baos );
+          GZIPOutputStream gzos = new GZIPOutputStream( base64OutputStream ) ) {
+      gzos.write( in.getBytes( charset ) );
+    }
+    return baos.toString();
   }
 }

--- a/core/src/main/java/org/pentaho/di/core/logging/KettleLogStore.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/KettleLogStore.java
@@ -88,14 +88,9 @@ public class KettleLogStore {
 
         if ( maxLogTimeoutMinutes > 0 ) {
           long minTimeBoundary = new Date().getTime() - maxLogTimeoutMinutes * 60 * 1000;
-
-          // Get the old lines to be removed
-          //
-          List<BufferLine> linesToRemove = appender.getBufferLinesBefore( minTimeBoundary );
-
           // Remove all lines at once to prevent concurrent modification problems.
           //
-          appender.removeBufferLines( linesToRemove );
+          appender.removeBufferLinesBefore( minTimeBoundary );
         }
       }
     };

--- a/core/src/main/java/org/pentaho/di/core/logging/LoggingBuffer.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/LoggingBuffer.java
@@ -24,22 +24,22 @@ package org.pentaho.di.core.logging;
 
 import org.pentaho.di.core.Const;
 
-import java.util.Collections;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.LinkedList;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class keeps the last N lines in a buffer
  *
  * @author matt
- *
  */
 public class LoggingBuffer {
   private String name;
 
-  private List<BufferLine> buffer;
+  private LinkedBlockingDeque<BufferLine> buffer;
 
   private int bufferSize;
 
@@ -47,125 +47,71 @@ public class LoggingBuffer {
 
   private List<KettleLoggingEventListener> eventListeners;
 
+  private LoggingRegistry loggingRegistry = LoggingRegistry.getInstance();
+
   public LoggingBuffer( int bufferSize ) {
     this.bufferSize = bufferSize;
-    buffer = Collections.synchronizedList( new LinkedList<BufferLine>() );
+    buffer = new LinkedBlockingDeque<BufferLine>();
     layout = new KettleLogLayout( true );
-    eventListeners = Collections.synchronizedList( new ArrayList<KettleLoggingEventListener>() );
+    eventListeners = new CopyOnWriteArrayList<KettleLoggingEventListener>();
   }
 
   /**
    * @return the number (sequence, 1..N) of the last log line. If no records are present in the buffer, 0 is returned.
    */
   public int getLastBufferLineNr() {
-    synchronized ( buffer ) {
-      if ( buffer.size() > 0 ) {
-        return buffer.get( buffer.size() - 1 ).getNr();
-      } else {
-        return 0;
-      }
-    }
+    BufferLine line = buffer.peekLast();
+    return line != null ? line.getNr() : 0;
   }
 
   /**
-   *
-   * @param channelId
-   *          channel IDs to grab
-   * @param includeGeneral
-   *          include general log lines
+   * @param channelId      channel IDs to grab
+   * @param includeGeneral include general log lines
    * @param from
    * @param to
    * @return
    */
   public List<KettleLoggingEvent> getLogBufferFromTo( List<String> channelId, boolean includeGeneral, int from,
-    int to ) {
-    List<KettleLoggingEvent> lines = new ArrayList<KettleLoggingEvent>();
-
-    synchronized ( buffer ) {
-      for ( BufferLine line : buffer ) {
-        if ( line.getNr() > from && line.getNr() <= to ) {
-          Object payload = line.getEvent().getMessage();
-          if ( payload instanceof LogMessage ) {
-            LogMessage message = (LogMessage) payload;
-
-            // Typically, the log channel id is the one from the transformation or job running currently.
-            // However, we also want to see the details of the steps etc.
-            // So we need to look at the parents all the way up if needed...
-            //
-            boolean include = channelId == null;
-
-            // See if we should include generic messages
-            //
-            if ( !include ) {
-              LoggingObjectInterface loggingObject =
-                LoggingRegistry.getInstance().getLoggingObject( message.getLogChannelId() );
-
-              if ( loggingObject != null
-                && includeGeneral && LoggingObjectType.GENERAL.equals( loggingObject.getObjectType() ) ) {
-                include = true;
-              }
-
-              // See if we should include a certain channel id (zero, one or more)
-              //
-              if ( !include ) {
-                for ( String id : channelId ) {
-                  if ( message.getLogChannelId().equals( id ) ) {
-                    include = true;
-                    break;
-                  }
-                }
-              }
-            }
-
-            if ( include ) {
-
-              try {
-                // String string = layout.format(line.getEvent());
-                lines.add( line.getEvent() );
-              } catch ( Exception e ) {
-                e.printStackTrace();
-              }
-            }
-          }
-        }
-      }
+                                                      int to ) {
+    Stream<BufferLine> bufferStream = buffer.stream().filter( line -> line.getNr() > from && line.getNr() <= to );
+    if ( channelId != null ) {
+      bufferStream = bufferStream.filter( line -> {
+        String logChannelId = getLogChId( line );
+        return includeGeneral ? isGeneral( logChannelId ) || channelId.contains( logChannelId ) : channelId.contains( logChannelId );
+      } );
     }
-
-    return lines;
+    return bufferStream.map( BufferLine::getEvent ).collect( Collectors.toList() );
   }
 
   /**
-   *
-   * @param parentLogChannelId
-   *          the parent log channel ID to grab
-   * @param includeGeneral
-   *          include general log lines
+   * @param parentLogChannelId the parent log channel ID to grab
+   * @param includeGeneral     include general log lines
    * @param from
    * @param to
    * @return
    */
   public List<KettleLoggingEvent> getLogBufferFromTo( String parentLogChannelId, boolean includeGeneral, int from,
-    int to ) {
+                                                      int to ) {
 
     // Typically, the log channel id is the one from the transformation or job running currently.
     // However, we also want to see the details of the steps etc.
     // So we need to look at the parents all the way up if needed...
     //
-    List<String> childIds = LoggingRegistry.getInstance().getLogChannelChildren( parentLogChannelId );
+    List<String> childIds = loggingRegistry.getLogChannelChildren( parentLogChannelId );
 
     return getLogBufferFromTo( childIds, includeGeneral, from, to );
   }
 
   public StringBuffer getBuffer( String parentLogChannelId, boolean includeGeneral, int startLineNr, int endLineNr ) {
-    StringBuffer stringBuffer = new StringBuffer( 10000 );
+    StringBuilder eventBuffer = new StringBuilder( 10000 );
 
     List<KettleLoggingEvent> events =
       getLogBufferFromTo( parentLogChannelId, includeGeneral, startLineNr, endLineNr );
     for ( KettleLoggingEvent event : events ) {
-      stringBuffer.append( layout.format( event ) ).append( Const.CR );
+      eventBuffer.append( layout.format( event ) ).append( Const.CR );
     }
 
-    return stringBuffer;
+    return new StringBuffer( eventBuffer );
   }
 
   public StringBuffer getBuffer( String parentLogChannelId, boolean includeGeneral ) {
@@ -184,10 +130,10 @@ public class LoggingBuffer {
   }
 
   public void doAppend( KettleLoggingEvent event ) {
-    synchronized ( buffer ) {
+    if ( event.getMessage() instanceof LogMessage ) {
       buffer.add( new BufferLine( event ) );
       while ( bufferSize > 0 && buffer.size() > bufferSize ) {
-        buffer.remove( 0 );
+        buffer.poll();
       }
     }
   }
@@ -224,8 +170,7 @@ public class LoggingBuffer {
   }
 
   /**
-   * @param maxNrLines
-   *          the maximum number of lines that this buffer should contain, 0 or lower means: no limit
+   * @param maxNrLines the maximum number of lines that this buffer should contain, 0 or lower means: no limit
    */
   public void setMaxNrLines( int maxNrLines ) {
     this.bufferSize = maxNrLines;
@@ -241,23 +186,10 @@ public class LoggingBuffer {
   /**
    * Removes all rows for the channel with the specified id
    *
-   * @param id
-   *          the id of the logging channel to remove
+   * @param id the id of the logging channel to remove
    */
   public void removeChannelFromBuffer( String id ) {
-    synchronized ( buffer ) {
-      Iterator<BufferLine> iterator = buffer.iterator();
-      while ( iterator.hasNext() ) {
-        BufferLine bufferLine = iterator.next();
-        Object payload = bufferLine.getEvent().getMessage();
-        if ( payload instanceof LogMessage ) {
-          LogMessage message = (LogMessage) payload;
-          if ( id.equals( message.getLogChannelId() ) ) {
-            iterator.remove();
-          }
-        }
-      }
-    }
+    buffer.removeIf( line -> id.equals( getLogChId( line ) ) );
   }
 
   public int size() {
@@ -265,21 +197,7 @@ public class LoggingBuffer {
   }
 
   public void removeGeneralMessages() {
-    synchronized ( buffer ) {
-      Iterator<BufferLine> iterator = buffer.iterator();
-      while ( iterator.hasNext() ) {
-        BufferLine bufferLine = iterator.next();
-        Object payload = bufferLine.getEvent().getMessage();
-        if ( payload instanceof LogMessage ) {
-          LogMessage message = (LogMessage) payload;
-          LoggingObjectInterface loggingObject =
-            LoggingRegistry.getInstance().getLoggingObject( message.getLogChannelId() );
-          if ( loggingObject != null && LoggingObjectType.GENERAL.equals( loggingObject.getObjectType() ) ) {
-            iterator.remove();
-          }
-        }
-      }
-    }
+    buffer.removeIf( line -> isGeneral( getLogChId( line ) ) );
   }
 
   public Iterator<BufferLine> getBufferIterator() {
@@ -292,20 +210,11 @@ public class LoggingBuffer {
   @Deprecated
   public String dump() {
     StringBuilder buf = new StringBuilder( 50000 );
-    synchronized ( buffer ) {
-      for ( BufferLine line : buffer ) {
-        Object payload = line.getEvent().getMessage();
-        if ( payload instanceof LogMessage ) {
-          LogMessage message = (LogMessage) payload;
-          // LoggingObjectInterface loggingObject =
-          // LoggingRegistry.getInstance().getLoggingObject(message.getLogChannelId());
-          buf
-            .append( message.getLogChannelId()
-              + "\t" + message.getSubject() + "\t" + message.getMessage() + "\n" );
-        }
-
-      }
-    }
+    buffer.forEach( line -> {
+      LogMessage message = (LogMessage) line.getEvent().getMessage();
+      buf.append( message.getLogChannelId() ).append( "\t" )
+        .append( message.getSubject() ).append( "\n" );
+    } );
     return buf.toString();
   }
 
@@ -314,27 +223,17 @@ public class LoggingBuffer {
   }
 
   public List<BufferLine> getBufferLinesBefore( long minTimeBoundary ) {
-    List<BufferLine> linesToRemove = new ArrayList<BufferLine>();
-    synchronized ( buffer ) {
-      for ( Iterator<BufferLine> i = buffer.iterator(); i.hasNext(); ) {
-        BufferLine bufferLine = i.next();
-        if ( bufferLine.getEvent().timeStamp < minTimeBoundary ) {
-          linesToRemove.add( bufferLine );
-        } else {
-          break;
-        }
-      }
-    }
-    return linesToRemove;
+    return buffer.stream().filter( line -> line.getEvent().timeStamp < minTimeBoundary )
+      .collect( Collectors.toList() );
+  }
+
+  public void removeBufferLinesBefore( long minTimeBoundary ) {
+    buffer.removeIf( line -> line.getEvent().timeStamp < minTimeBoundary );
   }
 
   public void addLogggingEvent( KettleLoggingEvent loggingEvent ) {
     doAppend( loggingEvent );
-    synchronized ( eventListeners ) {
-      for ( KettleLoggingEventListener listener : eventListeners ) {
-        listener.eventAdded( loggingEvent );
-      }
-    }
+    eventListeners.forEach( event -> event.eventAdded( loggingEvent ) );
   }
 
   public void addLoggingEventListener( KettleLoggingEventListener listener ) {
@@ -343,5 +242,14 @@ public class LoggingBuffer {
 
   public void removeLoggingEventListener( KettleLoggingEventListener listener ) {
     eventListeners.remove( listener );
+  }
+
+  private boolean isGeneral( String logChannelId ) {
+    LoggingObjectInterface loggingObject = loggingRegistry.getLoggingObject( logChannelId );
+    return loggingObject != null && LoggingObjectType.GENERAL.equals( loggingObject.getObjectType() );
+  }
+
+  private String getLogChId( BufferLine bufferLine ) {
+    return ( (LogMessage) bufferLine.getEvent().getMessage() ).getLogChannelId();
   }
 }

--- a/core/src/main/java/org/pentaho/di/core/xml/XMLHandlerCache.java
+++ b/core/src/main/java/org/pentaho/di/core/xml/XMLHandlerCache.java
@@ -22,8 +22,9 @@
 
 package org.pentaho.di.core.xml;
 
-import java.util.ArrayList;
-import java.util.Hashtable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * Singleton to help speed up lookups in an XML DOM tree.<br>
@@ -44,29 +45,23 @@ import java.util.Hashtable;
  * @since 22-Apr-2006
  */
 public class XMLHandlerCache {
-  public static final int MAX_NUMBER_OF_ENTRIES = 500;
 
-  private static XMLHandlerCache cache;
+  private static XMLHandlerCache instance;
 
-  private Hashtable<XMLHandlerCacheEntry, Integer> hashtable;
-  private ArrayList<XMLHandlerCacheEntry> list;
+  Map<XMLHandlerCacheEntry, Integer> cache;
 
-  private int cacheHits;
+  private volatile int cacheHits;
 
   private XMLHandlerCache() {
-    hashtable = new Hashtable<XMLHandlerCacheEntry, Integer>( MAX_NUMBER_OF_ENTRIES );
-    list = new ArrayList<XMLHandlerCacheEntry>( MAX_NUMBER_OF_ENTRIES );
-
+    cache = Collections.synchronizedMap( new WeakHashMap<XMLHandlerCacheEntry, Integer>() );
     cacheHits = 0;
   }
 
-  public static final synchronized XMLHandlerCache getInstance() {
-    if ( cache != null ) {
-      return cache;
+  public static synchronized XMLHandlerCache getInstance() {
+    if ( instance == null ) {
+      return instance = new XMLHandlerCache();
     }
-
-    cache = new XMLHandlerCache();
-    return cache;
+    return instance;
   }
 
   /**
@@ -75,20 +70,8 @@ public class XMLHandlerCache {
    * @param entry
    *          The cache entry to store
    */
-  public synchronized void storeCache( XMLHandlerCacheEntry entry, int lastChildNr ) {
-    hashtable.put( entry, Integer.valueOf( lastChildNr ) );
-    list.add( entry );
-
-    if ( list.size() > MAX_NUMBER_OF_ENTRIES ) {
-      // Simple: the oldest is the first in the list
-      XMLHandlerCacheEntry cacheEntry = list.get( 0 );
-
-      // Remove this one from the cache...
-      hashtable.remove( cacheEntry );
-
-      // Remove from the list
-      list.remove( 0 );
-    }
+  public void storeCache( XMLHandlerCacheEntry entry, int lastChildNr ) {
+    cache.put( entry, lastChildNr );
   }
 
   /**
@@ -99,10 +82,10 @@ public class XMLHandlerCache {
    * @return the last child position or -1 if nothing was found.
    */
   public int getLastChildNr( XMLHandlerCacheEntry entry ) {
-    Integer lastChildNr = hashtable.get( entry );
+    Integer lastChildNr = cache.get( entry );
     if ( lastChildNr != null ) {
       cacheHits++;
-      return lastChildNr.intValue();
+      return lastChildNr;
     }
     return -1;
   }
@@ -128,8 +111,7 @@ public class XMLHandlerCache {
    * Clears the cache
    *
    */
-  public synchronized void clear() {
-    this.hashtable.clear();
-    this.list.clear();
+  public void clear() {
+    cache.clear();
   }
 }

--- a/core/src/test/java/org/pentaho/di/cluster/HttpUtilTest.java
+++ b/core/src/test/java/org/pentaho/di/cluster/HttpUtilTest.java
@@ -78,6 +78,7 @@ public class HttpUtilTest {
    *
    * @throws IOException
    */
+  @Test
   public void testEncodeBase64ZippedString() throws IOException {
     String enc64 = HttpUtil.encodeBase64ZippedString( STANDART );
     String decoded = HttpUtil.decodeBase64ZippedString( enc64 );

--- a/core/src/test/java/org/pentaho/di/core/logging/LoggingBufferTest.java
+++ b/core/src/test/java/org/pentaho/di/core/logging/LoggingBufferTest.java
@@ -111,9 +111,11 @@ public class LoggingBufferTest {
     Assert.assertEquals( 0, buff.getNrLines() );
 
     // Load 20 records.  Only last 10 should be kept
+    LogMessage message = null;
     for ( int i = 1; i <= 20; i++ ) {
+      message = new LogMessage( "Test #" + i + Const.CR + "Hello World!", String.valueOf( i ), LogLevel.DETAILED );
       buff.addLogggingEvent(
-        new KettleLoggingEvent( "Test #" + i + Const.CR + "Hello World!", Long.valueOf( i ), LogLevel.DETAILED ) );
+        new KettleLoggingEvent( message, Long.valueOf( i ), LogLevel.DETAILED ) );
     }
     Assert.assertEquals( 10, buff.getNrLines() );
 
@@ -124,7 +126,7 @@ public class LoggingBufferTest {
     while ( it.hasNext() ) {
       BufferLine bl = it.next();
       Assert.assertNotNull( bl.getEvent() );
-      Assert.assertEquals( "Test #" + i + Const.CR + "Hello World!", bl.getEvent().getMessage() );
+      Assert.assertEquals( "Test #" + i + Const.CR + "Hello World!", ( (LogMessage) bl.getEvent().getMessage() ).getMessage() );
       Assert.assertEquals( Long.valueOf( i ).longValue(), bl.getEvent().getTimeStamp() );
       Assert.assertEquals( LogLevel.DETAILED, bl.getEvent().getLevel() );
       i++;
@@ -143,4 +145,19 @@ public class LoggingBufferTest {
       Assert.fail( "This should never be reached, as the LogBuffer is empty" );
     }
   }
+
+  @Test
+  public void testRemoveBufferLinesBefore() throws Exception {
+    LoggingBuffer loggingBuffer = new LoggingBuffer( 100 );
+    for ( int i = 0; i < 40; i++ ) {
+      KettleLoggingEvent event = new KettleLoggingEvent();
+      event.setMessage( new LogMessage( "test", LogLevel.BASIC ) );
+      event.setTimeStamp( i );
+      loggingBuffer.addLogggingEvent( event );
+    }
+    loggingBuffer.removeBufferLinesBefore( 20 );
+    Assert.assertEquals( 20, loggingBuffer.size() );
+    Assert.assertEquals(  0, loggingBuffer.getBufferLinesBefore( 20 ).size() );
+  }
+
 }

--- a/engine/src/main/java/org/pentaho/di/www/GetJobStatusServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/GetJobStatusServlet.java
@@ -23,13 +23,16 @@
 package org.pentaho.di.www;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.cluster.HttpUtil;
 import org.pentaho.di.core.Const;
@@ -40,13 +43,21 @@ import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.Job;
+import org.pentaho.di.www.cache.CarteStatusCache;
 
 
 public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginInterface {
   private static Class<?> PKG = GetJobStatusServlet.class; // for i18n purposes, needed by Translator2!!
 
   private static final long serialVersionUID = 3634806745372015720L;
+
   public static final String CONTEXT_PATH = "/kettle/jobStatus";
+
+  private static final byte[] XML_HEADER =
+    XMLHandler.getXMLHeader( Const.XML_ENCODING ).getBytes( Charset.forName( Const.XML_ENCODING ) );
+
+  @VisibleForTesting
+  CarteStatusCache cache = CarteStatusCache.getInstance();
 
   public GetJobStatusServlet() {
   }
@@ -56,122 +67,121 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
   }
 
   /**
-<div id="mindtouch">
-    <h1>/kettle/jobStatus</h1>
-    <a name="GET"></a>
-    <h2>GET</h2>
-    <p>Retrieves status of the specified job.
-  Status is returned as HTML or XML output depending on the input parameters.
-  Status contains information about last execution of the job.</p>
-    
-    <p><b>Example Request:</b><br />
-    <pre function="syntax.xml">
-    GET /kettle/jobStatus/?name=dummy_job&xml=Y
-    </pre>
-    
-    </p>
-    <h3>Parameters</h3>
-    <table class="pentaho-table">
-    <tbody>
-    <tr>
-      <th>name</th>
-      <th>description</th>
-      <th>type</th>
-    </tr>
-    <tr>
-    <td>name</td>
-    <td>Name of the job to be used for status generation.</td>
-    <td>query</td>
-    </tr>
-    <tr>
-    <td>xml</td>
-    <td>Boolean flag which defines output format <code>Y</code> forces XML output to be generated. 
-  HTML is returned otherwise.</td>
-    <td>boolean, optional</td>
-    </tr>
-    <tr>
-    <td>id</td>
-    <td>Carte id of the job to be used for status generation.</td>
-    <td>query, optional</td>
-    </tr>
-    <tr>
-    <td>from</td>
-    <td>Start line number of the execution log to be included into response.</td>
-    <td>integer, optional</td>
-    </tr>
-    </tbody>
-    </table>
-  
-  <h3>Response Body</h3>
+   <div id="mindtouch">
+   <h1>/kettle/jobStatus</h1>
+   <a name="GET"></a>
+   <h2>GET</h2>
+   <p>Retrieves status of the specified job.
+   Status is returned as HTML or XML output depending on the input parameters.
+   Status contains information about last execution of the job.</p>
 
-  <table class="pentaho-table">
-    <tbody>
-      <tr>
-        <td align="right">element:</td>
-        <td>(custom)</td>
-      </tr>
-      <tr>
-        <td align="right">media types:</td>
-        <td>text/xml, text/html</td>
-      </tr>
-    </tbody>
-  </table>
-    <p>Response XML or HTML response containing details about the job specified.
-  If an error occurs during method invocation <code>result</code> field of the response 
-  will contain <code>ERROR</code> status.</p>
-    
-    <p><b>Example Response:</b></p>
-    <pre function="syntax.xml">
-    <?xml version="1.0" encoding="UTF-8"?>
-    <jobstatus>
-    <jobname>dummy_job</jobname>
-    <id>a4d54106-25db-41c5-b9f8-73afd42766a6</id>
-    <status_desc>Finished</status_desc>
-    <error_desc/>
-    <logging_string>&#x3c;&#x21;&#x5b;CDATA&#x5b;H4sIAAAAAAAAADMyMDTRNzTUNzRXMDC3MjS2MjJQ0FVIKc3NrYzPyk8CsoNLEotKFPLTFEDc1IrU5NKSzPw8Xi4j4nRm5qUrpOaVFFUqRLuE&#x2b;vpGxhKj0y0zL7M4IzUFYieybgWNotTi0pwS2&#x2b;iSotLUWE1iTPNCdrhCGtRsXi4AOMIbLPwAAAA&#x3d;&#x5d;&#x5d;&#x3e;</logging_string>
-    <first_log_line_nr>0</first_log_line_nr>
-    <last_log_line_nr>20</last_log_line_nr>
-    <result>
-      <lines_input>0</lines_input>
-      <lines_output>0</lines_output>
-      <lines_read>0</lines_read>
-      <lines_written>0</lines_written>
-      <lines_updated>0</lines_updated>
-      <lines_rejected>0</lines_rejected>
-      <lines_deleted>0</lines_deleted>
-      <nr_errors>0</nr_errors>
-      <nr_files_retrieved>0</nr_files_retrieved>
-      <entry_nr>0</entry_nr>
-      <result>Y</result>
-      <exit_status>0</exit_status>
-      <is_stopped>N</is_stopped>
-      <log_channel_id/>
-      <log_text>null</log_text>
-      <result-file></result-file>
-      <result-rows></result-rows>
-    </result>
-  </jobstatus>
-    </pre>
-    
-    <h3>Status Codes</h3>
-    <table class="pentaho-table">
-  <tbody>
-    <tr>
-      <th>code</th>
-      <th>description</th>
-    </tr>
-    <tr>
-      <td>200</td>
-      <td>Request was processed.</td>
-    </tr>
-    <tr>
-      <td>500</td>
-      <td>Internal server error occurs during request processing.</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-  */
+   <p><b>Example Request:</b><br />
+   <pre function="syntax.xml">
+   GET /kettle/jobStatus/?name=dummy_job&xml=Y
+   </pre>
+
+   </p>
+   <h3>Parameters</h3>
+   <table class="pentaho-table">
+   <tbody>
+   <tr>
+   <th>name</th>
+   <th>description</th>
+   <th>type</th>
+   </tr>
+   <tr>
+   <td>name</td>
+   <td>Name of the job to be used for status generation.</td>
+   <td>query</td>
+   </tr>
+   <tr>
+   <td>xml</td>
+   <td>Boolean flag which defines output format <code>Y</code> forces XML output to be generated.
+   HTML is returned otherwise.</td>
+   <td>boolean, optional</td>
+   </tr>
+   <tr>
+   <td>id</td>
+   <td>Carte id of the job to be used for status generation.</td>
+   <td>query, optional</td>
+   </tr>
+   <tr>
+   <td>from</td>
+   <td>Start line number of the execution log to be included into response.</td>
+   <td>integer, optional</td>
+   </tr>
+   </tbody>
+   </table>
+
+   <h3>Response Body</h3>
+   <table class="pentaho-table">
+   <tbody>
+   <tr>
+   <td align="right">element:</td>
+   <td>(custom)</td>
+   </tr>
+   <tr>
+   <td align="right">media types:</td>
+   <td>text/xml, text/html</td>
+   </tr>
+   </tbody>
+   </table>
+   <p>Response XML or HTML response containing details about the job specified.
+   If an error occurs during method invocation <code>result</code> field of the response
+   will contain <code>ERROR</code> status.</p>
+
+   <p><b>Example Response:</b></p>
+   <pre function="syntax.xml">
+   <?xml version="1.0" encoding="UTF-8"?>
+   <jobstatus>
+   <jobname>dummy_job</jobname>
+   <id>a4d54106-25db-41c5-b9f8-73afd42766a6</id>
+   <status_desc>Finished</status_desc>
+   <error_desc/>
+   <logging_string>&#x3c;&#x21;&#x5b;CDATA&#x5b;H4sIAAAAAAAAADMyMDTRNzTUNzRXMDC3MjS2MjJQ0FVIKc3NrYzPyk8CsoNLEotKFPLTFEDc1IrU5NKSzPw8Xi4j4nRm5qUrpOaVFFUqRLuE&#x2b;vpGxhKj0y0zL7M4IzUFYieybgWNotTi0pwS2&#x2b;iSotLUWE1iTPNCdrhCGtRsXi4AOMIbLPwAAAA&#x3d;&#x5d;&#x5d;&#x3e;</logging_string>
+   <first_log_line_nr>0</first_log_line_nr>
+   <last_log_line_nr>20</last_log_line_nr>
+   <result>
+   <lines_input>0</lines_input>
+   <lines_output>0</lines_output>
+   <lines_read>0</lines_read>
+   <lines_written>0</lines_written>
+   <lines_updated>0</lines_updated>
+   <lines_rejected>0</lines_rejected>
+   <lines_deleted>0</lines_deleted>
+   <nr_errors>0</nr_errors>
+   <nr_files_retrieved>0</nr_files_retrieved>
+   <entry_nr>0</entry_nr>
+   <result>Y</result>
+   <exit_status>0</exit_status>
+   <is_stopped>N</is_stopped>
+   <log_channel_id/>
+   <log_text>null</log_text>
+   <result-file></result-file>
+   <result-rows></result-rows>
+   </result>
+   </jobstatus>
+   </pre>
+
+   <h3>Status Codes</h3>
+   <table class="pentaho-table">
+   <tbody>
+   <tr>
+   <th>code</th>
+   <th>description</th>
+   </tr>
+   <tr>
+   <td>200</td>
+   <td>Request was processed.</td>
+   </tr>
+   <tr>
+   <td>500</td>
+   <td>Internal server error occurs during request processing.</td>
+   </tr>
+   </tbody>
+   </table>
+   </div>
+   */
   public void doGet( HttpServletRequest request, HttpServletResponse response ) throws ServletException,
     IOException {
     if ( isJettyMode() && !request.getContextPath().startsWith( CONTEXT_PATH ) ) {
@@ -195,8 +205,6 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
     } else {
       response.setContentType( "text/html;charset=UTF-8" );
     }
-
-    PrintWriter out = response.getWriter();
 
     // ID is optional...
     //
@@ -229,37 +237,65 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
     }
 
     if ( job != null ) {
-      String status = job.getStatus();
-      int lastLineNr = KettleLogStore.getLastBufferLineNr();
-      String logText =
-        KettleLogStore.getAppender().getBuffer(
-          job.getLogChannel().getLogChannelId(), false, startLineNr, lastLineNr ).toString();
 
       if ( useXML ) {
-        response.setContentType( "text/xml" );
-        response.setCharacterEncoding( Const.XML_ENCODING );
-        out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-
-        SlaveServerJobStatus jobStatus = new SlaveServerJobStatus( jobName, id, status );
-        jobStatus.setFirstLoggingLineNr( startLineNr );
-        jobStatus.setLastLoggingLineNr( lastLineNr );
-        jobStatus.setLogDate( job.getLogDate() );
-
-        // The log can be quite large at times, we are going to put a base64 encoding around a compressed stream
-        // of bytes to handle this one.
-        String loggingString = HttpUtil.encodeBase64ZippedString( logText );
-        jobStatus.setLoggingString( loggingString );
-
-        // Also set the result object...
-        //
-        jobStatus.setResult( job.getResult() ); // might be null
-
         try {
-          out.println( jobStatus.getXML() );
+          OutputStream out = null;
+          byte[] data = null;
+          String logId = job.getLogChannelId();
+          boolean finishedOrStopped = job.isFinished() || job.isStopped();
+          if ( finishedOrStopped && ( data = cache.get( logId, startLineNr ) ) != null ) {
+            response.setContentLength( XML_HEADER.length + data.length );
+            out = response.getOutputStream();
+            out.write( XML_HEADER );
+            out.write( data );
+            out.flush();
+          } else {
+            int lastLineNr = KettleLogStore.getLastBufferLineNr();
+            String logText = getLogText( job, startLineNr, lastLineNr );
+
+            response.setContentType( "text/xml" );
+            response.setCharacterEncoding( Const.XML_ENCODING );
+
+            SlaveServerJobStatus jobStatus = new SlaveServerJobStatus( jobName, id, job.getStatus() );
+            jobStatus.setFirstLoggingLineNr( startLineNr );
+            jobStatus.setLastLoggingLineNr( lastLineNr );
+            jobStatus.setLogDate( job.getLogDate() );
+
+            // The log can be quite large at times, we are going to putIfAbsent a base64 encoding around a compressed
+            // stream
+
+
+            // of bytes to handle this one.
+            String loggingString = HttpUtil.encodeBase64ZippedString( logText );
+            jobStatus.setLoggingString( loggingString );
+
+            // Also set the result object...
+            //
+            jobStatus.setResult( job.getResult() ); // might be null
+
+
+            String xml = jobStatus.getXML();
+            data = xml.getBytes( Charset.forName( Const.XML_ENCODING ) );
+            out = response.getOutputStream();
+            response.setContentLength( XML_HEADER.length + data.length );
+            out.write( XML_HEADER );
+            out.write( data );
+            out.flush();
+            if ( finishedOrStopped && logId != null ) {
+              cache.put( logId, xml, startLineNr );
+            }
+          }
+          response.flushBuffer();
         } catch ( KettleException e ) {
           throw new ServletException( "Unable to get the job status in XML format", e );
         }
       } else {
+
+        PrintWriter out = response.getWriter();
+
+        int lastLineNr = KettleLogStore.getLastBufferLineNr();
+
         response.setContentType( "text/html" );
 
         out.println( "<HTML>" );
@@ -284,7 +320,7 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
 
           out.print( "<tr>" );
           out.print( "<td>" + Const.NVL( Encode.forHtml( jobName ), "" ) + "</td>" );
-          out.print( "<td>" + status + "</td>" );
+          out.print( "<td>" + job.getStatus() + "</td>" );
           out.print( "</tr>" );
           out.print( "</table>" );
 
@@ -344,7 +380,7 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
           out.println( "<p>" );
           out.println( "<textarea id=\"joblog\" cols=\"120\" rows=\"20\" wrap=\"off\" "
             + "name=\"Job log\" readonly=\"readonly\">"
-            + Encode.forHtml( logText ) + "</textarea>" );
+            + Encode.forHtml( getLogText( job, startLineNr, lastLineNr ) ) + "</textarea>" );
 
           out.println( "<script type=\"text/javascript\"> " );
           out.println( "  joblog.scrollTop=joblog.scrollHeight; " );
@@ -362,6 +398,7 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
         out.println( "</HTML>" );
       }
     } else {
+      PrintWriter out = response.getWriter();
       if ( useXML ) {
         out.println( new WebResult( WebResult.STRING_ERROR, BaseMessages.getString(
           PKG, "StartJobServlet.Log.SpecifiedJobNotFound", jobName, id ) ) );
@@ -386,4 +423,12 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
     return CONTEXT_PATH;
   }
 
+  private String getLogText( Job job, int startLineNr, int lastLineNr ) throws KettleException {
+    try {
+      return KettleLogStore.getAppender().getBuffer(
+        job.getLogChannel().getLogChannelId(), false, startLineNr, lastLineNr ).toString();
+    } catch ( OutOfMemoryError error ) {
+      throw new KettleException( "Log string is too long" );
+    }
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/www/GetTransStatusServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/GetTransStatusServlet.java
@@ -23,13 +23,16 @@
 package org.pentaho.di.www;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.cluster.HttpUtil;
 import org.pentaho.di.core.Const;
@@ -43,13 +46,22 @@ import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.step.BaseStepData.StepExecutionStatus;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepStatus;
+import org.pentaho.di.www.cache.CarteStatusCache;
 
 
 public class GetTransStatusServlet extends BaseHttpServlet implements CartePluginInterface {
+
   private static Class<?> PKG = GetTransStatusServlet.class; // for i18n purposes, needed by Translator2!!
 
   private static final long serialVersionUID = 3634806745372015720L;
+
   public static final String CONTEXT_PATH = "/kettle/transStatus";
+
+  private static final byte[] XML_HEADER =
+    XMLHandler.getXMLHeader( Const.XML_ENCODING ).getBytes( Charset.forName( Const.XML_ENCODING ) );
+
+  @VisibleForTesting
+  CarteStatusCache cache = CarteStatusCache.getInstance();
 
   public GetTransStatusServlet() {
   }
@@ -59,134 +71,134 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
   }
 
   /**
-  <div id="mindtouch">
-      <h1>/kettle/transStatus</h1>
-      <a name="GET"></a>
-      <h2>GET</h2>
-      <p>Retrieves status of the specified transformation. Status is returned as HTML or XML output 
-    depending on the input parameters. Status contains information about last execution of the transformation.</p>      
-      <p><b>Example Request:</b><br />
-      <pre function="syntax.xml">
-      GET /kettle/transStatus/?name=dummy-trans&xml=Y
-      </pre>
-      
-      </p>
-      <h3>Parameters</h3>
-      <table class="pentaho-table">
-      <tbody>
-      <tr>
-        <th>name</th>
-        <th>description</th>
-        <th>type</th>
-      </tr>
-      <tr>
-      <td>name</td>
-      <td>Name of the transformation to be used for status generation.</td>
-      <td>query</td>
-      </tr>
-      <tr>
-      <td>xml</td>
-      <td>Boolean flag which defines output format <code>Y</code> forces XML output to be generated. 
-    HTML is returned otherwise.</td>
-      <td>boolean, optional</td>
-      </tr>
-      <tr>
-      <td>id</td>
-      <td>Carte id of the transformation to be used for status generation.</td>
-      <td>query, optional</td>
-      </tr>
-      <tr>
-      <td>from</td>
-      <td>Start line number of the execution log to be included into response.</td>
-      <td>integer, optional</td>
-      </tr>
-      </tbody>
-      </table>
-    
-    <h3>Response Body</h3>
+   <div id="mindtouch">
+   <h1>/kettle/transStatus</h1>
+   <a name="GET"></a>
+   <h2>GET</h2>
+   <p>Retrieves status of the specified transformation. Status is returned as HTML or XML output
+   depending on the input parameters. Status contains information about last execution of the transformation.</p>
+   <p><b>Example Request:</b><br />
+   <pre function="syntax.xml">
+   GET /kettle/transStatus/?name=dummy-trans&xml=Y
+   </pre>
 
-    <table class="pentaho-table">
-      <tbody>
-        <tr>
-          <td align="right">element:</td>
-          <td>(custom)</td>
-        </tr>
-        <tr>
-          <td align="right">media types:</td>
-          <td>text/xml, text/html</td>
-        </tr>
-      </tbody>
-    </table>
-    <p> Response XML or HTML response containing details about the transformation specified.
-    If an error occurs during method invocation <code>result</code> field of the response 
-    will contain <code>ERROR</code> status.</p>
-      
-      <p><b>Example Response:</b></p>
-      <pre function="syntax.xml">
-      <?xml version="1.0" encoding="UTF-8"?>
-      <transstatus>
-        <transname>dummy-trans</transname>
-        <id>c56961b2-c848-49b8-abde-76c8015e29b0</id>
-        <status_desc>Stopped</status_desc>
-        <error_desc/>
-        <paused>N</paused>
-        <stepstatuslist>
-          <stepstatus><stepname>Dummy &#x28;do nothing&#x29;</stepname>
-          <copy>0</copy><linesRead>0</linesRead>
-          <linesWritten>0</linesWritten><linesInput>0</linesInput>
-          <linesOutput>0</linesOutput><linesUpdated>0</linesUpdated>
-          <linesRejected>0</linesRejected><errors>0</errors>
-          <statusDescription>Stopped</statusDescription><seconds>0.0</seconds>
-          <speed>-</speed><priority>-</priority><stopped>Y</stopped>
-          <paused>N</paused>
-          </stepstatus>
-        </stepstatuslist>
-        <first_log_line_nr>0</first_log_line_nr>
-        <last_log_line_nr>37</last_log_line_nr>
-        <result>
-          <lines_input>0</lines_input>
-          <lines_output>0</lines_output>
-          <lines_read>0</lines_read>
-          <lines_written>0</lines_written>
-          <lines_updated>0</lines_updated>
-          <lines_rejected>0</lines_rejected>
-          <lines_deleted>0</lines_deleted>
-          <nr_errors>0</nr_errors>
-          <nr_files_retrieved>0</nr_files_retrieved>
-          <entry_nr>0</entry_nr>
-          <result>Y</result>
-          <exit_status>0</exit_status>
-          <is_stopped>Y</is_stopped>
-          <log_channel_id>10e2c832-07da-409a-a5ba-4b90a234e957</log_channel_id>
-          <log_text/>
-          <result-file></result-file>
-          <result-rows></result-rows>
-        </result>
-        <logging_string>&#x3c;&#x21;&#x5b;CDATA&#x5b;H4sIAAAAAAAAADMyMDTRNzTUNzJRMDSyMrC0MjFV0FVIKc3NrdQtKUrMKwbyXDKLCxJLkjMy89IViksSi0pSUxTS8osUwPJARm5iSWZ&#x2b;nkI0kq5YXi4AQVH5bFoAAAA&#x3d;&#x5d;&#x5d;&#x3e;</logging_string>
-       </transstatus>
-      </pre>
-      
-      <h3>Status Codes</h3>
-      <table class="pentaho-table">
-    <tbody>
-      <tr>
-        <th>code</th>
-        <th>description</th>
-      </tr>
-      <tr>
-        <td>200</td>
-        <td>Request was processed.</td>
-      </tr>
-      <tr>
-        <td>500</td>
-        <td>Internal server error occurs during request processing.</td>
-      </tr>
-    </tbody>
-  </table>
-  </div>
-    */
+   </p>
+   <h3>Parameters</h3>
+   <table class="pentaho-table">
+   <tbody>
+   <tr>
+   <th>name</th>
+   <th>description</th>
+   <th>type</th>
+   </tr>
+   <tr>
+   <td>name</td>
+   <td>Name of the transformation to be used for status generation.</td>
+   <td>query</td>
+   </tr>
+   <tr>
+   <td>xml</td>
+   <td>Boolean flag which defines output format <code>Y</code> forces XML output to be generated.
+   HTML is returned otherwise.</td>
+   <td>boolean, optional</td>
+   </tr>
+   <tr>
+   <td>id</td>
+   <td>Carte id of the transformation to be used for status generation.</td>
+   <td>query, optional</td>
+   </tr>
+   <tr>
+   <td>from</td>
+   <td>Start line number of the execution log to be included into response.</td>
+   <td>integer, optional</td>
+   </tr>
+   </tbody>
+   </table>
+
+   <h3>Response Body</h3>
+   <table class="pentaho-table">
+   <tbody>
+   <tr>
+   <td align="right">element:</td>
+   <td>(custom)</td>
+   </tr>
+   <tr>
+   <td align="right">media types:</td>
+   <td>text/xml, text/html</td>
+   </tr>
+   </tbody>
+   </table>
+   <p> Response XML or HTML response containing details about the transformation specified.
+   If an error occurs during method invocation <code>result</code> field of the response
+   will contain <code>ERROR</code> status.</p>
+
+   <p><b>Example Response:</b></p>
+   <pre function="syntax.xml">
+   <?xml version="1.0" encoding="UTF-8"?>
+   <transstatus>
+   <transname>dummy-trans</transname>
+   <id>c56961b2-c848-49b8-abde-76c8015e29b0</id>
+   <status_desc>Stopped</status_desc>
+   <error_desc/>
+   <paused>N</paused>
+   <stepstatuslist>
+   <stepstatus><stepname>Dummy &#x28;do nothing&#x29;</stepname>
+   <copy>0</copy><linesRead>0</linesRead>
+   <linesWritten>0</linesWritten><linesInput>0</linesInput>
+   <linesOutput>0</linesOutput><linesUpdated>0</linesUpdated>
+   <linesRejected>0</linesRejected><errors>0</errors>
+   <statusDescription>Stopped</statusDescription><seconds>0.0</seconds>
+   <speed>-</speed><priority>-</priority><stopped>Y</stopped>
+   <paused>N</paused>
+   </stepstatus>
+   </stepstatuslist>
+   <first_log_line_nr>0</first_log_line_nr>
+   <last_log_line_nr>37</last_log_line_nr>
+   <result>
+   <lines_input>0</lines_input>
+   <lines_output>0</lines_output>
+   <lines_read>0</lines_read>
+   <lines_written>0</lines_written>
+   <lines_updated>0</lines_updated>
+   <lines_rejected>0</lines_rejected>
+   <lines_deleted>0</lines_deleted>
+   <nr_errors>0</nr_errors>
+   <nr_files_retrieved>0</nr_files_retrieved>
+   <entry_nr>0</entry_nr>
+   <result>Y</result>
+   <exit_status>0</exit_status>
+   <is_stopped>Y</is_stopped>
+   <log_channel_id>10e2c832-07da-409a-a5ba-4b90a234e957</log_channel_id>
+   <log_text/>
+   <result-file></result-file>
+   <result-rows></result-rows>
+   </result>
+   <logging_string>&#x3c;&#x21;&#x5b;CDATA&#x5b;H4sIAAAAAAAAADMyMDTRNzTUNzJRMDSyMrC0MjFV0FVIKc3NrdQtKUrMKwbyXDKLCxJLkjMy89IViksSi0pSUxTS8osUwPJARm5iSWZ&#x2b;nkI0kq5YXi4AQVH5bFoAAAA&#x3d;&#x5d;&#x5d;&#x3e;</logging_string>
+   </transstatus>
+   </pre>
+
+   <h3>Status Codes</h3>
+   <table class="pentaho-table">
+   <tbody>
+   <tr>
+   <th>code</th>
+   <th>description</th>
+   </tr>
+   <tr>
+   <td>200</td>
+   <td>Request was processed.</td>
+   </tr>
+   <tr>
+   <td>500</td>
+   <td>Internal server error occurs during request processing.</td>
+   </tr>
+   </tbody>
+   </table>
+   </div>
+   */
   public void doGet( HttpServletRequest request, HttpServletResponse response ) throws ServletException,
     IOException {
+
     if ( isJettyMode() && !request.getContextPath().startsWith( CONTEXT_PATH ) ) {
       return;
     }
@@ -211,8 +223,6 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
 
     }
 
-    PrintWriter out = response.getWriter();
-
     // ID is optional...
     //
     Trans trans;
@@ -235,51 +245,78 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
     }
 
     if ( trans != null ) {
-      String status = trans.getStatus();
-      int lastLineNr = KettleLogStore.getLastBufferLineNr();
-      String logText =
-        KettleLogStore.getAppender().getBuffer(
-          trans.getLogChannel().getLogChannelId(), false, startLineNr, lastLineNr ).toString();
-
       if ( useXML ) {
-        response.setContentType( "text/xml" );
-        response.setCharacterEncoding( Const.XML_ENCODING );
-        out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-
-        SlaveServerTransStatus transStatus = new SlaveServerTransStatus( transName, entry.getId(), status );
-        transStatus.setFirstLoggingLineNr( startLineNr );
-        transStatus.setLastLoggingLineNr( lastLineNr );
-        transStatus.setLogDate( trans.getLogDate() );
-
-        for ( int i = 0; i < trans.nrSteps(); i++ ) {
-          StepInterface baseStep = trans.getRunThread( i );
-          if ( ( baseStep.isRunning() ) || baseStep.getStatus() != StepExecutionStatus.STATUS_EMPTY ) {
-            StepStatus stepStatus = new StepStatus( baseStep );
-            transStatus.getStepStatusList().add( stepStatus );
-          }
-        }
-
-        // The log can be quite large at times, we are going to put a base64 encoding around a compressed stream
-        // of bytes to handle this one.
-        String loggingString = HttpUtil.encodeBase64ZippedString( logText );
-        transStatus.setLoggingString( loggingString );
-
-        // Also set the result object...
-        //
-        transStatus.setResult( trans.getResult() );
-
-        // Is the transformation paused?
-        //
-        transStatus.setPaused( trans.isPaused() );
-
-        // Send the result back as XML
-        //
         try {
-          out.println( transStatus.getXML() );
+          OutputStream out = null;
+          byte[] data = null;
+          String logId = trans.getLogChannelId();
+          boolean finishedOrStopped = trans.isFinishedOrStopped();
+          if ( finishedOrStopped && ( data = cache.get( logId, startLineNr ) ) != null ) {
+            response.setContentLength( XML_HEADER.length + data.length );
+            out = response.getOutputStream();
+            out.write( XML_HEADER );
+            out.write( data );
+            out.flush();
+          } else {
+            int lastLineNr = KettleLogStore.getLastBufferLineNr();
+
+            String logText = getLogText( trans, startLineNr, lastLineNr );
+
+            response.setContentType( "text/xml" );
+            response.setCharacterEncoding( Const.XML_ENCODING );
+
+            SlaveServerTransStatus transStatus =
+              new SlaveServerTransStatus( transName, entry.getId(), trans.getStatus() );
+            transStatus.setFirstLoggingLineNr( startLineNr );
+            transStatus.setLastLoggingLineNr( lastLineNr );
+            transStatus.setLogDate( trans.getLogDate() );
+
+            for ( int i = 0; i < trans.nrSteps(); i++ ) {
+              StepInterface baseStep = trans.getRunThread( i );
+              if ( ( baseStep.isRunning() ) || baseStep.getStatus() != StepExecutionStatus.STATUS_EMPTY ) {
+                StepStatus stepStatus = new StepStatus( baseStep );
+                transStatus.getStepStatusList().add( stepStatus );
+              }
+            }
+
+            // The log can be quite large at times, we are going to putIfAbsent a base64 encoding around a compressed
+            // stream
+            // of bytes to handle this one.
+            String loggingString = HttpUtil.encodeBase64ZippedString( logText );
+            transStatus.setLoggingString( loggingString );
+            //        transStatus.setLoggingUncompressedSize( logText.length() );
+
+            // Also set the result object...
+            //
+            transStatus.setResult( trans.getResult() );
+
+            // Is the transformation paused?
+            //
+            transStatus.setPaused( trans.isPaused() );
+
+            // Send the result back as XML
+            //
+            String xml = transStatus.getXML();
+            data = xml.getBytes( Charset.forName( Const.XML_ENCODING ) );
+            out = response.getOutputStream();
+            response.setContentLength( XML_HEADER.length + data.length );
+            out.write( XML_HEADER );
+            out.write( data );
+            out.flush();
+            if ( finishedOrStopped && logId != null ) {
+              cache.put( logId, xml, startLineNr );
+            }
+          }
+          response.flushBuffer();
         } catch ( KettleException e ) {
           throw new ServletException( "Unable to get the transformation status in XML format", e );
         }
+
       } else {
+        PrintWriter out = response.getWriter();
+
+        int lastLineNr = KettleLogStore.getLastBufferLineNr();
+
         response.setContentType( "text/html;charset=UTF-8" );
 
         out.println( "<HTML>" );
@@ -306,7 +343,7 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
           out.print( "<tr>" );
           out.print( "<td>" + Encode.forHtml( transName ) + "</td>" );
           out.print( "<td>" + Encode.forHtml( id ) + "</td>" );
-          out.print( "<td>" + Encode.forHtml( status ) + "</td>" );
+          out.print( "<td>" + Encode.forHtml( trans.getStatus() ) + "</td>" );
           out.print( "</tr>" );
           out.print( "</table>" );
 
@@ -412,7 +449,7 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
           out
             .println( "<textarea id=\"translog\" cols=\"120\" rows=\"20\" "
               + "wrap=\"off\" name=\"Transformation log\" readonly=\"readonly\">"
-              + Encode.forHtml( logText ) + "</textarea>" );
+              + Encode.forHtml( getLogText( trans, startLineNr, lastLineNr ) ) + "</textarea>" );
 
           out.println( "<script type=\"text/javascript\"> " );
           out.println( "  translog.scrollTop=translog.scrollHeight; " );
@@ -430,13 +467,14 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
         out.println( "</HTML>" );
       }
     } else {
+      PrintWriter out = response.getWriter();
       if ( useXML ) {
         out.println( new WebResult( WebResult.STRING_ERROR, BaseMessages.getString(
           PKG, "TransStatusServlet.Log.CoundNotFindSpecTrans", transName ) ) );
       } else {
         out.println( "<H1>"
           + Encode.forHtml( BaseMessages.getString(
-            PKG, "TransStatusServlet.Log.CoundNotFindTrans", transName ) ) + "</H1>" );
+          PKG, "TransStatusServlet.Log.CoundNotFindTrans", transName ) ) + "</H1>" );
         out.println( "<a href=\""
           + convertContextPath( GetStatusServlet.CONTEXT_PATH ) + "\">"
           + BaseMessages.getString( PKG, "TransStatusServlet.BackToStatusPage" ) + "</a><p>" );
@@ -454,6 +492,15 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
 
   public String getContextPath() {
     return CONTEXT_PATH;
+  }
+
+  private String getLogText( Trans trans, int startLineNr, int lastLineNr ) throws KettleException {
+    try {
+      return KettleLogStore.getAppender().getBuffer(
+        trans.getLogChannel().getLogChannelId(), false, startLineNr, lastLineNr ).toString();
+    } catch ( OutOfMemoryError error ) {
+      throw new KettleException( "Log string is too long", error );
+    }
   }
 
 }

--- a/engine/src/main/java/org/pentaho/di/www/PrepareExecutionTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/PrepareExecutionTransServlet.java
@@ -39,6 +39,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransConfiguration;
 import org.pentaho.di.trans.TransExecutionConfiguration;
+import org.pentaho.di.www.cache.CarteStatusCache;
 
 
 public class PrepareExecutionTransServlet extends BaseHttpServlet implements CartePluginInterface {
@@ -46,6 +47,7 @@ public class PrepareExecutionTransServlet extends BaseHttpServlet implements Car
 
   private static final long serialVersionUID = 3634806745372015720L;
   public static final String CONTEXT_PATH = "/kettle/prepareExec";
+  private CarteStatusCache cache = CarteStatusCache.getInstance();
 
   public PrepareExecutionTransServlet() {
   }
@@ -214,6 +216,7 @@ public class PrepareExecutionTransServlet extends BaseHttpServlet implements Car
 
         try {
           trans.prepareExecution( null );
+          cache.remove( trans.getLogChannelId() );
 
           if ( useXML ) {
             out.println( WebResult.OK.getXML() );

--- a/engine/src/main/java/org/pentaho/di/www/RemoveJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RemoveJobServlet.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
@@ -36,6 +37,7 @@ import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.Job;
+import org.pentaho.di.www.cache.CarteStatusCache;
 
 
 public class RemoveJobServlet extends BaseHttpServlet implements CartePluginInterface {
@@ -44,6 +46,9 @@ public class RemoveJobServlet extends BaseHttpServlet implements CartePluginInte
   private static final long serialVersionUID = -2051906998698124039L;
 
   public static final String CONTEXT_PATH = "/kettle/removeJob";
+
+  @VisibleForTesting
+  private CarteStatusCache cache = CarteStatusCache.getInstance();
 
   public RemoveJobServlet() {
   }
@@ -184,6 +189,7 @@ public class RemoveJobServlet extends BaseHttpServlet implements CartePluginInte
 
     if ( job != null ) {
 
+      cache.remove( job.getLogChannelId() );
       KettleLogStore.discardLines( job.getLogChannelId(), true );
       getJobMap().removeJob( entry );
 

--- a/engine/src/main/java/org/pentaho/di/www/RemoveTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RemoveTransServlet.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
@@ -36,6 +37,7 @@ import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
+import org.pentaho.di.www.cache.CarteStatusCache;
 
 
 public class RemoveTransServlet extends BaseHttpServlet implements CartePluginInterface {
@@ -44,6 +46,9 @@ public class RemoveTransServlet extends BaseHttpServlet implements CartePluginIn
   private static final long serialVersionUID = 6618979989596401783L;
 
   public static final String CONTEXT_PATH = "/kettle/removeTrans";
+
+  @VisibleForTesting
+  private CarteStatusCache cache = CarteStatusCache.getInstance();
 
   public RemoveTransServlet() {
   }
@@ -186,6 +191,7 @@ public class RemoveTransServlet extends BaseHttpServlet implements CartePluginIn
 
     if ( trans != null ) {
 
+      cache.remove( trans.getLogChannelId() );
       KettleLogStore.discardLines( trans.getLogChannelId(), true );
       getTransformationMap().removeTransformation( entry );
 

--- a/engine/src/main/java/org/pentaho/di/www/StartJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StartJobServlet.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
@@ -42,6 +43,7 @@ import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobConfiguration;
+import org.pentaho.di.www.cache.CarteStatusCache;
 
 
 public class StartJobServlet extends BaseHttpServlet implements CartePluginInterface {
@@ -52,6 +54,9 @@ public class StartJobServlet extends BaseHttpServlet implements CartePluginInter
   private static final long serialVersionUID = -8487225953910464032L;
 
   public static final String CONTEXT_PATH = "/kettle/startJob";
+
+  @VisibleForTesting
+  CarteStatusCache cache = CarteStatusCache.getInstance();
 
   public StartJobServlet() {
   }
@@ -218,6 +223,8 @@ public class StartJobServlet extends BaseHttpServlet implements CartePluginInter
               job.getRep().connect( null, null );
             }
           }
+
+          cache.remove( job.getLogChannelId() );
 
           // Create a new job object to start from a sane state. Then replace
           // the new job in the job map

--- a/engine/src/main/java/org/pentaho/di/www/StartTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StartTransServlet.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.StringUtils;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
@@ -42,6 +43,7 @@ import org.pentaho.di.core.logging.SimpleLoggingObject;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
+import org.pentaho.di.www.cache.CarteStatusCache;
 
 
 public class StartTransServlet extends BaseHttpServlet implements CartePluginInterface {
@@ -51,6 +53,9 @@ public class StartTransServlet extends BaseHttpServlet implements CartePluginInt
   private static final long serialVersionUID = -5879200987669847357L;
 
   public static final String CONTEXT_PATH = "/kettle/startTrans";
+
+  @VisibleForTesting
+  CarteStatusCache cache = CarteStatusCache.getInstance();
 
   public StartTransServlet() {
   }
@@ -204,6 +209,8 @@ public class StartTransServlet extends BaseHttpServlet implements CartePluginInt
       }
 
       if ( trans != null ) {
+
+        cache.remove( trans.getLogChannelId() );
 
         // Discard old log lines from old transformation runs
         //

--- a/engine/src/main/java/org/pentaho/di/www/cache/CachedItem.java
+++ b/engine/src/main/java/org/pentaho/di/www/cache/CachedItem.java
@@ -1,0 +1,64 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www.cache;
+
+import java.io.File;
+import java.io.Serializable;
+import java.time.LocalDate;
+
+public class CachedItem implements Serializable {
+
+  private File file;
+  private LocalDate exceedTime;
+  private int from;
+
+  public CachedItem( File file, int from ) {
+    this.file = file;
+    this.from = from;
+    exceedTime = LocalDate.now().plusDays( 1 );
+  }
+
+  public File getFile() {
+    return file;
+  }
+
+  public void setFile( File file ) {
+    this.file = file;
+  }
+
+  public int getFrom() {
+    return from;
+  }
+
+  public void setFrom( int from ) {
+    this.from = from;
+  }
+
+  public LocalDate getExceedTime() {
+    return exceedTime;
+  }
+
+  public void setExceedTime( LocalDate exceedTime ) {
+    this.exceedTime = exceedTime;
+  }
+}

--- a/engine/src/main/java/org/pentaho/di/www/cache/CarteStatusCache.java
+++ b/engine/src/main/java/org/pentaho/di/www/cache/CarteStatusCache.java
@@ -1,0 +1,212 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www.cache;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.io.FileUtils;
+import org.hibernate.cache.CacheException;
+import org.pentaho.di.core.Const;
+import org.hibernate.cache.Cache;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+
+public class CarteStatusCache implements Cache {
+
+  public static final String CARTE_STATUS_CACHE = "CARTE_CACHE";
+
+  private final ScheduledExecutorService removeService = Executors.newSingleThreadScheduledExecutor();
+
+  private final Map<String, CachedItem> cachedMap = new ConcurrentHashMap<>();
+
+  private static CarteStatusCache instance = null;
+
+  private int period = 0;
+
+  private TimeUnit timeUnit = null;
+
+
+  public static synchronized CarteStatusCache getInstance() {
+    if ( instance == null ) {
+      instance = new CarteStatusCache();
+    }
+    return instance;
+  }
+
+  private CarteStatusCache() {
+    period = Integer.parseInt( Const.getEnvironmentVariable( "CARTE_CLEAR_PERIOD", "1" ) );
+    timeUnit = TimeUnit.valueOf( Const.getEnvironmentVariable( "CARTE_CLEAR_TIMEUNIT", "DAYS" ) );
+    removeService.scheduleAtFixedRate( this::clear, 1, 1, TimeUnit.DAYS );
+  }
+
+
+  public void put( String logId, String cacheString, int from ) {
+    String randomPref = UUID.randomUUID().toString();
+    File file = null;
+    try {
+      file = File.createTempFile( randomPref, null );
+      file.deleteOnExit();
+      Files.write( file.toPath(), cacheString.getBytes( Const.XML_ENCODING ) );
+      CachedItem item = new CachedItem( file, from );
+      if ( ( item = cachedMap.put( logId, item ) ) != null ) {
+        removeTask( item.getFile() );
+      }
+    } catch ( Exception e ) {
+      cachedMap.remove( logId );
+      if ( file != null ) {
+        file.delete();
+      }
+    }
+  }
+
+
+  public byte[] get( String logId, int from ) {
+    CachedItem item = null;
+    try {
+      item = cachedMap.get( logId );
+      if ( item == null || item.getFrom() != from ) {
+        return null;
+      }
+
+      synchronized ( item.getFile() ) {
+        return Files.readAllBytes( item.getFile().toPath() );
+      }
+
+
+    } catch ( Exception e ) {
+      cachedMap.remove( logId );
+      if ( item != null ) {
+        removeTask( item.getFile() );
+      }
+    }
+    return null;
+  }
+
+  public void remove( String id ) {
+    CachedItem item = cachedMap.remove( id );
+    if ( item != null ) {
+      removeTask( item.getFile() );
+    }
+  }
+
+  private void removeTask( File file ) {
+    removeService.execute( () -> removeFile( file ) );
+  }
+
+  private void removeFile( File file ) {
+    synchronized ( file ) {
+      if ( file.exists() ) {
+        FileUtils.deleteQuietly( file );
+      }
+    }
+  }
+
+  @VisibleForTesting
+  Map<String, CachedItem> getMap() {
+    return cachedMap;
+  }
+
+  @Override
+  public Object read( Object key ) throws CacheException {
+    return cachedMap.get( key );
+  }
+
+  @Override
+  public Object get( Object key ) throws CacheException {
+    return cachedMap.get( key );
+  }
+
+  @Override
+  public void put( Object key, Object value ) throws CacheException {
+    cachedMap.put( (String) key, (CachedItem) value );
+  }
+
+  @Override
+  public void update( Object key, Object value ) throws CacheException {
+    put( (String) key, (CachedItem) value );
+  }
+
+  @Override
+  public void remove( Object key ) throws CacheException {
+    remove( (String) key );
+  }
+
+  @Override
+  public void clear() throws CacheException {
+    cachedMap.forEach( ( k, v ) -> {
+      if ( LocalDate.now().isAfter( v.getExceedTime() ) ) {
+        remove( k );
+      }
+    } );
+  }
+
+  @Override
+  public void destroy() throws CacheException {
+    clear();
+  }
+
+  @Override
+  public Map toMap() {
+    return cachedMap;
+  }
+
+  @Override
+  public void lock( Object key ) throws CacheException {
+  }
+
+  @Override
+  public void unlock( Object key ) throws CacheException {
+  }
+
+  @Override public long nextTimestamp() {
+    return 0;
+  }
+
+  @Override public int getTimeout() {
+    return 0;
+  }
+
+  @Override public String getRegionName() {
+    return null;
+  }
+
+  @Override public long getSizeInMemory() {
+    return 0;
+  }
+
+  @Override public long getElementCountInMemory() {
+    return 0;
+  }
+
+  @Override public long getElementCountOnDisk() {
+    return 0;
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/www/GetJobStatusServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/GetJobStatusServletTest.java
@@ -31,11 +31,13 @@ import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.www.cache.CarteStatusCache;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -45,9 +47,12 @@ import java.io.StringWriter;
 import static junit.framework.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.atLeastOnce;
 
 
 @RunWith( PowerMockRunner.class )
@@ -111,5 +116,45 @@ public class GetJobStatusServletTest {
 
     PowerMockito.verifyStatic( atLeastOnce() );
     Encode.forHtml( anyString() );
+  }
+
+  @Test
+  @PrepareForTest( { Job.class } )
+  public void testGetJobStatus() throws ServletException, IOException {
+    KettleLogStore.init();
+    CarteStatusCache cacheMock = mock( CarteStatusCache.class );
+    getJobStatusServlet.cache = cacheMock;
+    HttpServletRequest mockHttpServletRequest = mock( HttpServletRequest.class );
+    HttpServletResponse mockHttpServletResponse = mock( HttpServletResponse.class );
+    Job mockJob = PowerMockito.mock( Job.class );
+    JobMeta mockJobMeta = mock( JobMeta.class );
+    LogChannelInterface mockLogChannelInterface = mock( LogChannelInterface.class );
+    ServletOutputStream outMock = mock( ServletOutputStream.class );
+
+    String id = "123";
+    String logId = "logId";
+    String useXml = "Y";
+
+    when( mockHttpServletRequest.getContextPath() ).thenReturn( GetJobStatusServlet.CONTEXT_PATH );
+    when( mockHttpServletRequest.getParameter( "id" ) ).thenReturn( id );
+    when( mockHttpServletRequest.getParameter( "xml" ) ).thenReturn( useXml );
+    when( mockHttpServletResponse.getOutputStream() ).thenReturn( outMock );
+    when( mockJobMap.findJob( id ) ).thenReturn( mockJob );
+    PowerMockito.when( mockJob.getJobname() ).thenReturn( ServletTestUtils.BAD_STRING_TO_TEST );
+    PowerMockito.when( mockJob.getLogChannel() ).thenReturn( mockLogChannelInterface );
+    PowerMockito.when( mockJob.getJobMeta() ).thenReturn( mockJobMeta );
+    PowerMockito.when( mockJob.isFinished() ).thenReturn( true );
+    PowerMockito.when( mockJob.getLogChannelId() ).thenReturn( logId );
+    PowerMockito.when( mockJobMeta.getMaximum() ).thenReturn( new Point( 10, 10 ) );
+
+    getJobStatusServlet.doGet( mockHttpServletRequest, mockHttpServletResponse );
+
+    when( cacheMock.get( logId, 0 ) ).thenReturn( new byte[] { 0, 1, 2 } );
+    getJobStatusServlet.doGet( mockHttpServletRequest, mockHttpServletResponse );
+
+    verify( cacheMock, times( 2 ) ).get( logId, 0 );
+    verify( cacheMock, times( 1 ) ).put( eq( logId ), anyString(), eq( 0 ) );
+    verify( mockJob.getLogChannel(), times( 1 ) );
+
   }
 }

--- a/engine/src/test/java/org/pentaho/di/www/GetTransStatusServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/GetTransStatusServletTest.java
@@ -31,11 +31,13 @@ import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.www.cache.CarteStatusCache;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -45,9 +47,12 @@ import java.io.StringWriter;
 import static junit.framework.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith( PowerMockRunner.class )
 public class GetTransStatusServletTest {
@@ -109,4 +114,43 @@ public class GetTransStatusServletTest {
     PowerMockito.verifyStatic( atLeastOnce() );
     Encode.forHtml( anyString() );
   }
+
+  @Test
+  public void testGetTransStatus() throws ServletException, IOException {
+    KettleLogStore.init();
+    CarteStatusCache cacheMock = mock( CarteStatusCache.class );
+    getTransStatusServlet.cache = cacheMock;
+    HttpServletRequest mockHttpServletRequest = mock( HttpServletRequest.class );
+    HttpServletResponse mockHttpServletResponse = mock( HttpServletResponse.class );
+    Trans mockTrans = mock( Trans.class );
+    TransMeta mockTransMeta = mock( TransMeta.class );
+    LogChannelInterface mockChannelInterface = mock( LogChannelInterface.class );
+    ServletOutputStream outMock = mock( ServletOutputStream.class );
+
+    String id = "123";
+    String logId = "logId";
+    String useXml = "Y";
+
+    when( mockHttpServletRequest.getContextPath() ).thenReturn( GetTransStatusServlet.CONTEXT_PATH );
+    when( mockHttpServletRequest.getParameter( "id" ) ).thenReturn( id );
+    when( mockHttpServletRequest.getParameter( "xml" ) ).thenReturn( useXml );
+    when( mockHttpServletResponse.getOutputStream() ).thenReturn( outMock );
+    when( mockTransformationMap.getTransformation( any( CarteObjectEntry.class ) ) ).thenReturn( mockTrans );
+    when( mockTrans.getLogChannel() ).thenReturn( mockChannelInterface );
+    when( mockTrans.getTransMeta() ).thenReturn( mockTransMeta );
+    when( mockTrans.getLogChannelId() ).thenReturn( logId );
+    when( mockTrans.isFinishedOrStopped() ).thenReturn( true );
+
+    when( mockTransMeta.getMaximum() ).thenReturn( new Point( 10, 10 ) );
+
+    getTransStatusServlet.doGet( mockHttpServletRequest, mockHttpServletResponse );
+    when( cacheMock.get( logId, 0 ) ).thenReturn( new byte[] { 0, 1, 2 } );
+    getTransStatusServlet.doGet( mockHttpServletRequest, mockHttpServletResponse );
+
+    verify( cacheMock, times( 2 ) ).get( logId, 0 );
+    verify( cacheMock, times( 1 ) ).put( eq( logId ), anyString(), eq( 0 ) );
+    verify( mockTrans.getLogChannel(), times( 1 ) );
+
+  }
+
 }

--- a/engine/src/test/java/org/pentaho/di/www/cache/CarteStatusCacheTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/cache/CarteStatusCacheTest.java
@@ -1,0 +1,99 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.www.cache;
+
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+
+public class CarteStatusCacheTest {
+
+  CarteStatusCache cache = null;
+  CarteStatusCache cacheSpy = null;
+
+  @Before
+  public void setup() {
+    cache = CarteStatusCache.getInstance();
+    cacheSpy = spy( cache );
+  }
+
+  @Test
+  public void testGetInstance() {
+    Assert.assertTrue( CarteStatusCache.getInstance() == CarteStatusCache.getInstance() );
+  }
+
+  @Test
+  public void testPut() throws Exception {
+    initializeTestData( cache.getMap() );
+    String id = "40";
+    cacheSpy.put( "logId" + id, "test string data", 0 );
+    Assert.assertEquals( 41, cache.getMap().size() );
+    id = "20";
+    File mockFile = cache.getMap().get( "logId" + id ).getFile();
+    when( mockFile.exists() ).thenReturn( true );
+    cacheSpy.put(   "logId" + id, "test string data", 0  );
+    Assert.assertEquals( 41, cache.getMap().size() );
+  }
+
+  @Test
+  public void testGet() throws Exception {
+    initializeTestData( cache.getMap() );
+
+    Assert.assertNull( cacheSpy.get( "logId40", 0 ) );
+
+    File mockFile = cache.getMap().get( "logId1" ).getFile();
+    Path path = mock( Path.class );
+    when( mockFile.toPath() ).thenReturn( path );
+
+    cacheSpy.get( "logId1", 0 );
+
+    verify( mockFile ).toPath();
+  }
+
+  @Test
+  public void testRemove() throws Exception {
+    initializeTestData( cache.getMap() );
+    Assert.assertEquals( 40, cache.getMap().size() );
+    cacheSpy.remove( "logId1" );
+    Assert.assertEquals( 39, cache.getMap().size() );
+    Assert.assertNull( cache.getMap().get( "logId1" ) );
+  }
+
+
+  void initializeTestData( Map<String, CachedItem> map ) {
+    map.clear();
+    for ( int i = 0; i < 40; i++ ) {
+      map.put( "logId" + i, new CachedItem( mock( File.class ), 0 ) );
+    }
+  }
+}


### PR DESCRIPTION
-Optimized LoggingBuffer( by using concurrent collections and streams)
-Implemented local-temp-file cache for keeping statuses of stopped or finished transformations or jobs which significantly decreases carte response time and cpu usage ( especially for medium and large logs)
-The saved log content will be alive during specified by user properties in kettle.properties ( By default 1 day)
-The changes remove restrictions to saving limited number of logs ( It was 5000 lines by default before ) since statuses are saved as temp files, not in memory
-Optimized SpoonSlave:
  -Disabled excess events( which requested ktr/kjb status many times at one moment )
  -Fixed memory leak. SpoonSlave saved all the carte ktr/kjbs logs in map (id,log) and never cleared it( even if it was removed ) . In case of large logs we may catch OOME and Spoon crash.
  -Update slave view time is configurable now via kettle.properties (SPOON_CARTE_VIEW_UPDATE_TIME)
-Fixed critical memory leak which concerns xml parsing( XMLHandlerCache ). The implementation of it is incomplete. XMLHandler ,which we use every time we need to parse xml, caches nodes(which may be large ones) and never clears it. Sooner(if we parse large xml files) or later it may cause spoon crash (oome) . Reimplemented the cache with using WeakHashMap. You may face with it when running ktrs/kjbs with large logs on carte via spoon and after some time spoon will crash. Slave tab in spoon periodically sends multiple request to carte for status updates, parses xml responses  and then in profiler you could see large objects representing not cleared nodes. Note that it does not concern only slave tab but everywhere we use XmlHandler .