### PR TITLE
[SP-4187][BACKLOG-21008] Yarn job hangs in Transformation step set wi…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -512,4 +512,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/core/src/main/java/org/pentaho/di/core/logging/KettleLogStore.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/KettleLogStore.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -88,8 +88,8 @@ public class KettleLogStore {
 
         if ( maxLogTimeoutMinutes > 0 ) {
           long minTimeBoundary = new Date().getTime() - maxLogTimeoutMinutes * 60 * 1000;
-          // Remove all lines at once to prevent concurrent modification problems.
-          //
+
+          // Remove all the old lines.
           appender.removeBufferLinesBefore( minTimeBoundary );
         }
       }

--- a/core/src/test/java/org/pentaho/di/concurrency/ConcurrencyTestRunner.java
+++ b/core/src/test/java/org/pentaho/di/concurrency/ConcurrencyTestRunner.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/core/src/test/java/org/pentaho/di/concurrency/ExecutionResult.java
+++ b/core/src/test/java/org/pentaho/di/concurrency/ExecutionResult.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,9 +30,6 @@ import java.util.concurrent.Future;
  */
 class ExecutionResult<T> {
   static <T> ExecutionResult<T> from( Future<? extends T> future ) {
-    if ( !future.isDone() ) {
-      throw new IllegalArgumentException( "Future is not completed yet" );
-    }
     try {
       return new ExecutionResult<T>( future.get(), null );
     } catch ( InterruptedException e ) {

--- a/core/src/test/java/org/pentaho/di/concurrency/LoggingBufferConcurrencyTest.java
+++ b/core/src/test/java/org/pentaho/di/concurrency/LoggingBufferConcurrencyTest.java
@@ -1,0 +1,88 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.concurrency;
+
+import org.junit.Test;
+import org.pentaho.di.core.logging.KettleLoggingEvent;
+import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.logging.LogMessage;
+import org.pentaho.di.core.logging.LoggingBuffer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class LoggingBufferConcurrencyTest {
+
+    private LoggingBuffer buffer;
+
+    @Test
+    public void shouldNotFailProcessingEventsUnderHighContention() throws Exception {
+        int modifiersAmount = 100;
+        int readersAmount = 100;
+
+        buffer = new LoggingBuffer( 5000 );
+
+        AtomicBoolean condition = new AtomicBoolean( true );
+
+        List<StopOnErrorCallable<?>> modifiers = new ArrayList<>();
+        for ( int i = 0; i < modifiersAmount; i++ ) {
+            modifiers.add( new Appender( condition ) );
+        }
+        List<StopOnErrorCallable<?>> readers = new ArrayList<>();
+        for ( int i = 0; i < readersAmount; i++ ) {
+            readers.add( new Reader( condition ) );
+        }
+
+        ConcurrencyTestRunner<?, ?> runner =
+                new ConcurrencyTestRunner<>( modifiers, readers, condition, 5000 );
+        runner.runConcurrentTest();
+        runner.checkNoExceptionRaised();
+    }
+
+    private class Appender extends StopOnErrorCallable<Void> {
+      Appender( AtomicBoolean condition ) {
+        super( condition );
+      }
+
+      @Override
+      Void doCall() {
+        for ( int i = 0; i < 5000; i++ ) {
+          buffer.addLogggingEvent( new KettleLoggingEvent(
+              new LogMessage( "subject", LogLevel.DEBUG ), System.currentTimeMillis(), LogLevel.DEBUG ) );
+        }
+        return null;
+      }
+    }
+
+    private class Reader extends StopOnErrorCallable<StringBuffer> {
+      Reader( AtomicBoolean condition ) {
+        super( condition );
+      }
+
+      @Override
+      StringBuffer doCall() {
+        return buffer.getBuffer();
+      }
+    }
+}

--- a/core/src/test/java/org/pentaho/di/concurrency/StopOnErrorCallable.java
+++ b/core/src/test/java/org/pentaho/di/concurrency/StopOnErrorCallable.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/core/src/test/java/org/pentaho/di/core/logging/LoggingBufferTest.java
+++ b/core/src/test/java/org/pentaho/di/core/logging/LoggingBufferTest.java
@@ -1,7 +1,7 @@
 /*
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  * **************************************************************************
  *
@@ -147,7 +147,7 @@ public class LoggingBufferTest {
   }
 
   @Test
-  public void testRemoveBufferLinesBefore() throws Exception {
+  public void testRemoveBufferLinesBefore() {
     LoggingBuffer loggingBuffer = new LoggingBuffer( 100 );
     for ( int i = 0; i < 40; i++ ) {
       KettleLoggingEvent event = new KettleLoggingEvent();
@@ -157,7 +157,6 @@ public class LoggingBufferTest {
     }
     loggingBuffer.removeBufferLinesBefore( 20 );
     Assert.assertEquals( 20, loggingBuffer.size() );
-    Assert.assertEquals(  0, loggingBuffer.getBufferLinesBefore( 20 ).size() );
   }
 
 }

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -871,6 +871,13 @@
 
     <!-- Test dependencies -->
     <dependency>
+      <groupId>pentaho-kettle</groupId>
+      <artifactId>kettle-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
…th run

configuration Clusterd & never ends
 - replaced LinkedBlockingDeque with a plain ArrayList defended by
   ReadWriteLock, as LBD is not fully thread-safe due to bug in JDK.
   Also, LBD does not seem to be the right collection for LoggingBuffer
   (for exmaple, even though it is backed by linked list, iterator.remove
   runs in a linear time).
 - added concurrent test for logging buffer
 - moved ConcurrentTestRunner utility to the core module
 - added test jar to core module to be used by engine module, since it still needs
   ConcurrentTestRunner