### PR TITLE
[BACKLOG-22898] Change step metrics step number column meta to string to prevent sub step numbers from being cut off

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGridDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGridDelegate.java
@@ -222,6 +222,11 @@ public class TransGridDelegate extends SpoonDelegate implements XulEventHandler 
     fdView.bottom = new FormAttachment( 100, 0 );
     transGridView.setLayoutData( fdView );
 
+    //change the number column ValueMetaNumber to ValueMetaString to be compatible with sub trans numbering
+    ColumnInfo numberColumn = transGridView.getNumberColumn();
+    ValueMetaInterface numberColumnValueMeta = new ValueMetaString( "#" );
+    numberColumn.setValueMeta( numberColumnValueMeta );
+
     // Add a timer to update this view every couple of seconds...
     //
     final Timer tim = new Timer( "TransGraph: " + transGraph.getMeta().getName() );


### PR DESCRIPTION
[BACKLOG-22898] Change step metrics step number column meta to string to prevent sub step numbers from being cut off.