### PR TITLE
[PDI-16430] Delete truncate statement from getCopyCommand() function

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/pgbulkloader/PGBulkLoader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/pgbulkloader/PGBulkLoader.java
@@ -83,8 +83,6 @@ public class PGBulkLoader extends BaseStep implements StepInterface {
   public String getCopyCommand( ) throws KettleException {
     DatabaseMeta dm = meta.getDatabaseMeta();
 
-    String loadAction = environmentSubstitute( meta.getLoadAction() );
-
     StringBuilder contents = new StringBuilder( 500 );
 
     String tableName =
@@ -97,11 +95,6 @@ public class PGBulkLoader extends BaseStep implements StepInterface {
     // contents.append(Const.CR);
 
     // Create a Postgres / Greenplum COPY string for use with a psql client
-    if ( loadAction.equalsIgnoreCase( "truncate" ) ) {
-      contents.append( "TRUNCATE TABLE " );
-      contents.append( tableName + ";" );
-      contents.append( Const.CR );
-    }
     contents.append( "COPY " );
     // Table name
 


### PR DESCRIPTION
In PR https://github.com/pentaho/pentaho-kettle/pull/4292, the problem was basically fixed, except for a small place. 

Truncate statement shouldn't be returned as part of the copyCmd.