### PR TITLE
[BACKLOG-18831] - Data services return Null values when filtering num…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Condition.java
+++ b/core/src/main/java/org/pentaho/di/core/Condition.java
@@ -445,10 +445,19 @@ public class Condition implements Cloneable, XMLInterface {
             retval = ( fieldMeta.compare( field, fieldMeta2, field2 ) != 0 );
             break;
           case FUNC_SMALLER:
-            retval = ( fieldMeta.compare( field, fieldMeta2, field2 ) < 0 );
+            if ( fieldMeta.isNull( field ) ) {
+              // BACKLOG-18831
+              retval = false;
+            } else {
+              retval = ( fieldMeta.compare( field, fieldMeta2, field2 ) < 0 );
+            }
             break;
           case FUNC_SMALLER_EQUAL:
-            retval = ( fieldMeta.compare( field, fieldMeta2, field2 ) <= 0 );
+            if ( fieldMeta.isNull( field ) ) {
+              retval = false;
+            } else {
+              retval = ( fieldMeta.compare( field, fieldMeta2, field2 ) <= 0 );
+            }
             break;
           case FUNC_LARGER:
             retval = ( fieldMeta.compare( field, fieldMeta2, field2 ) > 0 );

--- a/core/src/test/java/org/pentaho/di/core/ConditionTest.java
+++ b/core/src/test/java/org/pentaho/di/core/ConditionTest.java
@@ -26,6 +26,8 @@ import junit.framework.TestCase;
 import org.junit.Test;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaAndData;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
 import org.pentaho.di.core.row.value.ValueMetaNumber;
 
 public class ConditionTest extends TestCase {
@@ -59,5 +61,20 @@ public class ConditionTest extends TestCase {
 
     assertTrue( condition.evaluate( rowMeta1, new Object[] { 1.0, 2.0, 1.0} ) );
     assertTrue( condition.evaluate( rowMeta2, new Object[] { 2.0, 1.0, 1.0} ) );
+  }
+
+  @Test
+  public void testNullLessThanNumberEvaluatesAsFalse() throws Exception {
+    RowMetaInterface rowMeta1 = new RowMeta();
+    rowMeta1.addValueMeta( new ValueMetaInteger( "name1" ) );
+
+    String left = "name1";
+    ValueMetaAndData right_exact = new ValueMetaAndData( new ValueMetaInteger( "name1" ), new Long( -10 ) );
+
+    Condition condition = new Condition( left, Condition.FUNC_SMALLER, null, right_exact );
+    assertFalse( condition.evaluate( rowMeta1, new Object[] { null, "test" } ) );
+
+    condition = new Condition( left, Condition.FUNC_SMALLER_EQUAL, null, right_exact );
+    assertFalse( condition.evaluate( rowMeta1, new Object[] { null, "test" } ) );
   }
 }


### PR DESCRIPTION
…bers

For (null < -10) condition result should be 'false'.
Check for null added to FUNC_SMALLER and FUNC_SMALLER_EQUAL, similarly to FUNC_REGEXP( https://github.com/pentaho/pentaho-kettle/blob/master/core/src/main/java/org/pentaho/di/core/Condition.java#L460 ).
Other FUNC's work correctly in case of null filed.