### PR TITLE
[SP-3694] Backport of PDI-16221 - "file" option of Kitchen and Pan do not work in the file system (7.1 Suite)

### DIFF
--- a/engine/src/org/pentaho/di/core/util/FileUtil.java
+++ b/engine/src/org/pentaho/di/core/util/FileUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,8 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
+
+import java.io.File;
 
 public class FileUtil {
   public static boolean createParentFolder( Class<?> PKG, String filename, boolean createParentFolder,
@@ -75,6 +77,16 @@ public class FileUtil {
     }
 
     return resultat;
+  }
+
+  /**
+   * Tests whether this abstract pathname is absolute.
+   *
+   * The pathname is absolute if its prefix is "/", "\" and on Microsoft Windows systems,
+   * a pathname is absolute if its prefix is a drive specifier followed by "\\", or if its prefix is "\\\\".
+   */
+  public static boolean isFullyQualified( String pathname ) {
+    return new File( pathname ).isAbsolute() || pathname.startsWith( "/" ) || pathname.startsWith( "\\" );
   }
 
 }

--- a/engine/src/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/org/pentaho/di/kitchen/Kitchen.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.di.kitchen;
 
-import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -36,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.util.FileUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.KettleEnvironment;
@@ -387,7 +387,7 @@ public class Kitchen {
           // If the filename starts with scheme like zip:, then isAbsolute() will return false even though
           // the path following the zip is absolute path. Check for isAbsolute only if the fileName does not
           // start with scheme
-          if ( !KettleVFS.startsWithScheme( fileName ) && !new File( fileName ).isAbsolute() ) {
+          if ( !KettleVFS.startsWithScheme( fileName ) && !FileUtil.isFullyQualified( fileName ) ) {
             fileName = initialDir.toString() + fileName;
           }
 

--- a/engine/src/org/pentaho/di/pan/Pan.java
+++ b/engine/src/org/pentaho/di/pan/Pan.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.di.pan;
 
-import java.io.File;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -31,6 +30,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.util.FileUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.KettleEnvironment;
@@ -387,7 +387,7 @@ public class Pan {
           // If the filename starts with scheme like zip:, then isAbsolute() will return false even though the
           // the path following the zip is absolute path. Check for isAbsolute only if the fileName does not
           // start with scheme
-          if ( !KettleVFS.startsWithScheme( fileName ) && !new File( fileName ).isAbsolute() ) {
+          if ( !KettleVFS.startsWithScheme( fileName ) && !FileUtil.isFullyQualified( fileName ) ) {
             fileName = initialDir.toString() + fileName;
           }
 

--- a/engine/test-src/org/pentaho/di/utils/FileUtilsTest.java
+++ b/engine/test-src/org/pentaho/di/utils/FileUtilsTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -57,5 +57,11 @@ public class FileUtilsTest {
     assertTrue( "Dir should exist", fl.exists() );
     fl.delete();
     new File( tempDir ).delete();
+  }
+
+  @Test
+  public void testIsFullyQualified() {
+    assertTrue( FileUtil.isFullyQualified( "/test" ) );
+    assertTrue( FileUtil.isFullyQualified( "\\test" ) );
   }
 }


### PR DESCRIPTION
- fixed definition of the absolute path