### PR TITLE
[PDI-17061] "Get rows from result" step does not pass rows when a transformation is executed on a remote carte server

### DIFF
--- a/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
+++ b/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -958,9 +958,18 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
 
   public SlaveServerTransStatus getTransStatus( String transName, String carteObjectId, int startLogLineNr )
     throws Exception {
-    String xml =
-      execService( GetTransStatusServlet.CONTEXT_PATH + "/?name=" + URLEncoder.encode( transName, "UTF-8" ) + "&id="
-        + Const.NVL( carteObjectId, "" ) + "&xml=Y&from=" + startLogLineNr, true );
+    return getTransStatus( transName, carteObjectId, startLogLineNr, false );
+  }
+
+  public SlaveServerTransStatus getTransStatus( String transName, String carteObjectId, int startLogLineNr,
+                                                boolean sendResultXmlWithStatus )
+    throws Exception {
+    String query = GetTransStatusServlet.CONTEXT_PATH + "/?name=" + URLEncoder.encode( transName, "UTF-8" ) + "&id="
+      + Const.NVL( carteObjectId, "" ) + "&xml=Y&from=" + startLogLineNr;
+    if ( sendResultXmlWithStatus ) {
+      query = query + "&" + GetTransStatusServlet.SEND_RESULT + "=Y";
+    }
+    String xml = execService( query, true );
     return SlaveServerTransStatus.fromXML( xml );
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1044,6 +1044,8 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
               if ( !transStatus.isRunning() ) {
                 // The transformation is finished, get the result...
                 //
+                //get the status with the result ( we don't do it above because of changing PDI-15781)
+                transStatus = remoteSlaveServer.getTransStatus( transMeta.getName(), carteObjectId, 0, true );
                 Result remoteResult = transStatus.getResult();
                 result.clear();
                 result.add( remoteResult );

--- a/engine/src/main/java/org/pentaho/di/www/SlaveServerTransStatus.java
+++ b/engine/src/main/java/org/pentaho/di/www/SlaveServerTransStatus.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -83,6 +83,10 @@ public class SlaveServerTransStatus {
   public String getXML() throws KettleException {
     // See PDI-15781
     boolean sendResultXmlWithStatus = EnvUtil.getSystemProperty( "KETTLE_COMPATIBILITY_SEND_RESULT_XML_WITH_FULL_STATUS", "N" ).equalsIgnoreCase( "Y" );
+    return getXML( sendResultXmlWithStatus );
+  }
+
+  public String getXML( boolean sendResultXmlWithStatus ) throws KettleException {
     StringBuilder xml = new StringBuilder();
 
     xml.append( XMLHandler.openTag( XML_TAG ) ).append( Const.CR );

--- a/engine/src/test/java/org/pentaho/di/www/SlaveServerTransStatusTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/SlaveServerTransStatusTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,6 +25,7 @@ package org.pentaho.di.www;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -32,8 +33,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -99,5 +104,22 @@ public class SlaveServerTransStatusTest {
       new SlaveServerTransStatusLoadSaveTester( SlaveServerTransStatus.class, attributes, attributeMap );
 
     tester.testSerialization();
+  }
+
+  @Test
+  public void testGetXML() throws KettleException {
+    SlaveServerTransStatus transStatus = new SlaveServerTransStatus();
+    RowMetaAndData rowMetaAndData = new RowMetaAndData();
+    String testData = "testData";
+    rowMetaAndData.addValue( new ValueMetaString(), testData );
+    List<RowMetaAndData> rows = new ArrayList<>();
+    rows.add( rowMetaAndData );
+    Result result = new Result();
+    result.setRows( rows );
+    transStatus.setResult( result );
+    //PDI-15781
+    Assert.assertFalse( transStatus.getXML().contains( testData ) );
+    //PDI-17061
+    Assert.assertTrue( transStatus.getXML( true ).contains( testData ) );
   }
 }


### PR DESCRIPTION
[PDI-17061] "Get rows from result" step does not pass rows when a transformation is executed on a remote carte server

added possibility to add result to XML when it needs