### PR TITLE
[PDI-16809|PDI-16812|PDI-16824] Add a checksum - generates wrong checksum

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.checksum;
 
+import java.io.ByteArrayOutputStream;
 import java.security.MessageDigest;
 import java.util.zip.Adler32;
 import java.util.zip.CRC32;
@@ -169,15 +170,32 @@ public class CheckSum extends BaseStep implements StepInterface {
   }
 
   private byte[] createCheckSum( Object[] r ) throws Exception {
-    StringBuilder Buff = new StringBuilder();
+    if ( meta.isOldChecksumBehaviour() ) {
+      StringBuilder Buff = new StringBuilder();
 
-    // Loop through fields
-    for ( int i = 0; i < data.fieldnr; i++ ) {
-      Buff.append( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[i] ) );
+      // Loop through fields
+      for ( int i = 0; i < data.fieldnr; i++ ) {
+        Buff.append( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[data.fieldnrs[i]] ) );
+      }
+
+      // Updates the digest using the specified array of bytes
+      data.digest.update( Buff.toString().getBytes() );
+    } else {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+      // Loop through fields
+      for ( int i = 0; i < data.fieldnr; i++ ) {
+        if ( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).isBinary() ) {
+          baos.write( getInputRowMeta().getBinary( r, data.fieldnrs[i] ) );
+        } else {
+          baos.write( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[data.fieldnrs[i]] )
+              .toString().getBytes() );
+        }
+      }
+
+      // Updates the digest using the specified array of bytes
+      data.digest.update( baos.toByteArray() );
     }
-
-    // Updates the digest using the specified array of bytes
-    data.digest.update( Buff.toString().getBytes() );
     // Completes the hash computation by performing final operations such as padding
     byte[] hash = data.digest.digest();
     // After digest has been called, the MessageDigest object is reset to its initialized state
@@ -218,20 +236,37 @@ public class CheckSum extends BaseStep implements StepInterface {
 
   private Long calculCheckSum( Object[] r ) throws Exception {
     Long retval;
-    StringBuilder Buff = new StringBuilder();
+    byte[] byteArray;
+    if ( meta.isOldChecksumBehaviour() ) {
+      StringBuilder Buff = new StringBuilder();
 
-    // Loop through fields
-    for ( int i = 0; i < data.fieldnr; i++ ) {
-      Buff.append( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[i] ) );
+      // Loop through fields
+      for ( int i = 0; i < data.fieldnr; i++ ) {
+        Buff.append( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[data.fieldnrs[i]] ) );
+      }
+      byteArray = Buff.toString().getBytes();
+    } else {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+      // Loop through fields
+      for ( int i = 0; i < data.fieldnr; i++ ) {
+        if ( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).isBinary() ) {
+          baos.write( getInputRowMeta().getBinary( r, data.fieldnrs[i] ) );
+        } else {
+          baos.write( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[data.fieldnrs[i]] )
+              .toString().getBytes() );
+        }
+      }
+      byteArray = baos.toByteArray();
     }
 
     if ( meta.getCheckSumType().equals( CheckSumMeta.TYPE_CRC32 ) ) {
       CRC32 crc32 = new CRC32();
-      crc32.update( Buff.toString().getBytes() );
+      crc32.update( byteArray );
       retval = new Long( crc32.getValue() );
     } else {
       Adler32 adler32 = new Adler32();
-      adler32.update( Buff.toString().getBytes() );
+      adler32.update( byteArray );
       retval = new Long( adler32.getValue() );
     }
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumMeta.java
@@ -99,6 +99,7 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
   private String checksumtype;
 
   private boolean compatibilityMode;
+  private boolean oldChecksumBehaviour;
 
   /** result type */
   private int resultType;
@@ -234,6 +235,7 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
       resultfieldName = XMLHandler.getTagValue( stepnode, "resultfieldName" );
       resultType = getResultTypeByCode( Const.NVL( XMLHandler.getTagValue( stepnode, "resultType" ), "" ) );
       compatibilityMode = parseCompatibilityMode( XMLHandler.getTagValue( stepnode, "compatibilityMode" ) );
