### PR TITLE
[SP-4329][PDI-8929] JobEntryTalendJobExec has static hashmap classLoaderCache that is mutated without protection

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/talendjobexec/JobEntryTalendJobExec.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/talendjobexec/JobEntryTalendJobExec.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,9 +29,9 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.vfs2.AllFileSelector;
 import org.apache.commons.vfs2.FileObject;
@@ -73,7 +73,7 @@ import org.w3c.dom.Node;
 public class JobEntryTalendJobExec extends JobEntryBase implements Cloneable, JobEntryInterface {
   private static Class<?> PKG = JobEntryTalendJobExec.class; // for i18n
 
-  private static Map<String, ClassLoader> classLoaderCache = new HashMap<String, ClassLoader>();
+  private static Map<String, ClassLoader> classLoaderCache = new ConcurrentHashMap<>();
 
   private String filename;
   private String className;

--- a/engine/src/test/java/org/pentaho/di/job/entries/talendjobexec/JobEntryTalendJobExecTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/talendjobexec/JobEntryTalendJobExecTest.java
@@ -21,11 +21,17 @@
  ******************************************************************************/
 package org.pentaho.di.job.entries.talendjobexec;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import java.util.List;
+import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mockito;
 import org.pentaho.di.job.entry.loadSave.JobEntryLoadSaveTestSupport;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 
@@ -45,4 +51,46 @@ public class JobEntryTalendJobExecTest extends JobEntryLoadSaveTestSupport<JobEn
         "className" );
   }
 
+  @Test //PDI-8929
+  public void testConcurrentExceptionClassLoaderCache3() throws Exception {
+
+    Field field = JobEntryTalendJobExec.class.getDeclaredField( "classLoaderCache" );
+    field.setAccessible( true );
+    Map<String, ClassLoader> cache = (Map<String, ClassLoader>) field.get( null );
+
+    cache.put( "test1", Mockito.mock( ClassLoader.class ) );
+    cache.put( "test2", Mockito.mock( ClassLoader.class ) );
+    cache.put( "test3", Mockito.mock( ClassLoader.class ) );
+    List<ClassLoader> test3ClassLoader = new ArrayList<>();
+
+    Thread thread1 = new Thread( () -> {
+      for ( String key : cache.keySet() ) {
+        try {
+          Thread.sleep( 300 );
+        } catch ( InterruptedException e ) {
+          e.printStackTrace();
+        }
+        if ( key.equals( "test3" ) ) {
+          test3ClassLoader.add( cache.get( key ) );
+        }
+      }
+    } );
+
+    Thread thread2 = new Thread( () -> {
+      try {
+        Thread.sleep( 100 );
+      } catch ( InterruptedException e ) {
+        e.printStackTrace();
+      }
+      cache.put( "test4", Mockito.mock( ClassLoader.class ) );
+    } );
+
+    thread1.start();
+    thread2.start();
+
+    thread1.join();
+    thread2.join();
+
+    Assert.assertTrue( !test3ClassLoader.isEmpty() );
+  }
 }


### PR DESCRIPTION
[SP-4329][PDI-8929] JobEntryTalendJobExec has static hashmap classLoaderCache that is mutated without protection

- changed HashMap to ConcurrentHashMap