### PR TITLE
[BACKLOG-18271] - CSV File Input: Columns with the same name in the csv are not read properly

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/csvinput/NamedFieldsMapping.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/csvinput/NamedFieldsMapping.java
@@ -22,8 +22,12 @@
 
 package org.pentaho.di.trans.steps.csvinput;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 
 public class NamedFieldsMapping implements FieldsMapping {
 
@@ -45,13 +49,19 @@ public class NamedFieldsMapping implements FieldsMapping {
   }
 
   public static NamedFieldsMapping mapping( String[] actualFieldNames, String[] metaFieldNames ) {
-    Map<String, Integer> metaNameToIndex = new HashMap<>();
+    MultiValuedMap<String, Integer> metaNameToIndex = new ArrayListValuedHashMap<String, Integer>();
     for ( int j = 0; j < metaFieldNames.length; j++ ) {
       metaNameToIndex.put( metaFieldNames[j], Integer.valueOf( j ) );
     }
     Map<Integer, Integer> actualToMetaFieldMapping = new HashMap<>();
     for ( int i = 0; i < actualFieldNames.length; i++ ) {
-      actualToMetaFieldMapping.put( i, metaNameToIndex.get( actualFieldNames[i] ) );
+      Collection<Integer> columnIndexes = metaNameToIndex.get( actualFieldNames[i] );
+      if ( columnIndexes.isEmpty() ) {
+        continue;
+      }
+      Integer columnIndex = columnIndexes.iterator().next();
+      metaNameToIndex.removeMapping( actualFieldNames[i], columnIndex );
+      actualToMetaFieldMapping.put( i, columnIndex );
     }
     return new NamedFieldsMapping( actualToMetaFieldMapping );
   }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/NamedFieldsMappingTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/NamedFieldsMappingTest.java
@@ -64,4 +64,20 @@ public class NamedFieldsMappingTest {
     assertEquals( 0, mapping.fieldMetaIndex( 1 ) );
   }
 
+  @Test
+  public void mappingWithNonUniqueColumnNames() {
+    NamedFieldsMapping mapping =
+        NamedFieldsMapping.mapping( new String[] { "Object", "Test", "Object" }, new String[] { "Object", "Test",
+          "Object" } );
+    assertEquals( 0, mapping.fieldMetaIndex( 0 ) );
+    assertEquals( 2, mapping.fieldMetaIndex( 2 ) );
+  }
+
+  @Test
+  public void fieldMetaIndexWithUnexistingField_nonUniqueColumnNames() {
+    NamedFieldsMapping mapping =
+        NamedFieldsMapping.mapping( new String[] { "Object", "Test", "Object" }, new String[] { "Object", "Test" } );
+    assertEquals( FieldsMapping.FIELD_DOES_NOT_EXIST, mapping.fieldMetaIndex( 2 ) );
+  }
+
 }


### PR DESCRIPTION
I modified mapping mechanism, so now it is possible to map indexes to non unique column names, thus it fixes the bug with getting data from columns that share the same name.
@pamval , @bmorrise  please review.
