### PR TITLE
[BACKLOG-19122] Data Grid "java.lang.IllegalArgumentException: Index out of bounds" inserting several meta fields

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/core/widget/TableView.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/widget/TableView.java
@@ -1498,6 +1498,8 @@ public class TableView extends Composite {
     text.dispose();
     table.setFocus();
 
+    tableViewModifyListener.cellFocusLost( rownr );
+
     String[] afterEdit = getItemText( row );
     checkChanged( new String[][]{ beforeEdit }, new String[][]{ afterEdit }, new int[]{ rownr } );
 


### PR DESCRIPTION
[BACKLOG-19122] Data Grid "java.lang.IllegalArgumentException: Index out of bounds" inserting several meta fields

was added calling cellFocusLost when it was focus was lost via keyboard