### PR TITLE
[BACKLOG-21649] Decoupling the parameter parsing from the execution l…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,19 +22,13 @@
 
 package org.pentaho.di.pan;
 
-import java.io.InputStream;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.FileUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.FileLoggingEventListener;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannel;
@@ -43,23 +37,14 @@ import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.parameters.NamedParams;
 import org.pentaho.di.core.parameters.NamedParamsDefault;
 import org.pentaho.di.core.parameters.UnknownParamException;
-import org.pentaho.di.core.plugins.PluginRegistry;
-import org.pentaho.di.core.plugins.RepositoryPluginType;
-import org.pentaho.di.core.xml.XMLHandler;
-import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.kitchen.Kitchen;
 import org.pentaho.di.metastore.MetaStoreConst;
-import org.pentaho.di.repository.RepositoriesMeta;
-import org.pentaho.di.repository.Repository;
-import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.repository.RepositoryMeta;
-import org.pentaho.di.repository.RepositoryOperation;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.version.BuildVersion;
 import org.pentaho.metastore.stores.delegate.DelegatingMetaStore;
-import org.w3c.dom.Document;
 
 public class Pan {
   private static Class<?> PKG = Pan.class; // for i18n purposes, needed by Translator2!!

--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -64,9 +64,12 @@ import org.w3c.dom.Document;
 public class Pan {
   private static Class<?> PKG = Pan.class; // for i18n purposes, needed by Translator2!!
 
-  private static final String STRING_PAN = "Pan";
+  public static final String STRING_PAN = "Pan";
+  private static LogChannelInterface log = new LogChannel( STRING_PAN );
 
   private static FileLoggingEventListener fileLoggingEventListener;
+
+  private static PanCommandExecutor commandExecutor = new PanCommandExecutor( PKG, log );
 
   public static void main( String[] a ) throws Exception {
     KettleClientEnvironment.getInstance().setClient( KettleClientEnvironment.ClientType.PAN );
@@ -165,16 +168,16 @@ public class Pan {
 
     if ( args.size() == 2 ) { // 2 internal hidden argument (flag and value)
       CommandLineOption.printUsage( options );
-      exitJVM( 9 );
+      exitJVM( PanReturnCode.CMD_LINE_PRINT.getCode() );
     }
 
-    LogChannelInterface log = new LogChannel( STRING_PAN );
+
 
     // Parse the options...
     if ( !CommandLineOption.parseArguments( args, options, log ) ) {
       log.logError( BaseMessages.getString( PKG, "Pan.Error.CommandLineError" ) );
 
-      exitJVM( 8 );
+      exitJVM( PanReturnCode.ERROR_LOADING_STEPS_PLUGINS.getCode() );
     }
 
     Kitchen.configureLogging( maxLogLinesOption, maxLogTimeoutOption );
@@ -241,380 +244,22 @@ public class Pan {
 
     // ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-    log.logMinimal( BaseMessages.getString( PKG, "Pan.Log.StartingToRun" ) );
-
-    Date start, stop;
-    Calendar cal;
-    SimpleDateFormat df = new SimpleDateFormat( "yyyy/MM/dd HH:mm:ss.SSS" );
-    cal = Calendar.getInstance();
-    start = cal.getTime();
-
-    if ( log.isDebug() ) {
-      log.logDebug( BaseMessages.getString( PKG, "Pan.Log.AllocatteNewTrans" ) );
-    }
-
-    TransMeta transMeta = new TransMeta();
-    // In case we use a repository...
-    Repository rep = null;
     try {
-      if ( log.isDebug() ) {
-        log.logDebug( BaseMessages.getString( PKG, "Pan.Log.StartingToLookOptions" ) );
-      }
 
-      // Read kettle transformation specified on command-line?
-      if ( !Utils.isEmpty( optionRepname )
-        || !Utils.isEmpty( optionFilename ) || !Utils.isEmpty( optionJarFilename ) ) {
-        if ( log.isDebug() ) {
-          log.logDebug( BaseMessages.getString( PKG, "Pan.Log.ParsingCommandline" ) );
-        }
+      PanCommandExecutor pan = new PanCommandExecutor( PKG, log );
+      pan.setMetaStore( metaStore );
+      int returnCode = pan.execute( optionRepname.toString(), optionNorep.toString(), optionUsername.toString(), optionPassword.toString(),
+              optionDirname.toString(), optionFilename.toString(), optionJarFilename.toString(), optionTransname.toString(),
+              optionListtrans.toString(), optionListdir.toString(), optionExprep.toString(), initialDir.toString(),
+              optionListrep.toString(), optionSafemode.toString(), optionMetrics.toString(), optionListParam.toString(),
+              optionParams, args.toArray( new String[ args.size() ] ) );
 
-        if ( !Utils.isEmpty( optionRepname ) && !"Y".equalsIgnoreCase( optionNorep.toString() ) ) {
-          if ( log.isDebug() ) {
-            log.logDebug( BaseMessages.getString( PKG, "Pan.Log.LoadingAvailableRep" ) );
-          }
+      exitJVM( returnCode );
 
-          RepositoriesMeta repsinfo = new RepositoriesMeta();
-          repsinfo.getLog().setLogLevel( log.getLogLevel() );
-
-          try {
-            repsinfo.readData();
-          } catch ( Exception e ) {
-            throw new KettleException( BaseMessages.getString( PKG, "Pan.Error.NoRepsDefined" ), e );
-          }
-
-          if ( log.isDebug() ) {
-            log.logDebug( BaseMessages.getString( PKG, "Pan.Log.FindingRep", "" + optionRepname ) );
-          }
-
-          repositoryMeta = repsinfo.findRepository( optionRepname.toString() );
-          if ( repositoryMeta != null ) {
-            // Define and connect to the repository...
-            if ( log.isDebug() ) {
-              log.logDebug( BaseMessages.getString( PKG, "Pan.Log.Allocate&ConnectRep" ) );
-            }
-
-            rep =
-              PluginRegistry.getInstance().loadClass(
-                RepositoryPluginType.class, repositoryMeta, Repository.class );
-            rep.init( repositoryMeta );
-            rep.getLog().setLogLevel( log.getLogLevel() );
-            rep.connect( optionUsername != null ? optionUsername.toString() : null, optionPassword != null
-              ? optionPassword.toString() : null );
-
-            rep.getSecurityProvider().validateAction( RepositoryOperation.EXECUTE_TRANSFORMATION );
-
-            // Default is the root directory
-            //
-            RepositoryDirectoryInterface directory = rep.loadRepositoryDirectoryTree();
-
-            // Add the IMetaStore of the repository to our delegation
-            //
-            if ( rep.getMetaStore() != null ) {
-              metaStore.addMetaStore( rep.getMetaStore() );
-            }
-
-            // Find the directory name if one is specified...
-            if ( !Utils.isEmpty( optionDirname ) ) {
-              directory = directory.findDirectory( optionDirname.toString() );
-            }
-
-            if ( directory != null ) {
-              // Check username, password
-              if ( log.isDebug() ) {
-                log.logDebug( BaseMessages.getString( PKG, "Pan.Log.CheckSuppliedUserPass" ) );
-              }
-
-              // Load a transformation
-              if ( !Utils.isEmpty( optionTransname ) ) {
-                if ( log.isDebug() ) {
-                  log.logDebug( BaseMessages.getString( PKG, "Pan.Log.LoadTransInfo" ) );
-                }
-
-                transMeta = rep.loadTransformation( optionTransname.toString(), directory, null, true, null );
-                if ( log.isDebug() ) {
-                  log.logDebug( BaseMessages.getString( PKG, "Pan.Log.AllocateTrans" ) );
-                }
-
-                trans = new Trans( transMeta );
-                trans.setRepository( rep );
-                trans.setMetaStore( metaStore );
-
-              } else if ( "Y".equalsIgnoreCase( optionListtrans.toString() ) ) {
-                // List the transformations in the repository
-                if ( log.isDebug() ) {
-                  log
-                    .logDebug( BaseMessages.getString( PKG, "Pan.Log.GettingListTransDirectory", "" + directory ) );
-                }
-
-                String[] transnames = rep.getTransformationNames( directory.getObjectId(), false );
-                for ( int i = 0; i < transnames.length; i++ ) {
-                  System.out.println( transnames[i] );
-                }
-              } else if ( "Y".equalsIgnoreCase( optionListdir.toString() ) ) {
-                // List the directories in the repository
-                String[] dirnames = rep.getDirectoryNames( directory.getObjectId() );
-                for ( int i = 0; i < dirnames.length; i++ ) {
-                  System.out.println( dirnames[i] );
-                }
-              } else if ( !Utils.isEmpty( optionExprep ) ) {
-                // Export the repository
-                System.out.println( BaseMessages.getString( PKG, "Pan.Log.ExportingObjectsRepToFile", ""
-                  + optionExprep ) );
-
-                rep.getExporter().exportAllObjects( null, optionExprep.toString(), directory, "all" );
-                System.out.println( BaseMessages.getString( PKG, "Pan.Log.FinishedExportObjectsRepToFile", ""
-                  + optionExprep ) );
-              } else {
-                System.out.println( BaseMessages.getString( PKG, "Pan.Error.NoTransNameSupplied" ) );
-              }
-            } else {
-              System.out.println( BaseMessages.getString( PKG, "Pan.Error.CanNotFindSpecifiedDirectory", ""
-                + optionDirname ) );
-              repositoryMeta = null;
-            }
-          } else {
-            System.out.println( BaseMessages.getString( PKG, "Pan.Error.NoRepProvided" ) );
-          }
-        }
-
-        // Try to load the transformation from file, even if it failed to load
-        // from the repository
-        // You could implement some fail-over mechanism this way.
-        //
-        if ( trans == null && !Utils.isEmpty( optionFilename ) ) {
-
-          String fileName = optionFilename.toString();
-          // If the filename starts with scheme like zip:, then isAbsolute() will return false even though the
-          // the path following the zip is absolute path. Check for isAbsolute only if the fileName does not
-          // start with scheme
-          if ( !KettleVFS.startsWithScheme( fileName ) && !FileUtil.isFullyQualified( fileName ) ) {
-            fileName = initialDir.toString() + fileName;
-          }
-
-          if ( log.isDetailed() ) {
-            log.logDetailed( BaseMessages.getString( PKG, "Pan.Log.LoadingTransXML", "" + fileName ) );
-          }
-          transMeta = new TransMeta( fileName );
-          trans = new Trans( transMeta );
-        }
-
-        // Try to load the transformation from a jar file
-        //
-        if ( trans == null && !Utils.isEmpty( optionJarFilename ) ) {
-          try {
-            if ( log.isDetailed() ) {
-              log.logDetailed( BaseMessages.getString( PKG, "Pan.Log.LoadingTransJar", "" + optionJarFilename ) );
-            }
-
-            InputStream inputStream = Pan.class.getResourceAsStream( optionJarFilename.toString() );
-            StringBuilder xml = new StringBuilder();
-            int c;
-            while ( ( c = inputStream.read() ) != -1 ) {
-              xml.append( (char) c );
-            }
-            inputStream.close();
-            Document document = XMLHandler.loadXMLString( xml.toString() );
-            transMeta = new TransMeta( XMLHandler.getSubNode( document, "transformation" ), null );
-            trans = new Trans( transMeta );
-          } catch ( Exception e ) {
-            System.out.println( BaseMessages.getString( PKG, "Pan.Error.ReadingJar", e.toString() ) );
-
-            System.out.println( Const.getStackTracker( e ) );
-            throw e;
-          }
-        }
-      }
-
-      if ( "Y".equalsIgnoreCase( optionListrep.toString() ) ) {
-        if ( log.isDebug() ) {
-          log.logDebug( BaseMessages.getString( PKG, "Pan.Log.GettingListReps" ) );
-        }
-
-        RepositoriesMeta ri = new RepositoriesMeta();
-        try {
-          ri.readData();
-        } catch ( Exception e ) {
-          throw new KettleException( BaseMessages.getString( PKG, "Pan.Error.UnableReadXML" ), e );
-        }
-
-        System.out.println( BaseMessages.getString( PKG, "Pan.Log.ListReps" ) );
-
-        for ( int i = 0; i < ri.nrRepositories(); i++ ) {
-          RepositoryMeta rinfo = ri.getRepository( i );
-          System.out.println( BaseMessages.getString(
-            PKG, "Pan.Log.RepNameDesc", "" + ( i + 1 ), rinfo.getName(), rinfo.getDescription() ) );
-        }
-      }
-    } catch ( Exception e ) {
-      trans = null;
-      transMeta = null;
-      if ( rep != null ) {
-        rep.disconnect();
-      }
-      System.out.println( BaseMessages.getString( PKG, "Pan.Error.ProcessStopError", e.getMessage() ) );
-
-      e.printStackTrace();
-      exitJVM( 1 );
+    } catch ( Throwable t ) {
+      t.printStackTrace();
+      exitJVM( PanReturnCode.UNEXPECTED_ERROR.getCode() );
     }
-
-    if ( trans == null ) {
-      if ( rep != null ) {
-        rep.disconnect();
-      }
-
-      if ( !"Y".equalsIgnoreCase( optionListtrans.toString() )
-        && !"Y".equalsIgnoreCase( optionListdir.toString() ) && !"Y".equalsIgnoreCase( optionListrep.toString() )
-        && Utils.isEmpty( optionExprep ) ) {
-        System.out.println( BaseMessages.getString( PKG, "Pan.Error.CanNotLoadTrans" ) );
-
-        exitJVM( 7 );
-      } else {
-        exitJVM( 0 );
-      }
-
-    }
-
-    try {
-      trans.setLogLevel( log.getLogLevel() );
-      configureParameters( trans, optionParams, transMeta );
-
-      // See if we want to run in safe mode:
-      if ( "Y".equalsIgnoreCase( optionSafemode.toString() ) ) {
-        trans.setSafeModeEnabled( true );
-      }
-
-      // Enable kettle metric gathering if required:
-      if ( "Y".equalsIgnoreCase( optionMetrics.toString() ) ) {
-        trans.setGatheringMetrics( true );
-      }
-
-      // List the parameters defined in this transformation
-      // Then simply exit...
-      //
-      if ( "Y".equalsIgnoreCase( optionListParam.toString() ) ) {
-        for ( String parameterName : trans.listParameters() ) {
-          String value = trans.getParameterValue( parameterName );
-          String deflt = trans.getParameterDefault( parameterName );
-          String descr = trans.getParameterDescription( parameterName );
-
-          if ( deflt != null ) {
-            System.out.println( "Parameter: "
-              + parameterName + "=" + Const.NVL( value, "" ) + ", default=" + deflt + " : "
-              + Const.NVL( descr, "" ) );
-          } else {
-            System.out.println( "Parameter: "
-              + parameterName + "=" + Const.NVL( value, "" ) + " : " + Const.NVL( descr, "" ) );
-          }
-        }
-
-        // stop right here...
-        //
-        exitJVM( 7 ); // same as the other list options
-      }
-
-      // allocate & run the required sub-threads
-      try {
-        trans.execute( args.toArray( new String[args.size()] ) );
-      } catch ( KettleException e ) {
-        System.out.println( BaseMessages.getString( PKG, "Pan.Error.UnablePrepareInitTrans" ) );
-
-        exitJVM( 3 );
-      }
-
-      trans.waitUntilFinished();
-
-      // Give the transformation up to 10 seconds to finish execution
-      for ( int i = 0; i < 100; i++ ) {
-        if ( !trans.isRunning() ) {
-          break;
-        }
-        try {
-          Thread.sleep( 100 );
-        } catch ( Exception e ) {
-          break;
-        }
-      }
-
-      if ( trans.isRunning() ) {
-        log.logError( BaseMessages.getString( PKG, "Pan.Log.NotStopping" ) );
-      }
-
-      log.logMinimal( BaseMessages.getString( PKG, "Pan.Log.Finished" ) );
-
-      cal = Calendar.getInstance();
-      stop = cal.getTime();
-      String begin = df.format( start ).toString();
-      String end = df.format( stop ).toString();
-
-      log.logMinimal( BaseMessages.getString( PKG, "Pan.Log.StartStop", begin, end ) );
-
-      long millis = stop.getTime() - start.getTime();
-      int seconds = (int) ( millis / 1000 );
-      if ( seconds <= 60 ) {
-        log.logMinimal( BaseMessages.getString( PKG, "Pan.Log.ProcessingEndAfter", String.valueOf( seconds ) ) );
-      } else if ( seconds <= 60 * 60 ) {
-        int min = ( seconds / 60 );
-        int rem = ( seconds % 60 );
-        log.logMinimal( BaseMessages.getString(
-          PKG, "Pan.Log.ProcessingEndAfterLong", String.valueOf( min ), String.valueOf( rem ), String
-            .valueOf( seconds ) ) );
-      } else if ( seconds <= 60 * 60 * 24 ) {
-        int rem;
-        int hour = ( seconds / ( 60 * 60 ) );
-        rem = ( seconds % ( 60 * 60 ) );
-        int min = rem / 60;
-        rem = rem % 60;
-        log.logMinimal( BaseMessages.getString(
-          PKG, "Pan.Log.ProcessingEndAfterLonger", String.valueOf( hour ), String.valueOf( min ), String
-            .valueOf( rem ), String.valueOf( seconds ) ) );
-      } else {
-        int rem;
-        int days = ( seconds / ( 60 * 60 * 24 ) );
-        rem = ( seconds % ( 60 * 60 * 24 ) );
-        int hour = rem / ( 60 * 60 );
-        rem = rem % ( 60 * 60 );
-        int min = rem / 60;
-        rem = rem % 60;
-        log.logMinimal( BaseMessages.getString(
-          PKG, "Pan.Log.ProcessingEndAfterLongest", String.valueOf( days ), String.valueOf( hour ), String
-            .valueOf( min ), String.valueOf( rem ), String.valueOf( seconds ) ) );
-      }
-
-      if ( trans.getResult().getNrErrors() == 0 ) {
-        trans.printStats( seconds );
-        exitJVM( 0 );
-      } else {
-
-        String transJVMExitCode = trans.getVariable( Const.KETTLE_TRANS_PAN_JVM_EXIT_CODE );
-
-        // If the trans has a return code to return to the OS, then we exit with that
-        if ( !Utils.isEmpty( transJVMExitCode ) ) {
-          try {
-            exitJVM( Integer.valueOf( transJVMExitCode ) );
-          } catch ( NumberFormatException nfe ) {
-            log
-              .logError( BaseMessages.getString(
-                PKG, "Pan.Error.TransJVMExitCodeInvalid", Const.KETTLE_TRANS_PAN_JVM_EXIT_CODE,
-                transJVMExitCode ) );
-            log.logError( BaseMessages.getString( PKG, "Pan.Log.JVMExitCode", "1" ) );
-            exitJVM( 1 );
-          }
-        } else { // the trans does not have a return code.
-          exitJVM( 1 );
-        }
-      }
-    } catch ( KettleException ke ) {
-      System.out.println( BaseMessages.getString( PKG, "Pan.Log.ErrorOccurred", "" + ke.getMessage() ) );
-
-      log.logError( BaseMessages.getString( PKG, "Pan.Log.UnexpectedErrorOccurred", "" + ke.getMessage() ) );
-
-      exitJVM( 2 );
-    } finally {
-      if ( rep != null ) {
-        rep.disconnect();
-      }
-    }
-
   }
 
   /**
@@ -627,24 +272,7 @@ public class Pan {
    */
   protected static void configureParameters( Trans trans, NamedParams optionParams,
                                              TransMeta transMeta ) throws UnknownParamException {
-    trans.initializeVariablesFrom( null );
-    trans.getTransMeta().setInternalKettleVariables( trans );
-
-    // Map the command line named parameters to the actual named parameters.
-    // Skip for
-    // the moment any extra command line parameter not known in the
-    // transformation.
-    String[] transParams = trans.listParameters();
-    for ( String param : transParams ) {
-      String value = optionParams.getParameterValue( param );
-      if ( value != null ) {
-        trans.setParameterValue( param, value );
-        transMeta.setParameterValue( param, value );
-      }
-    }
-    // Put the parameters over the already defined variable space. Parameters
-    // get priority.
-    trans.activateParameters();
+    PanCommandExecutor.configureParameters( trans, optionParams, transMeta );
   }
 
   private static final void exitJVM( int status ) {
@@ -662,5 +290,13 @@ public class Pan {
     }
 
     System.exit( status );
+  }
+
+  public static PanCommandExecutor getCommandExecutor() {
+    return commandExecutor;
+  }
+
+  public void setCommandExecutor( PanCommandExecutor commandExecutor ) {
+    this.commandExecutor = commandExecutor;
   }
 }

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -1,14 +1,33 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.di.pan;
 
-import com.sun.org.apache.regexp.internal.RE;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleSecurityException;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.parameters.NamedParams;
-import org.pentaho.di.core.parameters.NamedParamsDefault;
 import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.RepositoryPluginType;
@@ -16,8 +35,6 @@ import org.pentaho.di.core.util.FileUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.core.vfs.KettleVFS;
-import org.pentaho.di.core.util.FileUtil;
-import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.metastore.MetaStoreConst;
 import org.pentaho.di.repository.RepositoriesMeta;
 import org.pentaho.di.repository.Repository;
@@ -71,7 +88,7 @@ public class PanCommandExecutor {
 
     try {
 
-      if( getMetaStore() == null ) {
+      if ( getMetaStore() == null ) {
         setMetaStore( createDefaultMetastore() );
       }
 
@@ -80,9 +97,9 @@ public class PanCommandExecutor {
       // Read kettle transformation specified
       if ( !Utils.isEmpty( repoName ) || !Utils.isEmpty( filename ) || !Utils.isEmpty( jarFile ) ) {
 
-        logDebug("Pan.Log.ParsingCommandline");
+        logDebug( "Pan.Log.ParsingCommandline" );
 
-        if (!Utils.isEmpty( repoName ) && !YES.equalsIgnoreCase( noRepo ) ) {
+        if ( !Utils.isEmpty( repoName ) && !YES.equalsIgnoreCase( noRepo ) ) {
 
           // In case we use a repository...
           // some commands are to load a Trans from the repo; others are merely to print some repo-related information
@@ -99,7 +116,7 @@ public class PanCommandExecutor {
       }
 
       if ( YES.equalsIgnoreCase( listRepos ) ) {
-          printRepositories( loadRepositoryInfo() ); // list the repositories placed at repositories.xml
+        printRepositories( loadRepositoryInfo() ); // list the repositories placed at repositories.xml
       }
 
     } catch ( Exception e ) {
@@ -116,8 +133,8 @@ public class PanCommandExecutor {
       if ( !YES.equalsIgnoreCase( listTrans ) && !YES.equalsIgnoreCase( listDirs )
               && !YES.equalsIgnoreCase( listRepos ) && Utils.isEmpty( exportRepo ) ) {
 
-          System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.CanNotLoadTrans" ) );
-          return PanReturnCode.COULD_NOT_LOAD_TRANS.getCode();
+        System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.CanNotLoadTrans" ) );
+        return PanReturnCode.COULD_NOT_LOAD_TRANS.getCode();
       } else {
           return PanReturnCode.SUCCESS.getCode();
       }
@@ -134,10 +151,10 @@ public class PanCommandExecutor {
       // List the parameters defined in this transformation, and then simply exit
       if ( YES.equalsIgnoreCase( listParams ) ) {
 
-          printTransformationParameters( trans );
+        printTransformationParameters( trans );
 
-          // stop right here...
-          return PanReturnCode.COULD_NOT_LOAD_TRANS.getCode(); // same as the other list options
+        // stop right here...
+        return PanReturnCode.COULD_NOT_LOAD_TRANS.getCode(); // same as the other list options
       }
 
       // allocate & run the required sub-threads
@@ -150,7 +167,7 @@ public class PanCommandExecutor {
         return PanReturnCode.UNABLE_TO_PREP_INIT_TRANS.getCode();
       }
 
-      waitUntilFinished( trans , 100 ); // Give the transformation up to 10 seconds to finish execution
+      waitUntilFinished( trans, 100 ); // Give the transformation up to 10 seconds to finish execution
 
       if ( trans.isRunning() ) {
         getLog().logError( BaseMessages.getString( getPkgClazz(), "Pan.Log.NotStopping" ) );
@@ -176,7 +193,7 @@ public class PanCommandExecutor {
           try {
             return Integer.parseInt( transJVMExitCode );
 
-          } catch( NumberFormatException nfe ) {
+          } catch ( NumberFormatException nfe ) {
             getLog().logError( BaseMessages.getString( getPkgClazz(), "Pan.Error.TransJVMExitCodeInvalid",
                     Const.KETTLE_TRANS_PAN_JVM_EXIT_CODE, transJVMExitCode ) );
             getLog().logError( BaseMessages.getString( getPkgClazz(), "Pan.Log.JVMExitCode", "1" ) );
@@ -225,7 +242,7 @@ public class PanCommandExecutor {
 
         // Add the IMetaStore of the repository to our delegation
         if ( repo.getMetaStore() != null && getMetaStore() != null ) {
-          getMetaStore().addMetaStore( repo.getMetaStore( ));
+          getMetaStore().addMetaStore( repo.getMetaStore() );
         }
 
         // Find the directory name if one is specified...
@@ -240,17 +257,17 @@ public class PanCommandExecutor {
           // transname is not empty ? then command it to load a transformation
           if ( !Utils.isEmpty( transName ) ) {
 
-            logDebug("Pan.Log.LoadTransInfo");
+            logDebug("Pan.Log.LoadTransInfo" );
             TransMeta transMeta = repo.loadTransformation( transName, directory, null, true, null );
 
-            logDebug("Pan.Log.AllocateTrans");
+            logDebug("Pan.Log.AllocateTrans" );
             Trans trans = new Trans( transMeta );
             trans.setRepository( repo );
             trans.setMetaStore( getMetaStore() );
 
             return trans; // return transformation loaded from the repo
 
-          } else if ( YES.equalsIgnoreCase( listTrans) ) {
+          } else if ( YES.equalsIgnoreCase( listTrans ) ) {
 
             printRepositoryStoredTransformations( repo, directory ); // List the transformations in the repository
 
@@ -387,8 +404,8 @@ public class PanCommandExecutor {
 
   protected void printTransformationParameters( Trans transformation ) throws UnknownParamException {
 
-    if( transformation == null || transformation.listParameters() == null ) {
-        return;
+    if ( transformation == null || transformation.listParameters() == null ) {
+      return;
     }
 
     for ( String paramName : transformation.listParameters() ) {
@@ -400,19 +417,19 @@ public class PanCommandExecutor {
         System.out.println( "Parameter: " + paramName + "=" + Const.NVL( value, "" ) + ", default=" + deflt + " : " + Const.NVL( descr, "" ) );
       } else {
         System.out.println( "Parameter: " + paramName + "=" + Const.NVL( value, "" ) + " : " + Const.NVL( descr, "" ) );
-          }
       }
+    }
   }
 
   protected void printRepositoryDirectories( Repository repository, RepositoryDirectoryInterface directory ) throws KettleException {
 
-      String[] directories = repository.getDirectoryNames( directory.getObjectId() );
+    String[] directories = repository.getDirectoryNames( directory.getObjectId() );
 
-      if( directories != null ) {
-          for ( String dir :  directories ) {
-              System.out.println( dir );
-          }
+    if ( directories != null ) {
+      for ( String dir :  directories ) {
+        System.out.println( dir );
       }
+    }
   }
 
   protected void printRepositoryStoredTransformations( Repository repository, RepositoryDirectoryInterface directory ) throws KettleException {
@@ -420,7 +437,7 @@ public class PanCommandExecutor {
     logDebug( "Pan.Log.GettingListTransDirectory", "" + directory );
     String[] transformations = repository.getTransformationNames( directory.getObjectId(), false );
 
-    if( transformations != null ) {
+    if ( transformations != null ) {
       for ( String trans :  transformations ) {
         System.out.println( trans );
       }
@@ -446,7 +463,7 @@ public class PanCommandExecutor {
     RepositoriesMeta repsinfo = null;
 
     if ( Utils.isEmpty( optionRepname ) || ( repsinfo = loadRepositoryInfo() ) == null ) {
-        return null;
+      return null;
     }
 
     logDebug(  "Pan.Log.FindingRep", optionRepname );
@@ -472,24 +489,24 @@ public class PanCommandExecutor {
   protected Repository establishRepositoryConnection( RepositoryMeta repositoryMeta, final String username, final String password,
                                                       final RepositoryOperation... operations ) throws KettleException, KettleSecurityException {
 
-      Repository rep = PluginRegistry.getInstance().loadClass( RepositoryPluginType.class, repositoryMeta, Repository.class );
-      rep.init( repositoryMeta );
-      rep.getLog().setLogLevel( getLog().getLogLevel() );
-      rep.connect( username != null ? username : null, password != null ? password : null );
+    Repository rep = PluginRegistry.getInstance().loadClass( RepositoryPluginType.class, repositoryMeta, Repository.class );
+    rep.init( repositoryMeta );
+    rep.getLog().setLogLevel( getLog().getLogLevel() );
+    rep.connect( username != null ? username : null, password != null ? password : null );
 
-      if( operations != null ) {
-        // throws KettleSecurityException if username does does have permission for given operations
-        rep.getSecurityProvider().validateAction( operations );
-      }
+    if( operations != null ) {
+      // throws KettleSecurityException if username does does have permission for given operations
+      rep.getSecurityProvider().validateAction( operations );
+    }
 
-      return rep;
+    return rep;
   }
 
   protected SimpleDateFormat getDateFormat() {
     return dateFormat;
   }
 
-  private void waitUntilFinished(Trans trans, final long waitMillis ) {
+  private void waitUntilFinished( Trans trans, final long waitMillis ) {
 
     if ( trans != null && trans.isRunning() ) {
 
@@ -497,7 +514,7 @@ public class PanCommandExecutor {
 
       for ( int i = 0; i < 100; i++ ) {
         if ( !trans.isRunning() ) {
-            break;
+          break;
         }
 
         try {

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -1,0 +1,564 @@
+package org.pentaho.di.pan;
+
+import com.sun.org.apache.regexp.internal.RE;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleSecurityException;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.parameters.NamedParams;
+import org.pentaho.di.core.parameters.NamedParamsDefault;
+import org.pentaho.di.core.parameters.UnknownParamException;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.plugins.RepositoryPluginType;
+import org.pentaho.di.core.util.FileUtil;
+import org.pentaho.di.core.util.Utils;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.core.util.FileUtil;
+import org.pentaho.di.core.parameters.UnknownParamException;
+import org.pentaho.di.metastore.MetaStoreConst;
+import org.pentaho.di.repository.RepositoriesMeta;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryDirectoryInterface;
+import org.pentaho.di.repository.RepositoryMeta;
+import org.pentaho.di.repository.RepositoryOperation;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+import org.pentaho.metastore.stores.delegate.DelegatingMetaStore;
+import org.w3c.dom.Document;
+
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+public class PanCommandExecutor {
+
+  private static final String YES = "Y";
+
+  private LogChannelInterface log;
+  private Class<?> pkgClazz;
+  DelegatingMetaStore metaStore;
+
+  private SimpleDateFormat dateFormat = new SimpleDateFormat( "yyyy/MM/dd HH:mm:ss.SSS" );
+
+  public PanCommandExecutor( Class<?> pkgClazz ) {
+    this( pkgClazz, new LogChannel( Pan.STRING_PAN ) );
+  }
+
+  public PanCommandExecutor( Class<?> pkgClazz, LogChannelInterface log ) {
+    this.pkgClazz = pkgClazz;
+    this.log = log;
+  }
+
+  public int execute( final String repoName, final String noRepo, final String username, final String password,
+                      final String dirName, final String filename, final String jarFile, final String transName,
+                      final String listTrans, final String listDirs, final String exportRepo, final String initialDir,
+                      final String listRepos, final String safemode, final String metrics, final String listParams,
+                      final NamedParams params, final String[] arguments ) throws Throwable {
+
+    getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Pan.Log.StartingToRun" ) );
+
+    Date start = Calendar.getInstance().getTime(); // capture execution start time
+
+    logDebug( "Pan.Log.AllocatteNewTrans" );
+
+    Trans trans = null;
+
+    try {
+
+      if( getMetaStore() == null ) {
+        setMetaStore( createDefaultMetastore() );
+      }
+
+      logDebug( "Pan.Log.StartingToLookOptions" );
+
+      // Read kettle transformation specified
+      if ( !Utils.isEmpty( repoName ) || !Utils.isEmpty( filename ) || !Utils.isEmpty( jarFile ) ) {
+
+        logDebug("Pan.Log.ParsingCommandline");
+
+        if (!Utils.isEmpty( repoName ) && !YES.equalsIgnoreCase( noRepo ) ) {
+
+          // In case we use a repository...
+          // some commands are to load a Trans from the repo; others are merely to print some repo-related information
+          trans = executeRepositoryBasedCommand( repoName, username, password, dirName, transName, listTrans, listDirs, exportRepo );
+        }
+
+
+        // Try to load the transformation from file, even if it failed to load from the repository
+        // You could implement some fail-over mechanism this way.
+        if ( trans == null ) {
+          trans = executeFilesystemBasedCommand( initialDir, filename, jarFile );
+        }
+
+      }
+
+      if ( YES.equalsIgnoreCase( listRepos ) ) {
+          printRepositories( loadRepositoryInfo() ); // list the repositories placed at repositories.xml
+      }
+
+    } catch ( Exception e ) {
+
+      trans = null;
+
+      System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.ProcessStopError", e.getMessage() ) );
+      e.printStackTrace();
+      return PanReturnCode.ERRORS_DURING_PROCESSING.getCode();
+    }
+
+    if ( trans == null ) {
+
+      if ( !YES.equalsIgnoreCase( listTrans ) && !YES.equalsIgnoreCase( listDirs )
+              && !YES.equalsIgnoreCase( listRepos ) && Utils.isEmpty( exportRepo ) ) {
+
+          System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.CanNotLoadTrans" ) );
+          return PanReturnCode.COULD_NOT_LOAD_TRANS.getCode();
+      } else {
+          return PanReturnCode.SUCCESS.getCode();
+      }
+    }
+
+    try {
+
+      trans.setLogLevel( getLog().getLogLevel() );
+      configureParameters( trans, params, trans.getTransMeta() );
+
+      trans.setSafeModeEnabled( YES.equalsIgnoreCase( safemode ) ); // run in safe mode if requested
+      trans.setGatheringMetrics( YES.equalsIgnoreCase( metrics ) ); // enable kettle metric gathering if requested
+
+      // List the parameters defined in this transformation, and then simply exit
+      if ( YES.equalsIgnoreCase( listParams ) ) {
+
+          printTransformationParameters( trans );
+
+          // stop right here...
+          return PanReturnCode.COULD_NOT_LOAD_TRANS.getCode(); // same as the other list options
+      }
+
+      // allocate & run the required sub-threads
+      try {
+        trans.execute( arguments );
+
+      } catch ( KettleException ke ) {
+        logDebug( ke.getLocalizedMessage() );
+        System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.UnablePrepareInitTrans" ) );
+        return PanReturnCode.UNABLE_TO_PREP_INIT_TRANS.getCode();
+      }
+
+      waitUntilFinished( trans , 100 ); // Give the transformation up to 10 seconds to finish execution
+
+      if ( trans.isRunning() ) {
+        getLog().logError( BaseMessages.getString( getPkgClazz(), "Pan.Log.NotStopping" ) );
+      }
+
+      getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Pan.Log.Finished" ) );
+      Date stop = Calendar.getInstance().getTime(); // capture execution stop time
+
+      int completionTimeSeconds = calculateAndPrintElapsedTime( start, stop );
+
+      if ( trans.getResult().getNrErrors() == 0 ) {
+
+        trans.printStats( completionTimeSeconds );
+        return PanReturnCode.SUCCESS.getCode();
+
+      } else {
+
+        String transJVMExitCode = trans.getVariable( Const.KETTLE_TRANS_PAN_JVM_EXIT_CODE );
+
+        // If the trans has a return code to return to the OS, then we exit with that
+        if ( !Utils.isEmpty( transJVMExitCode ) ) {
+
+          try {
+            return Integer.parseInt( transJVMExitCode );
+
+          } catch( NumberFormatException nfe ) {
+            getLog().logError( BaseMessages.getString( getPkgClazz(), "Pan.Error.TransJVMExitCodeInvalid",
+                    Const.KETTLE_TRANS_PAN_JVM_EXIT_CODE, transJVMExitCode ) );
+            getLog().logError( BaseMessages.getString( getPkgClazz(), "Pan.Log.JVMExitCode", "1" ) );
+            return PanReturnCode.ERRORS_DURING_PROCESSING.getCode();
+          }
+
+        } else {
+            // the trans does not have a return code.
+            return PanReturnCode.ERRORS_DURING_PROCESSING.getCode();
+        }
+      }
+
+    } catch ( KettleException ke ) {
+
+      System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Log.ErrorOccurred", "" + ke.getMessage() ) );
+      getLog().logError( BaseMessages.getString( getPkgClazz(), "Pan.Log.UnexpectedErrorOccurred", "" + ke.getMessage() ) );
+
+      return PanReturnCode.UNEXPECTED_ERROR.getCode();
+
+    }
+  }
+
+  public Trans executeRepositoryBasedCommand( final String repoName, final String username, final String password, final String dirName,
+                                              final String transName, final String listTrans, final String listDirs, final String exportRepo ) throws Exception {
+
+
+    if ( Utils.isEmpty( repoName ) ) {
+      System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.NoRepProvided" ) );
+      return null;
+    }
+
+    Repository repo = null;
+
+    try {
+
+      RepositoryMeta repositoryMeta = loadRepositoryConnection( repoName );
+
+      if ( repositoryMeta != null ) {
+        // Define and connect to the repository...
+        logDebug( "Pan.Log.Allocate&ConnectRep" );
+
+        repo = establishRepositoryConnection( repositoryMeta, username, password, RepositoryOperation.EXECUTE_TRANSFORMATION );
+
+        // Default is the root directory
+        RepositoryDirectoryInterface directory = repo.loadRepositoryDirectoryTree();
+
+        // Add the IMetaStore of the repository to our delegation
+        if ( repo.getMetaStore() != null && getMetaStore() != null ) {
+          getMetaStore().addMetaStore( repo.getMetaStore( ));
+        }
+
+        // Find the directory name if one is specified...
+        if ( !Utils.isEmpty( dirName ) ) {
+          directory = directory.findDirectory( dirName );
+        }
+
+        if ( directory != null ) {
+          // Check username, password
+          logDebug( "Pan.Log.CheckSuppliedUserPass" );
+
+          // transname is not empty ? then command it to load a transformation
+          if ( !Utils.isEmpty( transName ) ) {
+
+            logDebug("Pan.Log.LoadTransInfo");
+            TransMeta transMeta = repo.loadTransformation( transName, directory, null, true, null );
+
+            logDebug("Pan.Log.AllocateTrans");
+            Trans trans = new Trans( transMeta );
+            trans.setRepository( repo );
+            trans.setMetaStore( getMetaStore() );
+
+            return trans; // return transformation loaded from the repo
+
+          } else if ( YES.equalsIgnoreCase( listTrans) ) {
+
+            printRepositoryStoredTransformations( repo, directory ); // List the transformations in the repository
+
+          } else if ( YES.equalsIgnoreCase( listDirs ) ) {
+
+            printRepositoryDirectories( repo, directory ); // List the directories in the repository
+
+          } else if ( !Utils.isEmpty( exportRepo ) ) {
+
+            // Export the repository
+            System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Log.ExportingObjectsRepToFile", "" + exportRepo ) );
+            repo.getExporter().exportAllObjects( null, exportRepo, directory, "all" );
+            System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Log.FinishedExportObjectsRepToFile", "" + exportRepo ) );
+
+          } else {
+            System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.NoTransNameSupplied" ) );
+          }
+        } else {
+          System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.CanNotFindSpecifiedDirectory", "" + dirName ) );
+        }
+      } else {
+        System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.NoRepProvided" ) );
+      }
+
+    } finally {
+
+      if ( repo != null ) {
+        repo.disconnect();
+      }
+
+    }
+
+    return null;
+  }
+
+  public Trans executeFilesystemBasedCommand( final String initialDir, final String filename, final String jarFilename ) throws Exception {
+
+    Trans trans = null;
+
+    // Try to load the transformation from file
+    if ( !Utils.isEmpty( filename ) ) {
+
+      String filepath = filename;
+      // If the filename starts with scheme like zip:, then isAbsolute() will return false even though the
+      // the path following the zip is absolute. Check for isAbsolute only if the fileName does not start with scheme
+      if ( !KettleVFS.startsWithScheme( filename ) && !FileUtil.isFullyQualified( filename ) ) {
+        filepath = initialDir + filename;
+      }
+
+      logDebug( "Pan.Log.LoadingTransXML", "" + filepath );
+      TransMeta transMeta = new TransMeta( filepath );
+      trans = new Trans( transMeta );
+
+    }
+
+    if ( !Utils.isEmpty( jarFilename ) ) {
+
+      try {
+
+        logDebug( "Pan.Log.LoadingTransJar", jarFilename );
+
+        InputStream inputStream = PanCommandExecutor.class.getResourceAsStream( jarFilename );
+        StringBuilder xml = new StringBuilder();
+        int c;
+        while ( ( c = inputStream.read() ) != -1 ) {
+          xml.append( (char) c );
+        }
+        inputStream.close();
+        Document document = XMLHandler.loadXMLString( xml.toString() );
+        TransMeta transMeta = new TransMeta( XMLHandler.getSubNode( document, "transformation" ), null );
+        trans = new Trans( transMeta );
+
+      } catch ( Exception e ) {
+
+        System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.ReadingJar", e.toString() ) );
+        System.out.println( Const.getStackTracker( e ) );
+        throw e;
+      }
+    }
+
+    return trans;
+  }
+
+  /**
+   * Configures the transformation with the given parameters and their values
+   *
+   * @param trans        the executable transformation object
+   * @param optionParams the list of parameters to set for the transformation
+   * @param transMeta    the transformation metadata
+   * @throws UnknownParamException
+   */
+  protected static void configureParameters( Trans trans, NamedParams optionParams,
+                                               TransMeta transMeta ) throws UnknownParamException {
+    trans.initializeVariablesFrom( null );
+    trans.getTransMeta().setInternalKettleVariables( trans );
+
+    // Map the command line named parameters to the actual named parameters.
+    // Skip for the moment any extra command line parameter not known in the transformation.
+    String[] transParams = trans.listParameters();
+    for ( String param : transParams ) {
+      String value = optionParams.getParameterValue( param );
+      if ( value != null ) {
+        trans.setParameterValue( param, value );
+        transMeta.setParameterValue( param, value );
+      }
+    }
+
+    // Put the parameters over the already defined variable space. Parameters get priority.
+    trans.activateParameters();
+  }
+
+  public DelegatingMetaStore createDefaultMetastore() throws MetaStoreException {
+    DelegatingMetaStore metaStore = new DelegatingMetaStore();
+    metaStore.addMetaStore( MetaStoreConst.openLocalPentahoMetaStore() );
+    metaStore.setActiveMetaStoreName( metaStore.getName() );
+    return metaStore;
+  }
+
+  public LogChannelInterface getLog() {
+    return log;
+  }
+
+  public Class<?> getPkgClazz() {
+    return pkgClazz;
+  }
+
+  public DelegatingMetaStore getMetaStore() {
+    return metaStore;
+  }
+
+  public void setMetaStore( DelegatingMetaStore metaStore ) {
+    this.metaStore = metaStore;
+  }
+
+  protected void printTransformationParameters( Trans transformation ) throws UnknownParamException {
+
+    if( transformation == null || transformation.listParameters() == null ) {
+        return;
+    }
+
+    for ( String paramName : transformation.listParameters() ) {
+      String value = transformation.getParameterValue( paramName );
+      String deflt = transformation.getParameterDefault( paramName );
+      String descr = transformation.getParameterDescription( paramName );
+
+      if ( deflt != null ) {
+        System.out.println( "Parameter: " + paramName + "=" + Const.NVL( value, "" ) + ", default=" + deflt + " : " + Const.NVL( descr, "" ) );
+      } else {
+        System.out.println( "Parameter: " + paramName + "=" + Const.NVL( value, "" ) + " : " + Const.NVL( descr, "" ) );
+          }
+      }
+  }
+
+  protected void printRepositoryDirectories( Repository repository, RepositoryDirectoryInterface directory ) throws KettleException {
+
+      String[] directories = repository.getDirectoryNames( directory.getObjectId() );
+
+      if( directories != null ) {
+          for ( String dir :  directories ) {
+              System.out.println( dir );
+          }
+      }
+  }
+
+  protected void printRepositoryStoredTransformations( Repository repository, RepositoryDirectoryInterface directory ) throws KettleException {
+
+    logDebug( "Pan.Log.GettingListTransDirectory", "" + directory );
+    String[] transformations = repository.getTransformationNames( directory.getObjectId(), false );
+
+    if( transformations != null ) {
+      for ( String trans :  transformations ) {
+        System.out.println( trans );
+      }
+    }
+  }
+
+  protected void printRepositories( RepositoriesMeta repositoriesMeta ) {
+
+    if ( repositoriesMeta != null ) {
+
+      logDebug( "Pan.Log.GettingListReps" );
+
+      for ( int i = 0; i < repositoriesMeta.nrRepositories(); i++ ) {
+        RepositoryMeta repInfo = repositoriesMeta.getRepository( i );
+        System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Log.RepNameDesc", "" + ( i + 1 ),
+                repInfo.getName(), repInfo.getDescription() ) );
+      }
+    }
+  }
+
+  protected RepositoryMeta loadRepositoryConnection( final String optionRepname ) throws KettleException {
+
+    RepositoriesMeta repsinfo = null;
+
+    if ( Utils.isEmpty( optionRepname ) || ( repsinfo = loadRepositoryInfo() ) == null ) {
+        return null;
+    }
+
+    logDebug(  "Pan.Log.FindingRep", optionRepname );
+    return repsinfo.findRepository( optionRepname );
+  }
+
+  protected RepositoriesMeta loadRepositoryInfo() throws KettleException {
+
+    RepositoriesMeta repsinfo = new RepositoriesMeta();
+    repsinfo.getLog().setLogLevel( getLog().getLogLevel() );
+
+    logDebug( "Pan.Log.LoadingAvailableRep" );
+
+    try {
+      repsinfo.readData();
+    } catch ( Exception e ) {
+      throw new KettleException( BaseMessages.getString( getPkgClazz(), "Pan.Error.NoRepsDefined" ), e );
+    }
+
+    return repsinfo;
+  }
+
+  protected Repository establishRepositoryConnection( RepositoryMeta repositoryMeta, final String username, final String password,
+                                                      final RepositoryOperation... operations ) throws KettleException, KettleSecurityException {
+
+      Repository rep = PluginRegistry.getInstance().loadClass( RepositoryPluginType.class, repositoryMeta, Repository.class );
+      rep.init( repositoryMeta );
+      rep.getLog().setLogLevel( getLog().getLogLevel() );
+      rep.connect( username != null ? username : null, password != null ? password : null );
+
+      if( operations != null ) {
+        // throws KettleSecurityException if username does does have permission for given operations
+        rep.getSecurityProvider().validateAction( operations );
+      }
+
+      return rep;
+  }
+
+  protected SimpleDateFormat getDateFormat() {
+    return dateFormat;
+  }
+
+  private void waitUntilFinished(Trans trans, final long waitMillis ) {
+
+    if ( trans != null && trans.isRunning() ) {
+
+      trans.waitUntilFinished();
+
+      for ( int i = 0; i < 100; i++ ) {
+        if ( !trans.isRunning() ) {
+            break;
+        }
+
+        try {
+          Thread.sleep( waitMillis );
+        } catch ( Exception e ) {
+          break;
+        }
+      }
+    }
+  }
+
+  private void logDebug( final String messageKey ) {
+    if ( getLog().isDebug() ) {
+      getLog().logDebug( BaseMessages.getString( getPkgClazz(), messageKey ) );
+    }
+  }
+
+  private void logDebug( final String messageKey, String... messageTokens ) {
+    if ( getLog().isDebug() ) {
+      getLog().logDebug( BaseMessages.getString( getPkgClazz(), messageKey, messageTokens ) );
+    }
+  }
+
+  private int calculateAndPrintElapsedTime( Date start, Date stop ) {
+
+    String begin = getDateFormat().format( start ).toString();
+    String end = getDateFormat().format( stop ).toString();
+
+    getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Pan.Log.StartStop", begin, end ) );
+
+    long millis = stop.getTime() - start.getTime();
+    int seconds = (int) ( millis / 1000 );
+    if ( seconds <= 60 ) {
+      getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Pan.Log.ProcessingEndAfter", String.valueOf( seconds ) ) );
+    } else if ( seconds <= 60 * 60 ) {
+      int min = ( seconds / 60 );
+      int rem = ( seconds % 60 );
+      getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Pan.Log.ProcessingEndAfterLong", String.valueOf( min ),
+                  String.valueOf( rem ), String.valueOf( seconds ) ) );
+    } else if ( seconds <= 60 * 60 * 24 ) {
+      int rem;
+      int hour = ( seconds / ( 60 * 60 ) );
+      rem = ( seconds % ( 60 * 60 ) );
+      int min = rem / 60;
+      rem = rem % 60;
+      getLog().logMinimal( BaseMessages.getString(  getPkgClazz(), "Pan.Log.ProcessingEndAfterLonger", String.valueOf( hour ),
+                  String.valueOf( min ), String.valueOf( rem ), String.valueOf( seconds ) ) );
+    } else {
+      int rem;
+      int days = ( seconds / ( 60 * 60 * 24 ) );
+      rem = ( seconds % ( 60 * 60 * 24 ) );
+      int hour = rem / ( 60 * 60 );
+      rem = rem % ( 60 * 60 );
+      int min = rem / 60;
+      rem = rem % 60;
+      getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Pan.Log.ProcessingEndAfterLongest", String.valueOf( days ),
+                  String.valueOf( hour ), String.valueOf( min ), String.valueOf( rem ), String.valueOf( seconds ) ) );
+    }
+
+    return seconds;
+  }
+}
+
+

--- a/engine/src/main/java/org/pentaho/di/pan/PanReturnCode.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanReturnCode.java
@@ -1,0 +1,40 @@
+package org.pentaho.di.pan;
+
+
+/**
+ * @see https://help.pentaho.com/Documentation/8.0/Products/Data_Integration/Command_Line_Tools
+ */
+public enum PanReturnCode {
+
+    SUCCESS ( 0, "The transformation ran without a problem" ),
+    ERRORS_DURING_PROCESSING ( 1, "Errors occurred during processing" ),
+    UNEXPECTED_ERROR ( 2, "An unexpected error occurred during loading / running of the transformation" ),
+    UNABLE_TO_PREP_INIT_TRANS ( 3, "Unable to prepare and initialize this transformation" ),
+    COULD_NOT_LOAD_TRANS ( 7, "The transformation couldn't be loaded from XML or the Repository" ),
+    ERROR_LOADING_STEPS_PLUGINS ( 8, "Error loading steps or plugins (error in loading one of the plugins mostly)" ),
+    CMD_LINE_PRINT ( 9, "Command line usage printing" );
+
+    private int code;
+    private String description;
+
+    private PanReturnCode( int code, String description ) {
+       setCode( code );
+       setDescription( description );
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/engine/src/main/java/org/pentaho/di/pan/PanReturnCode.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanReturnCode.java
@@ -1,3 +1,25 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.di.pan;
 
 
@@ -6,35 +28,35 @@ package org.pentaho.di.pan;
  */
 public enum PanReturnCode {
 
-    SUCCESS ( 0, "The transformation ran without a problem" ),
-    ERRORS_DURING_PROCESSING ( 1, "Errors occurred during processing" ),
-    UNEXPECTED_ERROR ( 2, "An unexpected error occurred during loading / running of the transformation" ),
-    UNABLE_TO_PREP_INIT_TRANS ( 3, "Unable to prepare and initialize this transformation" ),
-    COULD_NOT_LOAD_TRANS ( 7, "The transformation couldn't be loaded from XML or the Repository" ),
-    ERROR_LOADING_STEPS_PLUGINS ( 8, "Error loading steps or plugins (error in loading one of the plugins mostly)" ),
-    CMD_LINE_PRINT ( 9, "Command line usage printing" );
+  SUCCESS ( 0, "The transformation ran without a problem" ),
+  ERRORS_DURING_PROCESSING ( 1, "Errors occurred during processing" ),
+  UNEXPECTED_ERROR ( 2, "An unexpected error occurred during loading / running of the transformation" ),
+  UNABLE_TO_PREP_INIT_TRANS ( 3, "Unable to prepare and initialize this transformation" ),
+  COULD_NOT_LOAD_TRANS ( 7, "The transformation couldn't be loaded from XML or the Repository" ),
+  ERROR_LOADING_STEPS_PLUGINS ( 8, "Error loading steps or plugins (error in loading one of the plugins mostly)" ),
+  CMD_LINE_PRINT ( 9, "Command line usage printing" );
 
-    private int code;
-    private String description;
+  private int code;
+  private String description;
 
-    private PanReturnCode( int code, String description ) {
-       setCode( code );
-       setDescription( description );
-    }
+  private PanReturnCode( int code, String description ) {
+    setCode( code );
+    setDescription( description );
+  }
 
-    public int getCode() {
-        return code;
-    }
+  public int getCode() {
+    return code;
+  }
 
-    public void setCode(int code) {
-        this.code = code;
-    }
+  public void setCode(int code) {
+    this.code = code;
+  }
 
-    public String getDescription() {
-        return description;
-    }
+  public String getDescription() {
+    return description;
+  }
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
+  public void setDescription(String description) {
+    this.description = description;
+  }
 }


### PR DESCRIPTION
…ogic in Pan

- From this point onward, `Pan` keeps the parameter parsing logic and the `System.exitJVM()`, but delegates the execution to `PanCommandExecutor`
- `PanCommandExecutor` handles all the execution logic, returning an enum `PanStatusCode`, as per https://help.pentaho.com/Documentation/8.0/Products/Data_Integration/Command_Line_Tools

The PR ( https://github.com/pentaho/pentaho-kettle/pull/4963 ) we issued a few days ago to expand `PanIT`'s integration tests served as the basis, where this refactoring work was proven out

@pentaho/rogueone please review