### PR TITLE
[SP-3807][BACKLOG-19122] Data Grid "java.lang.IllegalArgumentException: Index out of bounds" inserting several meta fields

### DIFF
--- a/ui/src/org/pentaho/di/ui/core/widget/TableView.java
+++ b/ui/src/org/pentaho/di/ui/core/widget/TableView.java
@@ -1470,6 +1470,8 @@ public class TableView extends Composite {
     text.dispose();
     table.setFocus();
 
+    tableViewModifyListener.cellFocusLost( rownr );
+
     String[] afterEdit = getItemText( row );
     checkChanged( new String[][]{ beforeEdit }, new String[][]{ afterEdit }, new int[]{ rownr } );
 


### PR DESCRIPTION
[SP-3807][BACKLOG-19122] Data Grid "java.lang.IllegalArgumentException: Index out of bounds" inserting several meta fields

was added calling cellFocusLost when focus was lost via keyboard