### PR TITLE
Fixed JavaScript TruncateDate function for Month

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/script/ScriptAddedFunctions.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/script/ScriptAddedFunctions.java
@@ -2434,7 +2434,7 @@ public class ScriptAddedFunctions {
         switch ( level.intValue() ) {
         // MONTHS
           case 5:
-            cal.set( Calendar.MONTH, 1 );
+            cal.set( Calendar.MONTH, 0 );
             // DAYS
           case 4:
             cal.set( Calendar.DAY_OF_MONTH, 1 );


### PR DESCRIPTION
The Truncate Date function returned the wrong value for Month (Arg 5). 

Previous Behavior Truncate sets first of February.
New Behavior Truncate sets first of January.