### PR TITLE
[PDI-16638] - Fix multi-threading issue

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/filterrows/FilterRowsMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/filterrows/FilterRowsMeta.java
@@ -217,7 +217,8 @@ public class FilterRowsMeta extends BaseStepMeta implements StepMetaInterface {
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getTargetStreams() ) {
+    List<StreamInterface> targetStreams = getStepIOMeta().getTargetStreams();
+    for ( StreamInterface stream : targetStreams ) {
       stream.setStepMeta( StepMeta.findStep( steps, (String) stream.getSubject() ) );
     }
   }
@@ -341,6 +342,7 @@ public class FilterRowsMeta extends BaseStepMeta implements StepMetaInterface {
    * Returns the Input/Output metadata for this step.
    */
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, false, false, false, false );
@@ -349,6 +351,7 @@ public class FilterRowsMeta extends BaseStepMeta implements StepMetaInterface {
         PKG, "FilterRowsMeta.InfoStream.True.Description" ), StreamIcon.TRUE, null ) );
       ioMeta.addStream( new Stream( StreamType.TARGET, null, BaseMessages.getString(
         PKG, "FilterRowsMeta.InfoStream.False.Description" ), StreamIcon.FALSE, null ) );
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/fuzzymatch/FuzzyMatchMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fuzzymatch/FuzzyMatchMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,12 +22,9 @@
 
 package org.pentaho.di.trans.steps.fuzzymatch;
 
-import java.util.List;
-
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -37,6 +34,7 @@ import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaInteger;
 import org.pentaho.di.core.row.value.ValueMetaNumber;
 import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -58,6 +56,8 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.List;
 
 public class FuzzyMatchMeta extends BaseStepMeta implements StepMetaInterface {
   private static Class<?> PKG = FuzzyMatchMeta.class; // for i18n purposes, needed by Translator2!!
@@ -729,7 +729,8 @@ public class FuzzyMatchMeta extends BaseStepMeta implements StepMetaInterface {
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getInfoStreams() ) {
+    List<StreamInterface> infoStreams = getStepIOMeta().getInfoStreams();
+    for ( StreamInterface stream : infoStreams ) {
       stream.setStepMeta( StepMeta.findStep( steps, (String) stream.getSubject() ) );
     }
   }
@@ -755,6 +756,7 @@ public class FuzzyMatchMeta extends BaseStepMeta implements StepMetaInterface {
    * Returns the Input/Output metadata for this step. The generator step only produces output, does not accept input!
    */
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, false, false, false, false );
@@ -764,6 +766,7 @@ public class FuzzyMatchMeta extends BaseStepMeta implements StepMetaInterface {
           StreamType.INFO, null, BaseMessages.getString( PKG, "FuzzyMatchMeta.InfoStream.Description" ),
           StreamIcon.INFO, null );
       ioMeta.addStream( stream );
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/javafilter/JavaFilterMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/javafilter/JavaFilterMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,17 +22,14 @@
 
 package org.pentaho.di.trans.steps.javafilter;
 
-import java.util.List;
-import java.util.Objects;
-
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -53,6 +50,9 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Contains the meta-data for the java filter step: calculates conditions using Janino
@@ -135,7 +135,8 @@ public class JavaFilterMeta extends BaseStepMeta implements StepMetaInterface {
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getTargetStreams() ) {
+    List<StreamInterface> targetStreams = getStepIOMeta().getTargetStreams();
+    for ( StreamInterface stream : targetStreams ) {
       stream.setStepMeta( StepMeta.findStep( steps, (String) stream.getSubject() ) );
     }
   }
@@ -253,6 +254,7 @@ public class JavaFilterMeta extends BaseStepMeta implements StepMetaInterface {
    * Returns the Input/Output metadata for this step.
    */
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, false, false, false, false );
@@ -261,6 +263,7 @@ public class JavaFilterMeta extends BaseStepMeta implements StepMetaInterface {
         PKG, "JavaFilterMeta.InfoStream.True.Description" ), StreamIcon.TRUE, null ) );
       ioMeta.addStream( new Stream( StreamType.TARGET, null, BaseMessages.getString(
         PKG, "JavaFilterMeta.InfoStream.False.Description" ), StreamIcon.FALSE, null ) );
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
@@ -22,14 +22,9 @@
 
 package org.pentaho.di.trans.steps.jobexecutor;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -45,6 +40,7 @@ import org.pentaho.di.core.row.value.ValueMetaInteger;
 import org.pentaho.di.core.row.value.ValueMetaNone;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.util.CurrentDirectoryResolver;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -81,6 +77,10 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Meta-data for the Job executor step.