+      oldChecksumBehaviour = parseOldChecksumBehaviour( XMLHandler.getTagValue( stepnode, "oldChecksumBehaviour" ) );
 
       Node fields = XMLHandler.getSubNode( stepnode, "fields" );
       int nrfields = XMLHandler.countNodes( fields, "field" );
@@ -257,6 +259,14 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
     }
   }
 
+  private boolean parseOldChecksumBehaviour( String oldChecksumBehaviour ) {
+    if ( oldChecksumBehaviour == null ) {
+      return true; // It was previously not saved
+    } else {
+      return Boolean.parseBoolean( oldChecksumBehaviour ) || "Y".equalsIgnoreCase( oldChecksumBehaviour );
+    }
+  }
+
   private static String getResultTypeCode( int i ) {
     if ( i < 0 || i >= resultTypeCode.length ) {
       return resultTypeCode[0];
@@ -271,6 +281,7 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
     retval.append( "      " ).append( XMLHandler.addTagValue( "resultfieldName", resultfieldName ) );
     retval.append( "      " ).append( XMLHandler.addTagValue( "resultType", getResultTypeCode( resultType ) ) );
     retval.append( "      " ).append( XMLHandler.addTagValue( "compatibilityMode", compatibilityMode ) );
+    retval.append( "      " ).append( XMLHandler.addTagValue( "oldChecksumBehaviour", oldChecksumBehaviour ) );
 
     retval.append( "    <fields>" ).append( Const.CR );
     for ( int i = 0; i < fieldName.length; i++ ) {
@@ -305,6 +316,7 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
       resultfieldName = rep.getStepAttributeString( id_step, "resultfieldName" );
       resultType = getResultTypeByCode( Const.NVL( rep.getStepAttributeString( id_step, "resultType" ), "" ) );
       compatibilityMode = parseCompatibilityMode( rep.getStepAttributeString( id_step, "compatibilityMode" ) );
+      oldChecksumBehaviour = parseOldChecksumBehaviour( rep.getStepAttributeString( id_step, "oldChecksumBehaviour" ) );
 
       int nrfields = rep.countNrStepAttributes( id_step, "field_name" );
 
@@ -326,6 +338,7 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
       rep.saveStepAttribute( id_transformation, id_step, "resultfieldName", resultfieldName );
       rep.saveStepAttribute( id_transformation, id_step, "resultType", getResultTypeCode( resultType ) );
       rep.saveStepAttribute( id_transformation, id_step, "compatibilityMode", compatibilityMode );
+      rep.saveStepAttribute( id_transformation, id_step, "oldChecksumBehaviour", oldChecksumBehaviour );
 
       for ( int i = 0; i < fieldName.length; i++ ) {
         rep.saveStepAttribute( id_transformation, id_step, i, "field_name", fieldName[i] );
@@ -468,6 +481,10 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
     return compatibilityMode;
   }
 
+  public boolean isOldChecksumBehaviour() {
+    return oldChecksumBehaviour;
+  }
+
   /**
    * @deprecated Update to non-compatibility mode
    * @param compatibilityMode
@@ -475,5 +492,9 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
   @Deprecated
   public void setCompatibilityMode( boolean compatibilityMode ) {
     this.compatibilityMode = compatibilityMode;
+  }
+
+  public void setOldChecksumBehaviour( boolean oldChecksumBehaviour ) {
+    this.oldChecksumBehaviour = oldChecksumBehaviour;
   }
 }

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/checksum/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/checksum/messages/messages_en_US.properties
@@ -26,6 +26,9 @@ CheckSumDialog.ResultType.Binary=Binary
 CheckSumDialog.CompatibilityMode.Label=Compatibility Mode
 CheckSumDialog.CompatibilityMode.Tooltip=Enable hexadecimal output compatible with previous releases
 
+CheckSumDialog.OldChecksumBehaviourMode.Label=Old Checksum Behaviour Mode
+CheckSumDialog.OldChecksumBehaviourMode.Tooltip=Enable calculating checksum as in the previous releases
+
 #####################################################################
 ##
 ##  CheckSum

--- a/engine/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumMetaTest.java
@@ -70,7 +70,7 @@ public class CheckSumMetaTest implements InitializerInterface<CheckSumMeta> {
   @Test
   public void testSerialization() throws KettleException {
     List<String> attributes =
-      Arrays.asList( "FieldName", "ResultFieldName", "CheckSumType", "CompatibilityMode", "ResultType" );
+      Arrays.asList( "FieldName", "ResultFieldName", "CheckSumType", "CompatibilityMode", "ResultType", "oldChecksumBehaviour" );
 
     Map<String, String> getterMap = new HashMap<String, String>();
     Map<String, String> setterMap = new HashMap<String, String>();

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/checksum/CheckSumDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/checksum/CheckSumDialog.java
@@ -86,6 +86,10 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
   private Button wCompatibility;
   private FormData fdlCompatibility, fdCompatibility;
 
+  private Label wlOldChecksumBehaviour;
+  private Button wOldChecksumBehaviour;
+  private FormData fdlOldChecksumBehaviour, fdOldChecksumBehaviour;
+
   private ColumnInfo[] colinf;
 
   private Map<String, Integer> inputFields;
@@ -253,6 +257,30 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
     };
     wCompatibility.addSelectionListener( lsSelR );
 
+    wlOldChecksumBehaviour = new Label( shell, SWT.RIGHT );
+    wlOldChecksumBehaviour.setText( BaseMessages.getString( PKG, "CheckSumDialog.OldChecksumBehaviourMode.Label" ) );
+    props.setLook( wlOldChecksumBehaviour );
+    fdlOldChecksumBehaviour = new FormData();
+    fdlOldChecksumBehaviour.left = new FormAttachment( 0, 0 );
+    fdlOldChecksumBehaviour.top = new FormAttachment( wCompatibility, margin );
+    fdlOldChecksumBehaviour.right = new FormAttachment( middle, -margin );
+    wlOldChecksumBehaviour.setLayoutData( fdlOldChecksumBehaviour );
+    wOldChecksumBehaviour = new Button( shell, SWT.CHECK );
+    wOldChecksumBehaviour.setToolTipText( BaseMessages.getString( PKG, "CheckSumDialog.OldChecksumBehaviourMode.Tooltip" ) );
+    props.setLook( wOldChecksumBehaviour );
+    fdOldChecksumBehaviour = new FormData();
+    fdOldChecksumBehaviour.left = new FormAttachment( middle, 0 );
+    fdOldChecksumBehaviour.top = new FormAttachment( wCompatibility, margin );
+    fdOldChecksumBehaviour.right = new FormAttachment( 100, 0 );
+    wOldChecksumBehaviour.setLayoutData( fdOldChecksumBehaviour );
+    wOldChecksumBehaviour.addSelectionListener( new SelectionAdapter() {
+
+      @Override
+      public void widgetSelected( SelectionEvent e ) {
+        input.setChanged();
+      }
+    } );
+
     // Table with fields
     wlFields = new Label( shell, SWT.NONE );
     wlFields.setText( BaseMessages.getString( PKG, "CheckSumDialog.Fields.Label" ) );
@@ -418,6 +446,7 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
     }
     wResultType.setText( CheckSumMeta.getResultTypeDesc( input.getResultType() ) );
     wCompatibility.setSelection( input.isCompatibilityMode() );
+    wOldChecksumBehaviour.setSelection( input.isOldChecksumBehaviour() );
 
     Table table = wFields.table;
     if ( input.getFieldName().length > 0 ) {
@@ -458,6 +487,7 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
     input.setResultType( CheckSumMeta.getResultTypeByDesc( wResultType.getText() ) );
 
     input.setCompatibilityMode( wCompatibility.getSelection() );
+    input.setOldChecksumBehaviour( wOldChecksumBehaviour.getSelection() );
 
     int nrfields = wFields.nrNonEmpty();
     input.allocate( nrfields );


### PR DESCRIPTION
- added new logic for the binary data checksum generation
- added new compatibility flag "Old Checksum Behaviour Mode"
- added new checkbox on the "Add Checksum" step UI
- regression with the wrong field checksum calculation was fixed
- new tests were created