### PR TITLE
[BACKLOG-21249] Classes for generically handling stepmeta serialization

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/util/SerializationHelper.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/SerializationHelper.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -45,6 +45,10 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+@Deprecated
+/**
+ * See {@link org.pentaho.di.core.util.serialization.BaseSerializingMeta for an alternative. }
+ */
 public class SerializationHelper {
 
   private static final String INDENT_STRING = "    ";

--- a/engine/src/main/java/org/pentaho/di/core/util/serialization/BaseSerializingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/serialization/BaseSerializingMeta.java
@@ -1,0 +1,77 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.util.serialization;
+
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
+import org.pentaho.metastore.api.IMetaStore;
+import org.w3c.dom.Node;
+
+import java.util.List;
+
+import static org.pentaho.di.core.util.serialization.MetaXmlSerializer.deserialize;
+import static org.pentaho.di.core.util.serialization.MetaXmlSerializer.serialize;
+import static org.pentaho.di.core.util.serialization.StepMetaProps.from;
+
+/**
+ * Handles serialization of meta by implementing getXML/loadXML, readRep/saveRep.
+ *
+ * Uses {@link MetaXmlSerializer} amd {@link RepoSerializer} for generically
+ * handling child classes meta.
+ */
+public abstract class BaseSerializingMeta extends BaseStepMeta implements StepMetaInterface {
+
+  @Override public String getXML() {
+    return serialize( from( this ) );
+  }
+
+  @Override public void loadXML(
+    Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore ) throws KettleXMLException {
+    deserialize( stepnode ).to( this );
+  }
+
+  @Override public void readRep( Repository rep, IMetaStore metaStore, ObjectId
+    id_step, List<DatabaseMeta> databases )
+    throws KettleException {
+    RepoSerializer.builder()
+      .stepMeta( this )
+      .repo( rep )
+      .stepId( id_step )
+      .deserialize();
+  }
+
+  @Override public void saveRep( Repository rep, IMetaStore metaStore, ObjectId transId, ObjectId stepId )
+    throws KettleException {
+    RepoSerializer.builder()
+      .stepMeta( this )
+      .repo( rep )
+      .stepId( stepId )
+      .transId( transId )
+      .serialize();
+  }
+}

--- a/engine/src/main/java/org/pentaho/di/core/util/serialization/MetaXmlSerializer.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/serialization/MetaXmlSerializer.java
@@ -1,0 +1,102 @@
+/*
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ * **************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.core.util.serialization;
+
+import org.pentaho.di.core.xml.XMLHandler;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.Charset.defaultCharset;
+import static org.pentaho.di.core.util.serialization.StepMetaProps.STEP_TAG;
+
+/**
+ * Converts StepMetaProps to/from an XML string using JAXB.
+ */
+public class MetaXmlSerializer {
+
+  public static String serialize( StepMetaProps stepMetaProps ) {
+    try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() ) {
+      Marshaller marshalObj = JAXBContext.newInstance( StepMetaProps.class ).createMarshaller();
+      marshalObj.setProperty( Marshaller.JAXB_FORMATTED_OUTPUT, true );
+      marshalObj.setProperty( Marshaller.JAXB_FRAGMENT, true );
+      marshalObj.marshal( stepMetaProps, baos );
+      return baos.toString( defaultCharset().name() );
+    } catch ( JAXBException | IOException e ) {
+      throw new RuntimeException( e );
+    }
+  }
+
+  public static StepMetaProps deserialize( String ser ) {
+    try ( ByteArrayInputStream bais = new ByteArrayInputStream( ser.getBytes( defaultCharset() ) ) ) {
+      Unmarshaller unmarshaller = JAXBContext.newInstance( StepMetaProps.class ).createUnmarshaller();
+      return (StepMetaProps) unmarshaller.unmarshal( bais );
+    } catch ( IOException | JAXBException e ) {
+      throw new RuntimeException( e );
+    }
+  }
+
+  public static StepMetaProps deserialize( Node node ) {
+    return deserialize( nodeToString( XMLHandler.getSubNode( node, STEP_TAG ) ) );
+  }
+
+
+  /**
+   * Sets the namespaces used for deserialization, and converts to a string.
+   * <p>
+   * Shouldn't need to convert from Node->String, since the Unmarshaller should be able
+   * to take the node directly, but hit issues with the namespace not being read properly.
+   */
+  private static String nodeToString( Node node ) {
+    checkArgument( node instanceof Element );
+
+    StringWriter sw = new StringWriter();
+    try {
+      ( (Element) node )
+        .setAttributeNS( XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "xmlns:xsi",
+          "http://www.w3.org/2001/XMLSchema-instance" );
+      ( (Element) node )
+        .setAttributeNS( XMLConstants.XMLNS_ATTRIBUTE_NS_URI,
+          "xmlns:xs", "http://www.w3.org/2001/XMLSchema" );
+      TransformerFactory.newInstance()
+        .newTransformer()
+        .transform( new DOMSource( node ), new StreamResult( sw ) );
+    } catch ( TransformerException te ) {
+      throw new RuntimeException( te );
+    }
+    return sw.toString();
+  }
+
+}

