### PR TITLE
[SP-4186]: Backport of PDI-16885 - Values of parameters filled in during the Run Options dialog are not passed on when using the Pentaho Server run config (8.0 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -198,6 +198,8 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
 
   protected int undo_position;
 
+  protected RunOptions runOptions = new RunOptions();
+
   private boolean showDialog = true;
   private boolean alwaysShowRunOptions = true;
 
@@ -2090,4 +2092,29 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
     return this.versioningEnabled;
   }
 
+  private class RunOptions {
+    boolean clearingLog;
+    boolean safeModeEnabled;
+
+    RunOptions() {
+      clearingLog = true;
+      safeModeEnabled = false;
+    }
+  }
+
+  public boolean isClearingLog() {
+    return runOptions.clearingLog;
+  }
+
+  public void setClearingLog( boolean clearingLog ) {
+    this.runOptions.clearingLog = clearingLog;
+  }
+
+  public boolean isSafeModeEnabled() {
+    return runOptions.safeModeEnabled;
+  }
+
+  public void setSafeModeEnabled( boolean safeModeEnabled ) {
+    this.runOptions.safeModeEnabled = safeModeEnabled;
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -147,6 +147,10 @@ public class JobMeta extends AbstractMeta
 
   protected List<LogTableInterface> extraLogTables;
 
+  protected String startCopyName;
+
+  protected boolean expandingRemoteJob;
+
   /** The log channel interface. */
   protected LogChannelInterface log;
 
@@ -2820,5 +2824,21 @@ public class JobMeta extends AbstractMeta
       namedClusterEmbedManager = new NamedClusterEmbedManager( this, LogChannel.GENERAL );
     }
     return namedClusterEmbedManager;
