### PR TITLE
[PDI-16480] Salesforce: Datetime fields are not being set with Pentaho 7.1 version

### DIFF
--- a/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforce/SalesforceStep.java
+++ b/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforce/SalesforceStep.java
@@ -22,9 +22,12 @@
 
 package org.pentaho.di.trans.steps.salesforce;
 
+import com.google.common.primitives.Ints;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
@@ -33,6 +36,10 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
 
 public abstract class SalesforceStep extends BaseStep implements StepInterface {
 
@@ -99,5 +106,40 @@ public abstract class SalesforceStep extends BaseStep implements StepInterface {
       data.connection = null;
     }
     super.dispose( smi, sdi );
+  }
+
+  /**
+   * normalize object for future sent in Salesforce
+   *
+   * @param valueMeta value meta
+   * @param value pentaho internal value object
+   * @return object for sending in Salesforce
+   * @throws KettleValueException
+   */
+  public Object normalizeValue( ValueMetaInterface valueMeta, Object value ) throws KettleValueException {
+    if ( valueMeta.isDate() ) {
+      // Pass date field converted to UTC, see PDI-10836
+      Calendar cal = Calendar.getInstance( valueMeta.getDateFormatTimeZone() );
+      cal.setTime( valueMeta.getDate( value ) );
+      Calendar utc = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) );
+      // Reset time-related fields
+      utc.clear();
+      utc.set( cal.get( Calendar.YEAR ), cal.get( Calendar.MONTH ), cal.get( Calendar.DATE ),
+        cal.get( Calendar.HOUR_OF_DAY ), cal.get( Calendar.MINUTE ), cal.get( Calendar.SECOND ) );
+      value = utc;
+    } else if ( valueMeta.isStorageBinaryString() ) {
+      value = valueMeta.convertToNormalStorageType( value );
+    }
+
+    if ( ValueMetaInterface.TYPE_INTEGER == valueMeta.getType() ) {
+      // Salesforce integer values can be only http://www.w3.org/2001/XMLSchema:int
+      // see org.pentaho.di.ui.trans.steps.salesforceinput.SalesforceInputDialog#addFieldToTable
+      // So we need convert Hitachi Vantara integer (real java Long value) to real int.
+      // It will be sent correct as http://www.w3.org/2001/XMLSchema:int
+
+      // use checked cast for prevent losing data
+      value = Ints.checkedCast( (Long) value );
+    }
+    return value;
   }
 }

--- a/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsert.java
+++ b/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsert.java
@@ -23,10 +23,7 @@
 package org.pentaho.di.trans.steps.salesforceinsert;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.TimeZone;
 
-import com.google.common.primitives.Ints;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -144,31 +141,9 @@ public class SalesforceInsert extends SalesforceStep {
             fieldsToNull.add( SalesforceUtils.getFieldToNullName( log, meta.getUpdateLookup()[i], meta
                 .getUseExternalId()[i] ) );
           } else {
-            if ( valueMeta.isDate() ) {
-              // Pass date field converted to UTC, see PDI-10836
-              Calendar cal = Calendar.getInstance( valueMeta.getDateFormatTimeZone() );
-              cal.setTime( valueMeta.getDate( value ) );
-              Calendar utc = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) );
-              // Reset time-related fields
-              utc.clear();
-              utc.set( cal.get( Calendar.YEAR ), cal.get( Calendar.MONTH ), cal.get( Calendar.DATE ) );
-              value = utc.getTime();
-            } else if ( valueMeta.isStorageBinaryString() ) {
-              value = valueMeta.convertToNormalStorageType( value );
-            }
-
-            if ( ValueMetaInterface.TYPE_INTEGER == valueMeta.getType() ) {
-              // Salesforce integer values can be only http://www.w3.org/2001/XMLSchema:int
-              // see org.pentaho.di.ui.trans.steps.salesforceinput.SalesforceInputDialog#addFieldToTable
-              // So we need convert Hitachi Vantara integer (real java Long value) to real int.
-              // It will be sent correct as http://www.w3.org/2001/XMLSchema:int
-
-              // use checked cast for prevent losing data
-              value = Ints.checkedCast( (Long) value );
-            }
-
+            Object normalObject = normalizeValue( valueMeta, value );
             insertfields.add( SalesforceConnection.createMessageElement(
-              meta.getUpdateLookup()[i], value, meta.getUseExternalId()[i] ) );
+              meta.getUpdateLookup()[i], normalObject, meta.getUseExternalId()[i] ) );
           }
         }
 

--- a/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforceupdate/SalesforceUpdate.java
+++ b/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforceupdate/SalesforceUpdate.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowDataUtil;
+import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
@@ -136,8 +137,11 @@ public class SalesforceUpdate extends SalesforceStep {
             fieldsToNull.add( SalesforceUtils.getFieldToNullName( log, meta.getUpdateLookup()[i], meta
                 .getUseExternalId()[i] ) );
           } else {
+            ValueMetaInterface valueMeta = data.inputRowMeta.getValueMeta( data.fieldnrs[i] );
+            Object value = rowData[ data.fieldnrs[ i ] ];
+            Object normalObject = normalizeValue( valueMeta, value );
             updatefields.add( SalesforceConnection.createMessageElement( meta.getUpdateLookup()[i],
-                rowData[data.fieldnrs[i]], meta.getUseExternalId()[i] ) );
+              normalObject, meta.getUseExternalId()[i] ) );
           }
         }
 

