### PR TITLE
[PDI-14250] SFTP Put step corrupts file data when "Input is a stream" option is used

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/sftpput/SFTPPut.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/sftpput/SFTPPut.java
@@ -169,7 +169,7 @@ public class SFTPPut extends BaseStep implements StepInterface {
 
       if ( meta.isInputStream() ) {
         // Source data is a stream
-        inputStream = new ByteArrayInputStream( sourceData.getBytes() );
+        inputStream = new ByteArrayInputStream( getInputRowMeta().getBinary( r, data.indexOfSourceFileFieldName ) );
 
         if ( data.indexOfRemoteFilename == -1 ) {
           // for the case when put data is transferred via input field


### PR DESCRIPTION
- SFTPPut step was modified in order to work with input stream as with binary array