### PR TITLE
[SP3754][PDI-16472] Oracle bulk loader is not working with metadata injection (ArrayIndexOutOfBoundsException)

### DIFF
--- a/engine/src/org/pentaho/di/core/injection/AfterInjection.java
+++ b/engine/src/org/pentaho/di/core/injection/AfterInjection.java
@@ -1,0 +1,34 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.injection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention( RetentionPolicy.RUNTIME )
+@Target( ElementType.METHOD )
+public @interface AfterInjection {
+}
+

--- a/engine/src/org/pentaho/di/core/injection/bean/BeanInjector.java
+++ b/engine/src/org/pentaho/di/core/injection/bean/BeanInjector.java
@@ -24,11 +24,14 @@ package org.pentaho.di.core.injection.bean;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.injection.AfterInjection;
 
 /**
  * Engine for get/set metadata injection properties from bean.
@@ -323,5 +326,25 @@ public class BeanInjector {
     }
 
     return index < existList.size() ? existList : null;
+  }
+
+  public void runPostInjectionProcessing( Object object ) {
+    Method[] methods = object.getClass().getDeclaredMethods();
+    for ( Method m : methods ) {
+      AfterInjection annotationAfterInjection = m.getAnnotation( AfterInjection.class );
+      if ( annotationAfterInjection == null ) {
+        // no after injection annotations
+        continue;
+      }
+      if ( m.isSynthetic() || Modifier.isStatic( m.getModifiers() ) ) {
+        // method is static
+        throw new RuntimeException( "Wrong modifier for annotated method " + m );
+      }
+      try {
+        m.invoke( object );
+      } catch ( Exception e ) {
+        throw new RuntimeException( "Can not invoke after injection method " + m, e );
+      }
+    }
   }
 }

--- a/engine/src/org/pentaho/di/trans/steps/insertupdate/InsertUpdate.java
+++ b/engine/src/org/pentaho/di/trans/steps/insertupdate/InsertUpdate.java
@@ -63,7 +63,7 @@ public class InsertUpdate extends BaseStep implements StepInterface {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
 
-  private synchronized void lookupValues( RowMetaInterface rowMeta, Object[] row ) throws KettleException {
+  protected synchronized void lookupValues( RowMetaInterface rowMeta, Object[] row ) throws KettleException {
     // OK, now do the lookup.
     // We need the lookupvalues for that.
     Object[] lookupRow = new Object[data.lookupParameterRowMeta.size()];

--- a/engine/src/org/pentaho/di/trans/steps/insertupdate/InsertUpdateMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/insertupdate/InsertUpdateMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,6 +28,7 @@ import java.util.List;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.injection.AfterInjection;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.ProvidesModelerMeta;
 import org.pentaho.di.core.SQLStatement;
@@ -920,5 +921,23 @@ public class InsertUpdateMeta extends BaseStepMeta implements StepMetaInterface,
 
   @Override public List<String> getStreamFields() {
     return Arrays.asList( updateStream );
+  }
+
+  /**
+   * If we use injection we can have different arrays lengths.
+   * We need synchronize them for consistency behavior with UI
+   */
+  @AfterInjection
+  public void afterInjectionSynchronization() {
+    if ( keyStream == null || keyStream.length == 0 ) {
+      return;
+    }
+    int nrFields = keyStream.length;
+    //PDI-16349
+    if ( keyStream2.length < nrFields ) {
+      String[] newKeyStream2 = new String[ nrFields ];
+      System.arraycopy( keyStream2, 0, newKeyStream2, 0, keyStream2.length );
+      keyStream2 = newKeyStream2;
+    }
   }
 }

--- a/engine/src/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,9 +24,11 @@ package org.pentaho.di.trans.steps.orabulkloader;
 
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.injection.AfterInjection;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.ProvidesDatabaseConnectionInformation;
 import org.pentaho.di.core.SQLStatement;
