### PR TITLE
[BACKLOG-19695][CLEANUP] Remove unused property for commons-vfs2 version

### DIFF
--- a/plugins/xml-input-stream/pom.xml
+++ b/plugins/xml-input-stream/pom.xml
@@ -35,7 +35,6 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
-    <commons-vfs2.version>2.1-20150824</commons-vfs2.version>
     <pdi.version>8.1.0.0-SNAPSHOT</pdi.version>
     <mockito.version>1.9.5</mockito.version>
   </properties>

--- a/plugins/xml/pom.xml
+++ b/plugins/xml/pom.xml
@@ -33,7 +33,6 @@
   <properties>
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
-    <commons-vfs2.version>2.1-20150824</commons-vfs2.version>
     <pdi.version>8.1.0.0-SNAPSHOT</pdi.version>
     <mockito.version>1.9.5</mockito.version>
     <saxon.version>8.7</saxon.version>


### PR DESCRIPTION
The property exists but it's not used in this or any child project.

Related PRs:
https://github.com/pentaho/pentaho-det-ee/pull/530
https://github.com/pentaho/pentaho-det/pull/1142
https://github.com/pentaho/pentaho-ee/pull/1066