### PR TITLE
[SP-3818][PDI-16459] Salesforce Insert - sObject type 'string' is not supported

### DIFF
--- a/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforce/SalesforceConnection.java
+++ b/plugins/salesforce/src/org/pentaho/di/trans/steps/salesforce/SalesforceConnection.java
@@ -821,13 +821,7 @@ public class SalesforceConnection {
 
       for ( int i = 0; i < nrFields; i++ ) {
         Field field = fields[i];
-
-        if ( field.getRelationshipName() != null ) {
-          fieldsMapp[i] = field.getRelationshipName();
-        } else {
-          fieldsMapp[i] = field.getName();
-        }
-
+        fieldsMapp[i] = field.getName();
       }
       return fieldsMapp;
     }

--- a/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforce/SalesforceConnectionTest.java
+++ b/plugins/salesforce/test-src/org/pentaho/di/trans/steps/salesforce/SalesforceConnectionTest.java
@@ -34,8 +34,10 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Random;
 
+import com.sforce.soap.partner.Field;
 import com.sforce.soap.partner.sobject.SObject;
 import com.sforce.ws.wsdl.Constants;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -340,4 +342,18 @@ public class SalesforceConnectionTest {
     result.setValue( value );
     return result;
   }
+
+  @Test //PDI-16459
+  public void getFieldsTest() throws KettleException {
+    String name = "name";
+    SalesforceConnection conn = new SalesforceConnection( null, "http://localhost:1234", "aUser", "aPass" );
+    Field[] fields = new Field[ 1 ];
+    Field field = new Field();
+    field.setRelationshipName( "Parent" );
+    field.setName( name );
+    fields[ 0 ] = field;
+    String[] names = conn.getFields( fields );
+    Assert.assertEquals( name, names[ 0 ] );
+  }
+
 }


### PR DESCRIPTION
[SP-3818][PDI-16459] Salesforce Insert - sObject type 'string' is not supported

removed wrong using RelationshipName instead of Name