### PR TITLE
[SP-3806][PDI-16434]Salesforce Upsert (and possibly insert) fails when upserting an integer into account object

### DIFF
--- a/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsert.java
+++ b/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsert.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.TimeZone;
 
+import com.google.common.primitives.Ints;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -154,6 +155,16 @@ public class SalesforceInsert extends SalesforceStep {
               value = utc.getTime();
             } else if ( valueMeta.isStorageBinaryString() ) {
               value = valueMeta.convertToNormalStorageType( value );
+            }
+
+            if ( ValueMetaInterface.TYPE_INTEGER == valueMeta.getType() ) {
+              // Salesforce integer values can be only http://www.w3.org/2001/XMLSchema:int
+              // see org.pentaho.di.ui.trans.steps.salesforceinput.SalesforceInputDialog#addFieldToTable
+              // So we need convert Pentaho integer (real java Long value) to real int.
+              // It will be sent correct as http://www.w3.org/2001/XMLSchema:int
+
+              // use checked cast for prevent losing data
+              value = Ints.checkedCast( (Long) value );
             }
 
             insertfields.add( SalesforceConnection.createMessageElement(

--- a/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsert.java
+++ b/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsert.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,6 +24,7 @@ package org.pentaho.di.trans.steps.salesforceupsert;
 
 import java.util.ArrayList;
 
+import com.google.common.primitives.Ints;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -140,6 +141,16 @@ public class SalesforceUpsert extends SalesforceStep {
                 .getUseExternalId()[i] ) );
           } else {
             Object normalObject = valueMeta.convertToNormalStorageType( object );
+            if ( ValueMetaInterface.TYPE_INTEGER == valueMeta.getType() ) {
+              // Salesforce integer values can be only http://www.w3.org/2001/XMLSchema:int
+              // see org.pentaho.di.ui.trans.steps.salesforceinput.SalesforceInputDialog#addFieldToTable
+              // So we need convert Pentaho integer (real java Long value) to real int.
+              // It will be sent correct as http://www.w3.org/2001/XMLSchema:int
+
+              // use checked cast for prevent losing data
+              normalObject = Ints.checkedCast( (Long) normalObject );
+            }
+
             upsertfields.add( SalesforceConnection.createMessageElement( meta.getUpdateLookup()[i], normalObject, meta
                 .getUseExternalId()[i] ) );
           }

--- a/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsertTest.java
+++ b/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceinsert/SalesforceInsertTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -34,6 +34,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
+import com.sforce.ws.bind.XmlObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -45,6 +47,7 @@ import org.pentaho.di.core.logging.LoggingObjectInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
@@ -202,5 +205,24 @@ public class SalesforceInsertTest {
     doReturn( UUID.randomUUID().toString() ).when( meta ).getModule();
     doReturn( UUID.randomUUID().toString() ).when( meta ).getSalesforceIDFieldName();
     return meta;
+  }
+
+  @Test
+  public void testWriteToSalesForcePentahoIntegerValue() throws Exception {
+    SalesforceInsert sfInputStep =
+      new SalesforceInsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceInsertMeta meta =
+      generateSalesforceInsertMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceInsertData data = generateSalesforceInsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaInteger( "IntValue" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { 1L } );
+    XmlObject sObject = data.sfBuffer[ 0 ].getChild( ACCOUNT_ID );
+    Assert.assertEquals( sObject.getValue(), 1 );
   }
 }

--- a/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsertTest.java
+++ b/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforceupsert/SalesforceUpsertTest.java
@@ -34,6 +34,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
+import com.sforce.ws.bind.XmlObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -45,6 +47,7 @@ import org.pentaho.di.core.logging.LoggingObjectInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
@@ -202,4 +205,24 @@ public class SalesforceUpsertTest {
     doReturn( useExternalId ).when( meta ).getUseExternalId();
     return meta;
   }
+
+  @Test
+  public void testWriteToSalesForcePentahoIntegerValue() throws Exception {
+    SalesforceUpsert sfInputStep =
+      new SalesforceUpsert( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
+    SalesforceUpsertMeta meta =
+      generateSalesforceUpsertMeta( new String[] { ACCOUNT_ID }, new Boolean[] { false } );
+    SalesforceUpsertData data = generateSalesforceUpsertData();
+    sfInputStep.init( meta, data );
+
+    RowMeta rowMeta = new RowMeta();
+    ValueMetaBase valueMeta = new ValueMetaInteger( "IntValue" );
+    rowMeta.addValueMeta( valueMeta );
+    smh.initStepDataInterface.inputRowMeta = rowMeta;
+
+    sfInputStep.writeToSalesForce( new Object[] { 1L } );
+    XmlObject sObject = data.sfBuffer[ 0 ].getChild( ACCOUNT_ID );
+    Assert.assertEquals( sObject.getValue(), 1 );
+  }
+
 }


### PR DESCRIPTION
[SP-3806][PDI-16434]Salesforce Upsert (and possibly insert) fails when upserting an integer into account object

-fixing sending Pentaho Integer value to Salesforce (SalesforceInsert and SalesforceUpsert steps)