### PR TITLE
[SP-4186]: Backport of PDI-16885 - Values of parameters filled in dur…

### DIFF
--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/SchedulerRequest.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/SchedulerRequest.java
@@ -3,7 +3,7 @@
  *
  *  Pentaho Data Integration
  *
- *  Copyright (C) 2017 by Hitachi Vantara : http://www.pentaho.com
+ *  Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *  *******************************************************************************
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
@@ -29,6 +29,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
 import org.pentaho.di.base.AbstractMeta;
+import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.Repository;
 
@@ -108,11 +109,8 @@ public class SchedulerRequest {
   }
 
   public void submit( AbstractMeta meta ) {
-    String filename = getFullPath( meta );
     try {
-      httpPost.setEntity( new StringEntity( "<jobScheduleRequest>\n"
-        + "<inputFile>" + filename + "</inputFile>\n"
-        + "</jobScheduleRequest>" ) );
+      httpPost.setEntity( buildSchedulerRequestEntity( meta ) );
       httpclient.execute( httpPost );
       logMessage();
     } catch ( Exception e ) {
@@ -128,6 +126,26 @@ public class SchedulerRequest {
 
   private String getFullPath( AbstractMeta meta ) {
     return meta.getRepositoryDirectory().getPath() + "/" + meta.getName() + "." + meta.getDefaultExtension();
+  }
+
+  StringEntity buildSchedulerRequestEntity( AbstractMeta meta )
+          throws UnsupportedEncodingException, UnknownParamException {
+    String filename = getFullPath( meta );
+
+    StringBuilder sb = new StringBuilder();
+    sb.append( "<jobScheduleRequest>\n" );
+    sb.append( "<inputFile>" ).append( filename ).append( "</inputFile>\n" );
+    sb.append( "<pdiParameters>\n" );
+    for ( String param : meta.listParameters() ) {
+      sb.append( "<entry>\n" );
+      sb.append( "<key>" ).append( param ).append( "</key>\n" );
+      sb.append( "<value>" ).append( meta.getParameterValue( param ) ).append( "</value>\n" );
+      sb.append( "</entry>\n" );
+    }
+    sb.append( "</pdiParameters>\n" );
+    sb.append( "</jobScheduleRequest>" );
+
+    return new StringEntity( sb.toString() );
   }
 
 }

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/SchedulerRequestTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/SchedulerRequestTest.java
@@ -1,0 +1,70 @@
+/*
+  * *****************************************************************************
+  *
+  *  Pentaho Data Integration
+  *
+  *  Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+  *
+  *  *******************************************************************************
+  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+  *  this file except in compliance with the License. You may obtain a copy of the
+  *  License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  *  Unless required by applicable law or agreed to in writing, software
+  *  distributed under the License is distributed on an "AS IS" BASIS,
+  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *  See the License for the specific language governing permissions and
+  *  limitations under the License.
+  *
+  * *****************************************************************************
+  *
+  */
+
+package org.pentaho.di.engine.configuration.impl.pentaho.scheduler;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.base.AbstractMeta;
+import org.pentaho.di.core.parameters.UnknownParamException;
+import org.pentaho.di.repository.RepositoryDirectoryInterface;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doReturn;
+
+public class SchedulerRequestTest {
+  private static final String EMPTY_STRING = "";
+  private static final String TEST_PARAM_NAME = "paramName";
+  private static final String[] ARRAY_WITH_PARAM_NAME = new String[]{TEST_PARAM_NAME};
+
+  private SchedulerRequest schedulerRequest;
+
+  @Before
+  public void before() {
+    schedulerRequest = mock( SchedulerRequest.class );
+  }
+
+  @Test
+  @SuppressWarnings( "ResultOfMethodCallIgnored" )
+  public void testBuildSchedulerRequestEntity() throws UnknownParamException, UnsupportedEncodingException {
+    AbstractMeta abstractMeta = mock( AbstractMeta.class );
+    RepositoryDirectoryInterface repositoryDirectoryInterface = mock( RepositoryDirectoryInterface.class );
+
+    doReturn( repositoryDirectoryInterface ).when( abstractMeta ).getRepositoryDirectory();
+    doReturn( EMPTY_STRING ).when( repositoryDirectoryInterface ).getPath();
+    doReturn( EMPTY_STRING ).when( abstractMeta ).getName();
+    doReturn( EMPTY_STRING ).when( abstractMeta ).getDefaultExtension();
+    doReturn( ARRAY_WITH_PARAM_NAME ).when( abstractMeta ).listParameters();
+
+    doCallRealMethod().when( schedulerRequest ).buildSchedulerRequestEntity( abstractMeta );
+    schedulerRequest.buildSchedulerRequestEntity( abstractMeta );
+
+    verify( abstractMeta ).listParameters();
+    verify( abstractMeta ).getParameterValue( TEST_PARAM_NAME );
+  }
+}

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegate.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -860,6 +860,13 @@ public class SpoonTransformationDelegate extends SpoonDelegate {
     if ( execConfigAnswer ) {
       TransGraph activeTransGraph = spoon.getActiveTransGraph();
       activeTransGraph.transLogDelegate.addTransLog();
+
+      // Set the named parameters
+      Map<String, String> paramMap = executionConfiguration.getParams();
+      for ( String key : paramMap.keySet() ) {
+        transMeta.setParameterValue( key, Const.NVL( paramMap.get( key ), "" ) );
+      }
+      transMeta.activateParameters();
 
       ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.SpoonTransMetaExecutionStart.id, transMeta );
       ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.SpoonTransExecutionConfiguration.id,

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegateTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegateTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,19 +28,37 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.logging.TransLogTable;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.trans.TransExecutionConfiguration;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.ui.spoon.Spoon;
+import org.pentaho.di.ui.spoon.trans.TransGraph;
+import org.pentaho.di.ui.spoon.trans.TransLogDelegate;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class SpoonTransformationDelegateTest {
+  private static final String[] EMPTY_STRING_ARRAY = new String[]{};
+  private static final String TEST_PARAM_KEY = "paramKey";
+  private static final String TEST_PARAM_VALUE = "paramValue";
+  private static final Map<String, String> MAP_WITH_TEST_PARAM = new HashMap<String, String>() {
+    {
+      put( TEST_PARAM_KEY, TEST_PARAM_VALUE );
+    }
+  };
 
   private SpoonTransformationDelegate delegate;
   private Spoon spoon;
@@ -58,6 +76,8 @@ public class SpoonTransformationDelegateTest {
     spoon = mock( Spoon.class );
     spoon.delegates = mock( SpoonDelegates.class );
     spoon.delegates.tabs = mock( SpoonTabsDelegate.class );
+    spoon.variables = mock( RowMetaAndData.class );
+    delegate.spoon = spoon;
 
     doReturn( transformationMap ).when( delegate ).getTransformationList();
     doReturn( spoon ).when( delegate ).getSpoon();
@@ -90,5 +110,29 @@ public class SpoonTransformationDelegateTest {
     assertFalse( delegate.addTransformation( transMeta ) );
     delegate.closeTransformation( transMeta );
     assertTrue( delegate.addTransformation( transMeta ) );
+  }
+
+  @Test
+  @SuppressWarnings( "ResultOfMethodCallIgnored" )
+  public void testSetNamedParameters() throws KettleException {
+    doCallRealMethod().when( delegate ).executeTransformation( transMeta, true, false, false,
+            false, false, null, false, LogLevel.BASIC );
+
+    RowMetaInterface rowMetaInterface = mock( RowMetaInterface.class );
+    TransExecutionConfiguration transExecutionConfiguration = mock( TransExecutionConfiguration.class );
+    TransGraph activeTransGraph = mock( TransGraph.class );
+    activeTransGraph.transLogDelegate = mock( TransLogDelegate.class );
+
+    doReturn( rowMetaInterface ).when( spoon.variables ).getRowMeta();
+    doReturn( EMPTY_STRING_ARRAY ).when( rowMetaInterface ).getFieldNames();
+    doReturn( transExecutionConfiguration ).when( spoon ).getTransExecutionConfiguration();
+    doReturn( MAP_WITH_TEST_PARAM ).when( transExecutionConfiguration ).getParams();
+    doReturn( activeTransGraph ).when( spoon ).getActiveTransGraph();
+
+    delegate.executeTransformation( transMeta, true, false, false, false, false,
+            null, false, LogLevel.BASIC );
+
+    verify( transMeta ).setParameterValue( TEST_PARAM_KEY, TEST_PARAM_VALUE );
+    verify( transMeta ).activateParameters();
   }
 }


### PR DESCRIPTION
…ing the Run Options dialog are not passed on when using the Pentaho Server run config (8.0 Suite)]

This is the cherry-pick of the fix for [PDI-16885] Values of parameters are not passed on when using the Pentaho Server run config
- The filling of parameters from the execution configuration has been added
- PDI Parameters has been added to scheduler request