### PR TITLE
[BACKLOG-22165] Set the jms property name column to use variables, and get the environment substitute for the property variables

### DIFF
--- a/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsProducer.java
+++ b/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsProducer.java
@@ -77,8 +77,10 @@ public class JmsProducer extends BaseStep implements StepInterface {
       setOptions( producer );
 
       for ( Map.Entry<String, String> entry : meta.getPropertyValuesByName().entrySet() ) {
-        logDebug( "Setting Jms Property Name: " + entry.getKey() + " Value: " + entry.getValue() );
-        producer.setProperty( entry.getKey(), entry.getValue() );
+        String keySubstitute = environmentSubstitute( entry.getKey() );
+        String valueSubstitute = environmentSubstitute( entry.getValue() );
+        logDebug( "Setting Jms Property Name: " + keySubstitute + ", Value: " + valueSubstitute );
+        producer.setProperty( keySubstitute, valueSubstitute );
       }
 
       first = false;

--- a/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/ui/JmsProducerDialog.java
+++ b/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/ui/JmsProducerDialog.java
@@ -360,6 +360,7 @@ public class JmsProducerDialog extends BaseStepDialog implements StepDialogInter
 
     ColumnInfo propertyName = new ColumnInfo( BaseMessages.getString( PKG, "JmsProducerDialog.Properties.Column.Name" ),
       ColumnInfo.COLUMN_TYPE_TEXT, false, false );
+    propertyName.setUsingVariables( true );
 
     ColumnInfo propertyValue = new ColumnInfo( BaseMessages.getString( PKG, "JmsProducerDialog.Properties.Column.Value" ),
       ColumnInfo.COLUMN_TYPE_TEXT, false, false );


### PR DESCRIPTION
[BACKLOG-22165] Set the jms property name column to use variables, and get the environment substitute for the property variables