@@ -1056,5 +1058,33 @@ public class OraBulkLoaderMeta extends BaseStepMeta implements StepMetaInterface
   public String getMissingDatabaseConnectionInformationMessage() {
     // TODO Auto-generated method stub
     return null;
+  }
+
+  /**
+   * If we use injection we can have different arrays lengths.
+   * We need synchronize them for consistency behavior with UI
+   */
+  @AfterInjection
+  public void afterInjectionSynchronization() {
+    if ( fieldTable == null || fieldTable.length == 0 ) {
+      return;
+    }
+    int nrFields = fieldTable.length;
+    if ( fieldStream.length < nrFields ) {
+      String[] newFieldStream = new String[ nrFields ];
+      System.arraycopy( fieldStream, 0, newFieldStream, 0, fieldStream.length );
+      fieldStream = newFieldStream;
+    }
+    for ( int i = 0; i < fieldStream.length; i++ ) {
+      if ( fieldStream[ i ] == null ) {
+        fieldStream[ i ] = StringUtils.EMPTY;
+      }
+    }
+    //PDI-16472
+    if ( dateMask.length < nrFields ) {
+      String[] newDateMask = new String[ nrFields ];
+      System.arraycopy( dateMask, 0, newDateMask, 0, dateMask.length );
+      dateMask = newDateMask;
+    }
   }
 }

--- a/engine/src/org/pentaho/di/trans/steps/replacestring/ReplaceStringMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/replacestring/ReplaceStringMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,9 +24,11 @@ package org.pentaho.di.trans.steps.replacestring;
 
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.injection.AfterInjection;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -620,4 +622,76 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
     return getRegExByCode( tt );
   }
 
+
+  /**
+   * If we use injection we can have different arrays lengths.
+   * We need synchronize them for consistency behavior with UI
+   */
+  @AfterInjection
+  public void afterInjectionSynchronization() {
+    if ( fieldInStream == null || fieldInStream.length == 0 ) {
+      return;
+    }
+    int nrFields = fieldInStream.length;
+    //PDI-16423
+    if ( fieldOutStream.length < nrFields ) {
+      String[] newFieldOutStream = new String[ nrFields ];
+      System.arraycopy( fieldOutStream, 0, newFieldOutStream, 0, fieldOutStream.length );
+      fieldOutStream = newFieldOutStream;
+    }
+    nullToEmpty( fieldOutStream );
+
+    if ( useRegEx.length < nrFields ) {
+      int[] newUseRegEx = new int[ nrFields ];
+      System.arraycopy( useRegEx, 0, newUseRegEx, 0, useRegEx.length );
+      useRegEx = newUseRegEx;
+    }
+
+    if ( caseSensitive.length < nrFields ) {
+      int[] newCaseSensitive = new int[ nrFields ];
+      System.arraycopy( caseSensitive, 0, newCaseSensitive, 0, caseSensitive.length );
+      caseSensitive = newCaseSensitive;
+    }
+
+    if ( wholeWord.length < nrFields ) {
+      int[] newWholeWord = new int[ nrFields ];
+      System.arraycopy( wholeWord, 0, newWholeWord, 0, wholeWord.length );
+      wholeWord = newWholeWord;
+    }
+
+    if ( replaceString.length < nrFields ) {
+      String[] newReplaceStrings = new String[ nrFields ];
+      System.arraycopy( replaceString, 0, newReplaceStrings, 0, replaceString.length );
+      replaceString = newReplaceStrings;
+    }
+    nullToEmpty( replaceString );
+
+    if ( replaceByString.length < nrFields ) {
+      String[] newReplaceByString = new String[ nrFields ];
+      System.arraycopy( replaceByString, 0, newReplaceByString, 0, replaceByString.length );
+      replaceByString = newReplaceByString;
+    }
+    nullToEmpty( replaceByString );
+
+    if ( setEmptyString.length < nrFields ) {
+      boolean[] newSetEmptyString = new boolean[ nrFields ];
+      System.arraycopy( setEmptyString, 0, newSetEmptyString, 0, setEmptyString.length );
+      setEmptyString = newSetEmptyString;
+    }
+
+    if ( replaceFieldByString.length < nrFields ) {
+      String[] newFieldReplaceByString = new String[ nrFields ];
+      System.arraycopy( replaceFieldByString, 0, newFieldReplaceByString, 0, replaceFieldByString.length );
+      replaceFieldByString = newFieldReplaceByString;
+    }
+    nullToEmpty( replaceFieldByString );
+  }
+
+  private void nullToEmpty( String [] strings ) {
+    for ( int i = 0; i < strings.length; i++ ) {
+      if ( strings[ i ] == null ) {
+        strings[ i ] = StringUtils.EMPTY;
+      }
+    }
+  }
 }