@@ -852,6 +852,7 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
 
   @Override
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, true, false, true, false );
@@ -862,6 +863,7 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
         PKG, "JobExecutorMeta.ResultRowsStream.Description" ), StreamIcon.TARGET, null ) );
       ioMeta.addStream( new Stream( StreamType.TARGET, resultFilesTargetStepMeta, BaseMessages.getString(
         PKG, "JobExecutorMeta.ResultFilesStream.Description" ), StreamIcon.TARGET, null ) );
+      setStepIOMeta( ioMeta );
     }
     return ioMeta;
   }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/mapping/MappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/mapping/MappingMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,14 +22,9 @@
 
 package org.pentaho.di.trans.steps.mapping;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -38,6 +33,7 @@ import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -69,6 +65,10 @@ import org.pentaho.di.trans.steps.mappinginput.MappingInputMeta;
 import org.pentaho.di.trans.steps.mappingoutput.MappingOutputMeta;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Meta-data for the Mapping step: contains name of the (sub-)transformation to execute
@@ -800,6 +800,7 @@ public class MappingMeta extends StepWithMappingMeta implements StepMetaInterfac
 
   @Override
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
       // TODO Create a dynamic StepIOMeta so that we can more easily manipulate the info streams?
       ioMeta = new StepIOMeta( true, true, true, false, true, false );
@@ -811,19 +812,13 @@ public class MappingMeta extends StepWithMappingMeta implements StepMetaInterfac
           ioMeta.addStream( stream );
         }
       }
+      setStepIOMeta( ioMeta );
     }
     return ioMeta;
   }
 
   private boolean isInfoMapping( MappingIODefinition def ) {
     return !def.isMainDataPath() && !Utils.isEmpty( def.getInputStepname() );
-  }
-
-  /**
-   * Remove the cached {@link StepIOMeta} so it is recreated when it is next accessed.
-   */
-  public void resetStepIoMeta() {
-    ioMeta = null;
   }
 
   public boolean excludeFromRowLayoutVerification() {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/mergejoin/MergeJoinMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/mergejoin/MergeJoinMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,12 +22,9 @@
 
 package org.pentaho.di.trans.steps.mergejoin;
 
-import java.util.List;
-
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -36,6 +33,7 @@ import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -57,6 +55,8 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.List;
 
 /*
  * @author Biswapesh
@@ -155,7 +155,7 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
     for ( StreamInterface infoStream : infoStreams ) {
       stepIOMeta.addStream( new Stream( infoStream ) );
     }
-    retval.ioMeta = stepIOMeta;
+    retval.setStepIOMeta( stepIOMeta );
 
     return retval;
   }
@@ -246,7 +246,8 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getInfoStreams() ) {
+    List<StreamInterface> infoStreams = getStepIOMeta().getInfoStreams();
+    for ( StreamInterface stream : infoStreams ) {
       stream.setStepMeta( StepMeta.findStep( steps, (String) stream.getSubject() ) );
     }
   }
@@ -320,6 +321,7 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
    * Returns the Input/Output metadata for this step. The generator step only produces output, does not accept input!
    */
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, false, false, false, false );
@@ -328,6 +330,7 @@ public class MergeJoinMeta extends BaseStepMeta implements StepMetaInterface {
         PKG, "MergeJoinMeta.InfoStream.FirstStream.Description" ), StreamIcon.INFO, null ) );
       ioMeta.addStream( new Stream( StreamType.INFO, null, BaseMessages.getString(
         PKG, "MergeJoinMeta.InfoStream.SecondStream.Description" ), StreamIcon.INFO, null ) );
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/mergerows/MergeRowsMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/mergerows/MergeRowsMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,12 +22,9 @@
 
 package org.pentaho.di.trans.steps.mergerows;
 