--- a/engine/src/main/java/org/pentaho/di/core/util/serialization/README.md
+++ b/engine/src/main/java/org/pentaho/di/core/util/serialization/README.md
@@ -1,0 +1,49 @@
+Classes in this package support serializing/deserializing StepMetaInterface objects by leveraging 
+MetadataInjection annotations, eliminating the need to write tedious metadata serialization code.
+
+The simplest way for a step to use this strategy is to extend 
+the BaseSerializingMeta class, which implements the 
+  ````
+  .loadXML() / .getXML() 
+  .readRep() / .saveRep() 
+````
+
+The MetaXmlSerializer implementation uses JAXB.  The output XML will have a form like:
+```
+    <step-props>
+      <group name="some_group">
+        <property name="Prop1">
+          <value xsi:type="xs:string">value</value>
+        </property>
+        <property name="isLarge">
+          <value xsi:type="xs:boolean">false</value>
+        </property>
+      </group>
+    </step-props>
+```
+
+To serialize XML within a StepMetaInterface implementation, the call
+is:
+  ` MetaXmlSerializer.serialize( StepMetaProps.from( myMeta ) )`
+
+For deserialization:
+  ` MetaXmlSerializer.deserialize( xml ).to( myMeta )`
+
+Repo writes/reads use
+
+  ```
+RepoSerializer
+         .builder()
+         .repo( repo )
+         .stepMeta( stepMeta )
+         .stepId( stepId )
+         .transId( transId )
+         .serialize()   /  .deserialize()
+```
+
+If any properties need to be encrypted, mark them with the @Sensitive annotation.
+
+
+TODO:
+* Support for @InjectionDeep
+* Support for database lists / metastore