--- a/engine/src/org/pentaho/di/trans/steps/streamlookup/StreamLookupMeta.java
+++ b/engine/src/org/pentaho/di/trans/steps/streamlookup/StreamLookupMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,6 +31,7 @@ import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.injection.AfterInjection;
 import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -663,5 +664,38 @@ public class StreamLookupMeta extends BaseStepMeta implements StepMetaInterface 
    */
   public void setUsingIntegerPair( boolean usingIntegerPair ) {
     this.usingIntegerPair = usingIntegerPair;
+  }
+
+  /**
+   * If we use injection we can have different arrays lengths.
+   * We need synchronize them for consistency behavior with UI
+   */
+  @AfterInjection
+  public void afterInjectionSynchronization() {
+    if ( value == null || value.length == 0 ) {
+      return;
+    }
+    int nrFields = value.length;
+    //PDI-16110
+    if ( valueDefaultType.length < nrFields ) {
+      int[] newValueDefaultType = new int[ nrFields ];
+      System.arraycopy( valueDefaultType, 0, newValueDefaultType, 0, valueDefaultType.length );
+      for ( int i = valueDefaultType.length; i < newValueDefaultType.length; i++ ) {
+        newValueDefaultType[i] = -1; //set a undefined value (<0). It will be correct processed in a handleNullIf method
+      }
+      valueDefaultType = newValueDefaultType;
+    }
+    if ( valueName.length < nrFields ) {
+      String[] newValueName = new String[ nrFields ];
+      System.arraycopy( valueName, 0, newValueName, 0, valueName.length );
+      valueName = newValueName;
+    }
+
+    if ( valueDefault.length < nrFields ) {
+      String[] newValueDefault = new String[ nrFields ];
+      System.arraycopy( valueDefault, 0, newValueDefault, 0, valueDefault.length );
+      valueDefault = newValueDefault;
+    }
+
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/insertupdate/InsertUpdateMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/insertupdate/InsertUpdateMetaTest.java
@@ -22,20 +22,22 @@
 
 package org.pentaho.di.trans.steps.insertupdate;
 
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 import org.mockito.Mockito;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.database.Database;
+import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
@@ -43,7 +45,6 @@ import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.StepPluginType;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.util.Assert;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
@@ -94,13 +95,13 @@ public class InsertUpdateMetaTest {
   @Test
   public void testCommitCountFixed() {
     umi.setCommitSize( "100" );
-    assertTrue( umi.getCommitSize( upd ) == 100 );
+    Assert.assertTrue( umi.getCommitSize( upd ) == 100 );
   }
 
   @Test
   public void testCommitCountVar() {
     umi.setCommitSize( "${max.sz}" );
-    assertTrue( umi.getCommitSize( upd ) == 10 );
+    Assert.assertTrue( umi.getCommitSize( upd ) == 10 );
   }
 
   @Test
@@ -111,15 +112,15 @@ public class InsertUpdateMetaTest {
 
     InsertUpdateData tableOutputData = new InsertUpdateData();
     tableOutputData.insertRowMeta = Mockito.mock( RowMeta.class );
-    assertEquals( tableOutputData.insertRowMeta, insertUpdateMeta.getRowMeta( tableOutputData ) );
-    assertEquals( 3, insertUpdateMeta.getDatabaseFields().size() );
-    assertEquals( "f1", insertUpdateMeta.getDatabaseFields().get( 0 ) );
-    assertEquals( "f2", insertUpdateMeta.getDatabaseFields().get( 1 ) );
-    assertEquals( "f3", insertUpdateMeta.getDatabaseFields().get( 2 ) );
-    assertEquals( 3, insertUpdateMeta.getStreamFields().size() );
-    assertEquals( "s4", insertUpdateMeta.getStreamFields().get( 0 ) );
-    assertEquals( "s5", insertUpdateMeta.getStreamFields().get( 1 ) );
-    assertEquals( "s6", insertUpdateMeta.getStreamFields().get( 2 ) );
+    Assert.assertEquals( tableOutputData.insertRowMeta, insertUpdateMeta.getRowMeta( tableOutputData ) );
+    Assert.assertEquals( 3, insertUpdateMeta.getDatabaseFields().size() );
+    Assert.assertEquals( "f1", insertUpdateMeta.getDatabaseFields().get( 0 ) );
+    Assert.assertEquals( "f2", insertUpdateMeta.getDatabaseFields().get( 1 ) );
+    Assert.assertEquals( "f3", insertUpdateMeta.getDatabaseFields().get( 2 ) );
+    Assert.assertEquals( 3, insertUpdateMeta.getStreamFields().size() );
+    Assert.assertEquals( "s4", insertUpdateMeta.getStreamFields().get( 0 ) );
+    Assert.assertEquals( "s5", insertUpdateMeta.getStreamFields().get( 1 ) );
+    Assert.assertEquals( "s6", insertUpdateMeta.getStreamFields().get( 2 ) );
   }
 
   @Test
@@ -127,7 +128,7 @@ public class InsertUpdateMetaTest {
     umi.setCommitSize( "missed-var" );
     try {
       umi.getCommitSize( upd );
-      fail();
+      Assert.fail();
     } catch ( Exception ex ) {
     }
   }
@@ -222,4 +223,41 @@ public class InsertUpdateMetaTest {
     Assert.assertFalse( result );
   }
 
+  //PDI-16349
+  @Test
+  public void keyStream2ProcessRow() throws KettleException {
+    StepMockHelper<InsertUpdateMeta, InsertUpdateData> mockHelper =
+      new StepMockHelper<>( "insertUpdate", InsertUpdateMeta.class, InsertUpdateData.class );
+    Mockito.when(
+      mockHelper.logChannelInterfaceFactory.create( Mockito.any(), Mockito.any( LoggingObjectInterface.class ) ) )
+      .thenReturn( mockHelper.logChannelInterface );
+    Mockito.when( mockHelper.stepMeta.getStepMetaInterface() ).thenReturn( new InsertUpdateMeta() );
+
+    InsertUpdate insertUpdateStep =
+      new InsertUpdate( mockHelper.stepMeta, mockHelper.stepDataInterface, 0, mockHelper.transMeta, mockHelper.trans );
+    insertUpdateStep.setInputRowMeta( Mockito.mock( RowMetaInterface.class ) );
+    insertUpdateStep = Mockito.spy( insertUpdateStep );
+
+    InsertUpdateMeta insertUpdateMeta = new InsertUpdateMeta();
+    insertUpdateMeta.setKeyStream( new String[] { "test_field" } );
+    insertUpdateMeta.setKeyCondition( new String[] { "test_condition" } );
+    insertUpdateMeta.setKeyStream2( new String[] {} );
+    insertUpdateMeta.setUpdateLookup( new String[] {} );
+    insertUpdateMeta.setKeyLookup( new String[] {} );
+    insertUpdateMeta.setUpdateBypassed( true );
+    insertUpdateMeta.setDatabaseMeta( Mockito.mock( DatabaseMeta.class ) );
+    Database database = Mockito.mock( Database.class );
+    mockHelper.processRowsStepDataInterface.db = database;
+    Mockito.doReturn( Mockito.mock( Connection.class ) ).when( database ).getConnection();
+    Mockito.doNothing().when( insertUpdateStep ).lookupValues( Mockito.any(), Mockito.any() );
+    Mockito.doNothing().when( insertUpdateStep ).putRow( Mockito.any(), Mockito.any() );
+    Mockito.doReturn( new Object[] {} ).when( insertUpdateStep ).getRow();
+    insertUpdateStep.first = true;
+
+    insertUpdateMeta.afterInjectionSynchronization();
+    //run without a exception
+    insertUpdateStep.processRow( insertUpdateMeta, mockHelper.processRowsStepDataInterface );
+
+    Assert.assertEquals( insertUpdateMeta.getKeyStream().length, insertUpdateMeta.getKeyStream2().length );
+  }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.KettleEnvironment;
@@ -153,4 +154,19 @@ public class OraBulkLoaderMetaTest {
       return test.equals( actual );
     }
   }
+
+  //PDI-16472
+  @Test
+  public void testGetXML() {
+    OraBulkLoaderMeta oraBulkLoaderMeta = new OraBulkLoaderMeta();
+    oraBulkLoaderMeta.setFieldTable( new String[] { "fieldTable1", "fieldTable2" } );
+    oraBulkLoaderMeta.setFieldStream( new String[] { "fieldStreamValue1" } );
+    oraBulkLoaderMeta.setDateMask( new String[] {} );
+
+    oraBulkLoaderMeta.afterInjectionSynchronization();
+    //run without exception
+    oraBulkLoaderMeta.getXML();
+    Assert.assertEquals( oraBulkLoaderMeta.getFieldStream().length, oraBulkLoaderMeta.getDateMask().length );
+  }
+
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/replacestring/ReplaceStringTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/replacestring/ReplaceStringTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,7 +22,9 @@
 
 package org.pentaho.di.trans.steps.replacestring;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
@@ -94,5 +96,53 @@ public class ReplaceStringTest {
 
     Object[] output = replaceString.getOneRow( inputRowMeta, row );
     assertArrayEquals( "Output varies", expectedRow, output );
+  }
+
+  //PDI-16472
+  @Test
+  public void testSynchronizeDifferentFieldsArraysLengths() throws Exception {
+
+    ReplaceStringData data = new ReplaceStringData();
+    ReplaceString replaceString =
+      new ReplaceString( stepMockHelper.stepMeta, data, 0, stepMockHelper.transMeta, stepMockHelper.trans );
+
+    ReplaceStringMeta meta = new ReplaceStringMeta();
+    replaceString.init( meta, data );
+
+    meta.setFieldInStream( new String[] { "input1", "input2" } );
+    meta.setFieldOutStream( new String[] { "out" } );
+    meta.setUseRegEx( new int[] { 1 } );
+    meta.setCaseSensitive( new int[] { 0 } );
+    meta.setWholeWord( new int[] { 1 } );
+    meta.setReplaceString( new String[] { "string" } );
+    meta.setReplaceByString( new String[] { "string" } );
+    meta.setEmptyString( new boolean[] { true } );
+    meta.setFieldReplaceByString( new String[] { "string" } );
+
+    meta.afterInjectionSynchronization();
+
+    Assert.assertEquals( meta.getFieldInStream().length, meta.getFieldOutStream().length );
+    Assert.assertEquals( StringUtils.EMPTY, meta.getFieldOutStream()[ 1 ] );
+
+    Assert.assertEquals( meta.getFieldInStream().length, meta.getUseRegEx().length );
+    Assert.assertEquals( 0, meta.getUseRegEx()[ 1 ] );
+
+    Assert.assertEquals( meta.getFieldInStream().length, meta.getCaseSensitive().length );
+    Assert.assertEquals( 0, meta.getCaseSensitive()[ 1 ] );
+
+    Assert.assertEquals( meta.getFieldInStream().length, meta.getWholeWord().length );
+    Assert.assertEquals( 0, meta.getWholeWord()[ 1 ] );
+
+    Assert.assertEquals( meta.getFieldInStream().length, meta.getReplaceString().length );
+    Assert.assertEquals( StringUtils.EMPTY, meta.getReplaceString()[ 1 ] );
+
+    Assert.assertEquals( meta.getFieldInStream().length, meta.getReplaceByString().length );
+    Assert.assertEquals( StringUtils.EMPTY, meta.getReplaceByString()[ 1 ] );
+
+    Assert.assertEquals( meta.getFieldInStream().length, meta.isSetEmptyString().length );
+    Assert.assertEquals( false, meta.isSetEmptyString()[ 1 ] );
+
+    Assert.assertEquals( meta.getFieldInStream().length, meta.getFieldReplaceByString().length );
+    Assert.assertEquals( StringUtils.EMPTY, meta.getFieldReplaceByString()[ 1 ] );
   }
 }

