### PR TITLE
[PDI-16436]- Issues with 3 steps when exporting - importing in an EE repository

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -57,6 +57,7 @@ import org.pentaho.di.job.entry.JobEntryBase;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.job.entry.validator.AndValidator;
 import org.pentaho.di.job.entry.validator.JobEntryValidatorUtils;
+import org.pentaho.di.repository.HasRepositoryDirectories;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectory;
@@ -90,7 +91,7 @@ import java.util.UUID;
  * @since 01-10-2003, Rewritten on 18-06-2004
  *
  */
-public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInterface {
+public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInterface, HasRepositoryDirectories {
   private static Class<?> PKG = JobEntryJob.class; // for i18n purposes, needed by Translator2!!
 
   private String filename;
@@ -208,6 +209,16 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
 
   public void setDirectory( String directory ) {
     this.directory = directory;
+  }
+
+  @Override
+  public String[] getDirectories() {
+    return new String[]{ directory };
+  }
+
+  @Override
+  public void setDirectories( String[] directories ) {
+    this.directory = directories[0];
   }
 
   public boolean isPassingExport() {
@@ -1593,6 +1604,11 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
    */
   public ObjectLocationSpecificationMethod getSpecificationMethod() {
     return specificationMethod;
+  }
+
+  @Override
+  public ObjectLocationSpecificationMethod[] getSpecificationMethods() {
+    return new ObjectLocationSpecificationMethod[]{ specificationMethod };
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -60,6 +60,7 @@ import org.pentaho.di.job.entry.JobEntryBase;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.job.entry.validator.AndValidator;
 import org.pentaho.di.job.entry.validator.JobEntryValidatorUtils;
+import org.pentaho.di.repository.HasRepositoryDirectories;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectory;
@@ -89,7 +90,7 @@ import org.w3c.dom.Node;
  * @author Matt Casters
  * @since 1-Oct-2003, rewritten on 18-June-2004
  */
-public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryInterface {
+public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryInterface, HasRepositoryDirectories {
   private static Class<?> PKG = JobEntryTrans.class; // for i18n purposes, needed by Translator2!!
 
   private String transname;
@@ -224,6 +225,16 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
 
   public void setDirectory( String directory ) {
     this.directory = directory;
+  }
+
+  @Override
+  public String[] getDirectories() {
+    return new String[]{ directory };
+  }
+
+  @Override
+  public void setDirectories( String[] directories ) {
+    this.directory = directories[0];
   }
 
   public String getLogFilename() {
@@ -1585,6 +1596,11 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
    */
   public ObjectLocationSpecificationMethod getSpecificationMethod() {
     return specificationMethod;
+  }
+
+  @Override
+  public ObjectLocationSpecificationMethod[] getSpecificationMethods() {
+    return new ObjectLocationSpecificationMethod[] { specificationMethod };
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/repository/HasRepositoryDirectories.java
+++ b/engine/src/main/java/org/pentaho/di/repository/HasRepositoryDirectories.java
@@ -1,0 +1,58 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2017-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository;
+
+import org.pentaho.di.core.ObjectLocationSpecificationMethod;
+
+/**
+ * Interface indicating that a step has repository references to another file(s). The goal is
+ * updating directories during repo importing
+ */
+public interface HasRepositoryDirectories {
+
+  /**
+   * If step has reference(s) to another transformation(s)/job(s) returns an array of repository directories.
+   * An implementation is considered to define the array order itself.
+   *
+   * @return String array of repository directories
+   */
+  public String[] getDirectories();
+
+  /**
+   * If step has reference(s) to another transformation(s)/job(s) sets updated repository directories from
+   * incoming String array. An implementation is considered to define the array order itself.
+   *
+   * @param directory Array of updated rep directories to set
+   */
+  public void setDirectories( String[] directory );
+
+  /**
+   * If step has reference(s) to another transformation(s)/job(s) returns an array of specification method(s)
+   * defining the type of an access to a referenced file.
+   * An implementation is considered to define the array order itself.
+   *
+   * @return String array of specification method(s)
+   */
+  public ObjectLocationSpecificationMethod[] getSpecificationMethods();
+
+}

--- a/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
+++ b/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
@@ -23,6 +23,7 @@
 package org.pentaho.di.repository;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -46,8 +47,6 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleMissingPluginsException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.exception.LookupReferencesException;
-import org.pentaho.di.core.extension.ExtensionPointHandler;
-import org.pentaho.di.core.extension.KettleExtensionPoint;
 import org.pentaho.di.core.gui.HasOverwritePrompter;
 import org.pentaho.di.core.gui.OverwritePrompter;
 import org.pentaho.di.core.gui.SpoonFactory;
@@ -59,15 +58,14 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.imp.ImportRules;
 import org.pentaho.di.imp.rule.ImportValidationFeedback;
 import org.pentaho.di.job.JobMeta;
-import org.pentaho.di.job.entries.job.JobEntryJob;
-import org.pentaho.di.job.entries.trans.JobEntryTrans;
 import org.pentaho.di.job.entry.JobEntryCopy;
+import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.partition.PartitionSchema;
 import org.pentaho.di.shared.SharedObjectInterface;
 import org.pentaho.di.shared.SharedObjects;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
-import org.pentaho.di.trans.steps.mapping.MappingMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXParseException;
@@ -577,61 +575,39 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
    * package-local visibility for testing purposes
    */
   void patchTransSteps( TransMeta transMeta ) {
-
-    Object[] metaInjectObjectArray = new Object[4];
-
-    metaInjectObjectArray[0] = transDirOverride;
-    metaInjectObjectArray[1] = baseDirectory;
-    metaInjectObjectArray[3] = needToCheckPathForVariables;
-
     for ( StepMeta stepMeta : transMeta.getSteps() ) {
-      if ( stepMeta.isMapping() ) {
-        MappingMeta mappingMeta = (MappingMeta) stepMeta.getStepMetaInterface();
-        if ( mappingMeta.getSpecificationMethod() == ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME ) {
-          if ( transDirOverride != null ) {
-            mappingMeta.setDirectoryPath( transDirOverride );
-            continue;
-          }
-          String mappingMetaPath = resolvePath( baseDirectory.getPath(), mappingMeta.getDirectoryPath() );
-          mappingMeta.setDirectoryPath( mappingMetaPath );
-        }
-      }
-
-      metaInjectObjectArray[2] = stepMeta;
-
-      try {
-        ExtensionPointHandler
-          .callExtensionPoint( log, KettleExtensionPoint.RepositoryImporterPatchTransStep.id, metaInjectObjectArray );
-      } catch ( KettleException ke ) {
-        log.logError( ke.getMessage(), ke );
+      StepMetaInterface stepMetaInterface = stepMeta.getStepMetaInterface();
+      if ( stepMetaInterface instanceof HasRepositoryDirectories ) {
+        patchRepositoryDirectories( stepMetaInterface.isReferencedObjectEnabled(), (HasRepositoryDirectories) stepMetaInterface  );
       }
     }
   }
 
   private void patchJobEntries( JobMeta jobMeta ) {
     for ( JobEntryCopy copy : jobMeta.getJobCopies() ) {
-      if ( copy.isTransformation() ) {
-        JobEntryTrans entry = (JobEntryTrans) copy.getEntry();
-        if ( entry.getSpecificationMethod() == ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME ) {
-          if ( transDirOverride != null ) {
-            entry.setDirectory( transDirOverride );
-            continue;
+      JobEntryInterface jobEntryInterface = copy.getEntry();
+      if ( jobEntryInterface instanceof HasRepositoryDirectories ) {
+        patchRepositoryDirectories( jobEntryInterface.isReferencedObjectEnabled(), (HasRepositoryDirectories) jobEntryInterface  );
+      }
+    }}
+
+  private void patchRepositoryDirectories( boolean[] referenceEnabled, HasRepositoryDirectories metaWithReferences ) {
+    String[] repDirectories = metaWithReferences.getDirectories();
+    if ( referenceEnabled != null && repDirectories != null ) {
+      ObjectLocationSpecificationMethod[] specificationMethods = metaWithReferences.getSpecificationMethods();
+      String[] resolvedDirectories = Arrays.copyOf( repDirectories, repDirectories.length );
+      for ( int i = 0; i < referenceEnabled.length; i++ ) {
+        if ( referenceEnabled[ i ] ) {
+          if ( specificationMethods[ i ] == ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME ) {
+            if ( transDirOverride != null ) {
+              resolvedDirectories[ i ] = transDirOverride;
+            } else {
+              resolvedDirectories[ i ] = resolvePath( baseDirectory.getPath(), repDirectories[ i ] );
+            }
           }
-          String entryPath = resolvePath( baseDirectory.getPath(), entry.getDirectory() );
-          entry.setDirectory( entryPath );
         }
       }
-      if ( copy.isJob() ) {
-        JobEntryJob entry = (JobEntryJob) copy.getEntry();
-        if ( entry.getSpecificationMethod() == ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME ) {
-          if ( jobDirOverride != null ) {
-            entry.setDirectory( jobDirOverride );
-            continue;
-          }
-          String entryPath = resolvePath( baseDirectory.getPath(), entry.getDirectory() );
-          entry.setDirectory( entryPath );
-        }
-      }
+      metaWithReferences.setDirectories( resolvedDirectories );
     }
   }
 

--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -30,6 +30,7 @@ import org.pentaho.di.core.util.CurrentDirectoryResolver;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.repository.HasRepositoryDirectories;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
@@ -42,7 +43,7 @@ import org.pentaho.metastore.api.IMetaStore;
  * @since 02-jan-2017
  * @author Yury Bakhmutski
  */
-public abstract class StepWithMappingMeta extends BaseStepMeta {
+public abstract class StepWithMappingMeta extends BaseStepMeta implements HasRepositoryDirectories {
   //default value
   private static Class<?> PKG = StepWithMappingMeta.class;
 
@@ -173,6 +174,11 @@ public abstract class StepWithMappingMeta extends BaseStepMeta {
     return specificationMethod;
   }
 
+  @Override
+  public ObjectLocationSpecificationMethod[] getSpecificationMethods() {
+    return new ObjectLocationSpecificationMethod[] { specificationMethod };
+  }
+
   /**
    * @param specificationMethod the specificationMethod to set
    */
@@ -192,6 +198,16 @@ public abstract class StepWithMappingMeta extends BaseStepMeta {
    */
   public void setDirectoryPath( String directoryPath ) {
     this.directoryPath = directoryPath;
+  }
+
+  @Override
+  public String[] getDirectories() {
+    return new String[]{ directoryPath };
+  }
+
+  @Override
+  public void setDirectories( String[] directories ) {
+    this.directoryPath = directories[0];
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
@@ -49,6 +49,7 @@ import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.repository.HasRepositoryDirectories;
 import org.pentaho.di.repository.HasRepositoryInterface;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
@@ -88,7 +89,8 @@ import org.w3c.dom.Node;
  *
  */
 
-public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, HasRepositoryInterface {
+public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, HasRepositoryInterface,
+  HasRepositoryDirectories {
   private static Class<?> PKG = JobExecutorMeta.class; // for i18n purposes, needed by Translator2!!
   private String jobName;
   private String fileName;
@@ -916,6 +918,16 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
     this.directoryPath = directoryPath;
   }
 
+  @Override
+  public String[] getDirectories() {
+    return new String[]{ directoryPath };
+  }
+
+  @Override
+  public void setDirectories( String[] directories ) {
+    this.directoryPath = directories[0];
+  }
+
   /**
    * @return the fileName
    */
@@ -968,6 +980,11 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
    */
   public ObjectLocationSpecificationMethod getSpecificationMethod() {
     return specificationMethod;
+  }
+
+  @Override
+  public ObjectLocationSpecificationMethod[] getSpecificationMethods() {
+    return new ObjectLocationSpecificationMethod[] { specificationMethod };
   }
 
   /**

--- a/engine/src/test/java/org/pentaho/di/repository/RepositoryImporterTest.java
+++ b/engine/src/test/java/org/pentaho/di/repository/RepositoryImporterTest.java
@@ -22,10 +22,6 @@
 
 package org.pentaho.di.repository;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.util.Collections;
 
 import org.junit.Before;
@@ -39,13 +35,15 @@ import org.pentaho.di.core.exception.KettleMissingPluginsException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.job.JobMeta;
-import org.pentaho.di.job.entries.trans.JobEntryTrans;
 import org.pentaho.di.job.entry.JobEntryCopy;
+import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
-import org.pentaho.di.trans.steps.mapping.MappingMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import static org.mockito.Mockito.*;
 
 @RunWith( MockitoJUnitRunner.class )
 public class RepositoryImporterTest {
@@ -74,148 +72,147 @@ public class RepositoryImporterTest {
 
   @Test
   public void testImportJob_patchJobEntries_without_variables() throws KettleException {
-    JobEntryTrans jobEntryTrans = createJobEntryTrans( "/userName" );
-    MappingMeta mappingMeta = createMappingMeta();
-    RepositoryImporter importer = createRepositoryImporter( jobEntryTrans, mappingMeta, true );
+    JobEntryInterface jobEntry = createJobEntry( "/userName" );
+    StepMetaInterface stepMeta = createStepMeta( "" );
+    RepositoryImporter importer = createRepositoryImporter( jobEntry, stepMeta, true );
     importer.setBaseDirectory( baseDirectory );
 
     importer.importJob( entityNode, feedback );
-    verify( jobEntryTrans ).setDirectory( ROOT_PATH + USER_NAME_PATH );
+    verify( (HasRepositoryDirectories) jobEntry  ).setDirectories( new String[]{ ROOT_PATH + USER_NAME_PATH } );
   }
 
   @Test
   public void testImportJob_patchJobEntries_with_variable() throws KettleException {
-    JobEntryTrans jobEntryTrans = createJobEntryTrans( "${USER_VARIABLE}" );
-    MappingMeta mappingMeta = createMappingMeta();
-    RepositoryImporter importer = createRepositoryImporter( jobEntryTrans, mappingMeta, true );
+    JobEntryInterface jobEntryInterface = createJobEntry( "${USER_VARIABLE}" );
+    StepMetaInterface stepMeta = createStepMeta( "" );
+    RepositoryImporter importer = createRepositoryImporter( jobEntryInterface, stepMeta, true );
     importer.setBaseDirectory( baseDirectory );
 
     importer.importJob( entityNode, feedback );
-    verify( jobEntryTrans ).setDirectory( "${USER_VARIABLE}" );
+    verify( (HasRepositoryDirectories) jobEntryInterface ).setDirectories( new String[]{ "${USER_VARIABLE}" } );
   }
 
   @Test
   public void testImportJob_patchJobEntries_when_directory_path_starts_with_variable() throws KettleException {
-    JobEntryTrans jobEntryTrans = createJobEntryTrans( "${USER_VARIABLE}/myDir" );
-    MappingMeta mappingMeta = createMappingMeta();
-    RepositoryImporter importer = createRepositoryImporter( jobEntryTrans, mappingMeta, true );
+    JobEntryInterface jobEntryInterface = createJobEntry( "${USER_VARIABLE}/myDir" );
+    StepMetaInterface stepMeta = createStepMeta( "" );
+    RepositoryImporter importer = createRepositoryImporter( jobEntryInterface, stepMeta, true );
     importer.setBaseDirectory( baseDirectory );
 
     importer.importJob( entityNode, feedback );
-    verify( jobEntryTrans ).setDirectory( "${USER_VARIABLE}/myDir" );
+    verify( (HasRepositoryDirectories) jobEntryInterface ).setDirectories( new String[] { "${USER_VARIABLE}/myDir" } );
 
-    JobEntryTrans jobEntryTrans2 = createJobEntryTrans( "${USER_VARIABLE}/myDir" );
+    JobEntryInterface jobEntryInterface2 = createJobEntry( "${USER_VARIABLE}/myDir" );
     RepositoryImporter importerWithCompatibilityImportPath =
-        createRepositoryImporter( jobEntryTrans2, mappingMeta, false );
+        createRepositoryImporter( jobEntryInterface2, stepMeta, false );
     importerWithCompatibilityImportPath.setBaseDirectory( baseDirectory );
 
     importerWithCompatibilityImportPath.importJob( entityNode, feedback );
-    verify( jobEntryTrans2 ).setDirectory( ROOT_PATH + "/${USER_VARIABLE}/myDir" );
+    verify( (HasRepositoryDirectories) jobEntryInterface2 ).setDirectories( new String[]{ ROOT_PATH + "/${USER_VARIABLE}/myDir" } );
   }
 
   @Test
   public void testImportJob_patchJobEntries_when_directory_path_ends_with_variable() throws KettleException {
-    JobEntryTrans jobEntryTrans = createJobEntryTrans( "/myDir/${USER_VARIABLE}" );
-    MappingMeta mappingMeta = createMappingMeta();
-    RepositoryImporter importer = createRepositoryImporter( jobEntryTrans, mappingMeta, true );
+    JobEntryInterface jobEntryInterface = createJobEntry( "/myDir/${USER_VARIABLE}" );
+    StepMetaInterface stepMeta = createStepMeta( "" );
+    RepositoryImporter importer = createRepositoryImporter( jobEntryInterface, stepMeta, true );
     importer.setBaseDirectory( baseDirectory );
 
     importer.importJob( entityNode, feedback );
-    verify( jobEntryTrans ).setDirectory( "/myDir/${USER_VARIABLE}" );
+    verify( (HasRepositoryDirectories) jobEntryInterface ).setDirectories( new String[] { "/myDir/${USER_VARIABLE}" } );
 
-    JobEntryTrans jobEntryTrans2 = createJobEntryTrans( "/myDir/${USER_VARIABLE}" );
+    JobEntryInterface jobEntryInterface2 = createJobEntry( "/myDir/${USER_VARIABLE}" );
     RepositoryImporter importerWithCompatibilityImportPath =
-        createRepositoryImporter( jobEntryTrans2, mappingMeta, false );
+        createRepositoryImporter( jobEntryInterface2, stepMeta, false );
     importerWithCompatibilityImportPath.setBaseDirectory( baseDirectory );
 
     importerWithCompatibilityImportPath.importJob( entityNode, feedback );
-    verify( jobEntryTrans2 ).setDirectory( ROOT_PATH + "/myDir/${USER_VARIABLE}" );
+    verify( (HasRepositoryDirectories) jobEntryInterface2 ).setDirectories( new String[] { ROOT_PATH + "/myDir/${USER_VARIABLE}" } );
   }
 
   @Test
   public void testImportTrans_patchTransEntries_without_variables() throws KettleException {
-    JobEntryTrans jobEntryTrans = createJobEntryTrans();
-    MappingMeta mappingMeta = createMappingMeta( "/userName" );
-    RepositoryImporter importer = createRepositoryImporter( jobEntryTrans, mappingMeta, true );
+    JobEntryInterface jobEntryInterface = createJobEntry( "" );
+    StepMetaInterface stepMeta = createStepMeta( "/userName" );
+    RepositoryImporter importer = createRepositoryImporter( jobEntryInterface, stepMeta, true );
     importer.setBaseDirectory( baseDirectory );
 
     importer.importTransformation( entityNode, feedback );
-    verify( mappingMeta ).setDirectoryPath( ROOT_PATH + USER_NAME_PATH );
+    verify( (HasRepositoryDirectories) stepMeta ).setDirectories( new String[] { ROOT_PATH + USER_NAME_PATH } );
   }
 
   @Test
   public void testImportTrans_patchTransEntries_with_variable() throws KettleException {
-    JobEntryTrans jobEntryTrans = createJobEntryTrans();
-    MappingMeta mappingMeta = createMappingMeta( "${USER_VARIABLE}" );
-    RepositoryImporter importer = createRepositoryImporter( jobEntryTrans, mappingMeta, true );
+    JobEntryInterface jobEntryInterface = createJobEntry( "" );
+    StepMetaInterface stepMeta = createStepMeta(  "${USER_VARIABLE}" );
+    RepositoryImporter importer = createRepositoryImporter( jobEntryInterface, stepMeta, true );
     importer.setBaseDirectory( baseDirectory );
 
     importer.importTransformation( entityNode, feedback );
-    verify( mappingMeta ).setDirectoryPath( "${USER_VARIABLE}" );
+    verify( (HasRepositoryDirectories) stepMeta ).setDirectories( new String[] { "${USER_VARIABLE}" } );
   }
 
   @Test
   public void testImportTrans_patchTransEntries_when_directory_path_starts_with_variable() throws KettleException {
-    JobEntryTrans jobEntryTrans = createJobEntryTrans();
-    MappingMeta mappingMeta = createMappingMeta( "${USER_VARIABLE}/myDir" );
-    RepositoryImporter importer = createRepositoryImporter( jobEntryTrans, mappingMeta, true );
+    JobEntryInterface jobEntryInterface = createJobEntry( "" );
+    StepMetaInterface stepMeta = createStepMeta( "${USER_VARIABLE}/myDir" );
+    RepositoryImporter importer = createRepositoryImporter( jobEntryInterface, stepMeta, true );
     importer.setBaseDirectory( baseDirectory );
 
     importer.importTransformation( entityNode, feedback );
-    verify( mappingMeta ).setDirectoryPath( "${USER_VARIABLE}/myDir" );
+    verify( (HasRepositoryDirectories) stepMeta ).setDirectories( new String[] { "${USER_VARIABLE}/myDir" } );
 
-    MappingMeta mappingMeta2 = createMappingMeta( "${USER_VARIABLE}/myDir" );
+    StepMetaInterface stepMeta2 = createStepMeta( "${USER_VARIABLE}/myDir" );
     RepositoryImporter importerWithCompatibilityImportPath =
-        createRepositoryImporter( jobEntryTrans, mappingMeta2, false );
+        createRepositoryImporter( jobEntryInterface, stepMeta2, false );
     importerWithCompatibilityImportPath.setBaseDirectory( baseDirectory );
 
     importerWithCompatibilityImportPath.importTransformation( entityNode, feedback );
-    verify( mappingMeta2 ).setDirectoryPath( ROOT_PATH + "/${USER_VARIABLE}/myDir" );
+    verify( (HasRepositoryDirectories) stepMeta2 ).setDirectories( new String[] { ROOT_PATH + "/${USER_VARIABLE}/myDir" } );
   }
 
   @Test
   public void testImportTrans_patchTransEntries_when_directory_path_ends_with_variable() throws KettleException {
-    JobEntryTrans jobEntryTrans = createJobEntryTrans();
-    MappingMeta mappingMeta = createMappingMeta( "/myDir/${USER_VARIABLE}" );
-    RepositoryImporter importer = createRepositoryImporter( jobEntryTrans, mappingMeta, true );
+    JobEntryInterface jobEntryInterface = createJobEntry( "" );
+    StepMetaInterface stepMeta = createStepMeta(  "/myDir/${USER_VARIABLE}" );
+    RepositoryImporter importer = createRepositoryImporter( jobEntryInterface, stepMeta, true );
     importer.setBaseDirectory( baseDirectory );
 
     importer.importTransformation( entityNode, feedback );
-    verify( mappingMeta ).setDirectoryPath( "/myDir/${USER_VARIABLE}" );
+    verify( (HasRepositoryDirectories) stepMeta ).setDirectories( new String[] { "/myDir/${USER_VARIABLE}" } );
 
-    MappingMeta mappingMeta2 = createMappingMeta( "/myDir/${USER_VARIABLE}" );
+    StepMetaInterface stepMeta2 = createStepMeta( "/myDir/${USER_VARIABLE}" );
     RepositoryImporter importerWithCompatibilityImportPath =
-        createRepositoryImporter( jobEntryTrans, mappingMeta2, false );
+        createRepositoryImporter( jobEntryInterface, stepMeta2, false );
     importerWithCompatibilityImportPath.setBaseDirectory( baseDirectory );
 
     importerWithCompatibilityImportPath.importTransformation( entityNode, feedback );
-    verify( mappingMeta2 ).setDirectoryPath( ROOT_PATH + "/myDir/${USER_VARIABLE}" );
+    verify( (HasRepositoryDirectories) stepMeta2 ).setDirectories( new String[] { ROOT_PATH + "/myDir/${USER_VARIABLE}" } );
   }
 
-  private static JobEntryTrans createJobEntryTrans() {
-    return createJobEntryTrans( "" );
+  private static JobEntryInterface createJobEntry( String directory ) {
+    JobEntryInterface jobEntryInterface = mock( JobEntryInterface.class, withSettings().extraInterfaces( HasRepositoryDirectories.class ) );
+    when( jobEntryInterface.isReferencedObjectEnabled() ).thenReturn( new boolean[] { true } );
+    doAnswer( invocationOnMock -> new ObjectLocationSpecificationMethod[] { ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME } )
+      .when( ( (HasRepositoryDirectories) jobEntryInterface ) ).getSpecificationMethods();
+    doAnswer( invocationOnMock -> new String[] { directory } )
+      .when( (HasRepositoryDirectories) jobEntryInterface ).getDirectories();
+    return jobEntryInterface;
   }
 
-  private static JobEntryTrans createJobEntryTrans( String directory ) {
-    JobEntryTrans jet = mock( JobEntryTrans.class );
-    when( jet.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
-    when( jet.getDirectory() ).thenReturn( directory );
-    return jet;
+  private static StepMetaInterface createStepMeta( String directory ) {
+    StepMetaInterface stepMetaInterface = mock( StepMetaInterface.class, withSettings().extraInterfaces( HasRepositoryDirectories.class ) );
+    when( stepMetaInterface.isReferencedObjectEnabled() ).thenReturn( new boolean[] { true } );
+    doAnswer( invocationOnMock -> new ObjectLocationSpecificationMethod[] { ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME } )
+      .when( ( (HasRepositoryDirectories) stepMetaInterface ) ).getSpecificationMethods();
+    doAnswer( invocationOnMock -> new String[] { directory } )
+      .when( (HasRepositoryDirectories) stepMetaInterface ).getDirectories();
+    return stepMetaInterface;
   }
 
-  private static MappingMeta createMappingMeta() {
-    return createMappingMeta( "" );
-  }
-
-  private static MappingMeta createMappingMeta( String directory ) {
-    MappingMeta mappingMeta = mock( MappingMeta.class );
-    when( mappingMeta.getSpecificationMethod() ).thenReturn( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
-    when( mappingMeta.getDirectoryPath() ).thenReturn( directory );
-    return mappingMeta;
-  }
-
-  private static RepositoryImporter createRepositoryImporter( final JobEntryTrans jobEntryTrans,
-      final MappingMeta mappingMeta, final boolean needToCheckPathForVariables ) {
+  private static RepositoryImporter createRepositoryImporter( final JobEntryInterface jobEntryInterface, final
+                                                              StepMetaInterface stepMetaInterface,
+                                                              final boolean needToCheckPathForVariables ) {
     Repository repository = mock( Repository.class );
     LogChannelInterface log = mock( LogChannelInterface.class );
     RepositoryImporter importer = new RepositoryImporter( repository, log ) {
@@ -225,7 +222,7 @@ public class RepositoryImporterTest {
         JobMeta meta = mock( JobMeta.class );
         JobEntryCopy jec = mock( JobEntryCopy.class );
         when( jec.isTransformation() ).thenReturn( true );
-        when( jec.getEntry() ).thenReturn( jobEntryTrans );
+        when( jec.getEntry() ).thenReturn( jobEntryInterface );
         when( meta.getJobCopies() ).thenReturn( Collections.singletonList( jec ) );
         return meta;
       }
@@ -235,7 +232,7 @@ public class RepositoryImporterTest {
         TransMeta meta = mock( TransMeta.class );
         StepMeta stepMeta = mock( StepMeta.class );
         when( stepMeta.isMapping() ).thenReturn( true );
-        when( stepMeta.getStepMetaInterface() ).thenReturn( mappingMeta );
+        when( stepMeta.getStepMetaInterface() ).thenReturn( stepMetaInterface );
         when( meta.getSteps() ).thenReturn( Collections.singletonList( stepMeta ) );
         return meta;
       }

--- a/plugins/meta-inject/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
+++ b/plugins/meta-inject/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
@@ -46,6 +46,7 @@ import org.pentaho.di.core.util.CurrentDirectoryResolver;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.repository.HasRepositoryDirectories;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectory;
@@ -80,7 +81,8 @@ import org.w3c.dom.Node;
     documentationUrl = "0L0/0Y0/0K0/ETL_Metadata_Injection" )
 @InjectionSupported( localizationPrefix = "MetaInject.Injection.", groups = { "SOURCE_OUTPUT_FIELDS",
   "MAPPING_FIELDS" } )
-public class MetaInjectMeta extends BaseStepMeta implements StepMetaInterface, StepMetaChangeListenerInterface {
+public class MetaInjectMeta extends BaseStepMeta implements StepMetaInterface, StepMetaChangeListenerInterface,
+  HasRepositoryDirectories {
 
   private static Class<?> PKG = MetaInjectMeta.class; // for i18n purposes, needed by Translator2!!
 
@@ -448,6 +450,16 @@ public class MetaInjectMeta extends BaseStepMeta implements StepMetaInterface, S
     this.directoryPath = directoryPath;
   }
 
+  @Override
+  public String[] getDirectories() {
+    return new String[]{ directoryPath };
+  }
+
+  @Override
+  public void setDirectories( String[] directories ) {
+    this.directoryPath = directories[0];
+  }
+
   /**
    * @return the transObjectId
    */
@@ -472,6 +484,11 @@ public class MetaInjectMeta extends BaseStepMeta implements StepMetaInterface, S
    */
   public ObjectLocationSpecificationMethod getSpecificationMethod() {
     return specificationMethod;
+  }
+
+  @Override
+  public ObjectLocationSpecificationMethod[] getSpecificationMethods() {
+    return new ObjectLocationSpecificationMethod[] { specificationMethod };
   }
 
   /**


### PR DESCRIPTION
Issues with several steps during exporting - importing in an EE repository : directories are not updated properly. 
-Removed hardcoded step name checks (like stepMeta.isMapping() or stepMeta.isTransformation() ) which identify whether we should update step inner directories or not 
-Added interface which means that a step has directory(ies) to another transformations(jobs)
Affected by the issue steps : JobEntryJob, JobEntryTrans, Mapping, SimpleMapping, SingleThreader, TransExecutor, JobExecutor, Metainject, Pentaho MapReduce