+  }
+
+  public String getStartCopyName() {
+    return startCopyName;
+  }
+
+  public void setStartCopyName( String startCopyName ) {
+    this.startCopyName = startCopyName;
+  }
+
+  public boolean isExpandingRemoteJob() {
+    return expandingRemoteJob;
+  }
+
+  public void setExpandingRemoteJob( boolean expandingRemoteJob ) {
+    this.expandingRemoteJob = expandingRemoteJob;
   }
 }

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/SchedulerRequestTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/SchedulerRequestTest.java
@@ -1,0 +1,154 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.engine.configuration.impl.pentaho.scheduler;
+
+import org.apache.http.entity.StringEntity;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.base.AbstractMeta;
+import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.parameters.UnknownParamException;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.repository.RepositoryDirectoryInterface;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
+
+public class SchedulerRequestTest {
+  // input file
+  private static final String TEST_REPOSITORY_DIRECTORY = "/home/admin";
+  private static final String TEST_JOB_NAME = "jobName";
+  private static final String JOB_EXTENSION = "kjb";
+
+  // job parameters
+  private static final String STRING_PARAM_TYPE = "string";
+  private static final String LOG_LEVEL_PARAM_NAME = "logLevel";
+  private static final String TEST_LOG_LEVEL_PARAM_VALUE = "Rowlevel";
+  private static final String CLEAR_LOG_PARAM_NAME = "clearLog";
+  private static final String TEST_CLEAR_LOG_PARAM_VALUE = "true";
+  private static final String RUN_SAFE_MODE_PARAM_NAME = "runSafeMode";
+  private static final String TEST_RUN_SAFE_MODE_PARAM_VALUE = "false";
+  private static final String GATHERING_METRICS_PARAM_NAME = "gatheringMetrics";
+  private static final String TEST_GATHERING_METRICS_PARAM_VALUE = "false";
+  private static final String START_COPY_NAME_PARAM_NAME = "startCopyName";
+  private static final String TEST_START_COPY_NAME_PARAM_VALUE = "stepName";
+  private static final String EXPANDING_REMOTE_JOB_PARAM_NAME = "expandingRemoteJob";
+  private static final String TEST_EXPANDING_REMOTE_JOB_PARAM_VALUE = "false";
+
+  // pdi parameters
+  private static final String TEST_PDI_PARAM_NAME = "paramName";
+  private static final String TEST_PDI_PARAM_VALUE = "paramValue";
+  private static final String[] ARRAY_WITH_TEST_PDI_PARAM_NAME = new String[]{TEST_PDI_PARAM_NAME};
+
+  private static final String REFERENCE_TEST_REQUEST = String.format( "<jobScheduleRequest>\n"
+          + "<inputFile>%s/%s.%s</inputFile>\n"
+          + "<jobParameters>\n"
+          + "<name>%s</name>\n" + "<type>%s</type>\n" + "<stringValue>%s</stringValue>\n"
+          + "</jobParameters>\n"
+          + "<jobParameters>\n"
+          + "<name>%s</name>\n" + "<type>%s</type>\n" + "<stringValue>%s</stringValue>\n"
+          + "</jobParameters>\n"
+          + "<jobParameters>\n"
+          + "<name>%s</name>\n" + "<type>%s</type>\n" + "<stringValue>%s</stringValue>\n"
+          + "</jobParameters>\n"
+          + "<jobParameters>\n"
+          + "<name>%s</name>\n" + "<type>%s</type>\n" + "<stringValue>%s</stringValue>\n"
+          + "</jobParameters>\n"
+          + "<jobParameters>\n"
+          + "<name>%s</name>\n" + "<type>%s</type>\n" + "<stringValue>%s</stringValue>\n"
+          + "</jobParameters>\n"
+          + "<jobParameters>\n"
+          + "<name>%s</name>\n" + "<type>%s</type>\n" + "<stringValue>%s</stringValue>\n"
+          + "</jobParameters>\n"
+          + "<pdiParameters>\n"
+          + "<entry>\n"
+          + "<key>%s</key>\n" + "<value>%s</value>\n"
+          + "</entry>\n"
+          + "</pdiParameters>\n"
+          + "</jobScheduleRequest>", TEST_REPOSITORY_DIRECTORY, TEST_JOB_NAME, JOB_EXTENSION,
+        LOG_LEVEL_PARAM_NAME, STRING_PARAM_TYPE, TEST_LOG_LEVEL_PARAM_VALUE,
+        CLEAR_LOG_PARAM_NAME, STRING_PARAM_TYPE, TEST_CLEAR_LOG_PARAM_VALUE,
+        RUN_SAFE_MODE_PARAM_NAME, STRING_PARAM_TYPE, TEST_RUN_SAFE_MODE_PARAM_VALUE,
+        GATHERING_METRICS_PARAM_NAME, STRING_PARAM_TYPE, TEST_GATHERING_METRICS_PARAM_VALUE,
+        START_COPY_NAME_PARAM_NAME, STRING_PARAM_TYPE, TEST_START_COPY_NAME_PARAM_VALUE,
+        EXPANDING_REMOTE_JOB_PARAM_NAME, STRING_PARAM_TYPE, TEST_EXPANDING_REMOTE_JOB_PARAM_VALUE,
+        TEST_PDI_PARAM_NAME, TEST_PDI_PARAM_VALUE );
+
+  private SchedulerRequest schedulerRequest;
+
+  @Before
+  public void before() {
+    schedulerRequest = mock( SchedulerRequest.class );
+  }
+
+  @Test
+  @SuppressWarnings( "ResultOfMethodCallIgnored" )
+  public void testBuildSchedulerRequestEntity() throws UnknownParamException, UnsupportedEncodingException {
+    AbstractMeta meta = mock( JobMeta.class );
+    RepositoryDirectoryInterface repositoryDirectory = mock( RepositoryDirectoryInterface.class );
+
+    doReturn( repositoryDirectory ).when( meta ).getRepositoryDirectory();
+    doReturn( TEST_REPOSITORY_DIRECTORY ).when( repositoryDirectory ).getPath();
+    doReturn( TEST_JOB_NAME ).when( meta ).getName();
+    doReturn( JOB_EXTENSION ).when( meta ).getDefaultExtension();
+
+    doReturn( LogLevel.getLogLevelForCode( TEST_LOG_LEVEL_PARAM_VALUE ) ).when( meta ).getLogLevel();
+    doReturn( Boolean.valueOf( TEST_CLEAR_LOG_PARAM_VALUE ) ).when( meta ).isClearingLog();
+    doReturn( Boolean.valueOf( TEST_RUN_SAFE_MODE_PARAM_VALUE ) ).when( meta ).isSafeModeEnabled();
+    doReturn( Boolean.valueOf( TEST_GATHERING_METRICS_PARAM_VALUE ) ).when( meta ).isGatheringMetrics();
+    doReturn( TEST_START_COPY_NAME_PARAM_VALUE ).when( (JobMeta) meta ).getStartCopyName();
+    doReturn( Boolean.valueOf( TEST_EXPANDING_REMOTE_JOB_PARAM_VALUE ) ).when( (JobMeta) meta ).isExpandingRemoteJob();
+
+    doReturn( ARRAY_WITH_TEST_PDI_PARAM_NAME ).when( meta ).listParameters();
+    doReturn( TEST_PDI_PARAM_VALUE ).when( meta ).getParameterValue( TEST_PDI_PARAM_NAME );
+
+    doCallRealMethod().when( schedulerRequest ).buildSchedulerRequestEntity( meta );
+
+    assertTrue( compareContentOfStringEntities( schedulerRequest.buildSchedulerRequestEntity( meta ),
+            new StringEntity( REFERENCE_TEST_REQUEST ) ) );
+  }
+
+  private boolean compareContentOfStringEntities( StringEntity entity1, StringEntity entity2 ) {
+    if ( entity1.getContentLength() == entity2.getContentLength() ) {
+      try ( InputStream stream1 = entity1.getContent();
+            InputStream stream2 = entity2.getContent() ) {
+        while ( stream1.available() > 0 ) {
+          if ( stream1.read() != stream2.read() ) {
+            return false;
+          }
+        }
+        return true;
+      } catch ( IOException e ) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+}

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.ui.spoon.delegates;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
@@ -29,6 +30,7 @@ import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.NotePadMeta;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
@@ -1356,13 +1358,46 @@ public class SpoonJobDelegate extends SpoonDelegate {
     executionConfiguration.getUsedArguments( jobMeta, spoon.getArguments(), spoon.getMetaStore() );
     executionConfiguration.setLogLevel( DefaultLogLevel.getLogLevel() );
 
-    JobExecutionConfigurationDialog dialog =
-      new JobExecutionConfigurationDialog( spoon.getShell(), executionConfiguration, jobMeta );
+    JobExecutionConfigurationDialog dialog = newJobExecutionConfigurationDialog( spoon.getShell(),
+            executionConfiguration, jobMeta );
 
     if ( !jobMeta.isShowDialog() || dialog.open() ) {
 
       JobGraph jobGraph = spoon.getActiveJobGraph();
       jobGraph.jobLogDelegate.addJobLog();
+
+      // Set the variables that where specified...
+      //
+      for ( String varName : executionConfiguration.getVariables().keySet() ) {
+        String varValue = executionConfiguration.getVariables().get( varName );
+        jobMeta.setVariable( varName, varValue );
+      }
+
+      // Set and activate the parameters...
+      //
+      for ( String paramName : executionConfiguration.getParams().keySet() ) {
+        String paramValue = executionConfiguration.getParams().get( paramName );
+        jobMeta.setParameterValue( paramName, paramValue );
+      }
+      jobMeta.activateParameters();
+
+      // Set the log level
+      //
+      if ( executionConfiguration.getLogLevel() != null ) {
+        jobMeta.setLogLevel( executionConfiguration.getLogLevel() );
+      }
+
+      // Set the start step name
+      //
+      if ( executionConfiguration.getStartCopyName() != null ) {
+        jobMeta.setStartCopyName( executionConfiguration.getStartCopyName() );
+      }
+
+      // Set the run options
+      //
+      jobMeta.setClearingLog( executionConfiguration.isClearingLog() );
+      jobMeta.setSafeModeEnabled( executionConfiguration.isSafeModeEnabled() );
+      jobMeta.setExpandingRemoteJob( executionConfiguration.isExpandingRemoteJob() );
 
       ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.SpoonJobMetaExecutionStart.id, jobMeta );
       ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.SpoonJobExecutionConfiguration.id,
@@ -1381,20 +1416,6 @@ public class SpoonJobDelegate extends SpoonDelegate {
         if ( jobMeta.hasChanged() ) {
           jobGraph.showSaveFileMessage();
         }
-      }
-
-      // Set the variables that where specified...
-      //
-      for ( String varName : executionConfiguration.getVariables().keySet() ) {
-        String varValue = executionConfiguration.getVariables().get( varName );
-        jobMeta.setVariable( varName, varValue );
-      }
-
-      // Set and activate the parameters...
-      //
-      for ( String paramName : executionConfiguration.getParams().keySet() ) {
-        String paramValue = executionConfiguration.getParams().get( paramName );
-        jobMeta.setParameterValue( paramName, paramValue );
       }
 
       // Is this a local execution?
@@ -1421,5 +1442,11 @@ public class SpoonJobDelegate extends SpoonDelegate {
         }
       }
     }
+  }
+
+  @VisibleForTesting
+  JobExecutionConfigurationDialog newJobExecutionConfigurationDialog( Shell shell,
+      JobExecutionConfiguration executionConfiguration, JobMeta jobMeta ) {
+    return new JobExecutionConfigurationDialog( spoon.getShell(), executionConfiguration, jobMeta );
   }
 }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegate.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -860,6 +860,24 @@ public class SpoonTransformationDelegate extends SpoonDelegate {
     if ( execConfigAnswer ) {
       TransGraph activeTransGraph = spoon.getActiveTransGraph();
       activeTransGraph.transLogDelegate.addTransLog();
+
+      // Set the named parameters
+      Map<String, String> paramMap = executionConfiguration.getParams();
+      for ( String key : paramMap.keySet() ) {
+        transMeta.setParameterValue( key, Const.NVL( paramMap.get( key ), "" ) );
+      }
+      transMeta.activateParameters();
+
+      // Set the log level
+      //
+      if ( executionConfiguration.getLogLevel() != null ) {
+        transMeta.setLogLevel( executionConfiguration.getLogLevel() );
+      }
+
+      // Set the run options
+      transMeta.setClearingLog( executionConfiguration.isClearingLog() );
+      transMeta.setSafeModeEnabled( executionConfiguration.isSafeModeEnabled() );
+      transMeta.setGatheringMetrics( executionConfiguration.isGatheringMetrics() );
 
       ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.SpoonTransMetaExecutionStart.id, transMeta );
       ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.SpoonTransExecutionConfiguration.id,

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegateTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegateTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2017-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,13 +22,24 @@
 package org.pentaho.di.ui.spoon.delegates;
 
 
+import org.eclipse.swt.widgets.Shell;
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.JobLogTable;
+import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.job.JobExecutionConfiguration;
 import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.ui.job.dialog.JobExecutionConfigurationDialog;
 import org.pentaho.di.ui.spoon.Spoon;
+import org.pentaho.di.ui.spoon.job.JobGraph;
+import org.pentaho.di.ui.spoon.job.JobLogDelegate;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -36,8 +47,28 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class SpoonJobDelegateTest {
+  private static final String[] EMPTY_STRING_ARRAY = new String[]{};
+  private static final String TEST_VARIABLE_KEY = "variableKey";
+  private static final String TEST_VARIABLE_VALUE = "variableValue";
+  private static final Map<String, String> MAP_WITH_TEST_VARIABLE = new HashMap<String, String>() {
+    {
+      put( TEST_VARIABLE_KEY, TEST_VARIABLE_VALUE );
+    }
+  };
+  private static final String TEST_PARAM_KEY = "paramKey";
+  private static final String TEST_PARAM_VALUE = "paramValue";
+  private static final Map<String, String> MAP_WITH_TEST_PARAM = new HashMap<String, String>() {
+    {
+      put( TEST_PARAM_KEY, TEST_PARAM_VALUE );
+    }
+  };
+  private static final LogLevel TEST_LOG_LEVEL = LogLevel.BASIC;
+  private static final String TEST_START_COPY_NAME = "startCopyName";
+  private static final boolean TEST_BOOLEAN_PARAM = true;
+
   private SpoonJobDelegate delegate;
   private Spoon spoon;
   private JobLogTable jobLogTable;
@@ -53,6 +84,8 @@ public class SpoonJobDelegateTest {
     spoon = mock( Spoon.class );
     spoon.delegates = mock( SpoonDelegates.class );
     spoon.delegates.tabs = mock( SpoonTabsDelegate.class );
+    spoon.variables = mock( RowMetaAndData.class );
+    delegate.spoon = spoon;
 
     doReturn( jobMap ).when( delegate ).getJobList();
     doReturn( spoon ).when( delegate ).getSpoon();
@@ -67,5 +100,47 @@ public class SpoonJobDelegateTest {
     assertFalse( delegate.addJob( jobMeta ) );
     delegate.closeJob( jobMeta );
     assertTrue( delegate.addJob( jobMeta ) );
+  }
+
+  @Test
+  @SuppressWarnings( "ResultOfMethodCallIgnored" )
+  public void testSetParamsIntoMetaInExecuteJob() throws KettleException {
+    doCallRealMethod().when( delegate ).executeJob( jobMeta, true, false, null, false,
+        null, 0 );
+
+    JobExecutionConfiguration jobExecutionConfiguration = mock( JobExecutionConfiguration.class );
+    RowMetaInterface rowMeta = mock( RowMetaInterface.class );
+    Shell shell = mock( Shell.class );
+    JobExecutionConfigurationDialog jobExecutionConfigurationDialog = mock( JobExecutionConfigurationDialog.class );
+    JobGraph activeJobGraph = mock( JobGraph.class );
+    activeJobGraph.jobLogDelegate = mock( JobLogDelegate.class );
+
+
+    doReturn( jobExecutionConfiguration ).when( spoon ).getJobExecutionConfiguration();
+    doReturn( rowMeta ).when( spoon.variables ).getRowMeta();
+    doReturn( EMPTY_STRING_ARRAY ).when( rowMeta ).getFieldNames();
+    doReturn( shell ).when( spoon ).getShell();
+    doReturn( jobExecutionConfigurationDialog ).when( delegate ).newJobExecutionConfigurationDialog( shell,
+        jobExecutionConfiguration, jobMeta );
+    doReturn( activeJobGraph ).when( spoon ).getActiveJobGraph();
+    doReturn( MAP_WITH_TEST_VARIABLE ).when( jobExecutionConfiguration ).getVariables();
+    doReturn( MAP_WITH_TEST_PARAM ).when( jobExecutionConfiguration ).getParams();
+    doReturn( TEST_LOG_LEVEL ).when( jobExecutionConfiguration ).getLogLevel();
+    doReturn( TEST_START_COPY_NAME ).when( jobExecutionConfiguration ).getStartCopyName();
+    doReturn( TEST_BOOLEAN_PARAM ).when( jobExecutionConfiguration ).isClearingLog();
+    doReturn( TEST_BOOLEAN_PARAM ).when( jobExecutionConfiguration ).isSafeModeEnabled();
+    doReturn( TEST_BOOLEAN_PARAM ).when( jobExecutionConfiguration ).isExpandingRemoteJob();
+
+    delegate.executeJob( jobMeta, true, false, null, false,
+        null, 0 );
+
+    verify( jobMeta ).setVariable( TEST_VARIABLE_KEY, TEST_VARIABLE_VALUE );
+    verify( jobMeta ).setParameterValue( TEST_PARAM_KEY, TEST_PARAM_VALUE );
+    verify( jobMeta ).activateParameters();
+    verify( jobMeta ).setLogLevel( TEST_LOG_LEVEL );
+    verify( jobMeta ).setStartCopyName( TEST_START_COPY_NAME );
+    verify( jobMeta ).setClearingLog( TEST_BOOLEAN_PARAM );
+    verify( jobMeta ).setSafeModeEnabled( TEST_BOOLEAN_PARAM );
+    verify( jobMeta ).setExpandingRemoteJob( TEST_BOOLEAN_PARAM );
   }
 }

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegateTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegateTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,19 +28,39 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.logging.TransLogTable;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.trans.TransExecutionConfiguration;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.ui.spoon.Spoon;
+import org.pentaho.di.ui.spoon.trans.TransGraph;
+import org.pentaho.di.ui.spoon.trans.TransLogDelegate;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class SpoonTransformationDelegateTest {
+  private static final String[] EMPTY_STRING_ARRAY = new String[]{};
+  private static final String TEST_PARAM_KEY = "paramKey";
+  private static final String TEST_PARAM_VALUE = "paramValue";
+  private static final Map<String, String> MAP_WITH_TEST_PARAM = new HashMap<String, String>() {
+    {
+      put( TEST_PARAM_KEY, TEST_PARAM_VALUE );
+    }
+  };
+  private static final LogLevel TEST_LOG_LEVEL = LogLevel.BASIC;
+  private static final boolean TEST_BOOLEAN_PARAM = true;
 
   private SpoonTransformationDelegate delegate;
   private Spoon spoon;
@@ -58,6 +78,8 @@ public class SpoonTransformationDelegateTest {
     spoon = mock( Spoon.class );
     spoon.delegates = mock( SpoonDelegates.class );
     spoon.delegates.tabs = mock( SpoonTabsDelegate.class );
+    spoon.variables = mock( RowMetaAndData.class );
+    delegate.spoon = spoon;
 
     doReturn( transformationMap ).when( delegate ).getTransformationList();
     doReturn( spoon ).when( delegate ).getSpoon();
@@ -90,5 +112,37 @@ public class SpoonTransformationDelegateTest {
     assertFalse( delegate.addTransformation( transMeta ) );
     delegate.closeTransformation( transMeta );
     assertTrue( delegate.addTransformation( transMeta ) );
+  }
+
+  @Test
+  @SuppressWarnings( "ResultOfMethodCallIgnored" )
+  public void testSetParamsIntoMetaInExecuteTransformation() throws KettleException {
+    doCallRealMethod().when( delegate ).executeTransformation( transMeta, true, false, false,
+            false, false, null, false, LogLevel.BASIC );
+
+    RowMetaInterface rowMeta = mock( RowMetaInterface.class );
+    TransExecutionConfiguration transExecutionConfiguration = mock( TransExecutionConfiguration.class );
+    TransGraph activeTransGraph = mock( TransGraph.class );
+    activeTransGraph.transLogDelegate = mock( TransLogDelegate.class );
+
+    doReturn( rowMeta ).when( spoon.variables ).getRowMeta();
+    doReturn( EMPTY_STRING_ARRAY ).when( rowMeta ).getFieldNames();
+    doReturn( transExecutionConfiguration ).when( spoon ).getTransExecutionConfiguration();
+    doReturn( MAP_WITH_TEST_PARAM ).when( transExecutionConfiguration ).getParams();
+    doReturn( activeTransGraph ).when( spoon ).getActiveTransGraph();
+    doReturn( TEST_LOG_LEVEL ).when( transExecutionConfiguration ).getLogLevel();
+    doReturn( TEST_BOOLEAN_PARAM ).when( transExecutionConfiguration ).isClearingLog();
+    doReturn( TEST_BOOLEAN_PARAM ).when( transExecutionConfiguration ).isSafeModeEnabled();
+    doReturn( TEST_BOOLEAN_PARAM ).when( transExecutionConfiguration ).isGatheringMetrics();
+
+    delegate.executeTransformation( transMeta, true, false, false, false, false,
+            null, false, LogLevel.BASIC );
+
+    verify( transMeta ).setParameterValue( TEST_PARAM_KEY, TEST_PARAM_VALUE );
+    verify( transMeta ).activateParameters();
+    verify( transMeta ).setLogLevel( TEST_LOG_LEVEL );
+    verify( transMeta ).setClearingLog( TEST_BOOLEAN_PARAM );
+    verify( transMeta ).setSafeModeEnabled( TEST_BOOLEAN_PARAM );
+    verify( transMeta ).setGatheringMetrics( TEST_BOOLEAN_PARAM );
   }
 }


### PR DESCRIPTION
This is the backport of the following fixes:

### 1. [PDI-16885] Values of parameters are not passed on when using the Pentaho Server run config

- The filling of parameters from the execution configuration has been added
- PDI Parameters has been added to scheduler request

### 2. [PDI-17019] PDI 8.0 server run configuration settings are ignored

- The new fields for storing parameters have been added into AbstractMeta and JobMeta classes
- The updating of executionConfiguration have been added into SpoonJobDelegate and SpoonTransformationDelegate classes
- The schedule request generating has been fixed