### PR TITLE
[PDI-17407] Add correct crawling multiline message

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/i18n/MessagesSourceCrawler.java
+++ b/ui/src/main/java/org/pentaho/di/ui/i18n/MessagesSourceCrawler.java
@@ -349,7 +349,7 @@ public class MessagesSourceCrawler {
         if ( extraLine ) {
           line2 = reader.readLine();
           line += line2;
-          line = line.replaceAll( "BaseMessages.getString\\(\\s*PKG, ", "BaseMessages.getString( PKG," );
+          line = line.replaceAll( "BaseMessages.getString\\s*\\(\\s*PKG, ", "BaseMessages.getString( PKG," );
         }
       } while ( extraLine );
 

--- a/ui/src/main/java/org/pentaho/di/ui/i18n/MessagesSourceCrawler.java
+++ b/ui/src/main/java/org/pentaho/di/ui/i18n/MessagesSourceCrawler.java
@@ -349,6 +349,7 @@ public class MessagesSourceCrawler {
         if ( extraLine ) {
           line2 = reader.readLine();
           line += line2;
+          line = line.replaceAll( "BaseMessages.getString\\(\\s*PKG, ", "BaseMessages.getString( PKG," );
         }
       } while ( extraLine );
 


### PR DESCRIPTION
Replace zero or more spaces between `BaseMessages.getString(` 
and `PKG` on exactly one space when `Translator2` is crawling translation
keys from sources.

Key like this don't parsed and stayed invisible in Translator2:
miRowInsBef.setText( OsHelper.customizeMenuitemText( BaseMessages.getString(
  PKG, "TableView.menu.InsertBeforeRow" ) ) );