### PR TITLE
[PDI-16844] Steps Job Executor and Transformation should overwrite the child parameter by the parent parameter.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -194,8 +194,10 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
     Map<String, String> parameters = new HashMap<>();
     Set<String> subTransParameters = new HashSet<>( Arrays.asList( listParameters ) );
 
-    for ( int i = 0; i < mappingVariables.length; i++ ) {
-      parameters.put( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
+    if ( mappingVariables != null ) {
+      for ( int i = 0; i < mappingVariables.length; i++ ) {
+        parameters.put( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
+      }
     }
 
     for ( String variableName : parent.listVariables() ) {


### PR DESCRIPTION
[PDI-16844] Steps Job Executor and Transformation should overwrite the child parameter by the parent parameter.

- correction for case when mapping Variables is null. JobEntryTrans has parameters == null, when it was created not from UI.