### PR TITLE
[BACKLOG-17898] Stop unit test from touching the file system

### DIFF
--- a/core/src/test/java/org/pentaho/di/core/encryption/KettleTwoWayPasswordEncoderTest.java
+++ b/core/src/test/java/org/pentaho/di/core/encryption/KettleTwoWayPasswordEncoderTest.java
@@ -39,11 +39,6 @@ import org.pentaho.di.core.exception.KettleValueException;
  */
 public class KettleTwoWayPasswordEncoderTest {
 
-  @BeforeClass
-  public static void setUpBeforeClass() throws Exception {
-    KettleClientEnvironment.init();
-  }
-
   /**
    * Test password encryption.
    *


### PR DESCRIPTION
@pentaho/2-1b @smaring 

The removed code put stuff in `/tmp/vfs_cache` and didn't affect the tests at all.