### PR TITLE
[PDI-14250|PDI-14296] SFTP Put step corrupts file data when "Input is a stream" option is used | Load File Content in Memory corrupts data read from binary files

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/loadfileinput/LoadFileInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/loadfileinput/LoadFileInput.java
@@ -24,10 +24,10 @@ package org.pentaho.di.trans.steps.loadfileinput;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
@@ -97,7 +97,7 @@ public class LoadFileInput extends BaseStep implements StepInterface {
 
           // Create convert meta-data objects that will contain Date & Number formatters
           //
-          data.convertRowMeta = data.outputRowMeta.cloneToType( ValueMetaInterface.TYPE_STRING );
+          data.convertRowMeta = data.outputRowMeta.clone();
 
           if ( meta.getIsInFields() ) {
             // Check is filename field is provided
@@ -257,7 +257,7 @@ public class LoadFileInput extends BaseStep implements StepInterface {
 
   private void getFileContent() throws KettleException {
     try {
-      data.filecontent = getTextFileContent( data.file.toString(), meta.getEncoding() );
+      data.filecontent = getFileBinaryContent( data.file.toString() );
     } catch ( java.lang.OutOfMemoryError o ) {
       logError( "There is no enaugh memory to load the content of the file [" + data.file.getName() + "]" );
       throw new KettleException( o );
@@ -267,46 +267,24 @@ public class LoadFileInput extends BaseStep implements StepInterface {
   }
 
   /**
-   * Read a text file.
+   * Read a file.
    *
    * @param vfsFilename
    *          the filename or URL to read from
-   * @param charSetName
-   *          the character set of the string (UTF-8, ISO8859-1, etc)
-   * @return The content of the file as a String
+   * @return The content of the file as a byte[]
    * @throws KettleException
    */
-  public static String getTextFileContent( String vfsFilename, String encoding ) throws KettleException {
+  public static byte[] getFileBinaryContent( String vfsFilename ) throws KettleException {
     InputStream inputStream = null;
-    InputStreamReader reader = null;
 
-    String retval = null;
+    byte[] retval = null;
     try {
       inputStream = KettleVFS.getInputStream( vfsFilename );
-
-      if ( !Utils.isEmpty( encoding ) ) {
-        reader = new InputStreamReader( new BufferedInputStream( inputStream ), encoding );
-      } else {
-        reader = new InputStreamReader( new BufferedInputStream( inputStream ) );
-      }
-
-      int c;
-      StringBuilder StringBuilder = new StringBuilder();
-      while ( ( c = reader.read() ) != -1 ) {
-        StringBuilder.append( (char) c );
-      }
-
-      retval = StringBuilder.toString();
+      retval = IOUtils.toByteArray( new BufferedInputStream( inputStream ) );
     } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString(
         PKG, "LoadFileInput.Error.GettingFileContent", vfsFilename, e.toString() ) );
     } finally {
-      if ( reader != null ) {
-        try {
-          reader.close();
-        } catch ( Exception e ) { /* Ignore */
-        }
-      }
       if ( inputStream != null ) {
         try {
           inputStream.close();
@@ -370,20 +348,24 @@ public class LoadFileInput extends BaseStep implements StepInterface {
         // Get field
         LoadFileInputField loadFileInputField = meta.getInputFields()[i];
 
-        String o = null;
+        Object o = null;
+        int indexField = data.totalpreviousfields + i;
+        ValueMetaInterface targetValueMeta = data.outputRowMeta.getValueMeta( indexField );
+        ValueMetaInterface sourceValueMeta = data.convertRowMeta.getValueMeta( indexField );
+
         switch ( loadFileInputField.getElementType() ) {
           case LoadFileInputField.ELEMENT_TYPE_FILECONTENT:
 
             // DO Trimming!
             switch ( loadFileInputField.getTrimType() ) {
               case LoadFileInputField.TYPE_TRIM_LEFT:
-                data.filecontent = Const.ltrim( data.filecontent );
+                data.filecontent = Const.ltrim( new String( data.filecontent ) ).getBytes();
                 break;
               case LoadFileInputField.TYPE_TRIM_RIGHT:
-                data.filecontent = Const.rtrim( data.filecontent );
+                data.filecontent = Const.rtrim( new String( data.filecontent ) ).getBytes();
                 break;
               case LoadFileInputField.TYPE_TRIM_BOTH:
-                data.filecontent = Const.trim( data.filecontent );
+                data.filecontent = Const.trim( new String( data.filecontent ) ).getBytes();
                 break;
               default:
                 break;
@@ -397,11 +379,7 @@ public class LoadFileInput extends BaseStep implements StepInterface {
             break;
         }
 
-        int indexField = data.totalpreviousfields + i;
         // Do conversions
-        //
-        ValueMetaInterface targetValueMeta = data.outputRowMeta.getValueMeta( indexField );
-        ValueMetaInterface sourceValueMeta = data.convertRowMeta.getValueMeta( indexField );
         outputRowData[indexField] = targetValueMeta.convertData( sourceValueMeta, o );
 
         // Do we need to repeat this field if it is null?
@@ -483,7 +461,7 @@ public class LoadFileInput extends BaseStep implements StepInterface {
 
           // Create convert meta-data objects that will contain Date & Number formatters
           //
-          data.convertRowMeta = data.outputRowMeta.cloneToType( ValueMetaInterface.TYPE_STRING );
+          data.convertRowMeta = data.outputRowMeta.clone();
         } catch ( Exception e ) {
           logError( "Error at step initialization: " + e.toString() );
           logError( Const.getStackTracker( e ) );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/loadfileinput/LoadFileInputData.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/loadfileinput/LoadFileInputData.java
@@ -53,7 +53,7 @@ public class LoadFileInputData extends BaseStepData implements StepDataInterface
 
   public Object[] readrow;
 
-  public String filecontent;
+  public byte[] filecontent;
 
   public long fileSize;
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
@@ -2774,7 +2774,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
               return Context.getUndefinedValue();
             }
             // Returns file content
-            oRC = LoadFileInput.getTextFileContent( Context.toString( ArgList[0] ), null );
+            oRC = new String( LoadFileInput.getFileBinaryContent( Context.toString( ArgList[0] ) ) );
           } catch ( Exception e ) {
             throw Context
               .reportRuntimeError( "The function call loadFileContent throw an error : " + e.toString() );
@@ -2792,7 +2792,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
               encoding = Context.toString( ArgList[1] );
             }
             // Returns file content
-            oRC = LoadFileInput.getTextFileContent( Context.toString( ArgList[0] ), encoding );
+            oRC = new String( LoadFileInput.getFileBinaryContent( Context.toString( ArgList[0] ) ), encoding );
           } catch ( Exception e ) {
             throw Context
               .reportRuntimeError( "The function call loadFileContent throw an error : " + e.toString() );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/sftpput/SFTPPut.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/sftpput/SFTPPut.java
@@ -169,7 +169,7 @@ public class SFTPPut extends BaseStep implements StepInterface {
 
       if ( meta.isInputStream() ) {
         // Source data is a stream
-        inputStream = new ByteArrayInputStream( sourceData.getBytes() );
+        inputStream = new ByteArrayInputStream( getInputRowMeta().getBinary( r, data.indexOfSourceFileFieldName ) );
 
         if ( data.indexOfRemoteFilename == -1 ) {
           // for the case when put data is transferred via input field


### PR DESCRIPTION
- LoadFileInput step was modified in order to work with file content as a binary array, not as a String
- SFTPPut step was modified in order to work with input stream as with binary array
- filecontent field in the LoadFileInputData became byte[]