### PR TITLE
[SP-4045] - Backport of PDI-16786 - Export linked resources uses deprecated variable ${Internal.Job.Filename.Directory} or ${Internal.Transformation.Filename.Directory} (8.0 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -1481,9 +1481,9 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
       jobMeta.exportResources( jobMeta, definitions, namingInterface, repository, metaStore );
 
     // To get a relative path to it, we inject
-    // ${Internal.Job.Filename.Directory}
+    // ${Internal.Entry.Current.Directory}
     //
-    String newFilename = "${" + Const.INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY + "}/" + proposedNewFilename;
+    String newFilename = "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + proposedNewFilename;
 
     // Set the filename in the job
     //

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1485,9 +1485,9 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
     String proposedNewFilename =
       transMeta.exportResources( transMeta, definitions, namingInterface, repository, metaStore );
 
-    // To get a relative path to it, we inject ${Internal.Job.Filename.Directory}
+    // To get a relative path to it, we inject ${Internal.Entry.Current.Directory}
     //
-    String newFilename = "${" + Const.INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY + "}/" + proposedNewFilename;
+    String newFilename = "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + proposedNewFilename;
 
     // Set the correct filename inside the XML.
     //

--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -333,10 +333,10 @@ public abstract class StepWithMappingMeta extends BaseStepMeta implements HasRep
                       mappingTransMeta, definitions, resourceNamingInterface, repository, metaStore );
 
       // To get a relative path to it, we inject
-      // ${Internal.Transformation.Filename.Directory}
+      // ${Internal.Entry.Current.Directory}
       //
       String newFilename =
-              "${" + Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY + "}/" + proposedNewFilename;
+              "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + proposedNewFilename;
 
       // Set the correct filename inside the XML.
       //

--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
@@ -772,6 +772,22 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
     return references;
   }
 
+  /**
+   * This method was created exclusively for tests
+   * to bypass the mock static final method
+   * without using PowerMock
+   *
+   * @param executorMeta
+   * @param rep
+   * @param space
+   * @return JobMeta
+   * @throws KettleException
+   */
+  JobMeta loadJobMetaProxy( JobExecutorMeta executorMeta, Repository rep,
+                           VariableSpace space ) throws KettleException {
+    return loadJobMeta( executorMeta, rep, space );
+  }
+
   @Override
   public String exportResources( VariableSpace space, Map<String, ResourceDefinition> definitions,
     ResourceNamingInterface resourceNamingInterface, Repository repository, IMetaStore metaStore ) throws KettleException {
@@ -784,7 +800,7 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
       //
       // First load the executor job metadata...
       //
-      JobMeta executorJobMeta = loadJobMeta( this, repository, space );
+      JobMeta executorJobMeta = loadJobMetaProxy( this, repository, space );
 
       // Also go down into the mapping transformation and export the files
       // there. (mapping recursively down)
@@ -794,10 +810,10 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
           executorJobMeta, definitions, resourceNamingInterface, repository, metaStore );
 
       // To get a relative path to it, we inject
-      // ${Internal.Transformation.Filename.Directory}
+      // ${Internal.Entry.Current.Directory}
       //
       String newFilename =
-        "${" + Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY + "}/" + proposedNewFilename;
+        "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + proposedNewFilename;
 
       // Set the correct filename inside the XML.
       //

