### PR TITLE
[SP-4165][PDI-16387] Running a Job for Every Input Row, sub job does not reset variables or parameters with every execution

### DIFF
--- a/engine/src/test/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,7 +32,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.util.Assert;
 import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobEntryListener;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryCopy;
 
@@ -86,5 +88,22 @@ public class JobEntrySetVariablesTest {
     assertEquals( "日本語", entry.getVariable( "Japanese" ) );
     assertEquals( "English", entry.getVariable( "English" ) );
     assertEquals( "中文", entry.getVariable( "Chinese" ) );
+  }
+
+  @Test
+  //PDI-16387
+  public void testVariableTypeCurrentJob() throws Exception {
+    entry.setFilename( "src/test/resources/org/pentaho/di/job/entries/setvariables/UTF8Text.properties" );
+    entry.setVariableName( new String[] {} );
+    entry.setReplaceVars( true );
+    entry.setFileVariableType( JobEntrySetVariables.VARIABLE_TYPE_CURRENT_JOB );
+    Result result = entry.execute( new Result(), 0 );
+    for ( JobEntryListener  jobEntryListener : job.getJobEntryListeners() ) {
+      jobEntryListener.beforeExecution( job, null, entry );
+    }
+    Assert.assertTrue( result.getResult() );
+    Assert.assertNull( entry.getVariable( "Japanese" ) );
+    Assert.assertNull( entry.getVariable( "English" ) );
+    Assert.assertNull( entry.getVariable( "Chinese" ) );
   }
 }


### PR DESCRIPTION
[SP-4165][PDI-16387] Running a Job for Every Input Row, sub job does not reset variables or parameters with every execution

added recovering changed values of variables if we use VARIABLE_TYPE_CURRENT_JOB