-import java.util.List;
-
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleRowException;
@@ -38,6 +35,7 @@ import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -59,6 +57,8 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.List;
 
 /*
  * Created on 02-jun-2003
@@ -246,7 +246,8 @@ public class MergeRowsMeta extends BaseStepMeta implements StepMetaInterface {
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getInfoStreams() ) {
+    List<StreamInterface> infoStreams = getStepIOMeta().getInfoStreams();
+    for ( StreamInterface stream : infoStreams ) {
       stream.setStepMeta( StepMeta.findStep( steps, (String) stream.getSubject() ) );
     }
   }
@@ -383,6 +384,7 @@ public class MergeRowsMeta extends BaseStepMeta implements StepMetaInterface {
    */
   @Override
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, false, false, false, false );
@@ -391,6 +393,7 @@ public class MergeRowsMeta extends BaseStepMeta implements StepMetaInterface {
         PKG, "MergeRowsMeta.InfoStream.FirstStream.Description" ), StreamIcon.INFO, null ) );
       ioMeta.addStream( new Stream( StreamType.INFO, null, BaseMessages.getString(
         PKG, "MergeRowsMeta.InfoStream.SecondStream.Description" ), StreamIcon.INFO, null ) );
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/multimerge/MultiMergeJoinMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/multimerge/MultiMergeJoinMeta.java
@@ -22,8 +22,6 @@
 
 package org.pentaho.di.trans.steps.multimerge;
 
-import java.util.List;
-
 import org.apache.commons.lang.ArrayUtils;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
