### PR TITLE
BACKLOG-18646 - fixed issue with getting deleted trans files through SDK failing.  Changed the call to get trans objects to getFileById() instead of getFile()

### DIFF
--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
@@ -1560,7 +1560,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
     try {
 
       //RepositoryDirectoryInterface repDir = getRootDir().findDirectory( dirId );
-      RepositoryFile dirFile = pur.getFile( dirId.getId() );
+      RepositoryFile dirFile = pur.getFileById( dirId.getId() );
       RepositoryDirectory repDir = new RepositoryDirectory();
       repDir.setObjectId( dirId );
       repDir.setName( dirFile.getName() );


### PR DESCRIPTION
@rmansoor @tkafalas 