--- a/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsert.java
+++ b/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsert.java
@@ -24,7 +24,6 @@ package org.pentaho.di.trans.steps.salesforceupsert;
 
 import java.util.ArrayList;
 
-import com.google.common.primitives.Ints;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -140,17 +139,7 @@ public class SalesforceUpsert extends SalesforceStep {
             fieldsToNull.add( SalesforceUtils.getFieldToNullName( log, meta.getUpdateLookup()[i], meta
                 .getUseExternalId()[i] ) );
           } else {
-            Object normalObject = valueMeta.convertToNormalStorageType( object );
-            if ( ValueMetaInterface.TYPE_INTEGER == valueMeta.getType() ) {
-              // Salesforce integer values can be only http://www.w3.org/2001/XMLSchema:int
-              // see org.pentaho.di.ui.trans.steps.salesforceinput.SalesforceInputDialog#addFieldToTable
-              // So we need convert Hitachi Vantara integer (real java Long value) to real int.
-              // It will be sent correct as http://www.w3.org/2001/XMLSchema:int
-
-              // use checked cast for prevent losing data
-              normalObject = Ints.checkedCast( (Long) normalObject );
-            }
-
+            Object normalObject = normalizeValue( valueMeta, rowData[data.fieldnrs[i]] );
             upsertfields.add( SalesforceConnection.createMessageElement( meta.getUpdateLookup()[i], normalObject, meta
                 .getUseExternalId()[i] ) );
           }

--- a/plugins/salesforce/core/src/test/java/org/pentaho/di/trans/steps/salesforce/SalesforceStepTest.java
+++ b/plugins/salesforce/core/src/test/java/org/pentaho/di/trans/steps/salesforce/SalesforceStepTest.java
@@ -31,18 +31,28 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
 
 public class SalesforceStepTest {
 
@@ -115,4 +125,33 @@ public class SalesforceStepTest {
       super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
     }
   }
+
+  @Test
+  public void createIntObjectTest() throws KettleValueException {
+    SalesforceStep step =
+      spy( new MockSalesforceStep( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans ) );
+    ValueMetaInterface valueMeta = Mockito.mock( ValueMetaInterface.class );
+    Mockito.when( valueMeta.getType() ).thenReturn( ValueMetaInterface.TYPE_INTEGER );
+    Object value = step.normalizeValue( valueMeta, 100L );
+    Assert.assertTrue( value instanceof Integer );
+  }
+
+  @Test
+  public void createDateObjectTest() throws KettleValueException, ParseException {
+    SalesforceStep step =
+      spy( new MockSalesforceStep( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans ) );
+    ValueMetaInterface valueMeta = Mockito.mock( ValueMetaInterface.class );
+    DateFormat dateFormat = new SimpleDateFormat( "dd-MM-yyyy hh:mm:ss" );
+    Date date = dateFormat.parse( "12-10-2017 15:10:25" );
+    Mockito.when( valueMeta.isDate() ).thenReturn( true );
+    Mockito.when( valueMeta.getDateFormatTimeZone() ).thenReturn( TimeZone.getTimeZone( "UTC" ) );
+    Mockito.when( valueMeta.getDate( Mockito.eq( date ) ) ).thenReturn( date );
+    Object value = step.normalizeValue( valueMeta, date );
+    Assert.assertTrue( value instanceof Calendar );
+    DateFormat minutesDateFormat = new SimpleDateFormat( "mm:ss" );
+    //check not missing minutes and seconds
+    Assert.assertEquals( minutesDateFormat.format( date ), minutesDateFormat.format( ( (Calendar) value ).getTime() ) );
+
+  }
+
 }

--- a/plugins/salesforce/core/src/test/java/org/pentaho/di/trans/steps/salesforceinsert/PDI_10836_Test.java
+++ b/plugins/salesforce/core/src/test/java/org/pentaho/di/trans/steps/salesforceinsert/PDI_10836_Test.java
@@ -33,6 +33,7 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import com.sforce.ws.bind.XmlObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -118,7 +119,8 @@ public class PDI_10836_Test {
     DateFormat utc = new SimpleDateFormat( "yyyy-MM-dd" );
     utc.setTimeZone( TimeZone.getTimeZone( "UTC" ) );
 
+    XmlObject xmlObject = SalesforceConnection.getChildren( data.sfBuffer[ 0 ] )[ 0 ];
     Assert.assertEquals( "2013-10-16",
-      utc.format( SalesforceConnection.getChildren( data.sfBuffer[0] )[0].getValue() ) );
+      utc.format( ( (Calendar) xmlObject.getValue() ).getTime() ) );
   }
 }


### PR DESCRIPTION
[PDI-16480] Salesforce: Datetime fields are not being set with Pentaho 7.1 version

-added saving hh:mm:ss for saving datetime in Salesforce
-created one method with one rules for normalizing data for all Salesforce modify steps