### PR TITLE
[BACKLOG-20210] MQTT- create PDI Consumer Step

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -96,6 +96,7 @@
     <oro.version>2.0.8</oro.version>
     <javax.websocket-api.version>1.1</javax.websocket-api.version>
     <rxjava.version>2.0.4</rxjava.version>
+    <slf4j.version>1.7.25</slf4j.version>
   </properties>
 
   <dependencies>
@@ -145,6 +146,7 @@
       <version>${pentaho-reporting.version}</version>
     </dependency>
 
+
     <!-- Third-party dependencies -->
     <dependency>
       <groupId>commons-codec</groupId>
@@ -169,6 +171,13 @@
     <dependency>
       <groupId>rhino</groupId>
       <artifactId>js</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>
@@ -891,6 +900,7 @@
       <artifactId>powermock-api-mockito</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>

--- a/engine/src/main/java/org/pentaho/di/trans/streaming/api/StreamSource.java
+++ b/engine/src/main/java/org/pentaho/di/trans/streaming/api/StreamSource.java
@@ -23,6 +23,7 @@
 package org.pentaho.di.trans.streaming.api;
 
 
+
 /**
  * Defines a source of streaming data.  A StreamSource implementation is used
  * by {@link org.pentaho.di.trans.streaming.common.BaseStreamStep} when
@@ -51,4 +52,9 @@ public interface StreamSource<R>  {
    */
   void resume();
 
+  /**
+   * Open the source for loading rows.
+   * Used for initializing resources required to load the stream.
+   */
+  void open();
 }

--- a/engine/src/main/java/org/pentaho/di/trans/streaming/common/BaseStreamStep.java
+++ b/engine/src/main/java/org/pentaho/di/trans/streaming/common/BaseStreamStep.java
@@ -24,11 +24,18 @@ package org.pentaho.di.trans.streaming.common;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.exception.KettleMissingPluginsException;
 import org.pentaho.di.core.exception.KettleStepException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.trans.SubtransExecutor;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStep;
