### PR TITLE
[BACKLOG-19695] Update commons-vfs2 artifact version from 2.1 to 2.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,7 +29,7 @@
     <spring.framework.version>4.3.2.RELEASE</spring.framework.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-vfs2.version>2.1-20150824</commons-vfs2.version>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
     <commons-io.version>2.2</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-pool.version>1.5.7</commons-pool.version>

--- a/plugins/google-analytics/core/pom.xml
+++ b/plugins/google-analytics/core/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <pdi.version>8.1.0.0-SNAPSHOT</pdi.version>
-    <commons-vfs2.version>2.1-20150824</commons-vfs2.version>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-logging.version>1.2</commons-logging.version>

--- a/plugins/gpload/pom.xml
+++ b/plugins/gpload/pom.xml
@@ -37,7 +37,7 @@
 
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
-    <commons-vfs2.version>2.1-20150824</commons-vfs2.version>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
     <pdi.version>8.1.0.0-SNAPSHOT</pdi.version>
     <mockito.version>1.9.5</mockito.version>
   </properties>

--- a/plugins/json/core/pom.xml
+++ b/plugins/json/core/pom.xml
@@ -19,7 +19,7 @@
     <metaverse.version>8.1.0.0-SNAPSHOT</metaverse.version>
     <platform.version>8.1.0.0-SNAPSHOT</platform.version>
     <commons.io.version>1.4</commons.io.version>
-    <commons-vfs2.version>2.1-20150824</commons-vfs2.version>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
     <encoder.version>1.2</encoder.version>

--- a/plugins/openerp/pom.xml
+++ b/plugins/openerp/pom.xml
@@ -38,7 +38,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
-    <commons-vfs2.version>2.1-20150824</commons-vfs2.version>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
     <pdi.version>8.1.0.0-SNAPSHOT</pdi.version>
     <mockito.version>1.9.5</mockito.version>
     <openerp-java-api.version>1.3.0</openerp-java-api.version>

--- a/plugins/pentaho-googledrive-vfs/core/pom.xml
+++ b/plugins/pentaho-googledrive-vfs/core/pom.xml
@@ -18,7 +18,7 @@
         <project.http.version>1.22.0</project.http.version>
         <project.oauth.version>1.22.0</project.oauth.version>
         <!--project.build.sourceEncoding>UTF-8</project.build.sourceEncoding-->
-        <project.commons-vfs2.version>2.1-20150824</project.commons-vfs2.version>
+        <project.commons-vfs2.version>2.2</project.commons-vfs2.version>
         <project.junit.version>4.4</project.junit.version>
         <project.mockito.version>1.8.4</project.mockito.version>
         <pdi.version>8.1.0.0-SNAPSHOT</pdi.version>

--- a/plugins/repositories/core/pom.xml
+++ b/plugins/repositories/core/pom.xml
@@ -24,7 +24,7 @@
     <osgi.version>4.3.1</osgi.version>
     <json-simple.version>1.1</json-simple.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
-    <commons-vfs2.version>2.1-20150824</commons-vfs2.version>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
     <eclipse.version>3.6.0</eclipse.version>
     <pax-web-spi.version>3.1.4</pax-web-spi.version>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
**Warning:** To be merged together with all other projects that need this change, **please do not merge** until then 

**This PR relates to:**
https://github.com/pentaho/pentaho-commons-database/pull/152
https://github.com/pentaho/apache-vfs-browser/pull/42
https://github.com/pentaho/data-access/pull/992
https://github.com/pentaho/mondrian/pull/1033
https://github.com/pentaho/pdi-jms-plugin/pull/53
https://github.com/pentaho/pdi-platform-utils-plugin/pull/92
https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/76
https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/39
https://github.com/pentaho/big-data-plugin/pull/1340
https://github.com/pentaho/pentaho-cassandra-plugin/pull/106
https://github.com/pentaho/pentaho-data-mining/pull/15
https://github.com/pentaho/pentaho-det-ee/pull/531
https://github.com/pentaho/pentaho-ee/pull/1072
https://github.com/pentaho/pentaho-hadoop-shims/pull/733
https://github.com/pentaho/pentaho-hdfs-vfs/pull/20
https://github.com/pentaho/pentaho-kettle/pull/5051
https://github.com/pentaho/pentaho-reporting/pull/1112
https://github.com/pentaho/pentaho-platform/pull/4077
https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1254
https://github.com/pentaho/pentaho-platform-plugin-geo/pull/242
https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/693
https://github.com/pentaho/pentaho-s3-vfs/pull/31