### PR TITLE
Revert "[PDI-16535]-Errors creating transformations and jobs when the user connects to Pentaho Repository using a different case of the user name created"

### DIFF
--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryConnector.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryConnector.java
@@ -236,13 +236,7 @@ public class PurRepositoryConnector implements IRepositoryConnector {
 
       Boolean isAdmin = authorizationWebserviceFuture.get();
       result.getUser().setAdmin( isAdmin );
-      String[] users = result.getSecurityProvider().getUserLogins();
-      for ( String user:users ) {
-        if ( user.equalsIgnoreCase( username ) ) {
-          result.getUser().setLogin( user );
-          break;
-        }
-      }
+
       if ( log.isBasic() ) {
         log.logBasic( BaseMessages.getString( PKG, "PurRepositoryConnector.RegisterSecurityProvider.Start" ) );
       }


### PR DESCRIPTION
Reverts pentaho/pentaho-kettle#4532