### PR TITLE
[BACKLOG-20815] Extra columns included in append data step.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -109,7 +109,6 @@ import org.pentaho.di.trans.steps.mapping.MappingMeta;
 import org.pentaho.di.trans.steps.missing.MissingTrans;
 import org.pentaho.di.trans.steps.named.cluster.NamedClusterEmbedManager;
 import org.pentaho.di.trans.steps.singlethreader.SingleThreaderMeta;
-import org.pentaho.di.trans.steps.streamlookup.StreamLookupMeta;
 import org.pentaho.di.trans.steps.transexecutor.TransExecutorMeta;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Document;
@@ -1813,7 +1812,7 @@ public class TransMeta extends AbstractMeta
 
     // Resume the regular program...
 
-    List<StepMeta> prevSteps = getPreviousSteps( stepMeta );
+    List<StepMeta> prevSteps = findPreviousSteps( stepMeta, false );
 
     int nrPrevious = prevSteps.size();
 
@@ -1873,16 +1872,6 @@ public class TransMeta extends AbstractMeta
     stepsFieldsCache.put( fromToCacheEntry, rowMeta );
 
     return rowMeta;
-  }
-
-  @VisibleForTesting
-  List<StepMeta> getPreviousSteps( StepMeta stepMeta ) {
-    if ( stepMeta.getStepMetaInterface() instanceof StreamLookupMeta ) {
-      clearPreviousStepCache();
-      return findPreviousSteps( stepMeta, false );
-    } else {
-      return findPreviousSteps( stepMeta );
-    }
   }
 
   /**


### PR DESCRIPTION
Caused by a change to TransMeta.getStepFields() (adc9506bd)

That change switched from checking the number of prev steps via
findNrPrevSteps() to doing a count on the results of
findPreviousSteps().  The new logic, however, also includes the “info”
steps, changing behavior and resulting in extra columns in output
for some types of steps.

To address, switched to the overload of findPreviousSteps which
excludes info steps.

https://jira.pentaho.com/browse/BACKLOG-20815