### PR TITLE
[PDI-16731] TextOutput for empty not null values are not enclosed.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -430,7 +430,7 @@ public class TextFileOutput extends BaseStep implements StepInterface {
         }
       }
 
-      if ( str != null && str.length > 0 ) {
+      if ( str != null && (str.length > 0 || meta.isEnclosureForced() ) ) {
         List<Integer> enclosures = null;
         boolean writeEnclosures = false;
 


### PR DESCRIPTION
When field length is not specified at Fields Tab, but quote is enforced -> empty string  is left unquoted, so it is undistiguishable from NULL.

Similar code I suspect need to be propogated to S3 Text Output plugin