### PR TITLE
[SP-3778][PDI-16441] ${Internal.Job.Repository.Directory} and ${Internal.Transformation.Repository.Directory} kettle variable are not working in 6.1,7.0 and 7.1 versions

### DIFF
--- a/engine/src/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/org/pentaho/di/job/JobMeta.java
@@ -952,6 +952,9 @@ public class JobMeta extends AbstractMeta
       // Set the filename here so it can be used in variables for ALL aspects of the job FIX: PDI-8890
       if ( null == rep ) {
         setFilename( fname );
+      }  else {
+        // Set the repository here so it can be used in variables for ALL aspects of the job FIX: PDI-16441
+        setRepository( rep );
       }
 
       //

--- a/engine/src/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/org/pentaho/di/trans/TransMeta.java
@@ -2943,6 +2943,9 @@ public class TransMeta extends AbstractMeta
         // Set the filename here so it can be used in variables for ALL aspects of the transformation FIX: PDI-8890
         if ( null == rep ) {
           setFilename( fname );
+        } else {
+          // Set the repository here so it can be used in variables for ALL aspects of the job FIX: PDI-16441
+          setRepository( rep );
         }
 
         // Read all the database connections from the repository to make sure that we don't overwrite any there by


### PR DESCRIPTION
[SP-3778][PDI-16441] ${Internal.Job.Repository.Directory} and ${Internal.Transformation.Repository.Directory} kettle variable are not working in 6.1,7.0 and 7.1 versions

fixing loading a transformation and a job