### PR TITLE
[BACKLOG-21845] Grey out top left cell in disabled mqtt consumer/producer table by not selecting the cell after clearing the table

### DIFF
--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MqttDialogSecurityLayout.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MqttDialogSecurityLayout.java
@@ -38,6 +38,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableItem;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.ui.core.PropsUI;
@@ -287,7 +288,9 @@ class MqttDialogSecurityLayout {
   }
 
   private void populateSSLData() {
-    sslTable.clearAll();
+    sslTable.getTable().removeAll();
+    new TableItem( sslTable.getTable(), SWT.NONE );
+
     checkNotNull( sslTable.getItem( 0 ) );
     checkState( sslTable.getItem( 0 ).length == 2 );
 


### PR DESCRIPTION
[BACKLOG-21845] Grey out top left cell in disabled mqtt consumer/producer table by not selecting the cell after clearing the table.  TableView.clearAll() edits the top left cell in the table, so we do not call that method.