### PR TITLE
[BACKLOG-18612] Add functionality for subtrans logging within AEL/Spark

### DIFF
--- a/engine-ext/api/src/main/java/org/pentaho/di/engine/api/events/SubTransCreationEvent.java
+++ b/engine-ext/api/src/main/java/org/pentaho/di/engine/api/events/SubTransCreationEvent.java
@@ -1,0 +1,36 @@
+/*
+ * ! ******************************************************************************
+ *
+ *  Pentaho Data Integration
+ *
+ *  Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * *****************************************************************************
+ */
+
+package org.pentaho.di.engine.api.events;
+
+import org.pentaho.di.engine.api.model.LogicalModelElement;
+import org.pentaho.di.engine.api.reporting.SubTransCreation;
+
+public class SubTransCreationEvent<S extends LogicalModelElement> extends BaseEvent<S, SubTransCreation> {
+  private static final long serialVersionUID = -3994003778796690304L;
+
+  public SubTransCreationEvent( S source, SubTransCreation subTransCreation ) {
+    super( source, subTransCreation );
+  }
+}

--- a/engine-ext/api/src/main/java/org/pentaho/di/engine/api/reporting/SubTransCreation.java
+++ b/engine-ext/api/src/main/java/org/pentaho/di/engine/api/reporting/SubTransCreation.java
@@ -1,0 +1,52 @@
+/*
+ * ! ******************************************************************************
+ *
+ *  Pentaho Data Integration
+ *
+ *  Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ * ******************************************************************************
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * *****************************************************************************
+ */
+
+package org.pentaho.di.engine.api.reporting;
+
+import org.pentaho.di.engine.api.ExecutionContext;
+import org.pentaho.di.engine.api.model.Transformation;
+
+import java.io.Serializable;
+
+public class SubTransCreation implements Serializable {
+  private static final long serialVersionUID = 6249199047103429616L;
+  private ExecutionContext context;
+  private Transformation transformation;
+
+  public ExecutionContext getContext() {
+    return context;
+  }
+
+  public void setContext( ExecutionContext context ) {
+    this.context = context;
+  }
+
+  public Transformation getTransformation() {
+    return transformation;
+  }
+
+  public void setTransformation( Transformation transformation ) {
+    this.transformation = transformation;
+  }
+}

--- a/engine/src/main/java/org/pentaho/di/trans/ael/websocket/MessageEventService.java
+++ b/engine/src/main/java/org/pentaho/di/trans/ael/websocket/MessageEventService.java
@@ -24,6 +24,7 @@
 package org.pentaho.di.trans.ael.websocket;
 
 import org.pentaho.di.engine.api.events.PDIEvent;
+import org.pentaho.di.engine.api.model.ModelType;
 import org.pentaho.di.engine.api.remote.Message;
 import org.pentaho.di.engine.api.remote.RemoteSource;
 import org.pentaho.di.engine.api.remote.StopMessage;
@@ -176,15 +177,27 @@ public class MessageEventService {
           //others messages from the Daemon to Client are PDIEvent <RemoteSource, ?>
           RemoteSource keyRemoteSource = ( (RemoteSource) ( (PDIEvent) o1 ).getSource() );
           RemoteSource remoteSource = ( (RemoteSource) ( (PDIEvent) o2 ).getSource() );
-          if ( keyRemoteSource.getModelType() == remoteSource.getModelType()
-            && ( ( Objects.isNull( keyRemoteSource.getId() ) && Objects.isNull( remoteSource.getId() ) )
-            || ( Objects.nonNull( keyRemoteSource.getId() ) && keyRemoteSource.getId()
-            .equals( remoteSource.getId() ) ) ) ) {
+
+          if ( sameType( keyRemoteSource, remoteSource )
+               && ( sameId( keyRemoteSource, remoteSource ) || isTrans( keyRemoteSource ) ) ) {
             return 0;
           }
         }
       }
       return -1;
+    }
+
+    private boolean isTrans( RemoteSource source1 ) {
+      return source1.getModelType() == ModelType.TRANSFORMATION;
+    }
+
+    private boolean sameId( RemoteSource source1, RemoteSource source2 ) {
+      return ( Objects.isNull( source1.getId() ) && Objects.isNull( source2.getId() ) )
+        || ( Objects.nonNull( source1.getId() ) && source1.getId().equals( source2.getId() ) );
+    }
+
+    private boolean sameType( RemoteSource source1, RemoteSource source2 ) {
+      return source1.getModelType() == source2.getModelType();
     }
   }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/ael/websocket/MessageEventServiceTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/ael/websocket/MessageEventServiceTest.java
@@ -207,6 +207,16 @@ public class MessageEventServiceTest {
     verify( messageEventHandler2 ).execute( msg );
   }
 
+  @Test
+  public void testTransformationFireEvent() throws Exception {
+    addHandlers( transformationMessageEvent, messageEventHandler, messageEventHandler2 );
+
+    LogEvent logEvent = new LogEvent<>( new RemoteSource( ModelType.TRANSFORMATION, "Operation_ID" ), logEntry );
+    messageEventService.fireEvent( logEvent );
+    verify( messageEventHandler ).execute( logEvent );
+    verify( messageEventHandler2 ).execute( logEvent );
+  }
+
   public void addHandlers( Message messageEvent, MessageEventHandler handler,
                            MessageEventHandler handler2 ) throws KettleException {
     messageEventService.addHandler( messageEvent, handler );


### PR DESCRIPTION
This will allow the subtrans running within AEL/Spark to bubble up to
logging to the Client just like it does in the kettle classic engine.