@@ -36,29 +43,63 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.trans.step.StepStatus;
+import org.pentaho.di.trans.steps.transexecutor.TransExecutorData;
+import org.pentaho.di.trans.steps.transexecutor.TransExecutorParameters;
 import org.pentaho.di.trans.streaming.api.StreamSource;
 import org.pentaho.di.trans.streaming.api.StreamWindow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-public class BaseStreamStep<I> extends BaseStep {
+import static com.google.common.base.Throwables.propagate;
 
+public class BaseStreamStep extends BaseStep {
 
-  protected StreamWindow<I, Result> window;
-  protected StreamSource<I> source;
   private static final Class<?> PKG = BaseStreamStep.class;
+  private BaseStreamStepMeta stepMeta;
+
+  protected final Logger logger = LoggerFactory.getLogger( getClass() );
+  protected SubtransExecutor subtransExecutor;
+  protected StreamWindow<List<Object>, Result> window;
+  protected StreamSource<List<Object>> source;
 
   public BaseStreamStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr,
                          TransMeta transMeta, Trans trans ) {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
 
+  public boolean init( StepMetaInterface stepMetaInterface, StepDataInterface stepDataInterface ) {
+    Preconditions.checkNotNull( stepMetaInterface );
+    stepMeta = (BaseStreamStepMeta) stepMetaInterface;
 
-  public boolean processRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
+    String ktr = getFilePath( stepMeta.getTransformationPath() );
+
+    try {
+      subtransExecutor = new SubtransExecutor(
+        getTrans(), new TransMeta( ktr ), true,
+        new TransExecutorData(), new TransExecutorParameters() );
+
+    } catch ( KettleXMLException | KettleMissingPluginsException e ) {
+      logger.error( e.getLocalizedMessage(), e );
+    }
+
+    return super.init( stepMetaInterface, stepDataInterface );
+  }
+
+
+  @Override public boolean processRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
     Preconditions.checkArgument( first,
       BaseMessages.getString( PKG, "BaseStreamStep.ProcessRowsError" ) );
+    Preconditions.checkNotNull( source );
+    Preconditions.checkNotNull( window );
+
+    source.open();
 
     bufferStream().forEach( result -> {
         if ( result.getNrErrors() > 0 ) {
@@ -71,7 +112,7 @@ public class BaseStreamStep<I> extends BaseStep {
     return false;
   }
 
-  protected Iterable<Result> bufferStream() {
+  private Iterable<Result> bufferStream() {
     return window.buffer( source.rows() );
   }
 
@@ -91,10 +132,6 @@ public class BaseStreamStep<I> extends BaseStep {
     super.resumeRunning();
   }
 
-  @Override public Collection<StepStatus> subStatuses() {
-    return Collections.emptyList();
-  }
-
   @Override public void pauseRunning() {
     if ( source != null ) {
       source.pause();
@@ -110,6 +147,39 @@ public class BaseStreamStep<I> extends BaseStep {
         Throwables.propagate( e );
       }
     } );
+  }
+
+  private String getFilePath( String path ) {
+    try {
+      final FileObject fileObject = KettleVFS.getFileObject( environmentSubstitute( path ) );
+      if ( !fileObject.exists() ) {
+        throw new FileNotFoundException( path );
+      }
+      return Paths.get( fileObject.getURL().toURI() ).normalize().toString();
+    } catch ( URISyntaxException | FileNotFoundException | FileSystemException | KettleFileException e ) {
+      propagate( e );
+    }
+    return null;
+  }
+
+  protected int getBatchSize() {
+    try {
+      return Integer.parseInt( stepMeta.getBatchSize() );
+    } catch ( NumberFormatException nfe ) {
+      return 50;
+    }
+  }
+
+  protected long getDuration() {
+    try {
+      return Long.parseLong( stepMeta.getBatchDuration() );
+    } catch ( NumberFormatException nfe ) {
+      return 5000l;
+    }
+  }
+
+  @Override public Collection<StepStatus> subStatuses() {
+    return subtransExecutor != null ? subtransExecutor.getStatuses().values() : Collections.emptyList();
   }
 
 

--- a/engine/src/main/java/org/pentaho/di/trans/streaming/common/BlockingQueueStreamSource.java
+++ b/engine/src/main/java/org/pentaho/di/trans/streaming/common/BlockingQueueStreamSource.java
@@ -1,0 +1,103 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+
+package org.pentaho.di.trans.streaming.common;
+
+import io.reactivex.Observable;
+import io.reactivex.processors.FlowableProcessor;
+import io.reactivex.processors.ReplayProcessor;
+import org.pentaho.di.trans.streaming.api.StreamSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public abstract class BlockingQueueStreamSource<T> implements StreamSource<T> {
+
+  private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+  private final AtomicBoolean paused = new AtomicBoolean( false );
+
+  private final FlowableProcessor<T> publishProcessor = ReplayProcessor.create();
+
+  private final Semaphore acceptingRowsSemaphore = new Semaphore( 1 );
+  private final ExecutorService execService = Executors.newSingleThreadExecutor();
+  private Future<?> future;
+
+
+  @Override public Iterable<T> rows() {
+    return Observable
+      .fromPublisher( publishProcessor )
+      .blockingIterable();
+  }
+
+  @Override public void close() {
+    if ( !publishProcessor.hasComplete() ) {
+      publishProcessor.onComplete();
+    }
+  }
+
+  @Override public void pause() {
+    paused.set( true );
+    if ( !acceptingRowsSemaphore.tryAcquire() ) {
+      logger.info( "already paused" );
+    }
+  }
+
+  @Override public void resume() {
+    paused.set( false );
+    acceptingRowsSemaphore.release();
+  }
+
+
+  /**
+   * Accept rows, blocking if currently paused.
+   *
+   * Implementations should implement the open() function
+   * to pass external row events to the acceptRows method.
+   */
+  protected void acceptRows( List<T> rows ) {
+    try {
+      acceptingRowsSemaphore.acquire();
+      rows.stream()
+        .forEach( ( row ) -> publishProcessor.onNext( row ) );
+    } catch ( InterruptedException e ) {
+      logger.error( "Interrupted while adding row  " + rows, e );
+    } finally {
+      acceptingRowsSemaphore.release();
+    }
+  }
+
+  public void error( Throwable throwable ) {
+    publishProcessor.onError( throwable );
+  }
+
+  protected boolean isPaused() {
+    return paused.get();
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/trans/streaming/common/BlockingQueueStreamSourceTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/streaming/common/BlockingQueueStreamSourceTest.java
@@ -1,0 +1,153 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.streaming.common;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith ( MockitoJUnitRunner.class )
+public class BlockingQueueStreamSourceTest {
+  private ExecutorService execSvc = Executors.newCachedThreadPool();
+  private BlockingQueueStreamSource<String> streamSource = new BlockingQueueStreamSource<String>() {
+    @Override public void open() {
+
+    }
+  };
+
+  @Test
+  public void rowIterableBlocksTillRowReceived() throws Exception {
+    streamSource.open();
+    Iterator<String> iterator = streamSource.rows().iterator();
+
+    // first call .hasNext() on the iterator while streamSource is empty
+    Future<Boolean> hasNext = execSvc.submit( iterator::hasNext );
+
+    // should time out, since still waiting for rows
+    assertTimesOut( hasNext );
+
+    // add a row
+    streamSource.acceptRows( singletonList( "New Row" ) );
+
+    // verify that the future has completed, .hasNext() is no longer blocking and returns true
+    assertThat( getQuickly( hasNext ), equalTo( true ) );
+  }
+
+
+  @Test
+  public void streamIsPausable() throws InterruptedException, ExecutionException, TimeoutException {
+    streamSource.open();
+
+    Iterator<String> iter = streamSource.rows().iterator();
+    Future<String> nextString = execSvc.submit( iter::next );
+
+    // add a row
+    streamSource.acceptRows( singletonList( "row" ) );
+    // verify we can retrieve it
+    assertThat( getQuickly( nextString ), equalTo( "row" ) );
+
+    // pause receipt of new rows
+    streamSource.pause();
+
+    // trying to add another row to the source should time out, since paused.
+    assertTimesOut( execSvc.submit( () -> streamSource.acceptRows( singletonList( "new row" ) ) ) );
+
+    // resume accepting rows
+    streamSource.resume();
+
+    // add a new row
+    streamSource.acceptRows( singletonList( "new row after resume" ) );
+    // try to retrieve it
+    nextString = execSvc.submit( iter::next );
+    assertThat( getQuickly( nextString ), equalTo( "new row after resume" ) );
+
+  }
+
+  @Test
+  public void testRowsFilled() throws ExecutionException, InterruptedException {
+
+    // implement the blockingQueueStreamSource with an .open which will
+    // launch a thread that sends rows to the queue.
+    streamSource = new BlockingQueueStreamSource<String>() {
+      @Override public void open() {
+        execSvc.submit( () -> {
+          for ( int i = 0; i < 4; i++ ) {
+            acceptRows( singletonList( "new row " + i ) );
+            try {
+              Thread.sleep( 5 );
+            } catch ( InterruptedException e ) {
+              fail();
+            }
+          }
+        } );
+      }
+    };
+    streamSource.open();
+    Iterator<String> iterator = streamSource.rows().iterator();
+
+    Future<List<String>> iterLoop = execSvc.submit( () -> {
+      List<String> strings = new ArrayList<>();
+      do {
+        strings.add( iterator.next() );
+      } while ( strings.size() < 4 );
+      return strings;
+    } );
+    final List<String> quickly = getQuickly( iterLoop );
+    assertThat( quickly.size(), equalTo( 4 ) );
+  }
+
+
+  private <T> T getQuickly( Future<T> future ) {
+    try {
+      return future.get( 50, MILLISECONDS );
+    } catch ( InterruptedException | ExecutionException | TimeoutException e ) {
+      fail();
+    }
+    return null;
+  }
+
+  private <T> void assertTimesOut( Future<T> next ) {
+    try {
+      next.get( 100, MILLISECONDS );
+      fail( "Expected timeout exception" );
+    } catch ( Exception e ) {
+      assertThat( e, instanceOf( TimeoutException.class ) );
+    }
+  }
+}

--- a/plugins/file-stream/src/main/java/org/pentaho/di/trans/step/filestream/FileStream.java
+++ b/plugins/file-stream/src/main/java/org/pentaho/di/trans/step/filestream/FileStream.java
@@ -22,25 +22,21 @@
 
 package org.pentaho.di.trans.step.filestream;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.pentaho.di.core.exception.KettleFileException;
-import org.pentaho.di.core.exception.KettleMissingPluginsException;
-import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.vfs.KettleVFS;
-import org.pentaho.di.trans.SubtransExecutor;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
-import org.pentaho.di.trans.step.StepStatus;
-import org.pentaho.di.trans.steps.transexecutor.TransExecutorData;
-import org.pentaho.di.trans.steps.transexecutor.TransExecutorParameters;
+import org.pentaho.di.trans.streaming.api.StreamSource;
 import org.pentaho.di.trans.streaming.common.BaseStreamStep;
 import org.pentaho.di.trans.streaming.common.FixedTimeStreamWindow;
 import org.slf4j.Logger;
@@ -49,8 +45,6 @@ import org.slf4j.LoggerFactory;
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.base.Throwables.propagate;
@@ -58,11 +52,10 @@ import static com.google.common.base.Throwables.propagate;
 /**
  * An example step plugin for purposes of demonstrating a strategy for handling streams of data.
  */
-public class FileStream extends BaseStreamStep<List<String>> implements StepInterface {
+public class FileStream extends BaseStreamStep implements StepInterface {
 
   private static Class<?> PKG = FileStreamMeta.class; // for i18n purposes, needed by Translator2!!   $NON-NLS-1$
   private FileStreamMeta fileStreamMeta;
-  private SubtransExecutor subtransExecutor;
 
   private final Logger logger = LoggerFactory.getLogger( getClass() );
 
@@ -72,31 +65,32 @@ public class FileStream extends BaseStreamStep<List<String>> implements StepInte
   }
 
   public boolean init( StepMetaInterface stepMetaInterface, StepDataInterface stepDataInterface ) {
+    super.init( stepMetaInterface, stepDataInterface );
+
     Preconditions.checkNotNull( stepMetaInterface );
     fileStreamMeta = (FileStreamMeta) stepMetaInterface;
 
-    String ktr = getFilePath( fileStreamMeta.getTransformationPath() );
     String sourceFile = getFilePath( fileStreamMeta.getSourcePath() );
 
-    try {
-      subtransExecutor = new SubtransExecutor(
-        getTrans(), new TransMeta( ktr ), true,
-        new TransExecutorData(), new TransExecutorParameters() );
-
-    } catch ( KettleXMLException | KettleMissingPluginsException e ) {
-      logger.error( e.getLocalizedMessage(), e );
-    }
     RowMeta rowMeta = new RowMeta();
     rowMeta.addValueMeta( new ValueMetaString( "line" ) );
 
     window = new FixedTimeStreamWindow<>( subtransExecutor, rowMeta, getDuration(), getBatchSize() );
+
     try {
       source = new TailFileStreamSource( sourceFile );
     } catch ( FileNotFoundException e ) {
       logger.error( e.getLocalizedMessage(), e );
+      return false;
     }
-    return super.init( stepMetaInterface, stepDataInterface );
+    return true;
   }
+
+  @VisibleForTesting
+  protected StreamSource<List<Object>> getStreamSource() {
+    return source;
+  }
+
 
   private String getFilePath( String path ) {
     try {
@@ -109,26 +103,6 @@ public class FileStream extends BaseStreamStep<List<String>> implements StepInte
       propagate( e );
     }
     return null;
-  }
-
-  private int getBatchSize() {
-    try {
-      return Integer.parseInt( fileStreamMeta.getBatchSize() );
-    } catch ( NumberFormatException nfe ) {
-      return 50;
-    }
-  }
-
-  private long getDuration() {
-    try {
-      return Long.parseLong( fileStreamMeta.getBatchDuration() );
-    } catch ( NumberFormatException nfe ) {
-      return 5000l;
-    }
-  }
-
-  @Override public Collection<StepStatus> subStatuses() {
-    return subtransExecutor != null ? subtransExecutor.getStatuses().values() : Collections.emptyList();
   }
 
 }

--- a/plugins/file-stream/src/main/java/org/pentaho/di/trans/step/filestream/TailFileStreamSource.java
+++ b/plugins/file-stream/src/main/java/org/pentaho/di/trans/step/filestream/TailFileStreamSource.java
@@ -23,7 +23,7 @@
 package org.pentaho.di.trans.step.filestream;
 
 import org.pentaho.di.i18n.BaseMessages;
-import org.pentaho.di.trans.streaming.api.StreamSource;
+import org.pentaho.di.trans.streaming.common.BlockingQueueStreamSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,11 +31,12 @@ import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static java.util.Collections.singletonList;
 
 /**
  * A simple example implementation of StreamSource which streams rows from a specified file to an iterable.
@@ -43,63 +44,51 @@ import java.util.concurrent.atomic.AtomicReference;
  * Note that this class is strictly meant as an example and not intended for real use. It uses a simplistic strategy of
  * leaving a BufferedReader open in order to load rows as they come in, without real consideration of error conditions.
  */
-public class TailFileStreamSource implements StreamSource<List<String>> {
+public class TailFileStreamSource extends BlockingQueueStreamSource<List<Object>> {
 
   private static Class<?> PKG = FileStream.class; // for i18n purposes, needed by Translator2!!   $NON-NLS-1$
-  private final AtomicReference<BufferedReader> reader = new AtomicReference<>();
-  private final AtomicBoolean paused = new AtomicBoolean( false );
-  private final AtomicBoolean closed = new AtomicBoolean( false );
-
   private final Logger logger = LoggerFactory.getLogger( getClass() );
+  private final String filename;
+
+  private final ExecutorService executorService = Executors.newCachedThreadPool();
+  private Future<?> future;
 
   public TailFileStreamSource( String filename ) throws FileNotFoundException {
-    reader.set( new BufferedReader( new FileReader( filename ) ) );
+    this.filename = filename;
   }
 
-  @Override public Iterable<List<String>> rows() {
-    return () -> fileIterator();
+
+  @Override public void open() {
+    if ( future != null ) {
+      logger.warn( "open() called more than once" );
+      return;
+    }
+    future = executorService.submit( this::fileReadLoop );
   }
 
   @Override public void close() {
-    closed.set( true );
-    try {
-      if ( reader != null ) {
-        reader.get().close();
-      }
-    } catch ( IOException e ) {
-      logger.error( BaseMessages.getString( PKG, "FileStream.Error.FileCloseError" ), e );
+    super.close();
+    future.cancel( true );
+  }
 
+  private void fileReadLoop() {
+
+    try ( BufferedReader reader = new BufferedReader( new FileReader( filename ) ) ) {
+      while ( true ) {
+        acceptRows( singletonList( singletonList( getNextLine( reader ) ) ) );
+      }
+    } catch ( IOException | InterruptedException e ) {
+      logger.error( BaseMessages.getString( PKG, "FileStream.Error.FileStreamError" ), e );
     }
   }
 
-  @Override public void pause() {
-    this.paused.set( true );
+  private String getNextLine( BufferedReader reader ) throws IOException, InterruptedException {
+    String currentLine;
+    while ( isPaused() || ( currentLine = reader.readLine() ) == null ) {
+      Thread.sleep( 500 );
+    }
+    return currentLine;
   }
 
-  @Override public void resume() {
-    this.paused.set( false );
-  }
 
-  private Iterator<List<String>> fileIterator() {
-    return new Iterator<List<String>>() {
-
-      @Override public boolean hasNext() {
-        return !closed.get();
-      }
-
-      @Override public List<String> next() {
-        String currentLine = null;
-        try {
-
-          while ( paused.get() || ( currentLine = reader.get().readLine() ) == null ) {
-            Thread.sleep( 500 );
-          }
-        } catch ( IOException | InterruptedException e ) {
-          logger.error( BaseMessages.getString( PKG, "FileStream.Error.FileStreamError" ), e );
-        }
-        return Collections.singletonList( currentLine );
-      }
-    };
-
-  }
 }


### PR DESCRIPTION
Groundwork.  Created a BlockingQueueStreamSource base
implementation to handle pause/resume and creation of
a blocking iterable.
Also moved some more common logic up to BaseStreamStep.

Remaining to do-  moving logger messages into a resource.
That will come in a follow up commit.