### PR TITLE
[SP-4164][PDI-16387] Running a Job for Every Input Row, sub job does not reset variables or parameters with every execution

### DIFF
--- a/engine/src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
+++ b/engine/src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,12 +22,16 @@
 
 package org.pentaho.di.job.entries.setvariables;
 
+import org.pentaho.di.job.JobEntryListener;
+import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.job.entry.validator.AbstractFileValidator;
 import org.pentaho.di.job.entry.validator.AndValidator;
 import org.pentaho.di.job.entry.validator.JobEntryValidatorUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -78,6 +82,10 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
   public int[] variableType;
 
   public String filename;
+
+  // we need to recovery changed values of variables if we use VARIABLE_TYPE_CURRENT_JOB
+  private Map<String, String> changedInitialVariables = new HashMap<>();
+
   public int fileVariableType;
 
   public static final int VARIABLE_TYPE_JVM = 0;
@@ -97,6 +105,27 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
     replaceVars = true;
     variableName = null;
     variableValue = null;
+  }
+
+  @Override
+  public void setParentJob( Job parentJob ) {
+    super.setParentJob( parentJob );
+    // PDI-16387 Add a listener for recovering changed values of variables
+    JobEntryListener jobListener = new JobEntryListener() {
+      @Override
+      public void beforeExecution( Job job, JobEntryCopy jobEntryCopy, JobEntryInterface jobEntryInterface ) {
+        for ( String key : changedInitialVariables.keySet() ) {
+          setVariable( key, changedInitialVariables.get( key ) );
+          parentJob.setVariable( key, changedInitialVariables.get( key ) );
+        }
+        changedInitialVariables.clear();
+      }
+      @Override
+      public void afterExecution( Job job, JobEntryCopy jobEntryCopy, JobEntryInterface jobEntryInterface,
+                                  Result result ) {
+      }
+    };
+    parentJob.addJobEntryListener( jobListener );
   }
 
   public JobEntrySetVariables() {
@@ -290,6 +319,7 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
             break;
 
           case VARIABLE_TYPE_CURRENT_JOB:
+            changedInitialVariables.put( varname, getVariable( varname ) );
             setVariable( varname, value );
             if ( parentJob != null ) {
               parentJob.setVariable( varname, value );

--- a/engine/test-src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
+++ b/engine/test-src/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,7 +32,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.util.Assert;
 import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobEntryListener;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryCopy;
 
@@ -86,5 +88,22 @@ public class JobEntrySetVariablesTest {
     assertEquals( "日本語", entry.getVariable( "Japanese" ) );
     assertEquals( "English", entry.getVariable( "English" ) );
     assertEquals( "中文", entry.getVariable( "Chinese" ) );
+  }
+
+  @Test
+  //PDI-16387
+  public void testVariableTypeCurrentJob() throws Exception {
+    entry.setFilename( "test-src/org/pentaho/di/job/entries/setvariables/UTF8Text.properties" );
+    entry.setVariableName( new String[] {} );
+    entry.setReplaceVars( true );
+    entry.setFileVariableType( JobEntrySetVariables.VARIABLE_TYPE_CURRENT_JOB );
+    Result result = entry.execute( new Result(), 0 );
+    for ( JobEntryListener  jobEntryListener : job.getJobEntryListeners() ) {
+      jobEntryListener.beforeExecution( job, null, entry );
+    }
+    Assert.assertTrue( result.getResult() );
+    Assert.assertNull( entry.getVariable( "Japanese" ) );
+    Assert.assertNull( entry.getVariable( "English" ) );
+    Assert.assertNull( entry.getVariable( "Chinese" ) );
   }
 }


### PR DESCRIPTION
[SP-4164][PDI-16387] Running a Job for Every Input Row, sub job does not reset variables or parameters with every execution

added recovering changed values of variables if we use VARIABLE_TYPE_CURRENT_JOB