### PR TITLE
[SP-4066][PDI-16805] Salesforce Input doesn't get the transformation status 'changed'

### DIFF
--- a/plugins/salesforce/core/src/main/java/org/pentaho/di/ui/trans/steps/salesforceinput/SalesforceInputDialog.java
+++ b/plugins/salesforce/core/src/main/java/org/pentaho/di/ui/trans/steps/salesforceinput/SalesforceInputDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -40,6 +40,7 @@ import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.events.ShellAdapter;
 import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.graphics.Cursor;
@@ -217,6 +218,14 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
         input.setChanged();
       }
     };
+
+    SelectionListener checkBoxModifyListener = new SelectionAdapter() {
+      @Override
+      public void widgetSelected( SelectionEvent e ) {
+        input.setChanged();
+      }
+    };
+
     changed = input.hasChanged();
 
     FormLayout formLayout = new FormLayout();
@@ -639,6 +648,7 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
     fdlQueryAll.right = new FormAttachment( middle, -margin );
     wlQueryAll.setLayoutData( fdlQueryAll );
     wQueryAll = new Button( wAdvancedGroup, SWT.CHECK );
+    wQueryAll.addSelectionListener( checkBoxModifyListener );
     props.setLook( wQueryAll );
     wQueryAll.setToolTipText( BaseMessages.getString( PKG, "SalesforceInputDialog.QueryAll.Tooltip" ) );
     FormData fdQueryAll = new FormData();
@@ -807,6 +817,7 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
     fdInclURL.left = new FormAttachment( middle, 0 );
     fdInclURL.top = new FormAttachment( wAdvancedGroup, margin );
     wInclURL.setLayoutData( fdInclURL );
+    wInclURL.addSelectionListener( checkBoxModifyListener );
     wInclURL.addSelectionListener( new SelectionAdapter() {
       @Override
       public void widgetSelected( SelectionEvent e ) {
@@ -846,6 +857,7 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
     fdModule.left = new FormAttachment( middle, 0 );
     fdModule.top = new FormAttachment( wInclURLField, margin );
     wInclModule.setLayoutData( fdModule );
+    wInclModule.addSelectionListener( checkBoxModifyListener );
 
     wInclModule.addSelectionListener( new SelectionAdapter() {
       @Override
@@ -886,6 +898,7 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
     fdInclSQL.left = new FormAttachment( middle, 0 );
     fdInclSQL.top = new FormAttachment( wInclModuleField, margin );
     wInclSQL.setLayoutData( fdInclSQL );
+    wInclSQL.addSelectionListener( checkBoxModifyListener );
     wInclSQL.addSelectionListener( new SelectionAdapter() {
       @Override
       public void widgetSelected( SelectionEvent e ) {
@@ -925,6 +938,7 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
     fdInclTimestamp.left = new FormAttachment( middle, 0 );
     fdInclTimestamp.top = new FormAttachment( wInclSQLField, margin );
     wInclTimestamp.setLayoutData( fdInclTimestamp );
+    wInclTimestamp.addSelectionListener( checkBoxModifyListener );
     wInclTimestamp.addSelectionListener( new SelectionAdapter() {
       @Override
       public void widgetSelected( SelectionEvent e ) {
@@ -964,6 +978,7 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
     fdRownum.left = new FormAttachment( middle, 0 );
     fdRownum.top = new FormAttachment( wInclTimestampField, margin );
     wInclRownum.setLayoutData( fdRownum );
+    wInclRownum.addSelectionListener( checkBoxModifyListener );
 
     wInclRownum.addSelectionListener( new SelectionAdapter() {
       @Override
@@ -1005,6 +1020,7 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
     fdDeletionDate.left = new FormAttachment( middle, 0 );
     fdDeletionDate.top = new FormAttachment( wInclRownumField, margin );
     wInclDeletionDate.setLayoutData( fdDeletionDate );
+    wInclDeletionDate.addSelectionListener( checkBoxModifyListener );
 
     wInclDeletionDate.addSelectionListener( new SelectionAdapter() {
       @Override
@@ -1068,6 +1084,7 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
     fdlUseCompression.right = new FormAttachment( middle, -margin );
     wlUseCompression.setLayoutData( fdlUseCompression );
     wUseCompression = new Button( wContentComp, SWT.CHECK );
+    wUseCompression.addSelectionListener( checkBoxModifyListener );
     props.setLook( wUseCompression );
     wUseCompression.setToolTipText( BaseMessages.getString( PKG, "SalesforceInputDialog.UseCompression.Tooltip" ) );
     FormData fdUseCompression = new FormData();
@@ -1239,6 +1256,7 @@ public class SalesforceInputDialog extends SalesforceStepDialog {
         get();
         shell.setCursor( null );
         busy.dispose();
+        input.setChanged();
       }
     };
     lsPreview = new Listener() {


### PR DESCRIPTION
[SP-4066][PDI-16805] Salesforce Input doesn't get the transformation status 'changed'

- added status 'changed' when button 'Get fields' is pressed
- added status 'changed' for checkboxes of tab Content if they are changed