### PR TITLE
[PDI-13628]: "Read end dead" error when writing large file to Amazon S3 (OOME)

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -937,7 +937,7 @@ public class Const {
    * The name of the Kettle encryption seed environment variable for the KettleTwoWayPasswordEncoder class
    */
   public static final String KETTLE_TWO_WAY_PASSWORD_ENCODER_SEED = "KETTLE_TWO_WAY_PASSWORD_ENCODER_SEED";
-  
+
   /**
    * The XML file that contains the list of native Kettle logging plugins
    */
@@ -1130,6 +1130,11 @@ public class Const {
    * A variable to configure jetty option: lowResourcesMaxIdleTime for Carte
    */
   public static final String KETTLE_CARTE_JETTY_RES_MAX_IDLE_TIME = "KETTLE_CARTE_JETTY_RES_MAX_IDLE_TIME";
+
+  /**
+   * A variable to configure s3vfs to use a temporary file on upload data to S3 Amazon."
+   */
+  public static final String S3VFS_USE_TEMPORARY_FILE_ON_UPLOAD_DATA = "s3.vfs.useTempFileOnUploadData";
 
   /**
    * A variable to configure VFS USER_DIR_IS_ROOT option: should be "true" or "false"

--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -766,6 +766,10 @@ public class TextFileOutput extends BaseStep implements StepInterface {
     } catch ( Exception e ) {
       logError( "Exception trying to close file: " + e.toString() );
       setErrors( 1 );
+      //Clean resources
+      data.writer = null;
+      data.out = null;
+      data.fos = null;
       retval = false;
     }
 
@@ -892,6 +896,7 @@ public class TextFileOutput extends BaseStep implements StepInterface {
           data.fos.close();
         }
       } catch ( Exception e ) {
+        data.fos = null;
         logError( "Unexpected error closing file", e );
         setErrors( 1 );
       }

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -433,6 +433,13 @@
   </kettle-variable>
 
   <kettle-variable>
+    <description>Set this variable to Y to create S3 Object for upload based on a temporary file with data.
+    </description>
+    <variable>s3.vfs.useTempFileOnUploadData</variable>
+    <default-value>N</default-value>
+  </kettle-variable>
+
+  <kettle-variable>
     <description>Set this variable to restore the directory loading behavior of the repository as it was before 6.1. Changing this to false will make repository loading more expensive</description>
     <variable>KETTLE_LAZY_REPOSITORY</variable>
     <default-value>true</default-value>


### PR DESCRIPTION
Released resources to free up memory for the case when OOME occurs.
Introduced a new kettle property to allow user the choose old way vs new way (memory based vs file system based) during writing file to Amazon S3.