### PR TITLE
[PDI-16066] Transformation Executor Step does not Inherit Parameters

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -22,10 +22,13 @@
 
 package org.pentaho.di.trans;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.parameters.NamedParams;
+import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.util.CurrentDirectoryResolver;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
@@ -38,7 +41,12 @@ import org.pentaho.di.resource.ResourceDefinition;
 import org.pentaho.di.resource.ResourceNamingInterface;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.metastore.api.IMetaStore;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class is supposed to use in steps where the mapping to sub transformations takes place
@@ -66,8 +74,10 @@ public abstract class StepWithMappingMeta extends BaseStepMeta {
     TransMeta mappingTransMeta = null;
 
     CurrentDirectoryResolver r = new CurrentDirectoryResolver();
+    // send parentVariables = null we don't need it here for resolving resolveCurrentDirectory.
+    // Otherwise we destroy child variables and the option "Inherit all variables from the transformation" is enabled always.
     VariableSpace tmpSpace =
-      r.resolveCurrentDirectory( executorMeta.getSpecificationMethod(), space, rep, executorMeta.getParentStepMeta(),
+      r.resolveCurrentDirectory( executorMeta.getSpecificationMethod(), null, rep, executorMeta.getParentStepMeta(),
         executorMeta.getFileName() );
 
     switch ( executorMeta.getSpecificationMethod() ) {
@@ -158,16 +168,60 @@ public abstract class StepWithMappingMeta extends BaseStepMeta {
       default:
         break;
     }
+    if ( mappingTransMeta == null ) {  //skip warning
+      return null;
+    }
 
-    // Pass some important information to the mapping transformation metadata:
+    //  When the child parameter does exist in the parent parameters, overwrite the child parameter by the
+    // parent parameter.
+    replaceVariableValues( mappingTransMeta, space );
     if ( share ) {
-      mappingTransMeta.copyVariablesFrom( space );
+      // All other parent parameters need to get copied into the child parameters  (when the 'Inherit all
+      // variables from the transformation?' option is checked)
+      addMissingVariables( mappingTransMeta, space );
     }
     mappingTransMeta.setRepository( rep );
     mappingTransMeta.setMetaStore( metaStore );
     mappingTransMeta.setFilename( mappingTransMeta.getFilename() );
 
     return mappingTransMeta;
+  }
+
+  public static void activateParams( VariableSpace childVariableSpace, NamedParams childNamedParams, VariableSpace parent, String[] listParameters,
+                                     String[] mappingVariables, String[] inputFields ) {
+    Map<String, String> parameters = new HashMap<>();
+    Set<String> subTransParameters = new HashSet<>( Arrays.asList( listParameters ) );
+
+    for ( int i = 0; i < mappingVariables.length; i++ ) {
+      parameters.put( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
+    }
+
+    for ( String variableName : parent.listVariables() ) {
+      // When the child parameter does exist in the parent parameters, overwrite the child parameter by the
+      // parent parameter.
+      if ( parameters.containsKey( variableName ) ) {
+        parameters.put( variableName, parent.getVariable( variableName ) );
+      } else if ( ArrayUtils.contains( listParameters, variableName ) ) {
+        // there is a definition only in Transformation properties - params tab
+        parameters.put( variableName, parent.getVariable( variableName ) );
+      }
+    }
+
+    for ( Map.Entry<String, String> entry : parameters.entrySet() ) {
+      String key = entry.getKey();
+      String value = Const.NVL( entry.getValue(), "" );
+      if ( subTransParameters.contains( key ) ) {
+        try {
+          childNamedParams.setParameterValue( key, Const.NVL( entry.getValue(), "" ) );
+        } catch ( UnknownParamException e ) {
+          // this is explicitly checked for up front
+        }
+      } else {
+        childVariableSpace.setVariable( key, value );
+      }
+    }
+
+    childNamedParams.activateParameters();
   }
 
   /**
@@ -286,6 +340,30 @@ public abstract class StepWithMappingMeta extends BaseStepMeta {
       return proposedNewFilename;
     } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( PKG, "StepWithMappingMeta.Exception.UnableToLoadTrans", fileName ) );
+    }
+  }
+
+  private static  void addMissingVariables( TransMeta source, VariableSpace target ) {
+    if ( target == null ) {
+      return;
+    }
+    String[] variableNames = target.listVariables();
+    for ( String variable : variableNames ) {
+      if ( source.getVariable( variable ) == null ) {
+        source.setVariable( variable, target.getVariable( variable ) );
+      }
+    }
+  }
+
+  private static void replaceVariableValues( TransMeta childTransMeta, VariableSpace replaceBy ) {
+    if ( replaceBy == null ) {
+      return;
+    }
+    String[] variableNames = replaceBy.listVariables();
+    for ( String variableName : variableNames ) {
+      if ( childTransMeta.getVariable( variableName ) != null ) {
+        childTransMeta.setVariable( variableName, replaceBy.getVariable( variableName ) );
+      }
     }
   }
 }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/mapping/Mapping.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/mapping/Mapping.java
@@ -23,13 +23,7 @@
 package org.pentaho.di.trans.steps.mapping;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.core.Const;
@@ -41,6 +35,7 @@ import org.pentaho.di.core.logging.LogTableField;
 import org.pentaho.di.core.logging.TransLogTable;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.SingleThreadedTransExecutor;
+import org.pentaho.di.trans.StepWithMappingMeta;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.TransMeta.TransformationType;
@@ -280,39 +275,6 @@ public class Mapping extends BaseStep implements StepInterface {
     }
   }
 
-  public void setMappingParameters( Trans trans, TransMeta transMeta, MappingParameters mappingParameters )
-    throws KettleException {
-    if ( mappingParameters == null ) {
-      return;
-    }
-
-    Map<String, String> parameters = new HashMap<>();
-    Set<String> subTransParameters = new HashSet<>( Arrays.asList( transMeta.listParameters() ) );
-
-    if ( mappingParameters.isInheritingAllVariables() ) {
-      // This will include parameters
-      for ( String variableName : listVariables() ) {
-        parameters.put( variableName, getVariable( variableName ) );
-      }
-    }
-
-    String[] mappingVariables = mappingParameters.getVariable();
-    String[] inputFields = mappingParameters.getInputField();
-    for ( int i = 0; i < mappingVariables.length; i++ ) {
-      parameters.put( mappingVariables[i], environmentSubstitute( inputFields[i] ) );
-    }
-
-    for ( Entry<String, String> entry : parameters.entrySet() ) {
-      String key = entry.getKey();
-      String value = Const.NVL( entry.getValue(), "" );
-      if ( subTransParameters.contains( key ) ) {
-        trans.setParameterValue( key, Const.NVL( entry.getValue(), "" ) );
-      } else {
-        trans.setVariable( key, value );
-      }
-    }
-    trans.activateParameters();
-  }
 
   public void prepareMappingExecution() throws KettleException {
     initTransFromMeta();
@@ -567,7 +529,14 @@ public class Mapping extends BaseStep implements StepInterface {
 
     // Set the parameters values in the mapping.
     //
-    setMappingParameters( data.mappingTrans, data.mappingTransMeta, meta.getMappingParameters() );
+
+    MappingParameters mappingParameters = meta.getMappingParameters();
+    if ( mappingParameters != null ) {
+      StepWithMappingMeta
+        .activateParams( data.mappingTrans, data.mappingTrans, this, data.mappingTransMeta.listParameters(),
+          mappingParameters.getVariable(), mappingParameters.getInputField() );
+    }
+
   }
 
   void initServletConfig() {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/singlethreader/SingleThreaderMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/singlethreader/SingleThreaderMeta.java
@@ -293,6 +293,11 @@ public class SingleThreaderMeta extends StepWithMappingMeta implements StepMetaI
     return loadMappingMeta( mappingMeta, rep, null, space );
   }
 
+  public static final synchronized TransMeta loadSingleThreadedTransMeta( SingleThreaderMeta mappingMeta,
+                                                                          Repository rep, VariableSpace space, boolean passingAllParameters  ) throws KettleException {
+    return loadMappingMeta( mappingMeta, rep, null, space, passingAllParameters );
+  }
+
   public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta,
     RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
     Repository repository, IMetaStore metaStore ) {

--- a/engine/src/test/java/org/pentaho/di/trans/steps/mapping/MappingParametersTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/mapping/MappingParametersTest.java
@@ -23,8 +23,6 @@
 package org.pentaho.di.trans.steps.mapping;
 
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.After;
@@ -36,6 +34,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.StepWithMappingMeta;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.steps.StepMockUtil;
@@ -61,23 +60,6 @@ public class MappingParametersTest {
   }
 
   /**
-   * PDI-3064 Test copy variables from actually copy variables from parent to child transformation
-   * 
-   * @throws Exception
-   */
-  @Test
-  public void testInheritAllParametersCopy() throws Exception {
-    MappingParameters param = new MappingParameters();
-    step.setVariable( "a", "1" );
-    step.setVariable( "b", "2" );
-    param.setInheritingAllVariables( true );
-    when( transMeta.listParameters() ).thenReturn( new String[] { "a" } );
-    step.setMappingParameters( trans, transMeta, param );
-    verify( trans ).setVariable( "b", "2" );
-    verify( trans ).setParameterValue( "a", "1" );
-  }
-
-  /**
    * PDI-3064 Test parent transformation overrides parameters for child transformation.
    * 
    * @throws KettleException
@@ -88,8 +70,8 @@ public class MappingParametersTest {
     Mockito.when( param.getVariable() ).thenReturn( new String[] { "a", "b" } );
     Mockito.when( param.getInputField() ).thenReturn( new String[] { "11", "12" } );
     when( transMeta.listParameters() ).thenReturn( new String[] { "a" } );
-    step.setMappingParameters( trans, transMeta, param );
-
+    StepWithMappingMeta
+      .activateParams( trans, trans, step, transMeta.listParameters(), param.getVariable(), param.getInputField() );
     // parameters was overridden 2 times
     Mockito.verify( trans, Mockito.times( 1 ) ).setParameterValue( Mockito.anyString(), Mockito.anyString() );
     Mockito.verify( trans, Mockito.times( 1 ) ).setVariable( Mockito.anyString(), Mockito.anyString() );
@@ -104,17 +86,6 @@ public class MappingParametersTest {
   public void testDoNotOverrideMappingParametes() throws KettleException {
     prepareMappingParametesActions( false );
     Mockito.verify( transMeta, never() ).copyVariablesFrom( Mockito.any( VariableSpace.class ) );
-  }
-
-  /**
-   * Regression of PDI-3064 : keep correct 'inherit all variables' settings. This is a case for 'do override'
-   * 
-   * @throws KettleException
-   */
-  @Test
-  public void testDoOverrideMappingParametes() throws KettleException {
-    prepareMappingParametesActions( true );
-    Mockito.verify( transMeta, times( 1 ) ).copyVariablesFrom( Mockito.any( VariableSpace.class ) );
   }
 
   private void prepareMappingParametesActions( boolean override ) throws KettleException {


### PR DESCRIPTION
-fixed a broken option "Inherit all variables from the transformation"
-extracted a common behavior for activation params in one methods for children of StepWithMappingMeta
-overwriting parameters and the next logic
When the child parameter does not exist in the parent parameters, keep it.
When the child parameter does exist in the parent parameters, overwrite the child parameter by the parent parameter.
All other parent parameters need to get copied into the child parameters  (when the 'Inherit all variables from the transformation?' option is checked)

@bmorrise Could you please review and merge it?