@@ -44,6 +42,7 @@ import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.step.StepIOMetaInterface;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
@@ -52,6 +51,8 @@ import org.pentaho.di.trans.step.errorhandling.StreamIcon;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.List;
 
 /**
  * @author Biswapesh
@@ -237,11 +238,12 @@ public class MultiMergeJoinMeta extends BaseStepMeta implements StepMetaInterfac
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    getStepIOMeta().getInfoStreams().clear();
+    StepIOMetaInterface ioMeta = getStepIOMeta();
+    ioMeta.getInfoStreams().clear();
     for ( int i = 0; i < inputSteps.length; i++ ) {
       String inputStepName = inputSteps[i];
-      if ( i >= getStepIOMeta().getInfoStreams().size() ) {
-        getStepIOMeta().addStream(
+      if ( i >= ioMeta.getInfoStreams().size() ) {
+        ioMeta.addStream(
           new Stream( StreamType.INFO, StepMeta.findStep( steps, inputStepName ),
               BaseMessages.getString( PKG, "MultiMergeJoin.InfoStream.Description" ), StreamIcon.INFO, inputStepName ) );
       }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/simplemapping/SimpleMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/simplemapping/SimpleMappingMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,13 +22,9 @@
 
 package org.pentaho.di.trans.steps.simplemapping;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -36,6 +32,7 @@ import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -67,6 +64,9 @@ import org.pentaho.di.trans.steps.mappinginput.MappingInputMeta;
 import org.pentaho.di.trans.steps.mappingoutput.MappingOutputMeta;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Meta-data for the Mapping step: contains name of the (sub-)transformation to execute
@@ -470,17 +470,12 @@ public class SimpleMappingMeta extends StepWithMappingMeta implements StepMetaIn
 
   @Override
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
       ioMeta = new StepIOMeta( true, true, false, false, false, false );
+      setStepIOMeta( ioMeta );
     }
     return ioMeta;
-  }
-
-  /**
-   * Remove the cached {@link StepIOMeta} so it is recreated when it is next accessed.
-   */
-  public void resetStepIoMeta() {
-    ioMeta = null;
   }
 
   public boolean excludeFromRowLayoutVerification() {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/streamlookup/StreamLookupMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/streamlookup/StreamLookupMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,8 +21,6 @@
  ******************************************************************************/
 
 package org.pentaho.di.trans.steps.streamlookup;
-
-import java.util.List;
 
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
@@ -57,6 +55,8 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.List;
 
 @InjectionSupported( localizationPrefix = "StreamLookupMeta.Injection." )
 public class StreamLookupMeta extends BaseStepMeta implements StepMetaInterface {
@@ -123,21 +123,19 @@ public class StreamLookupMeta extends BaseStepMeta implements StepMetaInterface 
   @Override
   public Object clone() {
     StreamLookupMeta retval = (StreamLookupMeta) super.clone();
-
-    if ( getStepIOMeta() != null
-        && getStepIOMeta().getInfoStreams() != null
-        && retval.getStepIOMeta() != null
-        && getStepIOMeta().getInfoStreams() != null ) {
-      retval.getStepIOMeta().getInfoStreams().get( 0 ).setStreamType(
-        getStepIOMeta().getInfoStreams().get( 0 ).getStreamType() );
-      retval.getStepIOMeta().getInfoStreams().get( 0 ).setStepMeta(
-        getStepIOMeta().getInfoStreams().get( 0 ).getStepMeta() );
-      retval.getStepIOMeta().getInfoStreams().get( 0 ).setDescription(
-        getStepIOMeta().getInfoStreams().get( 0 ).getDescription() );
-      retval.getStepIOMeta().getInfoStreams().get( 0 ).setStreamIcon(
-        getStepIOMeta().getInfoStreams().get( 0 ).getStreamIcon() );
-      retval.getStepIOMeta().getInfoStreams().get( 0 ).setSubject(
-        getStepIOMeta().getInfoStreams().get( 0 ).getSubject() );
+    StepIOMetaInterface thisStepIO = getStepIOMeta();
+    StepIOMetaInterface thatStepIO = retval.getStepIOMeta();
+    if ( thisStepIO != null
+        && thisStepIO.getInfoStreams() != null
+        && thatStepIO != null
+        && thisStepIO.getInfoStreams() != null ) {
+      List<StreamInterface> thisInfoStream = thisStepIO.getInfoStreams();
+      List<StreamInterface> thatInfoStream = thatStepIO.getInfoStreams();
+      thatInfoStream.get( 0 ).setStreamType( thisInfoStream.get( 0 ).getStreamType() );
+      thatInfoStream.get( 0 ).setStepMeta( thisInfoStream.get( 0 ).getStepMeta() );
+      thatInfoStream.get( 0 ).setDescription( thisInfoStream.get( 0 ).getDescription() );
+      thatInfoStream.get( 0 ).setStreamIcon( thisInfoStream.get( 0 ).getStreamIcon() );
+      thatInfoStream.get( 0 ).setSubject( thisInfoStream.get( 0 ).getSubject() );
     }
 
     int nrkeys = keystream.length;
@@ -202,7 +200,8 @@ public class StreamLookupMeta extends BaseStepMeta implements StepMetaInterface 
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getInfoStreams() ) {
+    List<StreamInterface> infoStreams = getStepIOMeta().getInfoStreams();
+    for ( StreamInterface stream : infoStreams ) {
       stream.setStepMeta( StepMeta.findStep( steps, (String) stream.getSubject() ) );
     }
   }
@@ -512,6 +511,7 @@ public class StreamLookupMeta extends BaseStepMeta implements StepMetaInterface 
    */
   @Override
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, false, false, false, false );
@@ -520,6 +520,7 @@ public class StreamLookupMeta extends BaseStepMeta implements StepMetaInterface 
         new Stream( StreamType.INFO, null, BaseMessages.getString(
           PKG, "StreamLookupMeta.InfoStream.Description" ), StreamIcon.INFO, null );
       ioMeta.addStream( stream );
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/switchcase/SwitchCaseMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/switchcase/SwitchCaseMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,13 +22,9 @@
 
 package org.pentaho.di.trans.steps.switchcase;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -38,6 +34,7 @@ import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaBase;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -59,6 +56,9 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.di.trans.steps.fieldsplitter.DataTypeConverter;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /*
  * Created on 14-may-2008
@@ -256,7 +256,8 @@ public class SwitchCaseMeta extends BaseStepMeta implements StepMetaInterface {
     CheckResult cr;
 
     StepIOMetaInterface ioMeta = getStepIOMeta();
-    for ( StreamInterface stream : ioMeta.getTargetStreams() ) {
+    List<StreamInterface> targetStreams = ioMeta.getTargetStreams();
+    for ( StreamInterface stream : targetStreams ) {
       SwitchCaseTarget target = (SwitchCaseTarget) stream.getSubject();
 
       if ( target != null && target.caseTargetStep == null ) {
@@ -420,6 +421,7 @@ public class SwitchCaseMeta extends BaseStepMeta implements StepMetaInterface {
    * Returns the Input/Output metadata for this step.
    */
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, false, false, false, false, true );
@@ -441,6 +443,7 @@ public class SwitchCaseMeta extends BaseStepMeta implements StepMetaInterface {
         ioMeta.addStream( new Stream( StreamType.TARGET, getDefaultTargetStep(), BaseMessages.getString(
           PKG, "SwitchCaseMeta.TargetStream.Default.Description" ), StreamIcon.TARGET, null ) );
       }
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;
@@ -448,7 +451,8 @@ public class SwitchCaseMeta extends BaseStepMeta implements StepMetaInterface {
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getTargetStreams() ) {
+    List<StreamInterface> targetStreams = getStepIOMeta().getTargetStreams();
+    for ( StreamInterface stream : targetStreams ) {
       SwitchCaseTarget target = (SwitchCaseTarget) stream.getSubject();
       if ( target != null ) {
         StepMeta stepMeta = StepMeta.findStep( steps, target.caseTargetStepname );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/tableinput/TableInputMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/tableinput/TableInputMeta.java
@@ -459,7 +459,8 @@ public class TableInputMeta extends BaseStepMeta implements StepMetaInterface {
    *          optionally search the info step in a list of steps
    */
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getInfoStreams() ) {
+    List<StreamInterface> infoStreams = getStepIOMeta().getInfoStreams();
+    for ( StreamInterface stream : infoStreams ) {
       stream.setStepMeta( StepMeta.findStep( steps, (String) stream.getSubject() ) );
     }
   }
@@ -543,6 +544,7 @@ public class TableInputMeta extends BaseStepMeta implements StepMetaInterface {
    * Returns the Input/Output metadata for this step. The generator step only produces output, does not accept input!
    */
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, false, false, false, false );
@@ -552,6 +554,7 @@ public class TableInputMeta extends BaseStepMeta implements StepMetaInterface {
           StreamType.INFO, null, BaseMessages.getString( PKG, "TableInputMeta.InfoStream.Description" ),
           StreamIcon.INFO, null );
       ioMeta.addStream( stream );
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/transexecutor/TransExecutorMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/transexecutor/TransExecutorMeta.java
@@ -22,13 +22,9 @@
 
 package org.pentaho.di.trans.steps.transexecutor;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -38,6 +34,7 @@ import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaFactory;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -68,6 +65,9 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Meta-data for the Trans Executor step.
@@ -663,6 +663,7 @@ public class TransExecutorMeta extends StepWithMappingMeta implements StepMetaIn
 
   @Override
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, true, false, true, false );
@@ -675,6 +676,7 @@ public class TransExecutorMeta extends StepWithMappingMeta implements StepMetaIn
         "TransExecutorMeta.ResultFilesStream.Description" ), StreamIcon.TARGET, null ) );
       ioMeta.addStream( new Stream( StreamType.TARGET, executorsOutputStepMeta, BaseMessages.getString( PKG,
         "TransExecutorMeta.ExecutorOutputStream.Description" ), StreamIcon.OUTPUT, null ) );
