### PR TITLE
[BACKLOG-22822] Fix NPE when disposing ExcelInput step

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/excelinput/ExcelInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/excelinput/ExcelInput.java
@@ -827,9 +827,13 @@ public class ExcelInput extends BaseStep implements StepInterface {
       }
     }
     try {
-      fpis.close();
+      if ( fpis != null ) {
+        fpis.close();
+      }
     } catch ( IOException e ) {
       logDebug( Const.getStackTracker( e ) );
+	  } catch ( Exception e ) {
+	    // Ignore other close errors
     }
     super.dispose( smi, sdi );
   }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/excelinput/ExcelInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/excelinput/ExcelInput.java
@@ -832,8 +832,8 @@ public class ExcelInput extends BaseStep implements StepInterface {
       }
     } catch ( IOException e ) {
       logDebug( Const.getStackTracker( e ) );
-	  } catch ( Exception e ) {
-	    // Ignore other close errors
+    } catch ( Exception e ) {
+      // Ignore other close errors
     }
     super.dispose( smi, sdi );
   }


### PR DESCRIPTION
@pentaho/millenniumfalcon, @denisprotopopov and @mbatchelor please review.

Fixes regression introduced by PDI-16942 (https://github.com/pentaho/pentaho-kettle/pull/5014).
`fpis` **can** be null if `data.workbook` **is not null** when `getRowFromWorkbooks()` is called.

Note that PDI-16942 was backported to 8.0 (https://github.com/pentaho/pentaho-kettle/pull/5102) and 7.1 (https://github.com/pentaho/pentaho-kettle/pull/5115), so the regression probably is also present there.