### PR TITLE
[BACKLOG-18969] Transformations no longer run on carte after 7.1 upgrade

### DIFF
--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPoint.java
@@ -24,18 +24,29 @@
 
 package org.pentaho.di.engine.configuration.impl.extension;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
 import org.pentaho.di.engine.configuration.impl.EmbeddedRunConfigurationManager;
 import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfiguration;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entries.trans.JobEntryTrans;
+import org.pentaho.di.job.entry.JobEntryCopy;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Created by bmorrise on 5/15/17.
@@ -59,11 +70,64 @@ public class RunConfigurationImportExtensionPoint implements ExtensionPointInter
       EmbeddedRunConfigurationManager.build( embeddedMetaStore );
 
     List<RunConfiguration> runConfigurationList = embeddedRunConfigurationManager.load();
+    List<String> runConfigurationNames = runConfigurationList.stream().map( RunConfiguration::getName ).collect( Collectors.toList() );
+    runConfigurationNames.addAll( runConfigurationManager.getNames() );
+    runConfigurationList.addAll( createSlaveServerRunConfigurations( runConfigurationNames, abstractMeta ) );
 
     for ( RunConfiguration runConfiguration : runConfigurationList ) {
       if ( !runConfiguration.getName().equals( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
         runConfigurationManager.save( runConfiguration );
       }
     }
+  }
+
+  private List<RunConfiguration> createSlaveServerRunConfigurations( List<String> existingConfigurationNames, AbstractMeta abstractMeta ) {
+    List<RunConfiguration> runConfigurations = new ArrayList<>();
+    if ( abstractMeta instanceof JobMeta ) {
+      JobMeta jobMeta = (JobMeta) abstractMeta;
+
+      Map<String, List<JobEntryTrans>> slaveServerGroups = jobMeta.getJobCopies().stream()
+        .map( JobEntryCopy::getEntry )
+        .filter( entry -> entry instanceof JobEntryTrans )
+        .map( entry -> (JobEntryTrans) entry )
+        .filter( entry -> Utils.isEmpty( entry.getRunConfiguration() ) )
+        .filter( entry -> !Utils.isEmpty( entry.getRemoteSlaveServerName() ) )
+        .collect( Collectors.groupingBy( JobEntryTrans::getRemoteSlaveServerName ) );
+
+      slaveServerGroups.forEach( (remoteServerName, entries ) -> {
+        String runConfigurationName = createRunConfigurationName( existingConfigurationNames, remoteServerName );
+        DefaultRunConfiguration runConfiguration = createRunConfiguration( runConfigurationName, remoteServerName );
+        runConfigurations.add( runConfiguration );
+        entries.forEach( e -> e.setRunConfiguration( runConfiguration.getName() ) );
+      } );
+    }
+    return runConfigurations;
+  }
+
+  private DefaultRunConfiguration createRunConfiguration( String configurationName, String slaveServerName ) {
+    DefaultRunConfiguration runConfiguration = new DefaultRunConfiguration();
+    runConfiguration.setName( configurationName );
+    runConfiguration.setServer( slaveServerName );
+    runConfiguration.setLocal( false );
+    runConfiguration.setRemote( true );
+    return runConfiguration;
+  }
+
+  @VisibleForTesting String createRunConfigurationName( List<String> runConfigurations, String slaveServerName ) {
+    String defaultName = String.format( "pentaho_auto_%s_config", slaveServerName );
+    long count = runConfigurations.stream().filter( s -> s.matches( defaultName + "(_\\d)*" ) ).count();
+    if ( count == 0 ) {
+      return defaultName;
+    }
+
+    Optional<Integer> index = runConfigurations.stream()
+      .filter( s -> s.matches( defaultName + "_\\d+" ) )
+      .map( s -> s.substring( defaultName.length() + 1 ) )
+      .filter( s -> s.matches( "\\d+" ) )
+      .map( Integer::valueOf )
+      .sorted( Comparator.reverseOrder() )
+      .findFirst();
+
+    return String.format( "%s_%d", defaultName, index.orElse( 0 ) + 1 );
   }
 }

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPointTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPointTest.java
@@ -27,13 +27,27 @@ package org.pentaho.di.engine.configuration.impl.extension;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.di.base.AbstractMeta;
+import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfiguration;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entries.trans.JobEntryTrans;
+import org.pentaho.di.job.entry.JobEntryCopy;
 
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -64,4 +78,60 @@ public class RunConfigurationImportExtensionPointTest {
     verify( abstractMeta ).getEmbeddedMetaStore();
   }
 
