### PR TITLE
[SP-4220][PDI-16844] The step Job Executor should overwrite the child parameter by the parent parameter.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -76,6 +76,7 @@ import org.pentaho.di.resource.ResourceEntry;
 import org.pentaho.di.resource.ResourceEntry.ResourceType;
 import org.pentaho.di.resource.ResourceNamingInterface;
 import org.pentaho.di.resource.ResourceReference;
+import org.pentaho.di.trans.StepWithMappingMeta;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransExecutionConfiguration;
 import org.pentaho.di.trans.TransMeta;
@@ -880,27 +881,8 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
         //
         transMeta.clearParameters();
         String[] parameterNames = transMeta.listParameters();
-        for ( int idx = 0; idx < parameterNames.length; idx++ ) {
-          // Grab the parameter value set in the Trans job entry
-          //
-          String thisValue = namedParam.getParameterValue( parameterNames[ idx ] );
-          if ( !Utils.isEmpty( thisValue ) ) {
-            // Set the value as specified by the user in the job entry
-            //
-            transMeta.setParameterValue( parameterNames[ idx ], thisValue );
-          } else {
-            // See if the parameter had a value set in the parent job...
-            // This value should pass down to the transformation if that's what we opted to do.
-            //
-            if ( isPassingAllParameters() ) {
-              String parentValue = parentJob.getParameterValue( parameterNames[ idx ] );
-              if ( !Utils.isEmpty( parentValue ) ) {
-                transMeta.setParameterValue( parameterNames[ idx ], parentValue );
-              }
-            }
-          }
-        }
-
+        StepWithMappingMeta.activateParams( transMeta, transMeta, this, parameterNames,
+          parameters, parameterValues );
         boolean doFallback = true;
         SlaveServer remoteSlaveServer = null;
         TransExecutionConfiguration executionConfiguration = new TransExecutionConfiguration();
@@ -1300,7 +1282,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
           }
           if ( transMeta == null ) {
             logBasic( "Loading transformation from XML file [" + realFilename + "]" );
-            transMeta = new TransMeta( realFilename, metaStore, null, true, this, null );
+            transMeta = new TransMeta( realFilename, metaStore, null, true, null, null );
           }
           break;
         case REPOSITORY_BY_NAME:
@@ -1353,13 +1335,17 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       }
 
       if ( transMeta != null ) {
-        // copy parent variables to this loaded variable space.
-        //
-        transMeta.copyVariablesFrom( this );
-
         // set Internal.Entry.Current.Directory again because it was changed
         transMeta.setInternalKettleVariables();
+        //  When the child parameter does exist in the parent parameters, overwrite the child parameter by the
+        // parent parameter.
 
+        StepWithMappingMeta.replaceVariableValues( transMeta, space );
+        if ( isPassingAllParameters() ) {
+          // All other parent parameters need to get copied into the child parameters  (when the 'Inherit all
+          // variables from the transformation?' option is checked)
+          StepWithMappingMeta.addMissingVariables( transMeta, space );
+        }
         // Pass repository and metastore references
         //
         transMeta.setRepository( rep );

--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -359,19 +359,19 @@ public abstract class StepWithMappingMeta extends BaseStepMeta implements HasRep
     }
   }
 