--- a/engine/src/test/java/org/pentaho/di/job/entries/job/JobEntryJobTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/job/JobEntryJobTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,12 +28,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.doReturn;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -41,11 +44,14 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
 import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.resource.ResourceNamingInterface;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -176,5 +182,23 @@ public class JobEntryJobTest {
     jej.setParentJobMeta( null );
     verify( meta, times( 1 ) ).addCurrentDirectoryChangedListener( any() );
     verify( meta, times( 1 ) ).removeCurrentDirectoryChangedListener( any() );
+  }
+
+  @Test
+  public void testExportResources() throws Exception {
+    JobEntryJob jobEntryJob = spy( getJobEntryJob() );
+    JobMeta jobMeta = mock( JobMeta.class );
+
+    String testName = "test";
+
+    doReturn( jobMeta ).when( jobEntryJob ).getJobMeta( any( Repository.class ),
+            any( IMetaStore.class ), any( VariableSpace.class ) );
+    when( jobMeta.exportResources( any( JobMeta.class ), any( Map.class ), any( ResourceNamingInterface.class ),
+            any( Repository.class ), any( IMetaStore.class ) ) ).thenReturn( testName );
+
+    jobEntryJob.exportResources( null, null, null, null, null );
+
+    verify( jobMeta ).setFilename( "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + testName );
+    verify( jobEntryJob ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,12 +30,14 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doReturn;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -43,6 +45,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
 import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.database.DatabaseMeta;
@@ -53,6 +56,8 @@ import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.resource.ResourceNamingInterface;
+import org.pentaho.di.trans.TransMeta;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -197,5 +202,23 @@ public class JobEntryTransTest {
     jet.setParentJobMeta( null );
     verify( meta, times( 1 ) ).addCurrentDirectoryChangedListener( any() );
     verify( meta, times( 1 ) ).removeCurrentDirectoryChangedListener( any() );
+  }
+
+  @Test
+  public void testExportResources() throws KettleException {
+    JobEntryTrans jobEntryTrans = spy( getJobEntryTrans() );
+    TransMeta transMeta = mock( TransMeta.class );
+
+    String testName = "test";
+
+    doReturn( transMeta ).when( jobEntryTrans ).getTransMeta( any( Repository.class ),
+            any( VariableSpace.class ) );
+    when( transMeta.exportResources( any( TransMeta.class ), any( Map.class ), any( ResourceNamingInterface.class ),
+            any( Repository.class ), any( IMetaStore.class ) ) ).thenReturn( testName );
+
+    jobEntryTrans.exportResources( null, null, null, null, null );
+
+    verify( transMeta ).setFilename( "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + testName );
+    verify( jobEntryTrans ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -118,7 +118,7 @@ public class StepWithMappingMetaTest {
     when( transMeta.exportResources( any(), anyMap(), any(), any(), any() ) ).thenReturn( testName );
 
     stepWithMappingMeta.exportResources( null, null, null, null, null );
-    verify( transMeta ).setFilename( "${" + Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY + "}/" + testName );
+    verify( transMeta ).setFilename( "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + testName );
     verify( stepWithMappingMeta ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
 
   }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,12 +29,25 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.resource.ResourceNamingInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+import org.pentaho.metastore.api.IMetaStore;
 
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 
 /**
  * <p>
@@ -89,5 +102,23 @@ public class JobExecutorMetaTest {
     assertNull( jobExecutorMeta.getExecutionResultTargetStepMeta() );
     assertNull( jobExecutorMeta.getResultRowsTargetStepMeta() );
     assertNull( jobExecutorMeta.getResultFilesTargetStepMeta() );
+  }
+
+  @Test
+  public void testExportResources() throws KettleException {
+    JobExecutorMeta jobExecutorMeta = spy( new JobExecutorMeta() );
+    JobMeta jobMeta = mock( JobMeta.class );
+
+    String testName = "test";
+
+    doReturn( jobMeta ).when( jobExecutorMeta ).loadJobMetaProxy( any( JobExecutorMeta.class ),
+            any( Repository.class ), any( VariableSpace.class ) );
+    when( jobMeta.exportResources( any( JobMeta.class ), any( Map.class ), any( ResourceNamingInterface.class ),
+            any( Repository.class ), any( IMetaStore.class ) ) ).thenReturn( testName );
+
+    jobExecutorMeta.exportResources( null, null, null, null, null );
+
+    verify( jobMeta ).setFilename( "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + testName );
+    verify( jobExecutorMeta ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
   }
 }

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/autodoc/AutoDocMeta.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/autodoc/AutoDocMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -107,7 +107,7 @@ public class AutoDocMeta extends BaseStepMeta implements StepMetaInterface, Auto
   @Override
   public void setDefault() {
     outputType = OutputType.PDF;
-    targetFilename = "${Internal.Transformation.Filename.Directory}/kettle-autodoc.pdf";
+    targetFilename = "${Internal.Entry.Current.Directory}/kettle-autodoc.pdf";
     includingName = true;
     includingDescription = true;
     includingExtendedDescription = true;

--- a/plugins/meta-inject/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
+++ b/plugins/meta-inject/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
@@ -648,10 +648,10 @@ public class MetaInjectMeta extends BaseStepMeta implements StepMetaInterface, S
           metaStore );
 
       // To get a relative path to it, we inject
-      // ${Internal.Transformation.Filename.Directory}
+      // ${Internal.Entry.Current.Directory}
       //
       String newFilename =
-        "${" + Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY + "}/" + proposedNewFilename;
+        "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + proposedNewFilename;
 
       // Set the correct filename inside the XML.
       //

--- a/plugins/meta-inject/src/test/java/org/pentaho/di/trans/steps/metainject/MetaInjectMetaTest.java
+++ b/plugins/meta-inject/src/test/java/org/pentaho/di/trans/steps/metainject/MetaInjectMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -68,7 +68,7 @@ public class MetaInjectMetaTest {
   private static final String TEST_FILE_NAME = "TEST_FILE_NAME";
 
   private static final String EXPORTED_FILE_NAME =
-      "${" + Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY + "}/" + TEST_FILE_NAME;
+      "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + TEST_FILE_NAME;
 
   private MetaInjectMeta metaInjectMeta;
 


### PR DESCRIPTION
[SP-4045] - Backport of PDI-16786 - Export linked resources uses deprecated variable ${Internal.Job.Filename.Directory} or ${Internal.Transformation.Filename.Directory} (8.0 Suite)