--- a/engine/test-src/org/pentaho/di/trans/steps/streamlookup/StreamLookupMetaTest.java
+++ b/engine/test-src/org/pentaho/di/trans/steps/streamlookup/StreamLookupMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.KettleEnvironment;
@@ -105,5 +106,25 @@ public class StreamLookupMetaTest implements InitializerInterface<StepMetaInterf
     assertEquals( stepName, cloned.getStepIOMeta().getInfoStreams().get( 0 ).getStepname() );
     assertNotSame( meta.getStepIOMeta().getInfoStreams().get( 0 ),
       cloned.getStepIOMeta().getInfoStreams().get( 0 ) );
+  }
+
+  //PDI-16110
+  @Test
+  public void testGetXML() {
+    StreamLookupMeta streamLookupMeta = new StreamLookupMeta();
+    streamLookupMeta.setKeystream( new String[] { "testKeyStreamValue" } );
+    streamLookupMeta.setKeylookup( new String[] { "testKeyLookupValue" } );
+    streamLookupMeta.setValue( new String[] { "testValue" } );
+    streamLookupMeta.setValueName( new String[] {} );
+    streamLookupMeta.setValueDefault( new String[] {} );
+    streamLookupMeta.setValueDefaultType( new int[] {} );
+
+    //run without exception
+    streamLookupMeta.afterInjectionSynchronization();
+    streamLookupMeta.getXML();
+
+    Assert.assertEquals( streamLookupMeta.getKeystream().length, streamLookupMeta.getValueName().length );
+    Assert.assertEquals( streamLookupMeta.getKeystream().length, streamLookupMeta.getValueDefault().length );
+    Assert.assertEquals( streamLookupMeta.getKeystream().length, streamLookupMeta.getValueDefaultType().length );
   }
 }

