### PR TITLE
[BACKLOG-22805] Displaying MQTT Error messages appropriately

### DIFF
--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilder.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilder.java
@@ -277,7 +277,6 @@ public final class MQTTClientBuilder {
     } catch ( Exception e ) {
       String errorMsg = getString( PKG, "MQTTClientBuilder.Error.QOS",
         stepName, variableSpace.environmentSubstitute( qos ) );
-      logChannel.logError( errorMsg );
       throw new IllegalArgumentException( errorMsg );
     }
   }

--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSource.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSource.java
@@ -89,7 +89,7 @@ public class MQTTStreamSource extends BlockingQueueStreamSource<List<Object>> {
         .withMqttVersion( mqttConsumerMeta.getMqttVersion() )
         .withAutomaticReconnect( mqttConsumerMeta.getAutomaticReconnect() )
         .buildAndConnect();
-    } catch ( MqttException e ) {
+    } catch ( Exception e ) {
       mqttConsumer.stopAll();
       mqttConsumer.logError( e.toString() );
     }

--- a/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilderTest.java
+++ b/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilderTest.java
@@ -176,8 +176,6 @@ public class MQTTClientBuilderTest {
       // Initialization failed because QOS level isn't 0, 1 or 2
       assertTrue( e instanceof IllegalArgumentException );
     }
-    verify( logger )
-      .logError( BaseMessages.getString( MQTTConsumer.class, "MQTTClientBuilder.Error.QOS", "Step Name", "hello" ) );
   }
 
   @Test
@@ -191,8 +189,6 @@ public class MQTTClientBuilderTest {
       // Initialization failed because QOS level isn't 0, 1 or 2
       assertTrue( e instanceof IllegalArgumentException );
     }
-    verify( logger )
-      .logError( BaseMessages.getString( MQTTConsumer.class, "MQTTClientBuilder.Error.QOS", "Step Name", "72" ) );
   }
 
   @Test

--- a/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSourceTest.java
+++ b/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSourceTest.java
@@ -161,12 +161,10 @@ public class MQTTStreamSourceTest {
 
     when( consumerMeta.getMqttServer() ).thenReturn( "tcp:/127.0.0.1:" + port );
     //invalid tcp://server/port
-    try {
-      source.open();
-      fail( "Expected exception." );
-    } catch ( Exception e ) {
-      assertThat( e, instanceOf( IllegalArgumentException.class ) );
-    }
+    source.open();
+    verify( mqttConsumer ).stopAll();
+    verify( mqttConsumer )
+      .logError( "java.lang.IllegalArgumentException: MQTT Connection should be specified as servername:port" );
   }
 
   @Test


### PR DESCRIPTION
When a bad username/password was used the error message wasn't being
caught correctly and displayed. Samething was happening for QOS. This
fix unifies the behavior between MQTT Producer and Consumer when an
error message occurs and disconnects the from the client as needed.