### PR TITLE
[BACKLOG-23112] DET: many errors running test case "with SDR"

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -2044,9 +2044,10 @@ public class TransMeta extends AbstractMeta
     // Go get the fields...
     //
     RowMetaInterface before = row.clone();
-    compatibleGetStepFields( stepint, row, name, inform, nextStep, this );
+    RowMetaInterface[] clonedInfo = cloneRowMetaInterfaces( inform );
+    compatibleGetStepFields( stepint, row, name, clonedInfo, nextStep, this );
     if ( !isSomethingDifferentInRow( before, row ) ) {
-      stepint.getFields( before, name, inform, nextStep, this, repository, metaStore );
+      stepint.getFields( before, name, clonedInfo, nextStep, this, repository, metaStore );
       // pass the clone object to prevent from spoiling data by other steps
       row = before;
     }
@@ -6403,5 +6404,15 @@ public class TransMeta extends AbstractMeta
 
   private static String getStepMetaCacheKey( StepMeta stepMeta, boolean info ) {
     return String.format( "%1$b-%2$s-%3$s", info, stepMeta.getStepID(), stepMeta.toString() );
+  }
+
+  private static RowMetaInterface[] cloneRowMetaInterfaces( RowMetaInterface[] inform ) {
+    RowMetaInterface[] cloned = inform.clone();
+    for ( int i = 0; i < cloned.length; i++ ) {
+      if ( cloned[i] != null ) {
+        cloned[i] = cloned[i].clone();
+      }
+    }
+    return cloned;
   }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
@@ -92,6 +92,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -167,6 +168,27 @@ public class TransMetaTest {
 
     assertEquals( 1, thisStepsFields.size() );
     assertEquals( overriddenValue, thisStepsFields.getValueMeta( 0 ).getName() );
+  }
+
+  @Test
+  public void getThisStepFieldsPassesClonedInfoRowMeta() throws Exception {
+    // given
+    StepMetaInterface smi = mock( StepMetaInterface.class );
+    StepIOMeta ioMeta = mock( StepIOMeta.class );
+    when( smi.getStepIOMeta() ).thenReturn( ioMeta );
+
+    StepMeta thisStep = mockStepMeta( "thisStep" );
+    StepMeta nextStep = mockStepMeta( "nextStep" );
+    when( thisStep.getStepMetaInterface() ).thenReturn( smi );
+
+    RowMeta row = new RowMeta();
+    when( smi.getTableFields() ).thenReturn( row );
+
+    // when
+    transMeta.getThisStepFields( thisStep, nextStep, row );
+
+    // then
+    verify( smi, never() ).getFields( any(), any(), eq( new RowMetaInterface[] { row } ), any(), any(), any(), any() );
   }
 
   @Test


### PR DESCRIPTION
 - StreamLookupMeta should clone value metas before changing

Having introduced the caching of rowMetas, we observe that StreamLookupMeta fails to find a field it needs when a cache hit occurs. Because previously it already found and changed that field in rowMeta (due to its configuration). 
Before introducing step field cache, rowMeta was instantiated every time it was needed, and it was fine to change the field.
Now StreamLookupMeta should clone valueMetas before changing, as not to break cached objects.