### PR TITLE
[BACKLOG-19677] - getting substatus through same interface as kettle.…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/ael/websocket/StepInterfaceWebSocketEngineAdapter.java
+++ b/engine/src/main/java/org/pentaho/di/trans/ael/websocket/StepInterfaceWebSocketEngineAdapter.java
@@ -40,8 +40,13 @@ import org.pentaho.di.trans.ael.websocket.handler.MessageEventHandler;
 import org.pentaho.di.trans.step.BaseStep;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.step.StepMetaDataCombi;
+import org.pentaho.di.trans.step.StepStatus;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.pentaho.di.engine.api.model.Rows.TYPE.OUT;
 
@@ -57,13 +62,16 @@ public class StepInterfaceWebSocketEngineAdapter extends BaseStep {
 
   private final Operation operation;
   private final MessageEventService messageEventService;
+  private List<StepMetaDataCombi> subSteps;
 
   public StepInterfaceWebSocketEngineAdapter( Operation op, MessageEventService messageEventService, StepMeta stepMeta,
-                                              TransMeta transMeta, StepDataInterface dataInterface, Trans trans )
+                                              TransMeta transMeta, StepDataInterface dataInterface, Trans trans,
+                                              List<StepMetaDataCombi> subSteps )
     throws KettleException {
     super( stepMeta, dataInterface, 0, transMeta, trans );
     operation = op;
     this.messageEventService = messageEventService;
+    this.subSteps = subSteps;
     setInputRowSets( Collections.emptyList() );
     setOutputRowSets( Collections.emptyList() );
     init();
@@ -71,6 +79,10 @@ public class StepInterfaceWebSocketEngineAdapter extends BaseStep {
 
   @Override public void dispatch() {
     // No thanks. I'll take it from here.
+  }
+
+  @Override public Collection<StepStatus> subStatuses() {
+    return subSteps.stream().map( combi -> new StepStatus( combi.step ) ).collect( Collectors.toList() );
   }
 
   private void init() throws KettleException {

--- a/engine/src/main/java/org/pentaho/di/trans/step/StepStatus.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/StepStatus.java
@@ -204,12 +204,16 @@ public class StepStatus {
   }
 
   public String[] getTransLogFields() {
+    return getTransLogFields( statusDescription );
+  }
+
+  public String[] getTransLogFields( String overrideDescription ) {
     String[] fields =
       new String[] {
         "", // Row number
         stepname, Integer.toString( copy ), Long.toString( linesRead ), Long.toString( linesWritten ),
         Long.toString( linesInput ), Long.toString( linesOutput ), Long.toString( linesUpdated ),
-        Long.toString( linesRejected ), Long.toString( errors ), statusDescription, convertSeconds( seconds ),
+        Long.toString( linesRejected ), Long.toString( errors ), overrideDescription, convertSeconds( seconds ),
         speed, priority, };
 
     return fields;

--- a/engine/src/test/java/org/pentaho/di/trans/ael/websocket/StepInterfaceWebSocketEngineAdapterTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/ael/websocket/StepInterfaceWebSocketEngineAdapterTest.java
@@ -35,6 +35,8 @@ import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepMeta;
 
+import java.util.Collections;
+
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -57,7 +59,8 @@ public class StepInterfaceWebSocketEngineAdapterTest {
 
   @Test
   public void testHandlerCreation() throws KettleException {
-    new StepInterfaceWebSocketEngineAdapter( op, messageEventService, stepMeta, transMeta, dataInterface, tran );
+    new StepInterfaceWebSocketEngineAdapter( op, messageEventService, stepMeta, transMeta, dataInterface, tran,
+      Collections.emptyList() );
 
     assertTrue( messageEventService.hasHandlers( Util.getOperationRowEvent( op.getId() ) ) );
     assertTrue( messageEventService.hasHandlers( Util.getOperationStatusEvent( op.getId() ) ) );

--- a/engine/src/test/java/org/pentaho/di/trans/ael/websocket/TransWebSocketEngineAdapterTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/ael/websocket/TransWebSocketEngineAdapterTest.java
@@ -40,6 +40,7 @@ import org.pentaho.di.core.plugins.StepPluginType;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMetaDataCombi;
 
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -73,6 +74,9 @@ public class TransWebSocketEngineAdapterTest {
       new TransWebSocketEngineAdapter( transMeta, "", "", false );
     adapter.prepareExecution( new String[]{} );
     List<StepMetaDataCombi> steps = adapter.getSteps();
-    assertEquals( 4, steps.size() );
+    steps.sort( Comparator.comparing( s -> s.stepname ) );
+    assertEquals( 2, steps.size() );
+    assertEquals( 0, steps.get( 0 ).step.subStatuses().size() );
+    assertEquals( 2, steps.get( 1 ).step.subStatuses().size() );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/step/StepStatusTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/step/StepStatusTest.java
@@ -1,0 +1,37 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.step;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StepStatusTest {
+
+  @Test
+  public void testOverrideDescription() {
+    StepStatus status = new StepStatus();
+    status.setStatusDescription( "Empty" );
+    String[] overrides = status.getTransLogFields( "Override" );
+    assertEquals( "Override", overrides[10] );
+  }
+}

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGridDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGridDelegate.java
@@ -427,7 +427,7 @@ public class TransGridDelegate extends SpoonDelegate implements XulEventHandler 
           Collection<StepStatus> stepStatuses = baseStep.subStatuses();
           for ( StepStatus status : stepStatuses ) {
             ti = new TableItem( table, SWT.NONE );
-            String[] subFields = status.getTransLogFields();
+            String[] subFields = status.getTransLogFields( baseStep.getStatus().getDescription() );
 
             // Anti-flicker: if nothing has changed, don't change it on the
             // screen!


### PR DESCRIPTION
…  sub-steps will always have same status as parent