### PR TITLE
[BACKLOG-18129] In the thin repository dialog, when overwriting file …

### DIFF
--- a/plugins/file-open-save/core/src/main/javascript/app/components/error/error.component.js
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/error/error.component.js
@@ -31,9 +31,10 @@
  */
 define([
   "text!./error.html",
+  "../utils",
   "pentaho/i18n-osgi!file-open-save.messages",
   "css!./error.css"
-], function(errorTemplate, i18n) {
+], function(errorTemplate, utils, i18n) {
   "use strict";
 
   var options = {
@@ -126,10 +127,14 @@ define([
     function _setMessages() {
       switch (vm.errorType) {
         case 1:// Overwrite
+          var filename1 = vm.errorFile.name;
+          if (utils.getTextWidth(filename1) > 974) {
+            filename1 = utils.truncateString(filename1, 974) + "...";
+          }
           _setMessage(i18n.get("file-open-save-plugin.error.overwrite.title"),
             vm.errorFile.type === "job" ? i18n.get("file-open-save-plugin.error.overwrite.job.top-before.message") :
                                           i18n.get("file-open-save-plugin.error.overwrite.trans.top-before.message"),
-            " " + vm.errorFile.name + " ",
+            " " + filename1 + " ",
             i18n.get("file-open-save-plugin.error.overwrite.top-after.message"),
             i18n.get("file-open-save-plugin.error.overwrite.bottom.message"),
             i18n.get("file-open-save-plugin.error.overwrite.accept.button"),
@@ -173,10 +178,14 @@ define([
             i18n.get("file-open-save-plugin.error.delete-folder.no.button"));
           break;
         case 7:// File Exists
+          var filename7 = vm.errorFile.newName;
+          if (utils.getTextWidth(filename7) > 1064) {
+            filename7 = utils.truncateString(filename7, 1064) + "... ";
+          }
           _setMessage(i18n.get("file-open-save-plugin.error.file-exists.title"),
             i18n.get("file-open-save-plugin.error.file-exists.top.message"),
             " ",
-            vm.errorFile.newName + ".",
+            filename7 + ".",
             i18n.get("file-open-save-plugin.error.file-exists.bottom.message"),
             "",
             i18n.get("file-open-save-plugin.error.file-exists.close.button"));

--- a/plugins/file-open-save/core/src/main/javascript/app/components/utils.js
+++ b/plugins/file-open-save/core/src/main/javascript/app/components/utils.js
@@ -21,7 +21,8 @@ define(
       var _font = "14px OpenSansRegular";
       return {
         naturalCompare: naturalCompare,
-        getTextWidth: getTextWidth
+        getTextWidth: getTextWidth,
+        truncateString: truncateString
       };
 
     /**
@@ -92,5 +93,22 @@ define(
         context.font = _font;
         var metrics = context.measureText(text);
         return (Math.ceil(metrics.width) + 2);
+      }
+
+      /**
+       * Truncates a string to be less than length len (in terms of display length, not character length).
+       * @param {String} str - string to be truncated
+       * @param {Number} len - Maximum display length of str.
+       * @return {String} - the truncated string.
+       */
+      function truncateString(str, len) {
+        var res = str;
+        if (str && str.length > 0) {
+          var strLen = str.length;
+          while (getTextWidth(res) > len) {
+            res = str.slice(0, --strLen);
+          }
+        }
+        return res;
       }
     });


### PR DESCRIPTION
…names with extremely long name the message on the warning dialog gets cut off.

@bmorrise 