### PR TITLE
[PDI-16684] Every click on the PDI UI sending a request to the Pentaho Server

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -201,6 +201,8 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
   private boolean showDialog = true;
   private boolean alwaysShowRunOptions = true;
 
+  private Boolean versioningEnabled;
+
   public boolean isShowDialog() {
     return showDialog;
   }
@@ -2066,6 +2068,16 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
 
   public void setEmbeddedMetastoreProviderKey( String embeddedMetastoreProviderKey ) {
     this.embeddedMetastoreProviderKey = embeddedMetastoreProviderKey;
+  }
+
+  @Override
+  public void setVersioningEnabled( Boolean versioningEnabled ) {
+    this.versioningEnabled = versioningEnabled;
+  }
+
+  @Override
+  public Boolean getVersioningEnabled() {
+    return this.versioningEnabled;
   }
 
 }

--- a/engine/src/main/java/org/pentaho/di/core/EngineMetaInterface.java
+++ b/engine/src/main/java/org/pentaho/di/core/EngineMetaInterface.java
@@ -192,4 +192,20 @@ public interface EngineMetaInterface extends RepositoryElementInterface {
    * Sets the internal kettle variables.
    */
   public void setInternalKettleVariables();
+
+  /**
+   * Set versioning enabled
+   *
+   * @param versioningEnabled
+   *          is versioning enabled
+   */
+  public void setVersioningEnabled( Boolean versioningEnabled );
+
+  /**
+   * Is versioning enabled.
+   *
+   * @return is versioning enabled
+   */
+  public Boolean getVersioningEnabled();
+
 }

--- a/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
@@ -821,6 +821,16 @@ public class AbstractMetaTest {
     }
 
     @Override
+    public void setVersioningEnabled( Boolean isVersioningEnabled ) {
+
+    }
+
+    @Override
+    public Boolean getVersioningEnabled() {
+      return null;
+    }
+
+    @Override
     public String getLogChannelId() {
       return null;
     }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -6747,13 +6747,23 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     return fullPath;
   }
 
-  private static boolean isVersionEnabled( Repository rep, EngineMetaInterface jobTransMeta ) {
+  static boolean isVersionEnabled( Repository rep, EngineMetaInterface jobTransMeta ) {
+    //It is not necessary to check VersioningEnabled on the server every time (see PDI-16684)
+    if ( jobTransMeta.getVersioningEnabled() == null ) {
+      boolean versioningEnabled = checkIsVersioningEnabledOnServer( rep, jobTransMeta );
+      jobTransMeta.setVersioningEnabled( versioningEnabled );
+      return versioningEnabled;
+    }
+    return jobTransMeta.getVersioningEnabled();
+  }
+
+  private static boolean checkIsVersioningEnabledOnServer( Repository rep, EngineMetaInterface jobTransMeta ) {
     boolean versioningEnabled = true;
 
     String fullPath = getJobTransfFullPath( jobTransMeta );
     RepositorySecurityProvider
-        repositorySecurityProvider =
-        rep != null && rep.getSecurityProvider() != null ? rep.getSecurityProvider() : null;
+      repositorySecurityProvider =
+      rep != null && rep.getSecurityProvider() != null ? rep.getSecurityProvider() : null;
     if ( repositorySecurityProvider != null && fullPath != null ) {
       versioningEnabled = repositorySecurityProvider.isVersioningEnabled( fullPath );
     }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonSlave.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonSlave.java
@@ -1139,6 +1139,13 @@ public class SpoonSlave extends Composite implements TabItemInterface {
 
       public void setObjectRevision( ObjectRevision objectRevision ) {
       }
+
+      public void setVersioningEnabled( Boolean versioningEnabled ) {
+      }
+
+      public Boolean getVersioningEnabled() {
+        return null;
+      }
     };
   }
 


### PR DESCRIPTION
[PDI-16684] Every click on the PDI UI sending a request to the Pentaho Server
cache was added for versioningConfiguration property

It is not necessary to check VersioningEnabled on the server every time.
The property versioningConfiguration depends on files
server/pentaho-server/pentaho-solutions/system/ImportHandlerMimeTypeDefinitions.xml
server/pentaho-server/pentaho-solutions/system/repository.spring.properties
Live changes in these files are not supported. If we make changes in these files it doesn't change behavior without pentaho-server restart. So we don't need rechecked this property in server every time. It is enough to check it one time.

@bmorrise Could you please review and merge it?