### PR TITLE
[PDI-16845] When accessing files using vfs, sftp connections remain o…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/fileinput/FileInputList.java
+++ b/core/src/main/java/org/pentaho/di/core/fileinput/FileInputList.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -35,15 +35,12 @@ import org.apache.commons.vfs2.AllFileSelector;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileType;
-import org.apache.commons.vfs2.provider.sftp.SftpFileObject;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.KettleVFS;
-import org.pentaho.di.core.vfs.SftpFileObjectWithWindowsSupport;
-import org.pentaho.di.core.vfs.SftpFileSystemWindowsProvider;
 
 public class FileInputList {
   private List<FileObject> files = new ArrayList<FileObject>();
@@ -234,10 +231,6 @@ public class FileInputList {
               if ( fileObjects != null ) {
                 for ( int j = 0; j < fileObjects.length; j++ ) {
                   FileObject fileObject = fileObjects[ j ];
-                  if ( fileObject instanceof SftpFileObject ) {
-                    fileObject = new SftpFileObjectWithWindowsSupport( (SftpFileObject) fileObject,
-                      SftpFileSystemWindowsProvider.getSftpFileSystemWindows( (SftpFileObject) fileObject ) );
-                  }
                   if ( fileObject.exists() ) {
                     fileInputList.addFile( fileObject );
                   }

--- a/core/src/main/java/org/pentaho/di/core/vfs/ConcurrentFileSystemManager.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/ConcurrentFileSystemManager.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -51,7 +51,7 @@ public class ConcurrentFileSystemManager extends StandardFileSystemManager {
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
   public ConcurrentFileSystemManager() {
-    setConfiguration( StandardFileSystemManager.class.getResource( CONFIG_RESOURCE ) );
+    setConfiguration( this.getClass().getResource( CONFIG_RESOURCE ) );
   }
 
   @Override

--- a/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
@@ -30,8 +30,8 @@ import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.cache.WeakRefFilesCache;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
+import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.commons.vfs2.provider.local.LocalFile;
-import org.apache.commons.vfs2.provider.sftp.SftpFileObject;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.util.UUIDUtil;
@@ -148,20 +148,11 @@ public class KettleVFS {
         }
       }
 
-      FileObject fileObject = null;
-
       if ( fsOptions != null ) {
-        fileObject = fsManager.resolveFile( filename, fsOptions );
+        return fsManager.resolveFile( filename, fsOptions );
       } else {
-        fileObject = fsManager.resolveFile( filename );
+        return fsManager.resolveFile( filename );
       }
-
-      if ( fileObject instanceof SftpFileObject ) {
-        fileObject = new SftpFileObjectWithWindowsSupport( (SftpFileObject) fileObject,
-                SftpFileSystemWindowsProvider.getSftpFileSystemWindows( (SftpFileObject) fileObject ) );
-      }
-
-      return fileObject;
     } catch ( IOException e ) {
       throw new KettleFileException( "Unable to get VFS File object for filename '"
         + cleanseFilename( vfsFilename ) + "' : " + e.getMessage(), e );
@@ -522,6 +513,13 @@ public class KettleVFS {
     } catch ( FileSystemException ignored ) {
     }
 
+  }
+
+  /**
+   * @see StandardFileSystemManager#freeUnusedResources()
+   */
+  public static void freeUnusedResources() {
+    ( (StandardFileSystemManager) getInstance().getFileSystemManager() ).freeUnusedResources();
   }
 
   public enum Suffix {

--- a/core/src/main/java/org/pentaho/di/core/vfs/SftpFileObjectWithWindowsSupport.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/SftpFileObjectWithWindowsSupport.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,23 +22,14 @@
 
 package org.pentaho.di.core.vfs;
 
-import org.apache.commons.vfs2.FileContent;
-import org.apache.commons.vfs2.FileName;
-import org.apache.commons.vfs2.FileObject;
-import org.apache.commons.vfs2.FileSelector;
-import org.apache.commons.vfs2.FileSystem;
 import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileType;
-import org.apache.commons.vfs2.NameScope;
-import org.apache.commons.vfs2.operations.FileOperations;
+import org.apache.commons.vfs2.provider.AbstractFileName;
 import org.apache.commons.vfs2.provider.sftp.SftpFileObject;
 
-import java.net.URL;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-public class SftpFileObjectWithWindowsSupport implements FileObject {
+class SftpFileObjectWithWindowsSupport extends SftpFileObject {
 
   //icacls windows command permissions
   private static final String FULL_ACCESS = "(F)";
@@ -49,264 +40,53 @@ public class SftpFileObjectWithWindowsSupport implements FileObject {
   private static final String WRITE_DATA_ADD_FILES_ACCESS = "WD";
   private static final String READ_DATA_ADD_FILES_ACCESS = "RD";
 
-  private SftpFileObject sftpFileObject;
-  private SftpFileSystemWindows sftpFileSystemWindows;
   private String path;
 
-
-  public SftpFileObjectWithWindowsSupport( SftpFileObject sftpFileObject,
-                                           SftpFileSystemWindows sftpFileSystemWindows ) throws FileSystemException {
-    this.sftpFileObject = sftpFileObject;
-    this.path = sftpFileObject.getName().getPath();
-    this.sftpFileSystemWindows = sftpFileSystemWindows;
+  SftpFileObjectWithWindowsSupport( AbstractFileName name, SftpFileSystemWindows fileSystem )
+          throws FileSystemException {
+    super( name, fileSystem );
+    this.path = name.getPath();
   }
-
 
   @Override
-  public boolean isReadable() throws FileSystemException {
-    try {
-      if ( !this.sftpFileSystemWindows.isRemoteHostWindows() ) {
-        return sftpFileObject.isReadable();
-      } else {
-        return this.exists() && this.doIsReadable();
-      }
+  protected boolean doIsReadable() throws Exception {
+    SftpFileSystemWindows fileSystem = (SftpFileSystemWindows) getAbstractFileSystem();
+    if ( !fileSystem.isRemoteHostWindows() ) {
+      return super.doIsReadable();
+    } else {
+      List<String> userGroups = fileSystem.getUserGroups();
+      Map<String, String> filePermissions = fileSystem.getFilePermission( this.path );
 
-    } catch ( Exception var ) {
-      throw new FileSystemException( "vfs.provider/check-is-readable.error", sftpFileObject.getName(), var );
-    }
-  }
-
-  private boolean doIsReadable() throws Exception {
-    boolean readable;
-    List<String> userGroups = this.sftpFileSystemWindows.getUserGroups();
-    Map<String, String> filePermissions = this.sftpFileSystemWindows.getFilePermission( this.path );
-
-    for ( String group : userGroups ) {
-      String acl = filePermissions.get( group );
-      if ( acl != null ) {
-        readable = acl.contains( FULL_ACCESS ) || acl.contains( MODIFY_ACCESS )
-                || acl.contains( READ_AND_EXECUTE_ACCESS ) || acl.contains( READ_ACCESS )
-                || acl.contains( WRITE_ACCESS ) || acl.contains( WRITE_DATA_ADD_FILES_ACCESS )
-                || acl.contains( READ_DATA_ADD_FILES_ACCESS );
-        if ( readable ) {
-          return true;
+      for ( String group : userGroups ) {
+        String acl = filePermissions.get( group );
+        if ( acl != null ) {
+          return acl.contains( FULL_ACCESS ) || acl.contains( MODIFY_ACCESS )
+                  || acl.contains( READ_AND_EXECUTE_ACCESS ) || acl.contains( READ_ACCESS )
+                  || acl.contains( WRITE_ACCESS ) || acl.contains( WRITE_DATA_ADD_FILES_ACCESS )
+                  || acl.contains( READ_DATA_ADD_FILES_ACCESS );
         }
       }
+      return false;
     }
-    return false;
   }
 
   @Override
-  public boolean isWriteable() throws FileSystemException {
-    try {
-      if ( !this.sftpFileSystemWindows.isRemoteHostWindows() ) {
-        return sftpFileObject.isWriteable();
-      } else {
-        return this.exists() && this.doIsWriteable();
-      }
-
-    } catch ( Exception var ) {
-      throw new FileSystemException( "vfs.provider/check-is-writeable.error", sftpFileObject.getName(), var );
-    }
-  }
-
   protected boolean doIsWriteable() throws Exception {
-    boolean writeable;
-    List<String> userGroups = this.sftpFileSystemWindows.getUserGroups();
-    Map<String, String> filePermissions = this.sftpFileSystemWindows.getFilePermission( this.path );
+    SftpFileSystemWindows fileSystem = (SftpFileSystemWindows) getAbstractFileSystem();
+    if ( !fileSystem.isRemoteHostWindows() ) {
+      return super.doIsWriteable();
+    } else {
+      List<String> userGroups = fileSystem.getUserGroups();
+      Map<String, String> filePermissions = fileSystem.getFilePermission( this.path );
 
-    for ( String group : userGroups ) {
-      String acl = filePermissions.get( group );
-      if ( acl != null ) {
-        writeable = acl.contains( FULL_ACCESS ) || acl.contains( MODIFY_ACCESS )
-                || acl.contains( WRITE_ACCESS ) || acl.contains( WRITE_DATA_ADD_FILES_ACCESS );
-        if ( writeable ) {
-          return true;
+      for ( String group : userGroups ) {
+        String acl = filePermissions.get( group );
+        if ( acl != null ) {
+          return acl.contains( FULL_ACCESS ) || acl.contains( MODIFY_ACCESS )
+                  || acl.contains( WRITE_ACCESS ) || acl.contains( WRITE_DATA_ADD_FILES_ACCESS );
         }
       }
+      return false;
     }
-    return false;
   }
-
-  @Override
-  public boolean canRenameTo( FileObject fileObject ) {
-    return sftpFileObject.canRenameTo( fileObject );
-  }
-
-  @Override
-  public void close() throws FileSystemException {
-    sftpFileObject.close();
-  }
-
-  @Override
-  public void copyFrom( FileObject fileObject, FileSelector fileSelector ) throws FileSystemException {
-    sftpFileObject.copyFrom( fileObject, fileSelector );
-  }
-
-  @Override
-  public void createFile() throws FileSystemException {
-    sftpFileObject.createFile();
-  }
-
-  @Override
-  public void createFolder() throws FileSystemException {
-    sftpFileObject.createFolder();
-  }
-
-  @Override
-  public boolean delete() throws FileSystemException {
-    return sftpFileObject.delete();
-  }
-
-  @Override
-  public int delete( FileSelector fileSelector ) throws FileSystemException {
-    return sftpFileObject.delete( fileSelector );
-  }
-
-  @Override
-  public int deleteAll() throws FileSystemException {
-    return sftpFileObject.deleteAll();
-  }
-
-  @Override
-  public boolean exists() throws FileSystemException {
-    return sftpFileObject.exists();
-  }
-
-  @Override
-  public FileObject[] findFiles( FileSelector fileSelector ) throws FileSystemException {
-    return sftpFileObject.findFiles( fileSelector );
-  }
-
-  @Override
-  public void findFiles( FileSelector fileSelector, boolean b, List<FileObject> list ) throws FileSystemException {
-    sftpFileObject.findFiles( fileSelector, b, list );
-  }
-
-  @Override
-  public FileObject getChild( String s ) throws FileSystemException {
-    return sftpFileObject.getChild( s );
-  }
-
-  @Override
-  public FileObject[] getChildren() throws FileSystemException {
-    return sftpFileObject.getChildren();
-  }
-
-  @Override
-  public FileContent getContent() throws FileSystemException {
-    return sftpFileObject.getContent();
-  }
-
-  @Override
-  public FileOperations getFileOperations() throws FileSystemException {
-    return sftpFileObject.getFileOperations();
-  }
-
-  @Override
-  public FileSystem getFileSystem() {
-    return this.sftpFileSystemWindows;
-  }
-
-  @Override
-  public FileName getName() {
-    return sftpFileObject.getName();
-  }
-
-  @Override
-  public FileObject getParent() throws FileSystemException {
-    return sftpFileObject.getParent();
-  }
-
-  @Override
-  public String getPublicURIString() {
-    return sftpFileObject.getPublicURIString();
-  }
-
-  @Override
-  public FileType getType() throws FileSystemException {
-    return sftpFileObject.getType();
-  }
-
-  @Override
-  public URL getURL() throws FileSystemException {
-    return sftpFileObject.getURL();
-  }
-
-  @Override
-  public boolean isAttached() {
-    return sftpFileObject.isAttached();
-  }
-
-  @Override
-  public boolean isContentOpen() {
-    return sftpFileObject.isContentOpen();
-  }
-
-  @Override
-  public boolean isExecutable() throws FileSystemException {
-    return sftpFileObject.isExecutable();
-  }
-
-  @Override
-  public boolean isFile() throws FileSystemException {
-    return sftpFileObject.isFile();
-  }
-
-  @Override
-  public boolean isFolder() throws FileSystemException {
-    return sftpFileObject.isFolder();
-  }
-
-  @Override
-  public boolean isHidden() throws FileSystemException {
-    return sftpFileObject.isHidden();
-  }
-
-
-  @Override
-  public void moveTo( FileObject fileObject ) throws FileSystemException {
-    sftpFileObject.moveTo( fileObject );
-  }
-
-  @Override
-  public void refresh() throws FileSystemException {
-    sftpFileObject.refresh();
-  }
-
-  @Override
-  public FileObject resolveFile( String s ) throws FileSystemException {
-    return sftpFileObject.resolveFile( s );
-  }
-
-  @Override
-  public FileObject resolveFile( String s, NameScope nameScope ) throws FileSystemException {
-    return sftpFileObject.resolveFile( s, nameScope );
-  }
-
-  @Override
-  public boolean setExecutable( boolean b, boolean b1 ) throws FileSystemException {
-    return sftpFileObject.setExecutable( b, b1 );
-  }
-
-  @Override
-  public boolean setReadable( boolean b, boolean b1 ) throws FileSystemException {
-    return sftpFileObject.setReadable( b, b1 );
-  }
-
-  @Override
-  public boolean setWritable( boolean b, boolean b1 ) throws FileSystemException {
-    return sftpFileObject.setWritable( b, b1 );
-  }
-
-  @Override
-  public int compareTo( FileObject o ) {
-    return sftpFileObject.compareTo( o );
-  }
-
-  @Override
-  public Iterator<FileObject> iterator() {
-    return sftpFileObject.iterator();
-  }
-
 }

--- a/core/src/main/java/org/pentaho/di/core/vfs/SftpFileSystemWindows.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/SftpFileSystemWindows.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,9 +26,11 @@ import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.UserAuthenticationData;
+import org.apache.commons.vfs2.provider.AbstractFileName;
 import org.apache.commons.vfs2.provider.GenericFileName;
 import org.apache.commons.vfs2.provider.sftp.SftpClientFactory;
 import org.apache.commons.vfs2.provider.sftp.SftpFileProvider;
@@ -45,7 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class SftpFileSystemWindows extends SftpFileSystem {
+class SftpFileSystemWindows extends SftpFileSystem {
 
   private static final LogChannelInterface log = new LogChannel( "SftpFileSystemWindows" );
   private static final String WHO_AMI_GROUPS_FO_LIST = "Whoami /GROUPS /FO LIST"; //windows command for getting croups for current user
@@ -62,9 +64,28 @@ public class SftpFileSystemWindows extends SftpFileSystem {
   private List<String> userGroups;
   private Boolean windows;
 
-  public SftpFileSystemWindows( GenericFileName rootName, Session session, FileSystemOptions fileSystemOptions ) {
+  SftpFileSystemWindows( GenericFileName rootName, Session session, FileSystemOptions fileSystemOptions ) {
     super( rootName, session, fileSystemOptions );
     this.session = session;
+  }
+
+  @Override
+  protected FileObject createFile( AbstractFileName name ) throws FileSystemException {
+    return new SftpFileObjectWithWindowsSupport( name, this );
+  }
+
+  @Override
+  protected void doCloseCommunicationLink() {
+    if ( this.session != null ) {
+      this.session.disconnect();
+      this.session = null;
+    }
+    super.doCloseCommunicationLink();
+  }
+
+  @Override
+  public boolean isReleaseable() {
+    return !isOpen();
   }
 
   /**
@@ -73,7 +94,7 @@ public class SftpFileSystemWindows extends SftpFileSystem {
    * @throws JSchException
    * @throws IOException
    */
-  public List<String> getUserGroups() throws JSchException, IOException {
+  List<String> getUserGroups() throws JSchException, IOException {
     if ( userGroups == null ) {
       StringBuilder output = new StringBuilder();
       int code = this.executeCommand( WHO_AMI_GROUPS_FO_LIST, output );
@@ -119,7 +140,7 @@ public class SftpFileSystemWindows extends SftpFileSystem {
    * @throws JSchException
    * @throws IOException
    */
-  public String getUser() throws JSchException, IOException {
+  String getUser() throws JSchException, IOException {
     StringBuilder output = new StringBuilder();
     int code = this.executeCommand( WHO_AMI, output );
     if ( code != 0 ) {
@@ -137,7 +158,7 @@ public class SftpFileSystemWindows extends SftpFileSystem {
    * @throws JSchException
    * @throws IOException
    */
-  public Map<String, String> getFilePermission( String path ) throws JSchException, IOException {
+  Map<String, String> getFilePermission( String path ) throws JSchException, IOException {
     String windowsAbsPath;
     if ( path.startsWith( WINDOWS_PATH_DELIMITER ) ) {
       //cut first "/" windows does not have it
@@ -177,7 +198,7 @@ public class SftpFileSystemWindows extends SftpFileSystem {
    * @throws JSchException
    * @throws IOException
    */
-  public boolean isRemoteHostWindows() throws JSchException, IOException {
+  boolean isRemoteHostWindows() throws JSchException, IOException {
     if ( this.windows == null ) {
       StringBuilder output = new StringBuilder();
       int code = this.executeCommand( VER, output );

--- a/core/src/main/java/org/pentaho/di/core/vfs/SftpFileSystemWindowsProvider.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/SftpFileSystemWindowsProvider.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,29 +23,42 @@
 package org.pentaho.di.core.vfs;
 
 
-import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.provider.GenericFileName;
-import org.apache.commons.vfs2.provider.sftp.SftpFileObject;
+import org.apache.commons.vfs2.provider.sftp.SftpFileProvider;
 
-import java.util.HashMap;
+/**
+ * This class serves two main purposes.
+ * <ol>
+ *     <li>
+ *         To provide a correct way of running sftp commands on Windows server.
+ *         Current implementation of commons-vfs calls <code>id -G</code> or <code>id -u</code>,
+ *         which is incorrect for Windows.
+ *     </li>
+ *     <li>
+ *         To provide a way to release sftp connections, when we're done.
+ *         commons-vfs says we do not close fileSystemManager until application shutdown
+ *         (see <a href="https://issues.apache.org/jira/browse/VFS-454">VFS-454</a>).
+ *         Thus, we need to close the connections.<br/>
+ *         There is {@link org.apache.commons.vfs2.provider.AbstractFileProvider#freeUnusedResources()},
+ *         which we can use to achieve this. But, unfortunately, original SftpFileSystem only releases them
+ *         when all file objects it's associated with are garbage collected. This is too restrictive and inconvenient.
+ *         Here we make the sftp file system object releasable when there are open file objects,
+ *         we only need i/o streams to be closed. <br/>
+ *         This is pretty safe to do. Even a file object would want to open a stream once again (currently wouldn't),
+ *         the file system object re-creates session and opens a new connection.
+ *     </li>
+ * </ol>
+ * This provider replaces {@link SftpFileProvider} in FileSystemManager (see overridden providers.xml).
+ * And then used to spawn SftpFileSystemWindows and SftpFileObjectWithWindowsSupport.
+ */
+public class SftpFileSystemWindowsProvider extends SftpFileProvider {
 
-public class SftpFileSystemWindowsProvider {
-  private static HashMap<String, SftpFileSystemWindows> sftpFileSystemWindowsMap = new HashMap<>();
-
-  public static SftpFileSystemWindows getSftpFileSystemWindows( SftpFileObject sftpFileObject ) throws FileSystemException {
-    GenericFileName fileName;
-    if ( sftpFileObject.isFolder() ) {
-      fileName = (GenericFileName) sftpFileObject.getName();
-    } else {
-      fileName = (GenericFileName) sftpFileObject.getParent().getName();
-    }
-    SftpFileSystemWindows sftpFileSystemWindows = sftpFileSystemWindowsMap.get( fileName.toString() );
-    if ( sftpFileSystemWindows == null ) {
-      sftpFileSystemWindows = new SftpFileSystemWindows( fileName, null,
-              sftpFileObject.getFileSystem().getFileSystemOptions() );
-      sftpFileSystemWindowsMap.put( fileName.toString(), sftpFileSystemWindows );
-    }
-    return sftpFileSystemWindows;
+  @Override
+  protected FileSystem doCreateFileSystem( FileName name, FileSystemOptions fileSystemOptions ) {
+    return new SftpFileSystemWindows( (GenericFileName) name, null, fileSystemOptions );
   }
 
 }

--- a/core/src/main/resources/org/pentaho/di/core/vfs/providers.xml
+++ b/core/src/main/resources/org/pentaho/di/core/vfs/providers.xml
@@ -1,0 +1,111 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<providers>
+    <default-provider class-name="org.apache.commons.vfs2.provider.url.UrlFileProvider">
+    </default-provider>
+    <provider class-name="org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider">
+        <scheme name="file"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.zip.ZipFileProvider">
+        <scheme name="zip"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tar"/>
+        <if-available class-name="org.apache.commons.compress.archivers.tar.TarArchiveOutputStream"/>
+    </provider>
+
+    <provider class-name="org.apache.commons.vfs2.provider.bzip2.Bzip2FileProvider">
+        <scheme name="bz2"/>
+        <if-available class-name="org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.gzip.GzipFileProvider">
+        <scheme name="gz"/>
+    </provider>
+
+    <provider class-name="org.apache.commons.vfs2.provider.jar.JarFileProvider">
+        <scheme name="jar"/>
+        <scheme name="sar"/>
+        <scheme name="ear"/>
+        <scheme name="par"/>
+        <scheme name="ejb3"/>
+        <scheme name="war"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.temp.TemporaryFileProvider">
+        <scheme name="tmp"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.ftp.FtpFileProvider">
+        <scheme name="ftp"/>
+        <if-available class-name="org.apache.commons.net.ftp.FTPFile"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.ftps.FtpsFileProvider">
+        <scheme name="ftps"/>
+        <if-available class-name="org.apache.commons.net.ftp.FTPFile"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.http.HttpFileProvider">
+        <scheme name="http"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.https.HttpsFileProvider">
+        <scheme name="https"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+    </provider>
+
+    <!-- Custom Sftp provider -->
+    <provider class-name="org.pentaho.di.core.vfs.SftpFileSystemWindowsProvider">
+        <scheme name="sftp"/>
+        <if-available class-name="javax.crypto.Cipher"/>
+        <if-available class-name="com.jcraft.jsch.JSch"/>
+    </provider>
+
+    <provider class-name="org.apache.commons.vfs2.provider.res.ResourceFileProvider">
+        <scheme name="res"/>
+    </provider>
+        <provider class-name="org.apache.commons.vfs2.provider.webdav.WebdavFileProvider">
+        <scheme name="webdav"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+        <if-available class-name="org.apache.jackrabbit.webdav.client.methods.DavMethod"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tgz"/>
+        <if-available scheme="gz"/>
+        <if-available scheme="tar"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tbz2"/>
+        <if-available scheme="bz2"/>
+        <if-available scheme="tar"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.ram.RamFileProvider">
+        <scheme name="ram"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.hdfs.HdfsFileProvider">
+        <scheme name="hdfs"/>
+        <if-available class-name="org.apache.hadoop.fs.FileSystem"/>
+    </provider>
+
+    <extension-map extension="zip" scheme="zip"/>
+    <extension-map extension="tar" scheme="tar"/>
+    <mime-type-map mime-type="application/zip" scheme="zip"/>
+    <mime-type-map mime-type="application/x-tar" scheme="tar"/>
+    <mime-type-map mime-type="application/x-gzip" scheme="gz"/>
+    <extension-map extension="jar" scheme="jar"/>
+    <extension-map extension="bz2" scheme="bz2"/>
+    <extension-map extension="gz" scheme="gz"/>
+    <extension-map extension="tgz" scheme="tar"/>
+    <extension-map extension="tbz2" scheme="tar"/>
+
+</providers>

--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -460,6 +460,10 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
         jobMeta.disposeEmbeddedMetastoreProvider();
 
         fireJobFinishListeners();
+
+        // release unused vfs connections
+        KettleVFS.freeUnusedResources();
+
       } catch ( KettleException e ) {
         result.setNrErrors( 1 );
         result.setResult( false );

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -1349,6 +1349,9 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
         if ( transMeta.isUsingUniqueConnections() ) {
           trans.closeUniqueDatabaseConnections( getResult() );
         }
+
+        // release unused vfs connections
+        KettleVFS.freeUnusedResources();
       }
     };
     // This should always be done first so that the other listeners achieve a clean state to start from (setFinished and


### PR DESCRIPTION
…pen even after transformation/job completes

 - re-worked custom sftp provider, file system and file object
 - added cusomt providers.xml to make our custom sftp provider managed by vfs
 - sftp file system is now releasable even when there are open file objects (but not open streams!). this allows us to release sftp connections when a job or transformation is finished.

please, have a look at SftpFileSystemWindowsProvider's javadoc for details