### PR TITLE
[BACKLOG-22526] vulnerable component spring-security: upgrade from 4.…

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -68,7 +68,7 @@
 
     <!-- Spring -->
     <springframework4.version>4.3.2.RELEASE</springframework4.version>
-    <springframework4-security.version>4.1.3.RELEASE</springframework4-security.version>
+    <springframework4-security.version>4.1.5.RELEASE</springframework4-security.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
…1.3 to 4.1.5

**Minor patch upgrade**: from 4.1.3 to 4.1.5

@pentaho/rogueone
CC'ing @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅ 

List of PRs
- https://github.com/pentaho/marketplace/pull/148
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/33
- https://github.com/pentaho/pentaho-metadata-editor/pull/122
- https://github.com/pentaho/pentaho-kettle/pull/5203
- https://github.com/pentaho/pentaho-platform/pull/4100
- https://github.com/pentaho/pentaho-platform-ee/pull/1257
- https://github.com/pentaho/pentaho-karaf-assembly/pull/437
- https://github.com/pentaho/pdi-ee-plugin/pull/356
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/105
- https://github.com/pentaho/pentaho-reporting/pull/1127
- https://github.com/pentaho/pentaho-osgi-bundles/pull/264