### PR TITLE
[BACKLOG-21736] Adding input files for the case when JSON Input step file name is expressed in a field

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -22,6 +22,7 @@
     <sshd-sftp.version>0.11.0</sshd-sftp.version>
     <ftpserver-core.version>1.0.6</ftpserver-core.version>
     <bcprov-jdk14.version>1.51</bcprov-jdk14.version>
+    <pdi.version>${project.version}</pdi.version>
   </properties>
 
   <dependencies>
@@ -121,6 +122,18 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.di.plugins</groupId>
+      <artifactId>pdi-xml-plugin-core</artifactId>
+      <version>${pdi.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.di.plugins</groupId>
+      <artifactId>pdi-core-plugins-impl</artifactId>
+      <version>${pdi.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/plugins/json/core/src/main/java/org/pentaho/di/trans/steps/jsoninput/analyzer/JsonInputExternalResourceConsumer.java
+++ b/plugins/json/core/src/main/java/org/pentaho/di/trans/steps/jsoninput/analyzer/JsonInputExternalResourceConsumer.java
@@ -22,19 +22,13 @@
 
 package org.pentaho.di.trans.steps.jsoninput.analyzer;
 
-import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.steps.jsoninput.JsonInput;
 import org.pentaho.di.trans.steps.jsoninput.JsonInputMeta;
-import org.pentaho.metaverse.api.IAnalysisContext;
-import org.pentaho.metaverse.api.analyzer.kettle.KettleAnalyzerUtil;
+import org.pentaho.metaverse.api.IMetaverseConfig;
 import org.pentaho.metaverse.api.analyzer.kettle.step.BaseStepExternalResourceConsumer;
-import org.pentaho.metaverse.api.model.IExternalResourceInfo;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 
-import java.util.Collection;
-import java.util.Collections;
-
-public class JsonInputExternalResourceConsumer
-  extends BaseStepExternalResourceConsumer<JsonInput, JsonInputMeta> {
+public class JsonInputExternalResourceConsumer extends BaseStepExternalResourceConsumer<JsonInput, JsonInputMeta> {
 
   @Override
   public Class<JsonInputMeta> getMetaClass() {
@@ -47,22 +41,8 @@ public class JsonInputExternalResourceConsumer
   }
 
   @Override
-  public Collection<IExternalResourceInfo> getResourcesFromMeta(
-    final JsonInputMeta meta, final IAnalysisContext context ) {
-    Collection<IExternalResourceInfo> resources = Collections.emptyList();
-
-    // We only need to collect these resources if we're not data-driven and there are no used variables in the
-    // metadata relating to external files.
-    if ( !isDataDriven( meta ) ) {
-      resources = KettleAnalyzerUtil.getResourcesFromMeta( meta, context );
-    }
-    return resources;
-  }
-
-  @Override
-  public Collection<IExternalResourceInfo> getResourcesFromRow(
-    final JsonInput step, final RowMetaInterface rowMeta, final Object[] row ) {
-
-    return KettleAnalyzerUtil.getResourcesFromRow( step, rowMeta, row );
+  protected boolean resolveExternalResources() {
+    final IMetaverseConfig config = PentahoSystem.get( IMetaverseConfig.class );
+    return config == null ? false : config.getResolveExternalResources();
   }
 }

--- a/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsoninput/analyzer/JsonInputAnalyzerTest.java
+++ b/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsoninput/analyzer/JsonInputAnalyzerTest.java
@@ -153,10 +153,14 @@ public class JsonInputAnalyzerTest {
     assertTrue( types.contains( JsonInputMeta.class ) );
   }
 
-
   @Test
-  public void testTextFileInputExternalResourceConsumer() throws Exception {
-    JsonInputExternalResourceConsumer consumer = new JsonInputExternalResourceConsumer();
+  public void testJsonInputExternalResourceConsumer() throws Exception {
+    JsonInputExternalResourceConsumer consumer = new JsonInputExternalResourceConsumer() {
+      @Override
+      protected boolean resolveExternalResources() {
+        return true;
+      }
+    };
 
     StepMeta spyMeta = spy( new StepMeta( "test", meta ) );
 
@@ -170,16 +174,16 @@ public class JsonInputAnalyzerTest {
     when( meta.getFileInputList( Mockito.any( VariableSpace.class ) ) ).thenReturn( inputFiles );
 
     assertFalse( consumer.isDataDriven( meta ) );
+
     Collection<IExternalResourceInfo> resources = consumer.getResourcesFromMeta( meta );
     assertFalse( resources.isEmpty() );
     assertEquals( 2, resources.size() );
 
-
     when( meta.isAcceptingFilenames() ).thenReturn( true );
     assertTrue( consumer.isDataDriven( meta ) );
     assertTrue( consumer.getResourcesFromMeta( meta ).isEmpty() );
-    when( mockRowMetaInterface.getString( Mockito.any( Object[].class ), Mockito.anyString(), Mockito.anyString() ) )
-      .thenReturn( "/path/to/row/file" );
+    when( mockJsonInput.environmentSubstitute( Mockito.any( String.class ) ) ).thenReturn( "/path/to/row/file" );
+
     when( mockJsonInput.getStepMetaInterface() ).thenReturn( meta );
     resources = consumer.getResourcesFromRow( mockJsonInput, mockRowMetaInterface, new String[] { "id", "name" } );
     assertFalse( resources.isEmpty() );


### PR DESCRIPTION
Additionally, fixing failing integration tests.

Related pentaho-metaverse PR: https://github.com/pentaho/pentaho-metaverse/pull/455

@pentaho/r2d2 