### PR TITLE
[PDI-11089] - Cannot sort preview data (NullPointerException )

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -3885,6 +3885,8 @@ public class ValueMetaBase implements ValueMetaInterface {
         return getBoolean( data );
       case TYPE_BINARY:
         return getBinary( data );
+      case TYPE_TIMESTAMP:
+        return getDate( data );
       default:
         throw new KettleValueException( toString() + " : I can't convert the specified value to data type : "
             + conversionMetadata.getType() );

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -941,4 +941,14 @@ public class ValueMetaBaseTest {
     valueMetaBase.getValue( XMLHandler.loadXMLString( "<value-data>not empty</value-data>" ).getFirstChild() );
   }
 
+  @Test
+  public void testConvertStringToTimestampType() throws KettleValueException {
+    String timestampStringRepresentation = "2018/04/11 16:45:15.000000000";
+    Timestamp expectedTimestamp = Timestamp.valueOf( "2018-04-11 16:45:15.000000000" );
+
+    ValueMetaBase base = new ValueMetaString( "ValueMetaStringColumn" );
+    base.setConversionMetadata( new ValueMetaTimestamp( "ValueMetaTimestamp" ) );
+    Timestamp timestamp = ( Timestamp ) base.convertDataUsingConversionMetaData( timestampStringRepresentation );
+    assertEquals( expectedTimestamp, timestamp );
+  }
 }


### PR DESCRIPTION
* Allow the conversion of a date-time object with nanosecond precision.