### PR TITLE
[SP-3824][PDI-15268] PDI locks up when changing Job - Properties - Parameters.

### DIFF
--- a/ui/src/org/pentaho/di/ui/core/widget/TableView.java
+++ b/ui/src/org/pentaho/di/ui/core/widget/TableView.java
@@ -548,6 +548,10 @@ public class TableView extends Composite {
     lsFocusText = new FocusAdapter() {
       @Override
       public void focusLost( FocusEvent e ) {
+        if ( isWrongLostFocusEvent() ) {
+          return;
+        }
+
         final Display d = Display.getCurrent();
 
         if ( table.isDisposed() ) {
@@ -610,6 +614,18 @@ public class TableView extends Composite {
           worker.run();
         }
         tableViewModifyListener.cellFocusLost( rownr );
+      }
+
+      /**
+       * This is a workaround for SWT bug (see PDI-15268).
+       * Calling a context menu should be ignored in
+       * SWT org.eclipse.swt.widgets.Control#gtk_event_after
+       *
+       * @return true if it is wrong event
+       */
+      private boolean isWrongLostFocusEvent() {
+        Control controlGotFocus = Display.getCurrent().getCursorControl();
+        return Const.isLinux() && ( controlGotFocus == null || text.equals( controlGotFocus ) );
       }
     };
     lsFocusCombo = new FocusAdapter() {


### PR DESCRIPTION
[SP-3824][PDI-15268] PDI locks up when changing Job - Properties - Parameters.
added calculation wrong focus event (a workaround for SWT bug)