### PR TITLE
[BACKLOG-22633] Set all step rows without errors backgrounds to white so that fixed step errors don't stay red on the step metrics table.

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGridDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGridDelegate.java
@@ -415,6 +415,8 @@ public class TransGridDelegate extends SpoonDelegate implements XulEventHandler 
           // Error lines should appear in red:
           if ( baseStep.getErrors() > 0 ) {
             ti.setBackground( GUIResource.getInstance().getColorRed() );
+          } else {
+            ti.setBackground( GUIResource.getInstance().getColorWhite() );
           }
           nr++;
 


### PR DESCRIPTION
[BACKLOG-22633] Set all step rows without errors backgrounds to white so that fixed step errors don't stay red on the step metrics table.