### PR TITLE
[BACKLOG-22892] - base stream meta uses a different property for the …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -352,7 +352,7 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
 
       // change it in the job entry
       //
-      fileName = newFilename;
+      setFileName( newFilename );
 
       setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
 

--- a/engine/src/main/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMeta.java
@@ -111,6 +111,11 @@ public abstract class BaseStreamStepMeta extends StepWithMappingMeta implements 
     return batchDuration;
   }
 
+  @Override public void setFileName( String fileName ) {
+    super.setFileName( fileName );
+    setTransformationPath( fileName );
+  }
+
   public void check( List<CheckResultInterface> remarks, TransMeta transMeta,
                      StepMeta stepMeta, RowMetaInterface prev, String[] input, String[] output,
                      RowMetaInterface info, VariableSpace space, Repository repository,

--- a/engine/src/test/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMetaTest.java
@@ -301,6 +301,13 @@ public class BaseStreamStepMetaTest {
       .getFields( rowMeta, "origin", null, nextStepMeta, space, repo, null );
   }
 
+  @Test
+  public void settingFileNameAlsoSetsTransformationPath() {
+    StuffStreamMeta stuffStreamMeta = new StuffStreamMeta();
+    stuffStreamMeta.setFileName( "someName" );
+    assertEquals( "someName", stuffStreamMeta.getTransformationPath() );
+  }
+
   // Checks that a serialization->deserialization does not alter meta fields
   private void testRoundTrip( BaseStreamStepMeta thisMeta ) {
     StuffStreamMeta startingMeta = (StuffStreamMeta) thisMeta;


### PR DESCRIPTION
…transformation path, probably for no good reason.  export procedure can possibly change filename from StepWithMappingMeta which only knows about filename