+  @Test
+  public void shouldCreateRunConfigurationsForSlaveServer() throws Exception {
+    JobMeta jobMeta = mock( JobMeta.class );
+    JobEntryCopy jobEntryCopy1 = mock( JobEntryCopy.class );
+    JobEntryCopy jobEntryCopy2 = mock( JobEntryCopy.class );
+    JobEntryCopy jobEntryCopy3 = mock( JobEntryCopy.class );
+
+    JobEntryTrans trans1 = mock( JobEntryTrans.class );
+    JobEntryTrans trans2 = mock( JobEntryTrans.class );
+    JobEntryTrans trans3 = mock( JobEntryTrans.class );
+
+    ArgumentCaptor<DefaultRunConfiguration> rcCaptor =  ArgumentCaptor.forClass( DefaultRunConfiguration.class );
+    when( jobMeta.getEmbeddedMetaStore() ).thenReturn( embeddedMetaStore );
+    when( jobMeta.getSlaveServers() ).thenReturn( Arrays.asList(
+            new SlaveServer( "carte1", "host1", "1234", "user", "passw" ),
+            new SlaveServer( "carte2", "host2", "1234", "user", "passw" )
+            ) );
+    when( jobMeta.getJobCopies() ).thenReturn( Arrays.asList( jobEntryCopy1, jobEntryCopy2, jobEntryCopy3 ) );
+    when( jobEntryCopy1.getEntry() ).thenReturn( trans1 );
+    when( jobEntryCopy2.getEntry() ).thenReturn( trans2 );
+    when( jobEntryCopy3.getEntry() ).thenReturn( trans3 );
+
+    when( trans1.getRemoteSlaveServerName() ).thenReturn( "carte1" );
+    when( trans2.getRemoteSlaveServerName() ).thenReturn( "carte1" );
+    when( trans3.getRemoteSlaveServerName() ).thenReturn( "carte2" );
+    when( trans1.getRunConfiguration() ).thenReturn( null );
+    when( trans2.getRunConfiguration() ).thenReturn( null );
+    when( trans3.getRunConfiguration() ).thenReturn( null );
+    when( runConfigurationManager.getNames() ).thenReturn( Collections.singletonList( "pentaho_auto_carte1_config" ) );
+
+    runConfigurationImportExtensionPoint.callExtensionPoint( log, jobMeta );
+
+    verify( runConfigurationManager, times( 2 ) ).save( rcCaptor.capture() );
+    verify( trans1 ).setRunConfiguration( "pentaho_auto_carte1_config_1" );
+    verify( trans2 ).setRunConfiguration( "pentaho_auto_carte1_config_1" );
+    verify( trans3 ).setRunConfiguration( "pentaho_auto_carte2_config" );
+
+    List<DefaultRunConfiguration> allValues = rcCaptor.getAllValues();
+    DefaultRunConfiguration runConfiguration1 = allValues.get( 0 );
+    assertEquals( "pentaho_auto_carte1_config_1", runConfiguration1.getName() );
+    assertEquals( "carte1", runConfiguration1.getServer() );
+
+    DefaultRunConfiguration runConfiguration2 = allValues.get( 1 );
+    assertEquals( "pentaho_auto_carte2_config", runConfiguration2.getName() );
+    assertEquals( "carte2", runConfiguration2.getServer() );
+  }
+
+  @Test
+  public void testCreateRunConfigurationName() throws Exception {
+    assertEquals( "pentaho_auto_carte_config",
+      runConfigurationImportExtensionPoint.createRunConfigurationName( Collections.emptyList(), "carte" ) );
+
+    assertEquals( "pentaho_auto_carte_config_3",
+      runConfigurationImportExtensionPoint.createRunConfigurationName(
+        Arrays.asList( "pentaho_auto_carte_config_2", "pentaho_auto_carte_config_manuallyUpdated" ), "carte" ) );
+  }
 }


### PR DESCRIPTION
Changed to create run configuration with remote server info for cases when Run configuration does not exist for Transformation job entry but slave_server_name is specified.