### PR TITLE
[PDI-16494] Updated Ivy repository URL

### DIFF
--- a/assembly/ivysettings.xml
+++ b/assembly/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/build-res/ivysettings.xml
+++ b/build-res/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/core/ivysettings.xml
+++ b/core/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/dbdialog/ivysettings.xml
+++ b/dbdialog/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/engine/ivysettings.xml
+++ b/engine/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/aggregate-rows/ivysettings.xml
+++ b/plugins/aggregate-rows/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/elasticsearch-bulk-insert/ivysettings.xml
+++ b/plugins/elasticsearch-bulk-insert/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/get-previous-row-field/ivysettings.xml
+++ b/plugins/get-previous-row-field/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/googleanalytics/ivysettings.xml
+++ b/plugins/googleanalytics/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/gp-bulk-loader/ivysettings.xml
+++ b/plugins/gp-bulk-loader/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-drools5-plugin/ivysettings.xml
+++ b/plugins/kettle-drools5-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-dummy-plugin/ivysettings.xml
+++ b/plugins/kettle-dummy-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-gpload-plugin/ivysettings.xml
+++ b/plugins/kettle-gpload-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-hl7-plugin/ivysettings.xml
+++ b/plugins/kettle-hl7-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-json-plugin/ivysettings.xml
+++ b/plugins/kettle-json-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-openerp-plugin/ivysettings.xml
+++ b/plugins/kettle-openerp-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-palo-plugin/ivysettings.xml
+++ b/plugins/kettle-palo-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-s3csvinput-plugin/ivysettings.xml
+++ b/plugins/kettle-s3csvinput-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-sap-plugin/ivysettings.xml
+++ b/plugins/kettle-sap-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-shapefilereader-plugin/ivysettings.xml
+++ b/plugins/kettle-shapefilereader-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-version-checker/ivysettings.xml
+++ b/plugins/kettle-version-checker/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle-xml-plugin/ivysettings.xml
+++ b/plugins/kettle-xml-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/kettle5-log4j-plugin/ivysettings.xml
+++ b/plugins/kettle5-log4j-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/lucid-db-bulk-loader/ivysettings.xml
+++ b/plugins/lucid-db-bulk-loader/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/lucid-db-streaming-loader/ivysettings.xml
+++ b/plugins/lucid-db-streaming-loader/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/ms-access-bulk-loader/ivysettings.xml
+++ b/plugins/ms-access-bulk-loader/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/pdi-pur-plugin/ivysettings.xml
+++ b/plugins/pdi-pur-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/salesforce/ivysettings.xml
+++ b/plugins/salesforce/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/ssh2-plugin/ivysettings.xml
+++ b/plugins/ssh2-plugin/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/star-modeler/ivysettings.xml
+++ b/plugins/star-modeler/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/xml-input-stream/ivysettings.xml
+++ b/plugins/xml-input-stream/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/plugins/xml-input/ivysettings.xml
+++ b/plugins/xml-input/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 

--- a/ui/ivysettings.xml
+++ b/ui/ivysettings.xml
@@ -7,7 +7,7 @@
     override="false" />
     
   <!-- Repository for Pentaho-hosted artifacts -->  
-  <property name="pentaho.resolve.repo" value="http://ivy-nexus.pentaho.org/content/groups/omni" override="false" />
+  <property name="pentaho.resolve.repo" value="https://nexus.pentaho.org/content/groups/omni" override="false" />
   <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
   <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 


### PR DESCRIPTION
It seems that the repository URL for the Ivy repository has changed with the switch to Maven for PDI >= 8.0 from http://ivy-nexus.pentaho.org/content/groups/omni to https://nexus.pentaho.org/content/groups/omni. This means building the old 7.1 branch will fail because the dependency resolver defined in various ivysettings.xml files points to the wrong location.

The patch updates the repository URL in the main ivysettings.xml and 33 plugins. It would be great if this could go into 7.1.10-R.

This has issue has been reported as PDI-16494.