--- a/plugins/meta-inject-plugin/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInject.java
+++ b/plugins/meta-inject-plugin/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInject.java
@@ -266,6 +266,7 @@ public class MetaInject extends BaseStep implements StepInterface {
     // Collect all the metadata for this target step...
     //
     Map<TargetStepAttribute, SourceStepField> targetMap = meta.getTargetSourceMapping();
+    boolean wasInjection = false;
     for ( TargetStepAttribute target : targetMap.keySet() ) {
       SourceStepField source = targetMap.get( target );
 
@@ -293,6 +294,7 @@ public class MetaInject extends BaseStep implements StepInterface {
               if ( !skip ) {
                 // specified field exist - need to inject
                 injector.setProperty( targetStepMeta, target.getAttributeKey(), rows, source.getField() );
+                wasInjection = true;
               }
             } else {
               // target step doesn't have specified key - just report but don't fail like in 6.0 (BACKLOG-6753)
@@ -302,6 +304,9 @@ public class MetaInject extends BaseStep implements StepInterface {
           }
         }
       }
+    }
+    if ( wasInjection ) {
+      injector.runPostInjectionProcessing( targetStepMeta );
     }
   }
 


### PR DESCRIPTION
[SP3754][PDI-16472] Oracle bulk loader is not working with metadata injection (ArrayIndexOutOfBoundsException)
[PDI-16349] Metadata Injection for Insert/Update step get IndexOutOfBoundsException error
[PDI-16110] java.lang.ArrayIndexOutOfBoundsException exception with Metadata Injection step and Streamlookup step
[PDI-16423] Metadata Injection for String Replace step get IndexOutOfBoundsException error when not all the fields in the injection step are populated.

added AfterInjection annotation and implementation synchronization arrays lengths for consistency behavior with UI