### PR TITLE
[PDI-16932] Specifying the Select Fieldname in the Metadata Injectionstep does not give correct results.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -922,11 +922,11 @@ public class SelectValuesMeta extends BaseStepMeta implements StepMetaInterface 
 
     /** Select: length of field */
     @Injection( name = "FIELD_LENGTH", group = "FIELDS" )
-    private int length;
+    private int length = UNDEFINED;
 
     /** Select: Precision of field (for numbers) */
     @Injection( name = "FIELD_PRECISION", group = "FIELDS" )
-    private int precision;
+    private int precision = UNDEFINED;
 
     public String getName() {
       return name;

--- a/engine/src/test/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesMetaInjectionTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesMetaInjectionTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -145,5 +145,15 @@ public class SelectValuesMetaInjectionTest extends BaseMetadataInjectionTest<Sel
 
     // TODO check field type plugins
     skipPropertyTest( "META_TYPE" );
+  }
+
+  //PDI-16932 test default values length and precision after injection
+  @Test
+  public void testDefaultValue() throws Exception {
+    ValueMetaInterface valueMeta = new ValueMetaString( "f" );
+    injector.setProperty( meta, "FIELD_NAME", setValue( valueMeta, "testValue" ), "f" );
+    nonTestedProperties.clear(); // we don't need to test other properties
+    assertEquals( SelectValuesMeta.UNDEFINED, meta.getSelectFields()[ 0 ].getLength() );
+    assertEquals( SelectValuesMeta.UNDEFINED, meta.getSelectFields()[ 0 ].getPrecision() );
   }
 }


### PR DESCRIPTION
[PDI-16932] Specifying the Select Fieldname in the Metadata Injectionstep does not give correct results.
added default value for default values for length and precision