### PR TITLE
[BACKLOG-18274] - CSV Files with BOM are not being correctly read by CSV File Input Step

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/csvinput/CsvInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/csvinput/CsvInput.java
@@ -24,13 +24,14 @@ package org.pentaho.di.trans.steps.csvinput;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.provider.local.LocalFile;
 import org.pentaho.di.core.Const;
@@ -408,14 +409,15 @@ public class CsvInput extends BaseStep implements StepInterface {
     return mapping;
   }
 
-  String[] readFieldNamesFromFile( String fileName, CsvInputMeta csvInputMeta )
-    throws KettleException {
+  String[] readFieldNamesFromFile( String fileName, CsvInputMeta csvInputMeta ) throws KettleException {
     String delimiter = environmentSubstitute( csvInputMeta.getDelimiter() );
     String enclosure = environmentSubstitute( csvInputMeta.getEnclosure() );
     String realEncoding = environmentSubstitute( csvInputMeta.getEncoding() );
 
     try ( FileObject fileObject = KettleVFS.getFileObject( fileName, getTransMeta() );
-        InputStream inputStream = KettleVFS.getInputStream( fileObject ) ) {
+        BOMInputStream inputStream =
+            new BOMInputStream( KettleVFS.getInputStream( fileObject ), ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE,
+                ByteOrderMark.UTF_16BE ) ) {
       InputStreamReader reader = null;
       if ( Utils.isEmpty( realEncoding ) ) {
         reader = new InputStreamReader( inputStream );
@@ -426,11 +428,6 @@ public class CsvInput extends BaseStep implements StepInterface {
       String line =
           TextFileInput.getLine( log, reader, encodingType, TextFileInputMeta.FILE_FORMAT_UNIX, new StringBuilder(
               1000 ) );
-      // remove BOM
-      boolean containsBOM = line.indexOf( "\uFEFF" ) == 0;
-      if ( containsBOM ) {
-        line = line.substring( 1 );
-      }
       String[] fieldNames =
           CsvInput.guessStringsFromLine( log, line, delimiter, enclosure, csvInputMeta.getEscapeCharacter() );
       if ( !Utils.isEmpty( csvInputMeta.getEnclosure() ) ) {
@@ -446,7 +443,8 @@ public class CsvInput extends BaseStep implements StepInterface {
     TextFileInputField[] fields = csvInputMeta.getInputFields();
     String[] fieldNames = new String[fields.length];
     for ( int i = 0; i < fields.length; i++ ) {
-      fieldNames[i] = fields[i].getName();
+      // We need to sanitize field names because existing ktr files may contain field names with leading BOM
+      fieldNames[i] = EncodingType.removeBOMIfPresent( fields[i].getName() );
     }
     return fieldNames;
   }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/EncodingType.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/EncodingType.java
@@ -23,7 +23,9 @@
 package org.pentaho.di.trans.steps.textfileinput;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.ByteOrderMark;
 import org.pentaho.di.core.util.Utils;
 
 /**
@@ -33,6 +35,8 @@ import org.pentaho.di.core.util.Utils;
 public enum EncodingType {
   SINGLE( 1, 0, '\r', '\n' ), DOUBLE_BIG_ENDIAN( 2, 0xFEFF, 0x000d, 0x000a ), DOUBLE_LITTLE_ENDIAN(
     2, 0xFFFE, 0x0d00, 0x0a00 );
+
+  private static final String UTF_8_BOM = new String( ByteOrderMark.UTF_8.getBytes(), StandardCharsets.UTF_8 );
 
   private int length;
 
@@ -95,6 +99,10 @@ public enum EncodingType {
     }
 
     return encodingType;
+  }
+
+  public static String removeBOMIfPresent( String string ) {
+    return string.replaceFirst( UTF_8_BOM, "" );
   }
 
   public byte[] getBytes( String string, String encoding ) throws UnsupportedEncodingException {

--- a/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputUnicodeTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputUnicodeTest.java
@@ -22,6 +22,8 @@
 
 package org.pentaho.di.trans.steps.csvinput;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Assert;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
@@ -55,6 +57,18 @@ public class CsvInputUnicodeTest extends CsvInputUnitTestBase {
   private static final String TEST_DATA1 = String.format( TEXT, MULTI_CHAR_DELIM );
   private static final String TEST_DATA2 = String.format( TEXT_WITH_ENCLOSURES, ONE_CHAR_DELIM );
   private static final String TEST_DATA3 = String.format( TEXT_WITH_ENCLOSURES, MULTI_CHAR_DELIM );
+
+  private static final byte[] UTF8_BOM = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+  private static final String TEST_DATA_UTF8_BOM =
+      String.format( new String( UTF8_BOM, StandardCharsets.UTF_8 ) + TEXT, ONE_CHAR_DELIM );
+
+  private static final byte[] UTF16LE_BOM = { (byte) 0xFF, (byte) 0xFE };
+  private static final String TEST_DATA_UTF16LE_BOM =
+      String.format( new String( UTF16LE_BOM, StandardCharsets.UTF_16LE ) + TEST_DATA2, ONE_CHAR_DELIM );
+
+  private static final byte[] UTF16BE_BOM = { (byte) 0xFE, (byte) 0xFF };
+  private static final String TEST_DATA_UTF16BE_BOM =
+      String.format( new String( UTF16BE_BOM, StandardCharsets.UTF_16BE ) + TEST_DATA2, ONE_CHAR_DELIM );
 
   private static StepMockHelper<?, ?> stepMockHelper;
 
@@ -98,13 +112,28 @@ public class CsvInputUnicodeTest extends CsvInputUnitTestBase {
   }
 
   @Test
+  public void testUTF8_headerWithBOM() throws Exception {
+    doTest( UTF8, UTF8, TEST_DATA_UTF8_BOM, ONE_CHAR_DELIM );
+  }
+
+  @Test
   public void testUTF16LEDataWithEnclosures() throws Exception {
     doTest( UTF16LE, UTF16LE, TEST_DATA2, ONE_CHAR_DELIM );
   }
 
   @Test
+  public void testUTF16LE_headerWithBOM() throws Exception {
+    doTest( UTF16LE, UTF16LE, TEST_DATA_UTF16LE_BOM, ONE_CHAR_DELIM );
+  }
+
+  @Test
   public void testUTF16BEDataWithEnclosures() throws Exception {
     doTest( UTF16BE, UTF16BE, TEST_DATA2, ONE_CHAR_DELIM );
+  }
+
+  @Test
+  public void testUTF16BE_headerWithBOM() throws Exception {
+    doTest( UTF16BE, UTF16BE, TEST_DATA_UTF16BE_BOM, ONE_CHAR_DELIM );
   }
 
   @Test


### PR DESCRIPTION
@bmorrise , @pamval please review.
This PR excludes BOM from head strings. It also excludes BOM from field names that might exist in .ktr files (BOM comes to field names during "Get fields" operation and it would be better to keep this behaviour - as these "BOM'ed" fields could be copied to other steps).