### PR TITLE
[PDI-16658] - Fixes for the effects of PDI-16658.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -1614,6 +1614,11 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
       boolean wait = true;
       while ( wait ) {
         wait = transFinishedBlockingQueue.poll( 1, TimeUnit.DAYS ) == null;
+        if ( wait ) {
+          // poll returns immediately - this was hammering the CPU with poll checks. Added
+          // a sleep to let the CPU breathe
+          Thread.sleep( 1 );
+        }
       }
     } catch ( InterruptedException e ) {
       throw new RuntimeException( "Waiting for transformation to be finished interrupted!", e );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/userdefinedjavaclass/UserDefinedJavaClass.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/userdefinedjavaclass/UserDefinedJavaClass.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,9 +21,6 @@
  ******************************************************************************/
 
 package org.pentaho.di.trans.steps.userdefinedjavaclass;
-
-import java.util.List;
-import java.util.Map;
 
 import org.pentaho.di.core.BlockingRowSet;
 import org.pentaho.di.core.ResultFile;
@@ -44,10 +41,14 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.www.SocketRepository;
 
+import java.util.List;
+import java.util.Map;
+
 public class UserDefinedJavaClass extends BaseStep implements StepInterface {
   private TransformClassBase child;
   protected final UserDefinedJavaClassMeta meta;
   protected final UserDefinedJavaClassData data;
+  public static final String KETTLE_DEFAULT_CLASS_CACHE_SIZE = "KETTLE_DEFAULT_CLASS_CACHE_SIZE";
 
   public UserDefinedJavaClass( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr,
     TransMeta transMeta, Trans trans ) {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/userdefinedjavaclass/UserDefinedJavaClassDef.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/userdefinedjavaclass/UserDefinedJavaClassDef.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,7 +22,11 @@
 
 package org.pentaho.di.trans.steps.userdefinedjavaclass;
 
+import org.apache.commons.codec.binary.Hex;
 import org.pentaho.di.core.exception.KettleStepException;
+
+import java.security.MessageDigest;
+import java.util.Objects;
 
 public class UserDefinedJavaClassDef implements Cloneable {
   public enum ClassType {
@@ -40,6 +44,21 @@ public class UserDefinedJavaClassDef implements Cloneable {
     this.className = className;
     this.source = source;
     classActive = true;
+  }
+
+  public int hashCode() {
+    return Objects.hash( className, source );
+  }
+
+  public String getChecksum() throws KettleStepException {
+    String ck = this.className + this.source;
+    try {
+      byte[] b = MessageDigest.getInstance( "MD5" ).digest( ck.getBytes() );
+      return Hex.encodeHexString( b );
+    } catch ( Exception ex ) {
+      // Can't get MD5 hashcode ?
+      throw new KettleStepException( "Unable to obtain checksum of UDJC - " + this.className );
+    }
   }
 
   public ClassType getClassType() {

--- a/engine/src/test/java/org/pentaho/di/trans/steps/userdefinedjavaclass/UserDefinedJavaClassMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/userdefinedjavaclass/UserDefinedJavaClassMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -60,5 +60,41 @@ public class UserDefinedJavaClassMetaTest {
 
     userDefinedJavaClassMetaSpy.cookClasses();
     Assert.assertEquals( 1, userDefinedJavaClassMeta.cookErrors.size() );
+  }
+
+  @Test
+  public void cookClassesCachingTest() throws Exception {
+    String codeBlock1 = "public boolean processRow() {\n"
+        + "    return true;\n"
+        + "}\n\n";
+    String codeBlock2 = "public boolean processRow() {\n"
+        + "    // Random comment\n"
+        + "    return true;\n"
+        + "}\n\n";
+    UserDefinedJavaClassMeta userDefinedJavaClassMeta1 = new UserDefinedJavaClassMeta();
+
+    UserDefinedJavaClassDef userDefinedJavaClassDef1 = new UserDefinedJavaClassDef( UserDefinedJavaClassDef.ClassType.NORMAL_CLASS, "MainClass", codeBlock1 );
+
+    StepMeta stepMeta = Mockito.mock( StepMeta.class );
+    Mockito.when( stepMeta.getName() ).thenReturn( "User Defined Java Class" );
+    userDefinedJavaClassMeta1.setParentStepMeta( stepMeta );
+
+    UserDefinedJavaClassMeta userDefinedJavaClassMetaSpy = Mockito.spy( userDefinedJavaClassMeta1 );
+
+    Class<?> clazz1 = userDefinedJavaClassMetaSpy.cookClass( userDefinedJavaClassDef1 );
+    Class<?> clazz2 = userDefinedJavaClassMetaSpy.cookClass( userDefinedJavaClassDef1 );
+    Assert.assertTrue( clazz1 == clazz2 ); // Caching should work here and return exact same class
+
+    UserDefinedJavaClassMeta userDefinedJavaClassMeta2 = new UserDefinedJavaClassMeta();
+    UserDefinedJavaClassDef userDefinedJavaClassDef2 = new UserDefinedJavaClassDef( UserDefinedJavaClassDef.ClassType.NORMAL_CLASS, "AnotherClass", codeBlock2 );
+
+    StepMeta stepMeta2 = Mockito.mock( StepMeta.class );
+    Mockito.when( stepMeta2.getName() ).thenReturn( "Another UDJC" );
+    userDefinedJavaClassMeta2.setParentStepMeta( stepMeta2 );
+    UserDefinedJavaClassMeta userDefinedJavaClassMeta2Spy = Mockito.spy( userDefinedJavaClassMeta2 );
+
+    Class<?> clazz3 = userDefinedJavaClassMeta2Spy.cookClass( userDefinedJavaClassDef2 );
+
+    Assert.assertTrue( clazz3 != clazz1 ); // They should not be the exact same class
   }
 }


### PR DESCRIPTION
On PDI-16658, I advocate for actual re-writes of the code creating the issues in this case. The code is really broken. That said, these fixes are tactical and alleviate the massive performance slow-down, so they're valuable until such time as a sprint team can take up the task of re-implementation of the logging registry using a proper LRU cache and the observer (or possibly the visitor) pattern to make this area of PDI sane.