### PR TITLE
[BACKLOG-22806] Variable substitution doesn't work with MQTT SSL params

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/util/serialization/BaseSerializingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/serialization/BaseSerializingMeta.java
@@ -25,6 +25,7 @@ package org.pentaho.di.core.util.serialization;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -40,7 +41,7 @@ import static org.pentaho.di.core.util.serialization.StepMetaProps.from;
 
 /**
  * Handles serialization of meta by implementing getXML/loadXML, readRep/saveRep.
- *
+ * <p>
  * Uses {@link MetaXmlSerializer} amd {@link RepoSerializer} for generically
  * handling child classes meta.
  */
@@ -73,5 +74,15 @@ public abstract class BaseSerializingMeta extends BaseStepMeta implements StepMe
       .stepId( stepId )
       .transId( transId )
       .serialize();
+  }
+
+  /**
+   * Creates a copy of this stepMeta with variables globally substituted.
+   */
+  public StepMetaInterface withVariables( VariableSpace variables ) {
+    return StepMetaProps
+      .from( this )
+      .withVariables( variables )
+      .to( (StepMetaInterface) this.clone() );
   }
 }

--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTProducer.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTProducer.java
@@ -27,6 +27,7 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
+import org.pentaho.di.core.util.serialization.BaseSerializingMeta;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
@@ -68,7 +69,8 @@ public class MQTTProducer extends BaseStep implements StepInterface {
   @Override
   public boolean init( StepMetaInterface stepMetaInterface, StepDataInterface stepDataInterface ) {
     boolean isInitalized = super.init( stepMetaInterface, stepDataInterface );
-    meta = ( (MQTTProducerMeta) stepMetaInterface );
+    BaseSerializingMeta serializingMeta = (BaseSerializingMeta) stepMetaInterface;
+    meta = (MQTTProducerMeta) serializingMeta.withVariables( this ); // handle variable substitution up-front
     data = ( (MQTTProducerData) stepDataInterface );
 
     List<CheckResultInterface> remarks = new ArrayList<>();
@@ -150,7 +152,7 @@ public class MQTTProducer extends BaseStep implements StepInterface {
         }
       }
     } catch ( MqttException e ) {
-      logError( BaseMessages.getString( PKG, "MQTTProducer.Error.QOSNotSupported", meta.getQOS() )  );
+      logError( BaseMessages.getString( PKG, "MQTTProducer.Error.QOSNotSupported", meta.getQOS() ) );
       logError( e.getMessage(), e );
       setErrors( 1 );
       stopAll();

--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSource.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSource.java
@@ -65,7 +65,7 @@ public class MQTTStreamSource extends BlockingQueueStreamSource<List<Object>> {
   MQTTStreamSource( MQTTConsumerMeta mqttConsumerMeta, MQTTConsumer mqttConsumer ) {
     super( mqttConsumer );
     this.mqttConsumer = mqttConsumer;
-    this.mqttConsumerMeta = mqttConsumerMeta;
+    this.mqttConsumerMeta = (MQTTConsumerMeta) mqttConsumerMeta.withVariables( mqttConsumer );
   }
 
   @Override public void open() {

--- a/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilderTest.java
+++ b/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilderTest.java
@@ -39,7 +39,6 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
-import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 
@@ -56,7 +55,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -84,15 +82,10 @@ public class MQTTClientBuilderTest {
     when( step.getLogChannel() ).thenReturn( logger );
     when( step.getStepMeta() ).thenReturn( meta );
     when( step.getStepMeta().getName() ).thenReturn( "Step Name" );
-    when( step.environmentSubstitute( anyString() ) ).thenAnswer( ( answer -> answer.getArguments()[ 0 ] ) );
-    when( step.environmentSubstitute( any( String[].class ) ) )
-      .thenAnswer( ( answer -> answer.getArguments()[ 0 ] ) );
-
     builder
       .withBroker( "127.0.0.1:101010" )
       .withStep( step );
     builder.clientFactory = factory;
-
   }
 
   @Test
@@ -131,38 +124,6 @@ public class MQTTClientBuilderTest {
     assertArrayEquals( opts.getServerURIs(), new String[] { "ssl://127.0.0.1:3000" } );
     assertEquals( opts.getMqttVersion(), 3 );
     assertEquals( opts.isAutomaticReconnect(), false );
-  }
-
-  @Test
-  public void testEnvironmentSubstitute() throws MqttException {
-    builder
-      .withQos( "2" )
-      .withUsername( "user" )
-      .withPassword( "pass" )
-      .withIsSecure( true )
-      .withTopics( Collections.singletonList( "SomeTopic" ) )
-      .withSslConfig( ImmutableMap.of( "ssl.trustStore", "/some/path" ) )
-      .withCallback( callback )
-      .withKeepAliveInterval( "1000" )
-      .withMaxInflight( "2000" )
-      .withConnectionTimeout( "3000" )
-      .withCleanSession( "true" )
-      .withStorageLevel( "/Users/NoName/Temp" )
-      .withServerUris( "127.0.0.1:3000" )
-      .withMqttVersion( "3" )
-      .withAutomaticReconnect( "false" )
-      .buildAndConnect();
-
-    verify( step, times( 2 ) ).environmentSubstitute( "127.0.0.1:101010" );
-    verify( step, times( 3 ) ).environmentSubstitute( "2" );
-    verify( step, times( 2 ) ).environmentSubstitute( "1000" );
-    verify( step, times( 3 ) ).environmentSubstitute( "2000" );
-    verify( step, times( 2 ) ).environmentSubstitute( "3000" );
-    verify( step, times( 2 ) ).environmentSubstitute( "true" );
-    verify( step, times( 3 ) ).environmentSubstitute( "127.0.0.1:3000" );
-    verify( step, times( 2 ) ).environmentSubstitute( "3" );
-    verify( step, times( 3 ) ).environmentSubstitute( "false" );
-    verify( step ).environmentSubstitute( "/Users/NoName/Temp" );
   }
 
   @Test

--- a/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTProducerTest.java
+++ b/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTProducerTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
@@ -194,7 +193,7 @@ public class MQTTProducerTest {
     verify( mqttClient ).disconnect();
     verify( logChannel ).logError(
       "MQTT Producer - Received an exception publishing the message."
-      + "  Check that Quality of Service level ${qos} is supported by your MQTT Broker" );
+      + "  Check that Quality of Service level 0 is supported by your MQTT Broker" );
     verify( logChannel ).logError( "publish failed", mqttException );
     assertEquals( 0, trans.getSteps().get( 1 ).step.getLinesOutput() );
   }

--- a/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSourceTest.java
+++ b/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSourceTest.java
@@ -60,7 +60,6 @@ import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -95,6 +94,7 @@ public class MQTTStreamSourceTest {
     brokerService.start();
     brokerService.waitUntilStarted();
     when( consumerMeta.getQos() ).thenReturn( "2" );
+    when( consumerMeta.withVariables( any() ) ).thenReturn( consumerMeta );
     when( consumerMeta.getMqttServer() ).thenReturn( "127.0.0.1:" + port );
     when( consumerMeta.getTopics() ).thenReturn( singletonList( "mytopic" ) );
     when( mqttConsumer.environmentSubstitute( anyString() ) )


### PR DESCRIPTION
2 commits.  First commit adds a method to BaseSerializingMeta that supports swapping environment variables in all strings within a meta.  This can be used as an all purpose way of setting env variables without needing to remember to handle them individually.  Second commit updates MQTT consumer / producer to use this new method.