-  private static  void addMissingVariables( TransMeta source, VariableSpace target ) {
-    if ( target == null ) {
+  public static  void addMissingVariables( VariableSpace fromSpace, VariableSpace toSpace ) {
+    if ( toSpace == null ) {
       return;
     }
-    String[] variableNames = target.listVariables();
+    String[] variableNames = toSpace.listVariables();
     for ( String variable : variableNames ) {
-      if ( source.getVariable( variable ) == null ) {
-        source.setVariable( variable, target.getVariable( variable ) );
+      if ( fromSpace.getVariable( variable ) == null ) {
+        fromSpace.setVariable( variable, toSpace.getVariable( variable ) );
       }
     }
   }
 
-  private static void replaceVariableValues( TransMeta childTransMeta, VariableSpace replaceBy ) {
+  public static void replaceVariableValues( VariableSpace childTransMeta, VariableSpace replaceBy ) {
     if ( replaceBy == null ) {
       return;
     }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -46,6 +46,7 @@ import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobExecutionConfiguration;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.StepWithMappingMeta;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStep;
@@ -193,12 +194,9 @@ public class JobExecutor extends BaseStep implements StepInterface {
 
     data.executorJob = createJob( meta.getRepository(), data.executorJobMeta, this );
 
+    data.executorJob.shareVariablesWith( data.executorJobMeta );
     data.executorJob.setParentTrans( getTrans() );
     data.executorJob.setLogLevel( getLogLevel() );
-
-    if ( meta.getParameters().isInheritingAllVariables() ) {
-      data.executorJob.shareVariablesWith( this );
-    }
     data.executorJob.setInternalKettleVariables( this );
     data.executorJob.copyParametersFrom( data.executorJobMeta );
     data.executorJob.setArguments( getTrans().getArguments() );
@@ -366,37 +364,8 @@ public class JobExecutor extends BaseStep implements StepInterface {
     // Set parameters, when fields are used take the first row in the set.
     //
     JobExecutorParameters parameters = meta.getParameters();
-    data.executorJob.clearParameters();
-
-    String[] parameterNames = data.executorJob.listParameters();
-    for ( int i = 0; i < parameters.getVariable().length; i++ ) {
-      String variable = parameters.getVariable()[i];
-      String fieldName = parameters.getField()[i];
-      String inputValue = parameters.getInput()[i];
-      String value;
-      // Take the value from an input row or from a static value?
-      //
-      if ( !Utils.isEmpty( fieldName ) ) {
-        int idx = getInputRowMeta().indexOfValue( fieldName );
-        if ( idx < 0 ) {
-          throw new KettleException( BaseMessages.getString(
-            PKG, "JobExecutor.Exception.UnableToFindField", fieldName ) );
-        }
-
-        value = data.groupBuffer.get( 0 ).getString( idx, "" );
-      } else {
-        value = environmentSubstitute( inputValue );
-      }
-
-      // See if this is a parameter or just a variable...
-      //
-      if ( Const.indexOfString( variable, parameterNames ) < 0 ) {
-        data.executorJob.setVariable( variable, Const.NVL( value, "" ) );
-      } else {
-        data.executorJob.setParameterValue( variable, Const.NVL( value, "" ) );
-      }
-    }
-    data.executorJob.activateParameters();
+    StepWithMappingMeta.activateParams( data.executorJob, data.executorJob, this, data.executorJob.listParameters(),
+      parameters.getVariable(), parameters.getInput() );
   }
 
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
@@ -64,6 +64,7 @@ import org.pentaho.di.resource.ResourceEntry;
 import org.pentaho.di.resource.ResourceEntry.ResourceType;
 import org.pentaho.di.resource.ResourceNamingInterface;
 import org.pentaho.di.resource.ResourceReference;
+import org.pentaho.di.trans.StepWithMappingMeta;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.TransMeta.TransformationType;
@@ -645,7 +646,7 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
             }
           }
           if ( mappingJobMeta == null ) {
-            mappingJobMeta = new JobMeta( tmpSpace, realFilename, rep, metaStore, null );
+            mappingJobMeta = new JobMeta( null, realFilename, rep, metaStore, null );
             LogChannel.GENERAL.logDetailed( "Loading job from repository", "Job was loaded from XML file ["
               + realFilename + "]" );
           }
@@ -679,11 +680,11 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
         } else {
           // rep is null, let's try loading by filename
           try {
-            mappingJobMeta = new JobMeta( tmpSpace, realDirectory + "/" + realJobname, rep, metaStore, null );
+            mappingJobMeta = new JobMeta( null, realDirectory + "/" + realJobname, rep, metaStore, null );
           } catch ( KettleException ke ) {
             try {
               // add .kjb extension and try again
-              mappingJobMeta = new JobMeta( tmpSpace,
+              mappingJobMeta = new JobMeta( null,
                   realDirectory + "/" + realJobname + "." + Const.STRING_JOB_DEFAULT_EXT, rep, metaStore, null );
             } catch ( KettleException ke2 ) {
               throw new KettleException( BaseMessages.getString(
@@ -703,8 +704,15 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
     }
 
     // Pass some important information to the mapping transformation metadata:
-    //
-    mappingJobMeta.copyVariablesFrom( space );
+
+    //  When the child parameter does exist in the parent parameters, overwrite the child parameter by the
+    // parent parameter.
+    StepWithMappingMeta.replaceVariableValues( mappingJobMeta, space );
+    if ( executorMeta.getParameters().isInheritingAllVariables() ) {
+      // All other parent parameters need to get copied into the child parameters  (when the 'Inherit all
+      // variables from the transformation?' option is checked)
+      StepWithMappingMeta.addMissingVariables( mappingJobMeta, space );
+    }
     mappingJobMeta.setRepository( rep );
     mappingJobMeta.setMetaStore( metaStore );
     mappingJobMeta.setFilename( mappingJobMeta.getFilename() );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
@@ -27,12 +27,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.resource.ResourceNamingInterface;
@@ -120,5 +123,46 @@ public class JobExecutorMetaTest {
 
     verify( jobMeta ).setFilename( "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + testName );
     verify( jobExecutorMeta ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+  }
+
+  @Test
+  public void testLoadJobMeta() throws KettleException {
+    String param1 = "param1";
+    String param2 = "param2";
+    String param3 = "param3";
+    String parentValue1 = "parentValue1";
+    String parentValue2 = "parentValue2";
+    String childValue3 = "childValue3";
+
+    JobExecutorMeta jobExecutorMeta = spy( new JobExecutorMeta() );
+    Repository repository = Mockito.mock( Repository.class );
+
+    JobMeta meta = new JobMeta();
+    meta.setVariable( param2, "childValue2 should be override" );
+    meta.setVariable( param3, childValue3 );
+
+    Mockito.doReturn( meta ).when( repository )
+      .loadJob( Mockito.eq( "test.kjb" ), Mockito.anyObject(), Mockito.anyObject(), Mockito.anyObject() );
+
+    VariableSpace parentSpace = new Variables();
+    parentSpace.setVariable( param1, parentValue1 );
+    parentSpace.setVariable( param2, parentValue2 );
+
+    jobExecutorMeta.setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+    jobExecutorMeta.setFileName( "/home/admin/test.kjb" );
+
+    JobMeta jobMeta;
+
+    jobExecutorMeta.getParameters().setInheritingAllVariables( false );
+    jobMeta = JobExecutorMeta.loadJobMeta( jobExecutorMeta, repository, parentSpace );
+    Assert.assertEquals( null, jobMeta.getVariable( param1 ) );
+    Assert.assertEquals( parentValue2, jobMeta.getVariable( param2 ) );
+    Assert.assertEquals( childValue3, jobMeta.getVariable( param3 ) );
+
+    jobExecutorMeta.getParameters().setInheritingAllVariables( true );
+    jobMeta = JobExecutorMeta.loadJobMeta( jobExecutorMeta, repository, parentSpace );
+    Assert.assertEquals( parentValue1, jobMeta.getVariable( param1 ) );
+    Assert.assertEquals( parentValue2, jobMeta.getVariable( param2 ) );
+    Assert.assertEquals( childValue3, jobMeta.getVariable( param3 ) );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.jobexecutor;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,8 +64,10 @@ public class JobExecutorTest {
 
     meta = new JobExecutorMeta();
     data = new JobExecutorData();
-    doReturn( mock( Job.class ) ).when( executor ).createJob( any( Repository.class ), any( JobMeta.class ),
+    Job job = mock( Job.class );
+    doReturn( job ).when( executor ).createJob( any( Repository.class ), any( JobMeta.class ),
       any( LoggingObjectInterface.class ) );
+    doReturn( ArrayUtils.EMPTY_STRING_ARRAY ).when( job ).listParameters();
 
     data.groupBuffer = new ArrayList<>();
     data.groupSize = -1;


### PR DESCRIPTION
[SP-4220][PDI-16844] The step Job Executor should overwrite the child parameter by the parent parameter.
Overwriting parameters and the next logic:
1. When the child parameter does not exist in the parent parameters, keep it.
2. When the child parameter does exist in the parent parameters, overwrite the child parameter by the parent parameter.
3. All other parent parameters need to get copied into the child parameters (when the 'Inherit all variables from the transformation?' option is checked)