### PR TITLE
[BACKLOG-21866] Removing nonNull requirement for trans and step objid

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/util/serialization/RepoSerializer.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/serialization/RepoSerializer.java
@@ -111,8 +111,8 @@ public class RepoSerializer {
       new RepoSerializer(
         requireNonNull( stepMetaInterface ),
         requireNonNull( repo ),
-        requireNonNull( idTrans ),
-        requireNonNull( idStep ) )
+        idTrans,
+        idStep )
         .serialize();
     }
 
@@ -121,7 +121,7 @@ public class RepoSerializer {
         requireNonNull( stepMetaInterface ),
         requireNonNull( repo ),
         null,
-        requireNonNull( idStep ) )
+        idStep )
         .deserialize();
     }
 


### PR DESCRIPTION
They can be null during repo save operations.