+      setStepIOMeta( ioMeta );
     }
     return ioMeta;
   }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/validator/ValidatorMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/validator/ValidatorMeta.java
@@ -3,7 +3,7 @@
 
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,10 +22,6 @@
  ******************************************************************************/
 
 package org.pentaho.di.trans.steps.validator;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
@@ -57,6 +53,10 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Contains the meta-data for the Validator step: calculates predefined formula's
@@ -284,6 +284,7 @@ public class ValidatorMeta extends BaseStepMeta implements StepMetaInterface {
    * Returns the Input/Output metadata for this step.
    */
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, false, false, true, false );
@@ -297,6 +298,7 @@ public class ValidatorMeta extends BaseStepMeta implements StepMetaInterface {
               .getName(), "" ) ), StreamIcon.INFO, validation );
         ioMeta.addStream( stream );
       }
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;
@@ -304,7 +306,8 @@ public class ValidatorMeta extends BaseStepMeta implements StepMetaInterface {
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getInfoStreams() ) {
+    List<StreamInterface> infoStreams = getStepIOMeta().getInfoStreams();
+    for ( StreamInterface stream : infoStreams ) {
       Validation validation = (Validation) stream.getSubject();
       StepMeta stepMeta = StepMeta.findStep( steps, validation.getSourcingStepName() );
       validation.setSourcingStep( stepMeta );

--- a/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
@@ -22,6 +22,7 @@
 package org.pentaho.di.trans;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -29,6 +30,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.variables.VariableSpace;
@@ -42,19 +44,18 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -65,6 +66,15 @@ public class StepWithMappingMetaTest {
 
   @Mock
   TransMeta transMeta;
+
+  @Before
+  public void setupBefore() throws Exception {
+    // Without initialization of the Kettle Environment, the load of the transformation fails
+    // when run in Windows (saying it cannot find the Database plugin ID for Oracle). Digging into
+    // it I discovered that it's during the read of the shared objects xml which doesn't reference Oracle
+    // at all. Initializing the environment fixed everything.
+    KettleEnvironment.init();
+  }
 
   @Test
   public void loadMappingMeta() throws Exception {

--- a/engine/src/test/java/org/pentaho/di/trans/step/BaseStepMetaCloningTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/step/BaseStepMetaCloningTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,13 +22,13 @@
 
 package org.pentaho.di.trans.step;
 
-import java.util.List;
-
 import org.junit.Test;
 import org.pentaho.di.core.database.Database;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.step.errorhandling.Stream;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface;
+
+import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -36,8 +36,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 public class BaseStepMetaCloningTest {
 
@@ -51,7 +51,8 @@ public class BaseStepMetaCloningTest {
     BaseStepMeta meta = new BaseStepMeta();
     meta.setChanged( true );
     meta.databases = new Database[] { db1, db2 };
-    meta.ioMeta = new StepIOMeta( true, false, false, false, false, false );
+    StepIOMetaInterface ioMeta = new StepIOMeta( true, false, false, false, false, false );
+    meta.setStepIOMeta( ioMeta ); 
     meta.repository = repository;
     meta.parentStepMeta = stepMeta;
 
@@ -65,15 +66,16 @@ public class BaseStepMetaCloningTest {
     assertEquals( meta.repository, clone.repository );
     assertEquals( meta.parentStepMeta, clone.parentStepMeta );
 
-    assertNotNull( clone.ioMeta );
-    assertEquals( meta.ioMeta.isInputAcceptor(), clone.ioMeta.isInputAcceptor() );
-    assertEquals( meta.ioMeta.isInputDynamic(), clone.ioMeta.isInputDynamic() );
-    assertEquals( meta.ioMeta.isInputOptional(), clone.ioMeta.isInputOptional() );
-    assertEquals( meta.ioMeta.isOutputDynamic(), clone.ioMeta.isOutputDynamic() );
-    assertEquals( meta.ioMeta.isOutputProducer(), clone.ioMeta.isOutputProducer() );
-    assertEquals( meta.ioMeta.isSortedDataRequired(), clone.ioMeta.isSortedDataRequired() );
-    assertNotNull( clone.ioMeta.getInfoStreams() );
-    assertEquals( 0, clone.ioMeta.getInfoStreams().size() );
+    StepIOMetaInterface cloneIOMeta = clone.getStepIOMeta();
+    assertNotNull( cloneIOMeta );
+    assertEquals( ioMeta.isInputAcceptor(), cloneIOMeta.isInputAcceptor() );
+    assertEquals( ioMeta.isInputDynamic(), cloneIOMeta.isInputDynamic() );
+    assertEquals( ioMeta.isInputOptional(), cloneIOMeta.isInputOptional() );
+    assertEquals( ioMeta.isOutputDynamic(), cloneIOMeta.isOutputDynamic() );
+    assertEquals( ioMeta.isOutputProducer(), cloneIOMeta.isOutputProducer() );
+    assertEquals( ioMeta.isSortedDataRequired(), cloneIOMeta.isSortedDataRequired() );
+    assertNotNull( cloneIOMeta.getInfoStreams() );
+    assertEquals( 0, cloneIOMeta.getInfoStreams().size() );
   }
 
   @Test
@@ -86,13 +88,14 @@ public class BaseStepMetaCloningTest {
     BaseStepMeta meta = new BaseStepMeta();
     meta.setChanged( true );
     meta.databases = new Database[] { db1, db2 };
-    meta.ioMeta = new StepIOMeta( true, false, false, false, false, false );
+    StepIOMetaInterface ioMeta = new StepIOMeta( true, false, false, false, false, false );
+    meta.setStepIOMeta( ioMeta );
 
     final String refStepName = "referenced step";
     final StepMeta refStepMeta = mock( StepMeta.class );
     doReturn( refStepName ).when( refStepMeta ).getName();
     StreamInterface stream = new Stream( StreamInterface.StreamType.INFO, refStepMeta, null, null, refStepName );
-    meta.ioMeta.addStream( stream );
+    ioMeta.addStream( stream );
     meta.repository = repository;
     meta.parentStepMeta = stepMeta;
 
@@ -106,15 +109,17 @@ public class BaseStepMetaCloningTest {
     assertEquals( meta.repository, clone.repository );
     assertEquals( meta.parentStepMeta, clone.parentStepMeta );
 
-    assertNotNull( clone.ioMeta );
-    assertEquals( meta.ioMeta.isInputAcceptor(), clone.ioMeta.isInputAcceptor() );
-    assertEquals( meta.ioMeta.isInputDynamic(), clone.ioMeta.isInputDynamic() );
-    assertEquals( meta.ioMeta.isInputOptional(), clone.ioMeta.isInputOptional() );
-    assertEquals( meta.ioMeta.isOutputDynamic(), clone.ioMeta.isOutputDynamic() );
-    assertEquals( meta.ioMeta.isOutputProducer(), clone.ioMeta.isOutputProducer() );
-    assertEquals( meta.ioMeta.isSortedDataRequired(), clone.ioMeta.isSortedDataRequired() );
 
-    final List<StreamInterface> clonedInfoStreams = clone.ioMeta.getInfoStreams();
+    StepIOMetaInterface cloneIOMeta = clone.getStepIOMeta();
+    assertNotNull( cloneIOMeta );
+    assertEquals( ioMeta.isInputAcceptor(), cloneIOMeta.isInputAcceptor() );
+    assertEquals( ioMeta.isInputDynamic(), cloneIOMeta.isInputDynamic() );
+    assertEquals( ioMeta.isInputOptional(), cloneIOMeta.isInputOptional() );
+    assertEquals( ioMeta.isOutputDynamic(), cloneIOMeta.isOutputDynamic() );
+    assertEquals( ioMeta.isOutputProducer(), cloneIOMeta.isOutputProducer() );
+    assertEquals( ioMeta.isSortedDataRequired(), cloneIOMeta.isSortedDataRequired() );
+
+    final List<StreamInterface> clonedInfoStreams = cloneIOMeta.getInfoStreams();
     assertNotNull( clonedInfoStreams );
     assertEquals( 1, clonedInfoStreams.size() );
 

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/append/AppendMeta.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/append/AppendMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,8 +21,6 @@
  ******************************************************************************/
 
 package org.pentaho.di.trans.steps.append;
-
-import java.util.List;
 
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
@@ -55,6 +53,8 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface.StreamType;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.List;
 
 /**
  * @author Sven Boden
@@ -139,7 +139,9 @@ public class AppendMeta extends BaseStepMeta implements StepMetaInterface {
 
   @Override
   public void searchInfoAndTargetSteps( List<StepMeta> steps ) {
-    for ( StreamInterface stream : getStepIOMeta().getInfoStreams() ) {
+    StepIOMetaInterface ioMeta = getStepIOMeta();
+    List<StreamInterface> infoStreams = ioMeta.getInfoStreams();
+    for ( StreamInterface stream : infoStreams ) {
       stream.setStepMeta( StepMeta.findStep( steps, (String) stream.getSubject() ) );
     }
   }
@@ -204,6 +206,7 @@ public class AppendMeta extends BaseStepMeta implements StepMetaInterface {
    * Returns the Input/Output metadata for this step.
    */
   public StepIOMetaInterface getStepIOMeta() {
+    StepIOMetaInterface ioMeta = super.getStepIOMeta( false );
     if ( ioMeta == null ) {
 
       ioMeta = new StepIOMeta( true, true, false, false, false, false );
@@ -212,6 +215,7 @@ public class AppendMeta extends BaseStepMeta implements StepMetaInterface {
         PKG, "AppendMeta.InfoStream.FirstStream.Description" ), StreamIcon.INFO, null ) );
       ioMeta.addStream( new Stream( StreamType.INFO, null, BaseMessages.getString(
         PKG, "AppendMeta.InfoStream.SecondStream.Description" ), StreamIcon.INFO, null ) );
+      setStepIOMeta( ioMeta );
     }
 
     return ioMeta;


### PR DESCRIPTION
* Uses read/write lock on ioMeta
* Changes variable name in BaseStep
* Stops everyone from being able to use ioMeta directly
* Fixes several inefficient loops that keep calling into the getter

Note - If you process this PR, please immediately process the PR for pentaho-r-plugin. PDI will fail to start up without the fix.