--- a/engine/src/main/java/org/pentaho/di/core/util/serialization/RepoSerializer.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/serialization/RepoSerializer.java
@@ -1,0 +1,131 @@
+
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.util.serialization;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.step.StepMetaInterface;
+
+import static java.util.Objects.requireNonNull;
+import static org.pentaho.di.core.util.serialization.StepMetaProps.from;
+
+/**
+ * Writes/Reads StepMetaInterface to and from a {@link Repository}
+ * <p>
+ * Usage:
+ * <p>
+ * RepoSerializer
+ * .builder()
+ * .repo( repo )
+ * .stepMeta( stepMeta )
+ * .stepId( stepId )
+ * .transId( transId )
+ * .serialize();
+ * <p>
+ * Future enhancement could cover inclusion of Metastore and Databases for steps which need that info.
+ */
+public class RepoSerializer {
+
+  private final StepMetaInterface stepMetaInterface;
+  private final Repository rep;
+  private final ObjectId idTrans;
+  private final ObjectId idStep;
+  private static final String REPO_TAG = "step-xml";
+
+  private RepoSerializer( StepMetaInterface stepMetaInterface, Repository rep, ObjectId idTrans, ObjectId idStep ) {
+    this.stepMetaInterface = stepMetaInterface;
+    this.rep = rep;
+    this.idTrans = idTrans;
+    this.idStep = idStep;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public void serialize()
+    throws KettleException {
+    String xml = MetaXmlSerializer.serialize(
+      from( stepMetaInterface ) ); //.encryptedFields( encryptedFields ) );
+
+    rep.saveStepAttribute( idTrans, idStep, REPO_TAG, xml );
+  }
+
+  public void deserialize()
+    throws KettleException {
+    String xml = rep.getStepAttributeString( idStep, REPO_TAG );
+    requireNonNull( MetaXmlSerializer.deserialize( xml ) )
+      .to( stepMetaInterface );
+  }
+
+  public static class Builder {
+
+    private Repository repo;
+    private StepMetaInterface stepMetaInterface;
+    private ObjectId idTrans;
+    private ObjectId idStep;
+
+    public Builder repo( Repository repo ) {
+      this.repo = repo;
+      return this;
+    }
+
+    public Builder stepMeta( StepMetaInterface stepMetaInterface ) {
+      this.stepMetaInterface = stepMetaInterface;
+      return this;
+    }
+
+    public Builder transId( ObjectId idTrans ) {
+      this.idTrans = idTrans;
+      return this;
+    }
+
+    public Builder stepId( ObjectId idStep ) {
+      this.idStep = idStep;
+      return this;
+    }
+
+    public void serialize() throws KettleException {
+      new RepoSerializer(
+        requireNonNull( stepMetaInterface ),
+        requireNonNull( repo ),
+        requireNonNull( idTrans ),
+        requireNonNull( idStep ) )
+        .serialize();
+    }
+
+    public void deserialize() throws KettleException {
+      new RepoSerializer(
+        requireNonNull( stepMetaInterface ),
+        requireNonNull( repo ),
+        null,
+        requireNonNull( idStep ) )
+        .deserialize();
+    }
+
+
+  }
+
+}

--- a/engine/src/main/java/org/pentaho/di/core/util/serialization/Sensitive.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/serialization/Sensitive.java
@@ -1,0 +1,28 @@
+/*
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ * **************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.core.util.serialization;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention ( RetentionPolicy.RUNTIME )
+public @interface Sensitive {
+}

--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,6 +31,7 @@ import org.pentaho.di.core.parameters.NamedParams;
 import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.util.CurrentDirectoryResolver;
 import org.pentaho.di.core.util.Utils;
+import org.pentaho.di.core.util.serialization.BaseSerializingMeta;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.HasRepositoryDirectories;
@@ -40,7 +41,7 @@ import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.resource.ResourceDefinition;
 import org.pentaho.di.resource.ResourceNamingInterface;
-import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.metastore.api.IMetaStore;
 
 import java.util.Arrays;
@@ -55,7 +56,7 @@ import java.util.Set;
  * @since 02-jan-2017
  * @author Yury Bakhmutski
  */
-public abstract class StepWithMappingMeta extends BaseStepMeta implements HasRepositoryDirectories {
+public abstract class StepWithMappingMeta extends BaseSerializingMeta implements HasRepositoryDirectories, StepMetaInterface {
   //default value
   private static Class<?> PKG = StepWithMappingMeta.class;
 
@@ -147,13 +148,13 @@ public abstract class StepWithMappingMeta extends BaseStepMeta implements HasRep
           // rep is null, let's try loading by filename
           try {
             mappingTransMeta =
-              new TransMeta( realDirectory + "/" + realTransname, metaStore, rep, true, tmpSpace, null );
+              new TransMeta( realDirectory + "/" + realTransname, metaStore, null, true, tmpSpace, null );
           } catch ( KettleException ke ) {
             try {
               // add .ktr extension and try again
               mappingTransMeta =
                 new TransMeta( realDirectory + "/" + realTransname + "." + Const.STRING_TRANS_DEFAULT_EXT, metaStore,
-                  rep, true, tmpSpace, null );
+                  null, true, tmpSpace, null );
             } catch ( KettleException ke2 ) {
               throw new KettleException( BaseMessages.getString( PKG, "StepWithMappingMeta.Exception.UnableToLoadTrans",
                 realTransname ) + realDirectory );

--- a/engine/src/test/java/org/pentaho/di/core/util/serialization/MetaXmlSerializerTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/util/serialization/MetaXmlSerializerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ * **************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.core.util.serialization;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+
+import java.util.Collections;
+
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class MetaXmlSerializerTest {
+
+  @Before public void before() throws KettleException {
+    KettleEnvironment.init();
+  }
+
+  @Test public void testRoundTrip() {
+    StepMetaPropsTest.FooMeta fooMeta = StepMetaPropsTest.getTestFooMeta();
+    StepMetaPropsTest.FooMeta deserializedMeta = new StepMetaPropsTest.FooMeta();
+
+    requireNonNull( MetaXmlSerializer.deserialize(
+      MetaXmlSerializer.serialize(
+        StepMetaProps.from( fooMeta ) ) ) )
+      .to( deserializedMeta );
+
+    assertThat( fooMeta, equalTo( deserializedMeta ) );
+  }
+
+
+  @Test public void testRoundTripWithEmptyList() {
+    StepMetaPropsTest.FooMeta fooMeta = StepMetaPropsTest.getTestFooMeta();
+    StepMetaPropsTest.FooMeta deserializedMeta = new StepMetaPropsTest.FooMeta();
+
+    fooMeta.alist = Collections.emptyList();
+
+    requireNonNull( MetaXmlSerializer.deserialize(
+      MetaXmlSerializer.serialize(
+        StepMetaProps.from( fooMeta ) ) ) )
+      .to( deserializedMeta );
+
+    assertThat( deserializedMeta, equalTo( fooMeta ) );
+  }
+
+
+}

--- a/engine/src/test/java/org/pentaho/di/core/util/serialization/RepoSerializerTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/util/serialization/RepoSerializerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ * **************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.core.util.serialization;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.pentaho.di.core.util.serialization.MetaXmlSerializer.serialize;
+import static org.pentaho.di.core.util.serialization.StepMetaProps.from;
+
+@RunWith ( MockitoJUnitRunner.class )
+public class RepoSerializerTest {
+
+  @Mock private Repository repo;
+  @Mock private ObjectId transId, stepId;
+
+  private StepMetaPropsTest.FooMeta stepMeta = StepMetaPropsTest.getTestFooMeta();
+
+  @Before public void before() throws KettleException {
+    KettleEnvironment.init();
+  }
+
+  @Test
+  public void testSerialize() throws KettleException {
+    RepoSerializer
+      .builder()
+      .repo( repo )
+      .stepId( stepId )
+      .transId( transId )
+      .stepMeta( stepMeta )
+      .serialize();
+    verify( repo, times( 1 ) )
+      .saveStepAttribute( transId, stepId, "step-xml",
+        serialize( from( stepMeta ) ) );
+  }
+
+  @Test
+  public void testDeserialize() throws KettleException {
+    StepMetaPropsTest.FooMeta blankMeta = new StepMetaPropsTest.FooMeta();
+    when( repo.getStepAttributeString( stepId, "step-xml" ) ).thenReturn( serialize( from( stepMeta ) ) );
+
+    RepoSerializer
+      .builder()
+      .repo( repo )
+      .stepId( stepId )
+      .stepMeta( blankMeta )
+      .deserialize();
+
+    // blankMeta hydrated from the RepoSerializer should be the same as the serialized stepMeta
+    assertThat( stepMeta, equalTo( blankMeta ) );
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/core/util/serialization/StepMetaPropsTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/util/serialization/StepMetaPropsTest.java
@@ -1,0 +1,175 @@
+/*
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ * **************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pentaho.di.core.util.serialization;
+
+import com.google.common.base.Objects;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.injection.Injection;
+import org.pentaho.di.core.injection.InjectionSupported;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.step.StepInterface;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.streaming.common.BaseStreamStepMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+public class StepMetaPropsTest {
+
+
+  @InjectionSupported ( localizationPrefix = "stuff", groups = { "stuffGroup" } ) static class FooMeta
+    extends BaseStreamStepMeta {
+
+    @Sensitive
+    @Injection ( name = "FIELD1", group = "stuffGroup" ) String field1 = "default";
+    @Injection ( name = "FIELD2", group = "stuffGroup" ) int field2 = 123;
+
+    @Sensitive
+    @Injection ( name = "PassVerd" ) String password = "should.be.encrypted";
+
+
+    @Injection ( name = "ALIST" ) List<String> alist = new ArrayList<>();
+
+    @Sensitive
+    @Injection ( name = "SECURELIST" ) List<String> securelist = new ArrayList<>();
+
+    @Injection ( name = "BOOLEANLIST" ) List<Boolean> blist = new ArrayList<>();
+    @Injection ( name = "IntList" ) List<Integer> ilist = new ArrayList<>();
+
+
+    @Override
+    public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr,
+                                  TransMeta transMeta,
+                                  Trans trans ) {
+      return null;
+    }
+
+    @Override public StepDataInterface getStepData() {
+      return null;
+    }
+
+    @Override public boolean equals( Object o ) {
+      if ( this == o ) {
+        return true;
+      }
+      if ( o == null || getClass() != o.getClass() ) {
+        return false;
+      }
+      FooMeta fooMeta = (FooMeta) o;
+      return field2 == fooMeta.field2
+        && Objects.equal( field1, fooMeta.field1 )
+        && Objects.equal( alist, fooMeta.alist )
+        && Objects.equal( blist, fooMeta.blist )
+        && Objects.equal( ilist, fooMeta.ilist );
+    }
+
+    @Override public int hashCode() {
+      return Objects.hashCode( field1, field2, alist );
+    }
+
+    @Override public String toString() {
+      return String
+        .format( "FooMeta{%nfield1='%s', %nfield2=%d, %nalist=%s, %nblist=%s, %nilist=%s}",
+          field1, field2, alist, blist, ilist );
+    }
+  }
+
+
+  @Before
+  public void before() throws KettleException {
+    KettleEnvironment.init();
+  }
+
+  @Test
+  public void testToAndFrom() {
+    FooMeta foo = getTestFooMeta();
+
+    StepMetaProps fromMeta = StepMetaProps.from( foo );
+
+    FooMeta toMeta = new FooMeta();
+    fromMeta.to( toMeta );
+
+    assertThat( foo, equalTo( toMeta ) );
+  }
+
+  @Test
+  public void testEncrypt() {
+    FooMeta foo = getTestFooMeta();
+    foo.password = "p@ssword";
+    StepMetaProps stepMetaProps = StepMetaProps.from( foo );
+
+    assertThat( "password field should be encrypted, so should not be present in the .toString of the props",
+      stepMetaProps.toString(), not( containsString( "p@ssword" ) ) );
+
+    FooMeta toMeta = new FooMeta();
+    stepMetaProps.to( toMeta );
+
+    assertThat( foo, equalTo( toMeta ) );
+    assertThat( "p@ssword", equalTo( toMeta.password ) );
+  }
+
+  @Test
+  public void testEncryptedList() {
+    FooMeta foo = getTestFooMeta();
+
+    foo.securelist = asList( "shadow", "substance" );
+    StepMetaProps stepMetaProps = StepMetaProps.from( foo );
+
+
+    assertThat(
+      "secureList should be encrypted, so raw values should not be present in the .toString of the props",
+      stepMetaProps.toString(), not( containsString( "expectedString" ) ) );
+    asList( "shadow", "substance" ).forEach( val ->
+      assertThat( val + " should be encrypted, so should not be present in the .toString of the props",
+        stepMetaProps.toString(), not( containsString( val ) ) ) );
+
+    FooMeta toMeta = new FooMeta();
+    stepMetaProps.to( toMeta );
+
+    assertThat( foo, equalTo( toMeta ) );
+    assertThat( asList( "shadow", "substance" ), equalTo( toMeta.securelist ) );
+  }
+
+
+  static FooMeta getTestFooMeta() {
+    FooMeta foo = new FooMeta();
+
+    foo.field1 = "expectedString";
+    foo.field2 = 42;
+    foo.alist = asList( "one", "two", "three", "four" );
+    foo.blist = asList( true, false, false );
+    foo.ilist = asList( 1, 4, 26 );
+    return foo;
+  }
+
+
+}


### PR DESCRIPTION
 **StepMetaProps** - a slim "holder" for stepmeta properties
 **JAXBMetaSerializer** - reads and writes StepMetaProps as XML using JAXB
 **RepoSerializer** - reads and writes StepMetaProps to a repository.

To serialize XML within a StepMetaInterface implementation, the call
is:
  ` JAXBMetaSerializer.serialize( StepMetaProps.from( myMeta ) )`

For deserialization:
  ` JAXBMetaSerializer.deserialize( xml ).to( myMeta )`

Repo writes/reads use

  ```
RepoSerializer
         .builder()
         .repo( repo )
         .stepMeta( stepMeta )
         .stepId( stepId )
         .transId( transId )
         .serialize()   /  .deserialize()
```