### PR TITLE
[BACKLOG-19370]-[DEV] - Implement SparkOperaton and function to use s…

### DIFF
--- a/assemblies/pdi-ce/pom.xml
+++ b/assemblies/pdi-ce/pom.xml
@@ -726,7 +726,7 @@
     </dependency>
     <dependency>
       <groupId>com.databricks</groupId>
-      <artifactId>spark-avro_2.10</artifactId>
+      <artifactId>spark-avro_2.11</artifactId>
       <version>${databricks.version}</version>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
…park

native libraries to create schema and content for avro

The version of spark avro need to be updated according the comment from
Spark developer
https://stackoverflow.com/questions/44657950/spark-2-1-0-caused-by-java-lang-classnotfoundexception-scala-collection-gent

The spark 2.1.0 uses by default

com.databricks
spark-avro_2.11
3.2.0

http://jira.pentaho.com/browse/COMP-7216