### PR TITLE
[BACKLOG-21331] Jndi should not be test scoped as it is required at r…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -484,6 +484,11 @@
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>wstx-asl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>simple-jndi</artifactId>
+      <version>${simple-jndi.version}</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>
@@ -499,12 +504,6 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>simple-jndi</artifactId>
-      <version>${simple-jndi.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
@pentaho/2-1b @lgrill-pentaho 
Jndi stopped being included after the mavenization of https://github.com/pentaho/pentaho-metadata as it was being brought transitively from that project.

There are explicit references in kettle-core's code, so leaving it as a direct dependency.