### PR TITLE
[PDI-17248] MDI Set Variable is not replacing value after applying Se…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -32,6 +32,7 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.parameters.DuplicateParamException;
 import org.pentaho.di.core.parameters.NamedParams;
 import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.util.CurrentDirectoryResolver;
@@ -248,6 +249,15 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
           // this is explicitly checked for up front
         }
       } else {
+        try {
+          childNamedParams.addParameterDefinition( key, "", "" );
+          childNamedParams.setParameterValue( key, value );
+        } catch ( DuplicateParamException e ) {
+          // this was explicitly checked before
+        } catch ( UnknownParamException e ) {
+          // this is explicitly checked for up front
+        }
+
         childVariableSpace.setVariable( key, value );
       }
     }

--- a/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
@@ -260,6 +260,23 @@ public class StepWithMappingMetaTest {
 
   @Test
   @PrepareForTest( StepWithMappingMeta.class )
+  public void activateParamsTestWithNoParameterChild() throws Exception {
+    String newParam = "newParamParent";
+    String parentValue = "parentValue";
+
+    TransMeta parentMeta = new TransMeta();
+    TransMeta childVariableSpace = new TransMeta();
+
+    String[] parameters = childVariableSpace.listParameters();
+
+    StepWithMappingMeta.activateParams( childVariableSpace, childVariableSpace, parentMeta,
+      parameters, new String[] { newParam }, new String[] { parentValue } );
+
+    Assert.assertEquals( parentValue, childVariableSpace.getParameterValue( newParam ) );
+  }
+
+  @Test
+  @PrepareForTest( StepWithMappingMeta.class )
   public void testFileNameAsVariable() throws Exception {
 
     String transName = "test.ktr";

--- a/engine/src/test/java/org/pentaho/di/trans/steps/mapping/MappingParametersTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/mapping/MappingParametersTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -73,7 +73,8 @@ public class MappingParametersTest {
     StepWithMappingMeta
       .activateParams( trans, trans, step, transMeta.listParameters(), param.getVariable(), param.getInputField() );
     // parameters was overridden 2 times
-    Mockito.verify( trans, Mockito.times( 1 ) ).setParameterValue( Mockito.anyString(), Mockito.anyString() );
+    // new call of setParameterValue added in StepWithMappingMeta - wantedNumberOfInvocations is now to 2
+    Mockito.verify( trans, Mockito.times( 2 ) ).setParameterValue( Mockito.anyString(), Mockito.anyString() );
     Mockito.verify( trans, Mockito.times( 1 ) ).setVariable( Mockito.anyString(), Mockito.anyString() );
   }
 


### PR DESCRIPTION
…rvice Pack

As discussed with Jens, the child always get parameters from parent, even if the child doesn't have that same parameter in his context.  In that way, we need to create that same parameter in childNamedParams every time child doesn't have it, otherwise it gets lost, as in PDI-17248.

@pamval @mbatchelor @pentaho-lmartins 