### PR TITLE
[PDI-16858] - Log connection is set to "live_logging_info" on Transformation and Job logging

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/logging/BaseLogTable.java
+++ b/engine/src/main/java/org/pentaho/di/core/logging/BaseLogTable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -132,6 +132,8 @@ public abstract class BaseLogTable {
   }
 
   public void loadFromRepository( RepositoryAttributeInterface attributeInterface ) throws KettleException {
+    connectionName = schemaName = tableName = null;
+
     String connectionNameFromRepository =
       attributeInterface.getAttributeString( getLogTableCode() + PROP_LOG_TABLE_CONNECTION_NAME );
     if ( connectionNameFromRepository != null ) {


### PR DESCRIPTION
To assure that "lost values values" aren't assign to variables connectionName, schemaName and tableName even if the connectionNameFromRepository, schemaNameFromRepository and tableNameFromRepository return null values.

This "lost values values" might happen in between saving a job/transformation to repository, closing and open it again.

The "lost value values" are default parameters that might come from server side settings in between saving and open the job/transformation (if the connectionName, schemaName and tableName variables haven't been assign previously).

@duarteteixeira @pamval 