### PR TITLE
[SP-4276][BACKLOG-22632]-MapReduce job with "Hadoop File Output" step…

### DIFF
--- a/core/src/org/pentaho/di/core/vfs/providers.xml
+++ b/core/src/org/pentaho/di/core/vfs/providers.xml
@@ -92,10 +92,6 @@
     <provider class-name="org.apache.commons.vfs2.provider.ram.RamFileProvider">
         <scheme name="ram"/>
     </provider>
-    <provider class-name="org.apache.commons.vfs2.provider.hdfs.HdfsFileProvider">
-        <scheme name="hdfs"/>
-        <if-available class-name="org.apache.hadoop.fs.FileSystem"/>
-    </provider>
 
     <extension-map extension="zip" scheme="zip"/>
     <extension-map extension="tar" scheme="tar"/>


### PR DESCRIPTION
… in sub-transform fail with "Could not create output file" error (HA)