### PR TITLE
[PDI-16441] ${Internal.Job.Repository.Directory} and ${Internal.Transformation.Repository.Directory} kettle variable are not working in 6.1,7.0 and 7.1 versions

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -898,6 +898,9 @@ public class JobMeta extends AbstractMeta
       // Set the filename here so it can be used in variables for ALL aspects of the job FIX: PDI-8890
       if ( null == rep ) {
         setFilename( fname );
+      }  else {
+        // Set the repository here so it can be used in variables for ALL aspects of the job FIX: PDI-16441
+        setRepository( rep );
       }
 
       //

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -2886,6 +2886,9 @@ public class TransMeta extends AbstractMeta
         // Set the filename here so it can be used in variables for ALL aspects of the transformation FIX: PDI-8890
         if ( null == rep ) {
           setFilename( fname );
+        } else {
+          // Set the repository here so it can be used in variables for ALL aspects of the job FIX: PDI-16441
+          setRepository( rep );
         }
 
         // Read all the database connections from the repository to make sure that we don't overwrite any there by

--- a/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
@@ -21,14 +21,19 @@
  ******************************************************************************/
 package org.pentaho.di.trans;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
+import org.pentaho.di.core.gui.OverwritePrompter;
 import org.pentaho.di.core.gui.Point;
 import org.pentaho.di.core.listeners.ContentChangedListener;
 import org.pentaho.di.core.row.RowMeta;
@@ -40,6 +45,7 @@ import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.metastore.DatabaseMetaStoreUtil;
 import org.pentaho.di.repository.ObjectRevision;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.trans.step.StepIOMeta;
 import org.pentaho.di.trans.step.StepMeta;
@@ -51,6 +57,8 @@ import org.pentaho.di.trans.steps.userdefinedjavaclass.UserDefinedJavaClassDef;
 import org.pentaho.di.trans.steps.userdefinedjavaclass.UserDefinedJavaClassMeta;
 import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.stores.memory.MemoryMetaStore;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -398,4 +406,55 @@ public class TransMetaTest {
     @Override
     public abstract Object clone();
   }
+
+  @Test
+  public void testLoadXml() throws KettleException {
+    String directory = "/home/admin";
+    Node jobNode = Mockito.mock( Node.class );
+    NodeList nodeList = new NodeList() {
+     ArrayList<Node> nodes = new ArrayList<>(  );
+      {
+
+        Node nodeInfo = Mockito.mock( Node.class );
+        Mockito.when( nodeInfo.getNodeName() ).thenReturn( TransMeta.XML_TAG_INFO );
+        Mockito.when( nodeInfo.getChildNodes() ).thenReturn( this );
+
+        Node nodeDirectory = Mockito.mock( Node.class );
+        Mockito.when( nodeDirectory.getNodeName() ).thenReturn( "directory" );
+        Node child = Mockito.mock( Node.class );
+        Mockito.when( nodeDirectory.getFirstChild() ).thenReturn( child );
+        Mockito.when( child.getNodeValue() ).thenReturn( directory );
+
+        nodes.add( nodeDirectory );
+        nodes.add( nodeInfo );
+
+      }
+
+      @Override public Node item( int index ) {
+        return nodes.get( index );
+      }
+
+      @Override public int getLength() {
+        return nodes.size();
+      }
+    };
+
+    Mockito.when( jobNode.getChildNodes() ).thenReturn( nodeList );
+
+    Repository rep = Mockito.mock( Repository.class );
+    RepositoryDirectory repDirectory =
+      new RepositoryDirectory( new RepositoryDirectory( new RepositoryDirectory(), "home" ), "admin" );
+    Mockito.when( rep.findDirectory( Mockito.eq( directory ) ) ).thenReturn( repDirectory );
+    TransMeta meta = new TransMeta();
+
+    VariableSpace variableSpace = Mockito.mock( VariableSpace.class );
+    Mockito.when( variableSpace.listVariables() ).thenReturn( new String[0] );
+
+    meta.loadXML( jobNode, null, Mockito.mock( IMetaStore.class ), rep, false, variableSpace,
+      Mockito.mock( OverwritePrompter.class ) );
+    meta.setInternalKettleVariables( null );
+
+    Assert.assertEquals( repDirectory.getPath(), meta.getVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_REPOSITORY_DIRECTORY ) );
+  }
+
 }


### PR DESCRIPTION
[PDI-16441] ${Internal.Job.Repository.Directory} and ${Internal.Transformation.Repository.Directory} kettle variable are not working in 6.1,7.0 and 7.1 versions

fixing loading a transformation and a job