### PR TITLE
[SP-4219][PDI-16844] Steps Job Executor and Transformation should overwrite the child parameter by the parent parameter.

### DIFF
--- a/engine/src/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -193,8 +193,10 @@ public abstract class StepWithMappingMeta extends BaseStepMeta implements HasRep
     Map<String, String> parameters = new HashMap<>();
     Set<String> subTransParameters = new HashSet<>( Arrays.asList( listParameters ) );
 
-    for ( int i = 0; i < mappingVariables.length; i++ ) {
-      parameters.put( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
+    if ( mappingVariables != null ) {
+      for ( int i = 0; i < mappingVariables.length; i++ ) {
+        parameters.put( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
+      }
     }
 
     for ( String variableName : parent.listVariables() ) {


### PR DESCRIPTION
[SP-4219][PDI-16844] Steps Job Executor and Transformation should overwrite the child parameter by the parent parameter.

- correction for case when mapping Variables is null. JobEntryTrans has parameters == null, when it was created not from UI.