### PR TITLE
[BACKLOG-22541] have params accept 'true' as well as the default 'yes'

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractBaseCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractBaseCommandExecutor.java
@@ -183,6 +183,10 @@ public abstract class AbstractBaseCommandExecutor {
     }
   }
 
+  public boolean isEnabled( final String value ) {
+    return YES.equalsIgnoreCase( value ) || Boolean.parseBoolean( value ); // both are NPE safe, both are case-insensitive
+  }
+
   public LogChannelInterface getLog() {
     return log;
   }

--- a/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
@@ -94,7 +94,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
 
         logDebug( "Kitchen.Log.ParsingCommandLine" );
 
-        if ( !Utils.isEmpty( repoName ) && !YES.equalsIgnoreCase( noRepo ) ) {
+        if ( !Utils.isEmpty( repoName ) && !isEnabled( noRepo ) ) {
 
           /**
            * if set, _trust_user_ needs to be considered. See pur-plugin's:
@@ -102,7 +102,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
            * @link https://github.com/pentaho/pentaho-kettle/blob/8.0.0.0-R/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryConnector.java#L97-L101
            * @link https://github.com/pentaho/pentaho-kettle/blob/8.0.0.0-R/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/WebServiceManager.java#L130-L133
            */
-          if ( YES.equalsIgnoreCase( trustUser ) ) {
+          if ( isEnabled( trustUser ) ) {
             System.setProperty( "pentaho.repository.client.attemptTrust", YES );
           }
 
@@ -122,7 +122,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
           job = executeFilesystemBasedCommand( initialDir, filename );
         }
 
-      } else if ( YES.equalsIgnoreCase( listRepos ) ) {
+      } else if ( isEnabled( listRepos ) ) {
 
         printRepositories( loadRepositoryInfo( "Kitchen.Log.ListRep", "Kitchen.Error.NoRepDefinied" ) ); // list the repositories placed at repositories.xml
 
@@ -136,7 +136,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     }
 
     if ( job == null ) {
-      if ( !YES.equalsIgnoreCase( listJobs ) && !YES.equalsIgnoreCase( listDirs ) && !YES.equalsIgnoreCase( listRepos ) ) {
+      if ( !isEnabled( listJobs ) && !isEnabled( listDirs ) && !isEnabled( listRepos ) ) {
         System.out.println( BaseMessages.getString( getPkgClazz(), "Kitchen.Error.canNotLoadJob" ) );
       }
 
@@ -199,7 +199,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
       }
 
       // List the parameters defined in this job, then simply exit...
-      if ( YES.equalsIgnoreCase( listParams ) ) {
+      if ( isEnabled( listParams ) ) {
 
         printJobParameters( job );
 
@@ -214,7 +214,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
       if ( repository != null ) {
         repository.disconnect();
       }
-      if ( YES.equalsIgnoreCase( trustUser ) ) {
+      if ( isEnabled( trustUser ) ) {
         System.clearProperty( "pentaho.repository.client.attemptTrust" ); // we set it, now we sanitize it
       }
     }
@@ -273,11 +273,11 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
 
           return new Job( repository, jobMeta );
 
-        } else if ( YES.equalsIgnoreCase( listJobs ) ) {
+        } else if ( isEnabled( listJobs ) ) {
 
           printRepositoryStoredJobs( repository, directory ); // List the jobs in the repository
 
-        } else if ( YES.equalsIgnoreCase( listDirs ) ) {
+        } else if ( isEnabled( listDirs ) ) {
 
           printRepositoryDirectories( repository, directory ); // List the directories in the repository
         }

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -88,7 +88,7 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
 
         logDebug( "Pan.Log.ParsingCommandline" );
 
-        if ( !Utils.isEmpty( repoName ) && !YES.equalsIgnoreCase( noRepo ) ) {
+        if ( !Utils.isEmpty( repoName ) && !isEnabled( noRepo ) ) {
 
           /**
            * if set, _trust_user_ needs to be considered. See pur-plugin's:
@@ -96,7 +96,7 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
            * @link https://github.com/pentaho/pentaho-kettle/blob/8.0.0.0-R/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryConnector.java#L97-L101
            * @link https://github.com/pentaho/pentaho-kettle/blob/8.0.0.0-R/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/WebServiceManager.java#L130-L133
            */
-          if ( YES.equalsIgnoreCase( trustUser ) ) {
+          if ( isEnabled( trustUser ) ) {
             System.setProperty( "pentaho.repository.client.attemptTrust", YES );
           }
 
@@ -118,7 +118,7 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
 
       }
 
-      if ( YES.equalsIgnoreCase( listRepos ) ) {
+      if ( isEnabled( listRepos ) ) {
         printRepositories( loadRepositoryInfo( "Pan.Log.LoadingAvailableRep", "Pan.Error.NoRepsDefined" ) ); // list the repositories placed at repositories.xml
       }
 
@@ -136,8 +136,7 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
 
     if ( trans == null ) {
 
-      if ( !YES.equalsIgnoreCase( listTrans ) && !YES.equalsIgnoreCase( listDirs )
-              && !YES.equalsIgnoreCase( listRepos ) && Utils.isEmpty( exportRepo ) ) {
+      if ( !isEnabled( listTrans ) && !isEnabled( listDirs ) && !isEnabled( listRepos ) && Utils.isEmpty( exportRepo ) ) {
 
         System.out.println( BaseMessages.getString( getPkgClazz(), "Pan.Error.CanNotLoadTrans" ) );
         return CommandExecutorCodes.Pan.COULD_NOT_LOAD_TRANS.getCode();
@@ -151,11 +150,11 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
       trans.setLogLevel( getLog().getLogLevel() );
       configureParameters( trans, params, trans.getTransMeta() );
 
-      trans.setSafeModeEnabled( YES.equalsIgnoreCase( safemode ) ); // run in safe mode if requested
-      trans.setGatheringMetrics( YES.equalsIgnoreCase( metrics ) ); // enable kettle metric gathering if requested
+      trans.setSafeModeEnabled( isEnabled( safemode ) ); // run in safe mode if requested
+      trans.setGatheringMetrics( isEnabled( metrics ) ); // enable kettle metric gathering if requested
 
       // List the parameters defined in this transformation, and then simply exit
-      if ( YES.equalsIgnoreCase( listParams ) ) {
+      if ( isEnabled( listParams ) ) {
 
         printTransformationParameters( trans );
 
@@ -224,7 +223,7 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
       if ( repository != null ) {
         repository.disconnect();
       }
-      if ( YES.equalsIgnoreCase( trustUser ) ) {
+      if ( isEnabled( trustUser ) ) {
         System.clearProperty( "pentaho.repository.client.attemptTrust" ); // we set it, now we sanitize it
       }
     }
@@ -274,11 +273,11 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
 
             return trans; // return transformation loaded from the repo
 
-          } else if ( YES.equalsIgnoreCase( listTrans ) ) {
+          } else if ( isEnabled( listTrans ) ) {
 
             printRepositoryStoredTransformations( repository, directory ); // List the transformations in the repository
 
-          } else if ( YES.equalsIgnoreCase( listDirs ) ) {
+          } else if ( isEnabled( listDirs ) ) {
 
             printRepositoryDirectories( repository, directory ); // List the directories in the repository
 

--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
@@ -176,7 +176,8 @@ public class KitchenTest {
       System.setErr( new PrintStream( sysErrContent ) );
 
       Kitchen.setCommandExecutor( testPanCommandExecutor );
-      Kitchen.main( new String[] { "/listdir:Y", "/rep:test-repo", "/level:Basic" } );
+      // (case-insensitive) should accept either 'Y' (default) or 'true'
+      Kitchen.main( new String[] { "/listdir:true", "/rep:test-repo", "/level:Basic" } );
 
     } catch ( SecurityException e ) {
       // All OK / expected: SecurityException is purposely thrown when Pan triggers System.exitJVM()
@@ -219,6 +220,7 @@ public class KitchenTest {
       System.setErr( new PrintStream( sysErrContent ) );
 
       Kitchen.setCommandExecutor( testPanCommandExecutor );
+      // (case-insensitive) should accept either 'Y' (default) or 'true'
       Kitchen.main( new String[] { "/listjobs:Y", "/rep:test-repo", "/level:Basic" } );
 
     } catch ( SecurityException e ) {

--- a/engine/src/test/java/org/pentaho/di/pan/PanTest.java
+++ b/engine/src/test/java/org/pentaho/di/pan/PanTest.java
@@ -194,7 +194,8 @@ public class PanTest {
       System.setErr( new PrintStream( sysErrContent ) );
 
       Pan.setCommandExecutor( testPanCommandExecutor );
-      Pan.main( new String[] { "/listdir:Y", "/rep:test-repo", "/level:Basic" } );
+      // (case-insensitive) should accept either 'Y' (default) or 'true'
+      Pan.main( new String[] { "/listdir:true", "/rep:test-repo", "/level:Basic" } );
 
     } catch ( SecurityException e ) {
       // All OK / expected: SecurityException is purposely thrown when Pan triggers System.exitJVM()
@@ -237,6 +238,7 @@ public class PanTest {
       System.setErr( new PrintStream( sysErrContent ) );
 
       Pan.setCommandExecutor( testPanCommandExecutor );
+      // (case-insensitive) should accept either 'Y' (default) or 'true'
       Pan.main( new String[] { "/listtrans:Y", "/rep:test-repo", "/level:Basic" } );
 
     } catch ( SecurityException e ) {


### PR DESCRIPTION

@pentaho/rogueone please review

Under pentaho-kettle/engine:

- to trigger the execution of Kitchen-specific UTs and ITs and no others:
  - `mvn clean verify -Dtest=KitchenTest -DrunITs -Dit.test=KitchenIT`
- to do the above and allow for source code attachment on executing test cases ( port 5005 ):
  - `mvn clean verify -Dtest=KitchenTest -DrunITs -Dit.test=KitchenIT -Dmaven.failsafe.debug`
- to trigger the execution of Pan-specific UTs and ITs and no others:
  - `mvn clean verify -Dtest=PanTest -DrunITs -Dit.test=PanIT`
- to do the above and allow for source code attachment on executing test cases ( port 5005 ):
  - `mvn clean verify -Dtest=PanTest -DrunITs -Dit.test=PanIT -Dmaven.failsafe.debug`
