### PR TITLE
[CLEANUP] Fixing errors preventing ErrorProne compilation, + checkestyle

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entry/validator/JobEntryValidatorUtils.java
+++ b/engine/src/main/java/org/pentaho/di/job/entry/validator/JobEntryValidatorUtils.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -136,7 +136,9 @@ public class JobEntryValidatorUtils {
    */
   public static boolean validateMask( CheckResultSourceInterface source, String propertyName,
     List<CheckResultInterface> remarks, String mask, int levelOnFail ) {
-    return validateMask( source, propertyName, remarks, mask, LEVEL_FAILURE_DEFAULT );
+    // TODO review.  Appears unused, and would cause stackoverflow if it _was_ used.  commenting out.
+    //return validateMask( source, propertyName, remarks, mask, LEVEL_FAILURE_DEFAULT );
+    throw new UnsupportedOperationException(  );
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConnectionDelegate.java
+++ b/engine/src/main/java/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryConnectionDelegate.java
@@ -26,6 +26,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -234,7 +235,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       // at the column in question...
       //
       String errorColumn = "TRANSFORMATION";
-      RowMetaInterface tableFields = callRead( () -> database.getTableFieldsMeta( null, KettleDatabaseRepository.TABLE_R_TRANS_PARTITION_SCHEMA ) );
+      RowMetaInterface tableFields =
+        callRead( () -> database.getTableFieldsMeta( null, KettleDatabaseRepository.TABLE_R_TRANS_PARTITION_SCHEMA ) );
       if ( tableFields.indexOfValue( errorColumn ) >= 0 ) {
         throw new KettleException( BaseMessages.getString( PKG, "Repository.FixFor300Required.Message" ) );
       }
@@ -314,8 +316,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   /**
-   * @param database
-   *          the database to set
+   * @param database the database to set
    */
   public void setDatabase( Database database ) {
     this.database = database;
@@ -329,8 +330,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   /**
-   * @param databaseMeta
-   *          the databaseMeta to set
+   * @param databaseMeta the databaseMeta to set
    */
   public void setDatabaseMeta( DatabaseMeta databaseMeta ) {
     this.databaseMeta = databaseMeta;
@@ -344,8 +344,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   /**
-   * @param majorVersion
-   *          the majorVersion to set
+   * @param majorVersion the majorVersion to set
    */
   public void setMajorVersion( int majorVersion ) {
     this.majorVersion = majorVersion;
@@ -359,8 +358,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   /**
-   * @param minorVersion
-   *          the minorVersion to set
+   * @param minorVersion the minorVersion to set
    */
   public void setMinorVersion( int minorVersion ) {
     this.minorVersion = minorVersion;
@@ -393,7 +391,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
     RowMetaAndData parameter = getParameterMetaData( id_transformation );
 
-    stepAttributesBuffer = callRead( () -> database.getRows( database.openQuery( ps, parameter.getRowMeta(), parameter.getData() ), -1, null ) );
+    stepAttributesBuffer = callRead(
+      () -> database.getRows( database.openQuery( ps, parameter.getRowMeta(), parameter.getData() ), -1, null ) );
     stepAttributesRowMeta = database.getReturnRowMeta();
 
     // must use java-based sort to ensure compatibility with binary search
@@ -411,14 +410,14 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   /**
-   * @param stepAttributesBuffer
-   *          The stepAttributesBuffer to set.
+   * @param stepAttributesBuffer The stepAttributesBuffer to set.
    */
   public void setStepAttributesBuffer( List<Object[]> stepAttributesBuffer ) {
     this.stepAttributesBuffer = stepAttributesBuffer;
   }
 
-  private synchronized RowMetaAndData searchStepAttributeInBuffer( ObjectId id_step, String code, long nr ) throws KettleValueException {
+  private synchronized RowMetaAndData searchStepAttributeInBuffer( ObjectId id_step, String code, long nr )
+    throws KettleValueException {
     int index = searchStepAttributeIndexInBuffer( id_step, code, nr );
     if ( index < 0 ) {
       return null;
@@ -434,7 +433,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return new RowMetaAndData( stepAttributesRowMeta, r );
   }
 
-  private synchronized int searchStepAttributeIndexInBuffer( ObjectId id_step, String code, long nr ) throws KettleValueException {
+  private synchronized int searchStepAttributeIndexInBuffer( ObjectId id_step, String code, long nr )
+    throws KettleValueException {
     Object[] key = new Object[] { new LongObjectId( id_step ).longValue(), // ID_STEP
       code, // CODE
       new Long( nr ), // NR
@@ -521,7 +521,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_NUM )
         + " FROM "
         + databaseMeta
-          .getQuotedSchemaTableCombination( null, KettleDatabaseRepository.TABLE_R_TRANS_ATTRIBUTE )
+        .getQuotedSchemaTableCombination( null, KettleDatabaseRepository.TABLE_R_TRANS_ATTRIBUTE )
         + " WHERE " + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ) + " = ?  AND "
         + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ) + " = ? AND "
         + KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR + " = ? ";
@@ -560,7 +560,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   public synchronized void closeStepAttributeInsertPreparedStatement() throws KettleException {
     if ( psStepAttributesInsert != null ) {
       database.emptyAndCommit( psStepAttributesInsert, useBatchProcessing, 1 ); // batch
-                                                                                // mode!
+      // mode!
       psStepAttributesInsert = null;
     }
   }
@@ -568,7 +568,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   public synchronized void closeTransAttributeInsertPreparedStatement() throws KettleException {
     if ( psTransAttributesInsert != null ) {
       database.emptyAndCommit( psTransAttributesInsert, useBatchProcessing, 1 ); // batch
-                                                                                 // mode!
+      // mode!
       psTransAttributesInsert = null;
     }
   }
@@ -576,7 +576,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   public synchronized void closeJobAttributeInsertPreparedStatement() throws KettleException {
     if ( psJobAttributesInsert != null ) {
       database.emptyAndCommit( psJobAttributesInsert, useBatchProcessing, 1 ); // batch
-                                                                               // mode!
+      // mode!
       psJobAttributesInsert = null;
     }
   }
@@ -701,7 +701,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return r.getString( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_VALUE_STR, null );
   }
 
-  public synchronized boolean getStepAttributeBoolean( ObjectId id_step, int nr, String code, boolean def ) throws KettleException {
+  public synchronized boolean getStepAttributeBoolean( ObjectId id_step, int nr, String code, boolean def )
+    throws KettleException {
     RowMetaAndData r = null;
     if ( stepAttributesBuffer != null ) {
       r = searchStepAttributeInBuffer( id_step, code, nr );
@@ -720,22 +721,22 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   public ObjectId saveStepAttribute( ObjectId id_transformation, ObjectId id_step, long nr, String code,
-    String value ) throws KettleException {
+                                     String value ) throws KettleException {
     return saveStepAttribute( code, nr, id_transformation, id_step, 0.0, value );
   }
 
   public ObjectId saveStepAttribute( ObjectId id_transformation, ObjectId id_step, long nr, String code,
-    double value ) throws KettleException {
+                                     double value ) throws KettleException {
     return saveStepAttribute( code, nr, id_transformation, id_step, value, null );
   }
 
   public ObjectId saveStepAttribute( ObjectId id_transformation, ObjectId id_step, long nr, String code,
-    boolean value ) throws KettleException {
+                                     boolean value ) throws KettleException {
     return saveStepAttribute( code, nr, id_transformation, id_step, 0.0, value ? "Y" : "N" );
   }
 
   private ObjectId saveStepAttribute( String code, long nr, ObjectId id_transformation, ObjectId id_step,
-    double value_num, String value_str ) throws KettleException {
+                                      double value_num, String value_str ) throws KettleException {
     return insertStepAttribute( id_transformation, id_step, nr, code, value_num, value_str );
   }
 
@@ -749,7 +750,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       String sql =
         "SELECT COUNT(*) FROM "
           + databaseMeta.getQuotedSchemaTableCombination(
-            null, KettleDatabaseRepository.TABLE_R_STEP_ATTRIBUTE ) + " WHERE "
+          null, KettleDatabaseRepository.TABLE_R_STEP_ATTRIBUTE ) + " WHERE "
           + quote( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP ) + " = ? AND "
           + quote( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_CODE ) + " = ?";
       RowMetaAndData table = new RowMetaAndData();
@@ -767,7 +768,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
   // TRANS ATTRIBUTES: get
 
-  public synchronized String getTransAttributeString( ObjectId id_transformation, int nr, String code ) throws KettleException {
+  public synchronized String getTransAttributeString( ObjectId id_transformation, int nr, String code )
+    throws KettleException {
     RowMetaAndData r = null;
     r = getTransAttributeRow( id_transformation, nr, code );
     if ( r == null ) {
@@ -776,7 +778,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return r.getString( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_STR, null );
   }
 
-  public synchronized boolean getTransAttributeBoolean( ObjectId id_transformation, int nr, String code ) throws KettleException {
+  public synchronized boolean getTransAttributeBoolean( ObjectId id_transformation, int nr, String code )
+    throws KettleException {
     RowMetaAndData r = null;
     r = getTransAttributeRow( id_transformation, nr, code );
     if ( r == null ) {
@@ -785,7 +788,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return r.getBoolean( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_STR, false );
   }
 
-  public synchronized double getTransAttributeNumber( ObjectId id_transformation, int nr, String code ) throws KettleException {
+  public synchronized double getTransAttributeNumber( ObjectId id_transformation, int nr, String code )
+    throws KettleException {
     RowMetaAndData r = null;
     r = getTransAttributeRow( id_transformation, nr, code );
     if ( r == null ) {
@@ -794,7 +798,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return r.getNumber( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_NUM, 0.0 );
   }
 
-  public synchronized long getTransAttributeInteger( ObjectId id_transformation, int nr, String code ) throws KettleException {
+  public synchronized long getTransAttributeInteger( ObjectId id_transformation, int nr, String code )
+    throws KettleException {
     RowMetaAndData r = null;
     r = getTransAttributeRow( id_transformation, nr, code );
     if ( r == null ) {
@@ -807,7 +812,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     String sql =
       "SELECT COUNT(*) FROM "
         + databaseMeta
-          .getQuotedSchemaTableCombination( null, KettleDatabaseRepository.TABLE_R_TRANS_ATTRIBUTE )
+        .getQuotedSchemaTableCombination( null, KettleDatabaseRepository.TABLE_R_TRANS_ATTRIBUTE )
         + " WHERE " + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ) + " = ? AND "
         + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ) + " = ?";
     RowMetaAndData table = new RowMetaAndData();
@@ -825,12 +830,13 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return (int) r.getInteger( 0, 0L );
   }
 
-  public synchronized List<Object[]> getTransAttributes( ObjectId id_transformation, String code, long nr ) throws KettleException {
+  public synchronized List<Object[]> getTransAttributes( ObjectId id_transformation, String code, long nr )
+    throws KettleException {
     String sql =
       "SELECT *"
         + " FROM "
         + databaseMeta
-          .getQuotedSchemaTableCombination( null, KettleDatabaseRepository.TABLE_R_TRANS_ATTRIBUTE )
+        .getQuotedSchemaTableCombination( null, KettleDatabaseRepository.TABLE_R_TRANS_ATTRIBUTE )
         + " WHERE " + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ) + " = ? AND "
         + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ) + " = ? AND "
         + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR ) + " = ?" + " ORDER BY "
@@ -846,15 +852,17 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     table.addValue( new ValueMetaInteger(
       KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR ), new Long( nr ) );
 
-    return callRead( () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
+    return callRead(
+      () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
   }
 
-  public synchronized List<Object[]> getTransAttributesWithPrefix( ObjectId id_transformation, String codePrefix ) throws KettleException {
+  public synchronized List<Object[]> getTransAttributesWithPrefix( ObjectId id_transformation, String codePrefix )
+    throws KettleException {
     String sql =
       "SELECT *"
         + " FROM "
         + databaseMeta
-          .getQuotedSchemaTableCombination( null, KettleDatabaseRepository.TABLE_R_TRANS_ATTRIBUTE )
+        .getQuotedSchemaTableCombination( null, KettleDatabaseRepository.TABLE_R_TRANS_ATTRIBUTE )
         + " WHERE " + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ) + " = ?"
         + " AND " + quote( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ) + " LIKE '" + codePrefix
         + "%'";
@@ -864,7 +872,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       new ValueMetaInteger(
         KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ),
       new LongObjectId( id_transformation ) );
-    return callRead( () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
+    return callRead(
+      () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
   }
 
   // JOB ATTRIBUTES: get
@@ -942,10 +951,12 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     table.addValue( new ValueMetaInteger(
       KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_NR ), new Long( nr ) );
 
-    return callRead( () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
+    return callRead(
+      () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
   }
 
-  public synchronized List<Object[]> getJobAttributesWithPrefix( ObjectId jobId, String codePrefix ) throws KettleException {
+  public synchronized List<Object[]> getJobAttributesWithPrefix( ObjectId jobId, String codePrefix )
+    throws KettleException {
     String sql =
       "SELECT *"
         + " FROM "
@@ -958,7 +969,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB ),
       new LongObjectId( jobId ) );
 
-    return callRead( () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
+    return callRead(
+      () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
   }
 
   // JOBENTRY ATTRIBUTES: SAVE
@@ -968,38 +980,42 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   //
 
   public ObjectId saveJobEntryAttribute( ObjectId id_job, ObjectId id_jobentry,
-    long nr, String code, String value ) throws KettleException {
+                                         long nr, String code, String value ) throws KettleException {
     return saveJobEntryAttribute( code, nr, id_job, id_jobentry, 0.0, value );
   }
 
   public ObjectId saveJobEntryAttribute( ObjectId id_job, ObjectId id_jobentry,
-    long nr, String code, double value ) throws KettleException {
+                                         long nr, String code, double value ) throws KettleException {
     return saveJobEntryAttribute( code, nr, id_job, id_jobentry, value, null );
   }
 
   public ObjectId saveJobEntryAttribute( ObjectId id_job, ObjectId id_jobentry,
-    long nr, String code, boolean value ) throws KettleException {
+                                         long nr, String code, boolean value ) throws KettleException {
     return saveJobEntryAttribute( code, nr, id_job, id_jobentry, 0.0, value ? "Y" : "N" );
   }
 
   private ObjectId saveJobEntryAttribute( String code, long nr, ObjectId id_job, ObjectId id_jobentry,
-    double value_num, String value_str ) throws KettleException {
+                                          double value_num, String value_str ) throws KettleException {
     return insertJobEntryAttribute( id_job, id_jobentry, nr, code, value_num, value_str );
   }
 
   public synchronized ObjectId insertJobEntryAttribute( ObjectId id_job, ObjectId id_jobentry, long nr,
-    String code, double value_num, String value_str ) throws KettleException {
+                                                        String code, double value_num, String value_str )
+    throws KettleException {
     ObjectId id = getNextJobEntryAttributeID();
 
     RowMetaAndData table = new RowMetaAndData();
 
     //CHECKSTYLE:LineLength:OFF
-    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY_ATTRIBUTE ), id );
+    table
+      .addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY_ATTRIBUTE ), id );
     table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOB ), id_job );
-    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ), id_jobentry );
+    table
+      .addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ), id_jobentry );
     table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_NR ), new Long( nr ) );
     table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE ), code );
-    table.addValue( new ValueMetaNumber( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_NUM ), new Double( value_num ) );
+    table.addValue( new ValueMetaNumber( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_NUM ),
+      new Double( value_num ) );
     table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_STR ), value_str );
 
     database.prepareInsert( table.getRowMeta(), KettleDatabaseRepository.TABLE_R_JOBENTRY_ATTRIBUTE );
@@ -1062,7 +1078,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_NUM )
         + " FROM "
         + databaseMeta.getQuotedSchemaTableCombination(
-          null, KettleDatabaseRepository.TABLE_R_JOBENTRY_ATTRIBUTE ) + " WHERE "
+        null, KettleDatabaseRepository.TABLE_R_JOBENTRY_ATTRIBUTE ) + " WHERE "
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ) + " = ? AND "
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE ) + " = ?  AND "
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_NR ) + " = ? ";
@@ -1099,7 +1115,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     } );
   }
 
-  public synchronized long getJobEntryAttributeInteger( ObjectId id_jobentry, int nr, String code ) throws KettleException {
+  public synchronized long getJobEntryAttributeInteger( ObjectId id_jobentry, int nr, String code )
+    throws KettleException {
     RowMetaAndData r = getJobEntryAttributeRow( id_jobentry, nr, code );
     if ( r == null ) {
       return 0;
@@ -1107,7 +1124,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return r.getInteger( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_NUM, 0L );
   }
 
-  public synchronized double getJobEntryAttributeNumber( ObjectId id_jobentry, int nr, String code ) throws KettleException {
+  public synchronized double getJobEntryAttributeNumber( ObjectId id_jobentry, int nr, String code )
+    throws KettleException {
     RowMetaAndData r = getJobEntryAttributeRow( id_jobentry, nr, code );
     if ( r == null ) {
       return 0.0;
@@ -1115,7 +1133,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return r.getNumber( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_NUM, 0.0 );
   }
 
-  public synchronized String getJobEntryAttributeString( ObjectId id_jobentry, int nr, String code ) throws KettleException {
+  public synchronized String getJobEntryAttributeString( ObjectId id_jobentry, int nr, String code )
+    throws KettleException {
     RowMetaAndData r = getJobEntryAttributeRow( id_jobentry, nr, code );
     if ( r == null ) {
       return null;
@@ -1123,7 +1142,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return r.getString( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_VALUE_STR, null );
   }
 
-  public synchronized boolean getJobEntryAttributeBoolean( ObjectId id_jobentry, int nr, String code, boolean def ) throws KettleException {
+  public synchronized boolean getJobEntryAttributeBoolean( ObjectId id_jobentry, int nr, String code, boolean def )
+    throws KettleException {
     RowMetaAndData r = getJobEntryAttributeRow( id_jobentry, nr, code );
     if ( r == null ) {
       return def;
@@ -1139,7 +1159,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     String sql =
       "SELECT COUNT(*) FROM "
         + databaseMeta.getQuotedSchemaTableCombination(
-          null, KettleDatabaseRepository.TABLE_R_JOBENTRY_ATTRIBUTE ) + " WHERE "
+        null, KettleDatabaseRepository.TABLE_R_JOBENTRY_ATTRIBUTE ) + " WHERE "
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ) + " = ? AND "
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE ) + " = ?";
     RowMetaAndData table = new RowMetaAndData();
@@ -1157,12 +1177,12 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   public synchronized List<Object[]> getJobEntryAttributesWithPrefix( ObjectId jobId, ObjectId jobEntryId,
-    String codePrefix ) throws KettleException {
+                                                                      String codePrefix ) throws KettleException {
     String sql =
       "SELECT *"
         + " FROM "
         + databaseMeta.getQuotedSchemaTableCombination(
-          null, KettleDatabaseRepository.TABLE_R_JOBENTRY_ATTRIBUTE ) + " WHERE "
+        null, KettleDatabaseRepository.TABLE_R_JOBENTRY_ATTRIBUTE ) + " WHERE "
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOB ) + " = ?" + " AND "
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ) + " = ?" + " AND "
         + quote( KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_CODE ) + " LIKE '" + codePrefix + "%'";
@@ -1178,7 +1198,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
         KettleDatabaseRepository.FIELD_JOBENTRY_ATTRIBUTE_ID_JOBENTRY ),
       new LongObjectId( jobEntryId ) );
 
-    return callRead( () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
+    return callRead(
+      () -> database.getRows( sql, table.getRowMeta(), table.getData(), ResultSet.FETCH_FORWARD, false, 0, null ) );
   }
 
   // ///////////////////////////////////////////////////////////////////////////////////
@@ -1378,17 +1399,20 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   public synchronized ObjectId insertStepAttribute( ObjectId id_transformation, ObjectId id_step, long nr,
-    String code, double value_num, String value_str ) throws KettleException {
+                                                    String code, double value_num, String value_str )
+    throws KettleException {
     ObjectId id = getNextStepAttributeID();
 
     RowMetaAndData table = new RowMetaAndData();
 
     table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP_ATTRIBUTE ), id );
-    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_TRANSFORMATION ), id_transformation );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_TRANSFORMATION ),
+      id_transformation );
     table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_ID_STEP ), id_step );
     table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_NR ), new Long( nr ) );
     table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_CODE ), code );
-    table.addValue( new ValueMetaNumber( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_VALUE_NUM ), new Double( value_num ) );
+    table.addValue( new ValueMetaNumber( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_VALUE_NUM ),
+      new Double( value_num ) );
     table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_STEP_ATTRIBUTE_VALUE_STR ), value_str );
 
     /*
@@ -1412,16 +1436,18 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   public synchronized ObjectId insertTransAttribute( ObjectId id_transformation, long nr, String code,
-    long value_num, String value_str ) throws KettleException {
+                                                     long value_num, String value_str ) throws KettleException {
     ObjectId id = getNextTransAttributeID();
 
     RowMetaAndData table = new RowMetaAndData();
 
     table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANS_ATTRIBUTE ), id );
-    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ), id_transformation );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_ID_TRANSFORMATION ),
+      id_transformation );
     table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_NR ), new Long( nr ) );
     table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_CODE ), code );
-    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_NUM ), new Long( value_num ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_NUM ),
+      new Long( value_num ) );
     table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_TRANS_ATTRIBUTE_VALUE_STR ), value_str );
 
     /*
@@ -1445,7 +1471,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   public synchronized ObjectId insertJobAttribute( ObjectId id_job, long nr, String code, long value_num,
-    String value_str ) throws KettleException {
+                                                   String value_str ) throws KettleException {
     ObjectId id = getNextJobAttributeID();
 
     // System.out.println("Insert job attribute : id_job="+id_job+", code="+code+", value_str="+value_str);
@@ -1456,7 +1482,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_ID_JOB ), id_job );
     table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_NR ), new Long( nr ) );
     table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_CODE ), code );
-    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_VALUE_NUM ), new Long( value_num ) );
+    table.addValue( new ValueMetaInteger( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_VALUE_NUM ),
+      new Long( value_num ) );
     table.addValue( new ValueMetaString( KettleDatabaseRepository.FIELD_JOB_ATTRIBUTE_VALUE_STR ), value_str );
 
     /*
@@ -1479,10 +1506,11 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return id;
   }
 
-  public synchronized void updateTableRow( String tablename, String idfield, RowMetaAndData values, ObjectId id ) throws KettleException {
-    String[] sets = new String[values.size()];
+  public synchronized void updateTableRow( String tablename, String idfield, RowMetaAndData values, ObjectId id )
+    throws KettleException {
+    String[] sets = new String[ values.size() ];
     for ( int i = 0; i < values.size(); i++ ) {
-      sets[i] = values.getValueMeta( i ).getName();
+      sets[ i ] = values.getValueMeta( i ).getName();
     }
     String[] codes = new String[] { idfield };
     String[] condition = new String[] { "=" };
@@ -1496,12 +1524,13 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     database.closeUpdate();
   }
 
-  public synchronized void updateTableRow( String tablename, String idfield, RowMetaAndData values ) throws KettleException {
+  public synchronized void updateTableRow( String tablename, String idfield, RowMetaAndData values )
+    throws KettleException {
     long id = values.getInteger( idfield, 0L );
     values.removeValue( idfield );
-    String[] sets = new String[values.size()];
+    String[] sets = new String[ values.size() ];
     for ( int i = 0; i < values.size(); i++ ) {
-      sets[i] = values.getValueMeta( i ).getName();
+      sets[ i ] = values.getValueMeta( i ).getName();
     }
     String[] codes = new String[] { idfield };
     String[] condition = new String[] { "=" };
@@ -1517,11 +1546,12 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   /**
    * @param id_directory
    * @return A list of RepositoryObjects
-   *
    * @throws KettleException
    */
   public synchronized List<RepositoryElementMetaInterface> getRepositoryObjects( String tableName,
-    RepositoryObjectType objectType, ObjectId id_directory ) throws KettleException {
+                                                                                 RepositoryObjectType objectType,
+                                                                                 ObjectId id_directory )
+    throws KettleException {
     try {
       String idField;
       if ( RepositoryObjectType.TRANSFORMATION.equals( objectType ) ) {
@@ -1651,17 +1681,17 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   public static final ObjectId[] convertLongList( List<Long> list ) {
-    ObjectId[] ids = new ObjectId[list.size()];
+    ObjectId[] ids = new ObjectId[ list.size() ];
     for ( int i = 0; i < ids.length; i++ ) {
-      ids[i] = new LongObjectId( list.get( i ) );
+      ids[ i ] = new LongObjectId( list.get( i ) );
     }
     return ids;
   }
 
   private String[] getQuotedSchemaTablenames( String[] tables ) {
-    String[] quoted = new String[tables.length];
+    String[] quoted = new String[ tables.length ];
     for ( int i = 0; i < quoted.length; i++ ) {
-      quoted[i] = database.getDatabaseMeta().getQuotedSchemaTableCombination( null, tables[i] );
+      quoted[ i ] = database.getDatabaseMeta().getQuotedSchemaTableCombination( null, tables[ i ] );
     }
     return quoted;
   }
@@ -1695,15 +1725,14 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   /**
-   * @param stepAttributesRowMeta
-   *          the stepAttributesRowMeta to set
+   * @param stepAttributesRowMeta the stepAttributesRowMeta to set
    */
   public void setStepAttributesRowMeta( RowMetaInterface stepAttributesRowMeta ) {
     this.stepAttributesRowMeta = stepAttributesRowMeta;
   }
 
   public synchronized LongObjectId getIDWithValue( String tablename, String idfield, String lookupfield,
-    String value ) throws KettleException {
+                                                   String value ) throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
     par.addValue( new ValueMetaString( "value" ), value );
     RowMetaAndData result = getOneRow(
@@ -1729,13 +1758,15 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return sb.toString();
   }
 
-  public Map<String, LongObjectId> getValueToIdMap( String tablename, String idfield, String lookupfield ) throws KettleException {
+  public Map<String, LongObjectId> getValueToIdMap( String tablename, String idfield, String lookupfield )
+    throws KettleException {
     String sql = new StringBuilder( "SELECT " ).append( lookupfield ).append( ", " ).append( idfield )
       .append( " FROM " ).append( tablename ).toString();
 
     Map<String, LongObjectId> result = new HashMap<String, LongObjectId>();
-    for ( Object[] row : callRead( () -> database.getRows( sql, new RowMeta(), new Object[]{}, ResultSet.FETCH_FORWARD, false, -1, null ) ) ) {
-      result.put( String.valueOf( row[0] ), new LongObjectId( ( (Number) row[ 1 ] ).longValue() ) );
+    for ( Object[] row : callRead(
+      () -> database.getRows( sql, new RowMeta(), new Object[] {}, ResultSet.FETCH_FORWARD, false, -1, null ) ) ) {
+      result.put( String.valueOf( row[ 0 ] ), new LongObjectId( ( (Number) row[ 1 ] ).longValue() ) );
     }
     return result;
   }
@@ -1750,7 +1781,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       params.addValueMeta( value );
     }
 
-    List<Object[]> rows = callRead( () -> database.getRows( sql, params, values, ResultSet.FETCH_FORWARD, false, -1, null ) );
+    List<Object[]> rows =
+      callRead( () -> database.getRows( sql, params, values, ResultSet.FETCH_FORWARD, false, -1, null ) );
 
     LongObjectId[] result = new LongObjectId[ rows.size() ];
     int i = 0;
@@ -1761,7 +1793,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   public synchronized ObjectId getIDWithValue( String tablename, String idfield, String lookupfield, String value,
-    String lookupkey, ObjectId key ) throws KettleException {
+                                               String lookupkey, ObjectId key ) throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
     par.addValue( new ValueMetaString( "value" ), value );
     par.addValue( new ValueMetaInteger( "key" ), new LongObjectId( key ) );
@@ -1777,7 +1809,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return null;
   }
 
-  public synchronized ObjectId getIDWithValue( String tablename, String idfield, String[] lookupkey, ObjectId[] key ) throws KettleException {
+  public synchronized ObjectId getIDWithValue( String tablename, String idfield, String[] lookupkey, ObjectId[] key )
+    throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
     String sql = "SELECT " + idfield + " FROM " + tablename + " ";
 
@@ -1787,8 +1820,8 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       } else {
         sql += "AND   ";
       }
-      par.addValue( new ValueMetaInteger( lookupkey[i] ), new LongObjectId( key[i] ) );
-      sql += lookupkey[i] + " = ? ";
+      par.addValue( new ValueMetaInteger( lookupkey[ i ] ), new LongObjectId( key[ i ] ) );
+      sql += lookupkey[ i ] + " = ? ";
     }
     RowMetaAndData result = getOneRow( sql, par.getRowMeta(), par.getData() );
     if ( result != null && result.getRowMeta() != null && result.getData() != null && result.isNumeric( 0 ) ) {
@@ -1798,15 +1831,16 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
   }
 
   public synchronized LongObjectId getIDWithValue( String tablename, String idfield, String lookupfield,
-    String value, String[] lookupkey, ObjectId[] key ) throws KettleException {
+                                                   String value, String[] lookupkey, ObjectId[] key )
+    throws KettleException {
     RowMetaAndData par = new RowMetaAndData();
     par.addValue( new ValueMetaString( lookupfield ), value );
 
     String sql = "SELECT " + idfield + " FROM " + tablename + " WHERE " + lookupfield + " = ? ";
 
     for ( int i = 0; i < lookupkey.length; i++ ) {
-      par.addValue( new ValueMetaInteger( lookupkey[i] ), new LongObjectId( key[i] ) );
-      sql += "AND " + lookupkey[i] + " = ? ";
+      par.addValue( new ValueMetaInteger( lookupkey[ i ] ), new LongObjectId( key[ i ] ) );
+      sql += "AND " + lookupkey[ i ] + " = ? ";
     }
 
     RowMetaAndData result = getOneRow( sql, par.getRowMeta(), par.getData() );
@@ -1859,11 +1893,13 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
     return callRead( () -> database.getOneRow( sql ) );
   }
 
-  public RowMetaAndData getOneRow( String sql, RowMetaInterface rowMeta, Object[] rowData ) throws KettleDatabaseException {
+  public RowMetaAndData getOneRow( String sql, RowMetaInterface rowMeta, Object[] rowData )
+    throws KettleDatabaseException {
     return callRead( () -> database.getOneRow( sql, rowMeta, rowData ) );
   }
 
-  public synchronized String getStringWithID( String tablename, String keyfield, ObjectId id, String fieldname ) throws KettleException {
+  public synchronized String getStringWithID( String tablename, String keyfield, ObjectId id, String fieldname )
+    throws KettleException {
     String sql = "SELECT " + fieldname + " FROM " + tablename + " WHERE " + keyfield + " = ?";
     RowMetaAndData par = new RowMetaAndData();
     par.addValue( new ValueMetaInteger( keyfield ), id );
@@ -1945,10 +1981,10 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
 
   public RowMetaAndData getParameterMetaData( ObjectId... ids ) throws KettleException {
     RowMetaInterface parameterMeta = new RowMeta();
-    Object[] parameterData = new Object[ids.length];
+    Object[] parameterData = new Object[ ids.length ];
     for ( int i = 0; i < ids.length; i++ ) {
       parameterMeta.addValueMeta( new ValueMetaInteger( "id" + ( i + 1 ) ) );
-      parameterData[i] = Long.valueOf( ids[i].getId() );
+      parameterData[ i ] = Long.valueOf( ids[ i ].getId() );
     }
     return new RowMetaAndData( parameterMeta, parameterData );
   }
@@ -1961,7 +1997,7 @@ public class KettleDatabaseRepositoryConnectionDelegate extends KettleDatabaseRe
       database.setValues( param, ps );
       ps.execute();
     } catch ( SQLException e ) {
-      throw new KettleException( "Unable to perform delete with SQL: " + sql + ", ids=" + ids.toString(), e );
+      throw new KettleException( "Unable to perform delete with SQL: " + sql + ", ids=" + Arrays.toString( ids ), e );
     }
   }
 

--- a/engine/src/main/java/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryTransDelegate.java
+++ b/engine/src/main/java/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryTransDelegate.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.Preconditions;
 import org.pentaho.di.cluster.ClusterSchema;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.Const;
@@ -148,7 +149,7 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
    *          the transformation metadata to store
    * @param monitor
    *          the way we report progress to the user, can be null if no UI is present
-   * @param overwrite
+   * @param overwriteAssociated
    *          Overwrite existing object(s)?
    * @throws KettleException
    *           if an error occurs.
@@ -418,8 +419,6 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
   /**
    * Save the parameters of this transformation to the repository.
    *
-   * @param rep
-   *          The repository to save to.
    *
    * @throws KettleException
    *           Upon any error.
@@ -439,8 +438,6 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
   /**
    * Read a transformation with a certain name from a repository
    *
-   * @param rep
-   *          The repository to read from.
    * @param transname
    *          The name of the transformation.
    * @param repdir
@@ -687,9 +684,6 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
 
   /**
    * Load the transformation name & other details from a repository.
-   *
-   * @param rep
-   *          The repository to load the details from.
    */
   private void loadRepTrans( TransMeta transMeta ) throws KettleException {
     try {
@@ -832,9 +826,6 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
   /**
    * Load the parameters of this transformation from the repository. The current ones already loaded will be erased.
    *
-   * @param rep
-   *          The repository to load from.
-   *
    * @throws KettleException
    *           Upon any error.
    */
@@ -948,7 +939,7 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
   /**
    * Read all the databases from the repository, insert into the TransMeta object, overwriting optionally
    *
-   * @param TransMeta
+   * @param transMeta
    *          The transformation to load into.
    * @param overWriteShared
    *          if an object with the same name exists, overwrite
@@ -985,7 +976,7 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
   /**
    * Read the clusters in the repository and add them to this transformation if they are not yet present.
    *
-   * @param TransMeta
+   * @param transMeta
    *          The transformation to load into.
    * @param overWriteShared
    *          if an object with the same name exists, overwrite
@@ -1017,7 +1008,7 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
   /**
    * Read the partitions in the repository and add them to this transformation if they are not yet present.
    *
-   * @param TransMeta
+   * @param transMeta
    *          The transformation to load into.
    * @param overWriteShared
    *          if an object with the same name exists, overwrite
@@ -1048,7 +1039,7 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
   /**
    * Read the slave servers in the repository and add them to this transformation if they are not yet present.
    *
-   * @param TransMeta
+   * @param transMeta
    *          The transformation to load into.
    * @param overWriteShared
    *          if an object with the same name exists, overwrite
@@ -1178,7 +1169,7 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
         hopTransMeta.setToStep( StepMeta.findStep( steps, stepMeta.getName() ) );
       }
 
-      if ( hopTransMeta.getFromStep() == null || hopTransMeta.getFromStep() == null ) {
+      if ( hopTransMeta.getFromStep() == null ) {
         // This not a valid hop. Skipping it is better than refusing to load the transformation. PDI-5519
         //
         return null;
@@ -1345,9 +1336,10 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
     step = (StepMeta) logTable.getSubject( TransLogTable.ID.LINES_REJECTED );
     if ( step != null ) {
       ObjectId rejectedId = step.getObjectId();
+      Preconditions.checkNotNull( rejectedId );
       repository.connectionDelegate.insertTransAttribute(
         transMeta.getObjectId(), 0, KettleDatabaseRepository.TRANS_ATTRIBUTE_ID_STEP_REJECTED,
-        rejectedId == null ? null : Long.valueOf( rejectedId.toString() ), null );
+        Long.valueOf( rejectedId.toString() ), null );
     }
 
     repository.connectionDelegate.insertTransAttribute(

--- a/engine/src/main/java/org/pentaho/di/trans/steps/dimensionlookup/DimensionLookup.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/dimensionlookup/DimensionLookup.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,6 +25,7 @@ package org.pentaho.di.trans.steps.dimensionlookup;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -75,7 +76,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
   int[] columnLookupArray = null;
 
   public DimensionLookup( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
-    Trans trans ) {
+                          Trans trans ) {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
 
@@ -154,27 +155,27 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       }
 
       // Lookup values
-      data.keynrs = new int[meta.getKeyStream().length];
+      data.keynrs = new int[ meta.getKeyStream().length ];
       for ( int i = 0; i < meta.getKeyStream().length; i++ ) {
         // logDetailed("Lookup values key["+i+"] --> "+key[i]+", row==null?"+(row==null));
-        data.keynrs[i] = data.inputRowMeta.indexOfValue( meta.getKeyStream()[i] );
-        if ( data.keynrs[i] < 0 ) { // couldn't find field!
+        data.keynrs[ i ] = data.inputRowMeta.indexOfValue( meta.getKeyStream()[ i ] );
+        if ( data.keynrs[ i ] < 0 ) { // couldn't find field!
           throw new KettleStepException( BaseMessages.getString(
-            PKG, "DimensionLookup.Exception.KeyFieldNotFound", meta.getKeyStream()[i] ) );
+            PKG, "DimensionLookup.Exception.KeyFieldNotFound", meta.getKeyStream()[ i ] ) );
         }
       }
 
       // Return values
-      data.fieldnrs = new int[meta.getFieldStream().length];
+      data.fieldnrs = new int[ meta.getFieldStream().length ];
       for ( int i = 0; meta.getFieldStream() != null && i < meta.getFieldStream().length; i++ ) {
-        if ( !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[i] ) ) {
-          data.fieldnrs[i] = data.outputRowMeta.indexOfValue( meta.getFieldStream()[i] );
-          if ( data.fieldnrs[i] < 0 ) {
+        if ( !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[ i ] ) ) {
+          data.fieldnrs[ i ] = data.outputRowMeta.indexOfValue( meta.getFieldStream()[ i ] );
+          if ( data.fieldnrs[ i ] < 0 ) {
             throw new KettleStepException( BaseMessages.getString(
-              PKG, "DimensionLookup.Exception.KeyFieldNotFound", meta.getFieldStream()[i] ) );
+              PKG, "DimensionLookup.Exception.KeyFieldNotFound", meta.getFieldStream()[ i ] ) );
           }
         } else {
-          data.fieldnrs[i] = -1;
+          data.fieldnrs[ i ] = -1;
         }
 
       }
@@ -189,7 +190,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
           //
           data.cacheKeyRowMeta = new RowMeta();
           for ( int i = 0; i < data.keynrs.length; i++ ) {
-            ValueMetaInterface key = data.inputRowMeta.getValueMeta( data.keynrs[i] );
+            ValueMetaInterface key = data.inputRowMeta.getValueMeta( data.keynrs[ i ] );
             data.cacheKeyRowMeta.addValueMeta( key.clone() );
           }
 
@@ -224,7 +225,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
     //
     for ( int lazyFieldIndex : data.lazyList ) {
       ValueMetaInterface valueMeta = getInputRowMeta().getValueMeta( lazyFieldIndex );
-      r[lazyFieldIndex] = valueMeta.convertToNormalStorageType( r[lazyFieldIndex] );
+      r[ lazyFieldIndex ] = valueMeta.convertToNormalStorageType( r[ lazyFieldIndex ] );
     }
 
     try {
@@ -272,8 +273,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
   /**
    * Pre-load the cache by reading the whole dimension table from disk...
    *
-   * @throws KettleException
-   *           in case there is a database or cache problem.
+   * @throws KettleException in case there is a database or cache problem.
    */
   private void preloadCache() throws KettleException {
     try {
@@ -284,10 +284,10 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       String sql = "SELECT " + databaseMeta.quoteField( meta.getKeyField() );
       // sql+=", "+databaseMeta.quoteField(meta.getVersionField());
       for ( int i = 0; i < meta.getKeyLookup().length; i++ ) {
-        sql += ", " + meta.getKeyLookup()[i]; // the natural key field in the table
+        sql += ", " + meta.getKeyLookup()[ i ]; // the natural key field in the table
       }
       for ( int i = 0; i < meta.getFieldLookup().length; i++ ) {
-        sql += ", " + meta.getFieldLookup()[i]; // the extra fields to retrieve...
+        sql += ", " + meta.getFieldLookup()[ i ]; // the extra fields to retrieve...
       }
       sql += ", " + databaseMeta.quoteField( meta.getDateFrom() ); // extra info in cache
       sql += ", " + databaseMeta.quoteField( meta.getDateTo() ); // extra info in cache
@@ -298,9 +298,9 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       List<Object[]> rows = data.db.getRows( sql, -1 );
       RowMetaInterface rowMeta = data.db.getReturnRowMeta();
 
-      data.preloadKeyIndexes = new int[meta.getKeyLookup().length];
+      data.preloadKeyIndexes = new int[ meta.getKeyLookup().length ];
       for ( int i = 0; i < data.preloadKeyIndexes.length; i++ ) {
-        data.preloadKeyIndexes[i] = rowMeta.indexOfValue( meta.getKeyLookup()[i] ); // the field in the table
+        data.preloadKeyIndexes[ i ] = rowMeta.indexOfValue( meta.getKeyLookup()[ i ] ); // the field in the table
       }
       data.preloadFromDateIndex = rowMeta.indexOfValue( meta.getDateFrom() );
       data.preloadToDateIndex = rowMeta.indexOfValue( meta.getDateTo() );
@@ -318,12 +318,12 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       //
       data.preloadIndexes = new ArrayList<Integer>();
       for ( int i = 0; i < meta.getKeyStream().length; i++ ) {
-        int index = data.inputRowMeta.indexOfValue( meta.getKeyStream()[i] );
+        int index = data.inputRowMeta.indexOfValue( meta.getKeyStream()[ i ] );
         if ( index < 0 ) {
           // Just to be safe...
           //
           throw new KettleStepException( BaseMessages.getString(
-            PKG, "DimensionLookup.Exception.KeyFieldNotFound", meta.getFieldStream()[i] ) );
+            PKG, "DimensionLookup.Exception.KeyFieldNotFound", meta.getFieldStream()[ i ] ) );
         }
         data.preloadIndexes.add( index );
       }
@@ -335,7 +335,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
   }
 
   private synchronized Object[] lookupValues( RowMetaInterface rowMeta, Object[] row ) throws KettleException {
-    Object[] outputRow = new Object[data.outputRowMeta.size()];
+    Object[] outputRow = new Object[ data.outputRowMeta.size() ];
 
     RowMetaInterface lookupRowMeta;
     Object[] lookupRow;
@@ -365,13 +365,13 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       //
       data.returnRowMeta = data.preloadCache.getRowMeta();
       lookupRowMeta = preloadRowMeta;
-      lookupRow = new Object[preloadRowMeta.size()];
+      lookupRow = new Object[ preloadRowMeta.size() ];
 
       // Assemble the lookup row, convert data if needed...
       //
       for ( int i = 0; i < data.preloadIndexes.size(); i++ ) {
         int from = data.preloadIndexes.get( i ); // Input row index
-        int to = data.preloadCache.getKeyIndexes()[i]; // Lookup row index
+        int to = data.preloadCache.getKeyIndexes()[ i ]; // Lookup row index
 
         // From data type...
         //
@@ -383,7 +383,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
 
         // From value:
         //
-        Object fromData = row[from];
+        Object fromData = row[ from ];
 
         // To value:
         //
@@ -391,12 +391,12 @@ public class DimensionLookup extends BaseStep implements StepInterface {
 
         // Set the key in the row...
         //
-        lookupRow[to] = toData;
+        lookupRow[ to ] = toData;
       }
 
       // Also set the lookup date on the "end of date range" (toDate) position
       //
-      lookupRow[data.preloadFromDateIndex] = valueDate;
+      lookupRow[ data.preloadFromDateIndex ] = valueDate;
 
       // Look up the row in the pre-load cache...
       //
@@ -408,26 +408,26 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       }
 
     } else {
-      lookupRow = new Object[data.lookupRowMeta.size()];
+      lookupRow = new Object[ data.lookupRowMeta.size() ];
       lookupRowMeta = data.lookupRowMeta;
 
       // Construct the lookup row...
       //
       for ( int i = 0; i < meta.getKeyStream().length; i++ ) {
         try {
-          lookupRow[i] = row[data.keynrs[i]];
+          lookupRow[ i ] = row[ data.keynrs[ i ] ];
         } catch ( Exception e ) { // TODO : remove exception??
           throw new KettleStepException(
             BaseMessages
               .getString(
                 PKG,
-                "DimensionLookup.Exception.ErrorDetectedInGettingKey", i + "", data.keynrs[i] + "/" + rowMeta.size(),
+                "DimensionLookup.Exception.ErrorDetectedInGettingKey", i + "", data.keynrs[ i ] + "/" + rowMeta.size(),
                 rowMeta.getString( row ) ) );
         }
       }
 
-      lookupRow[meta.getKeyStream().length] = valueDate; // ? >= date_from
-      lookupRow[meta.getKeyStream().length + 1] = valueDate; // ? < date_to
+      lookupRow[ meta.getKeyStream().length ] = valueDate; // ? >= date_from
+      lookupRow[ meta.getKeyStream().length + 1 ] = valueDate; // ? < date_to
 
       if ( isDebug() ) {
         logDebug( BaseMessages.getString( PKG, "DimensionLookup.Log.LookupRow" )
@@ -462,12 +462,12 @@ public class DimensionLookup extends BaseStep implements StepInterface {
     //
     if ( !meta.isUpdate() ) {
       if ( returnRow == null ) {
-        returnRow = new Object[data.returnRowMeta.size()];
-        returnRow[0] = data.notFoundTk;
+        returnRow = new Object[ data.returnRowMeta.size() ];
+        returnRow[ 0 ] = data.notFoundTk;
 
         if ( meta.getCacheSize() >= 0 ) { // need -oo to +oo as well...
-          returnRow[returnRow.length - 2] = data.min_date;
-          returnRow[returnRow.length - 1] = data.max_date;
+          returnRow[ returnRow.length - 2 ] = data.min_date;
+          returnRow[ returnRow.length - 1 ] = data.max_date;
         }
       }
       // else {
@@ -542,10 +542,10 @@ public class DimensionLookup extends BaseStep implements StepInterface {
           dimInsert( data.inputRowMeta, row, technicalKey, true, valueVersion, valueDateFrom, valueDateTo );
 
         incrementLinesOutput();
-        returnRow = new Object[data.returnRowMeta.size()];
+        returnRow = new Object[ data.returnRowMeta.size() ];
         int returnIndex = 0;
 
-        returnRow[returnIndex] = technicalKey;
+        returnRow[ returnIndex ] = technicalKey;
         returnIndex++;
 
         // See if we need to store this record in the cache as well...
@@ -596,38 +596,39 @@ public class DimensionLookup extends BaseStep implements StepInterface {
 
         // Column lookup array - initialize to all -1
         if ( columnLookupArray == null ) {
-          columnLookupArray = new int[meta.getFieldStream().length];
+          columnLookupArray = new int[ meta.getFieldStream().length ];
           for ( int i = 0; i < columnLookupArray.length; i++ ) {
-            columnLookupArray[i] = -1;
+            columnLookupArray[ i ] = -1;
           }
         }
         // Integer returnRowColNum = null;
         int returnRowColNum = -1;
         String findColumn = null;
         for ( int i = 0; i < meta.getFieldStream().length; i++ ) {
-          if ( data.fieldnrs[i] >= 0 ) {
+          if ( data.fieldnrs[ i ] >= 0 ) {
             // Only compare real fields, not last updated row, last version, etc
             //
-            ValueMetaInterface v1 = data.outputRowMeta.getValueMeta( data.fieldnrs[i] );
-            Object valueData1 = row[data.fieldnrs[i]];
-            findColumn = meta.getFieldStream()[i];
+            ValueMetaInterface v1 = data.outputRowMeta.getValueMeta( data.fieldnrs[ i ] );
+            Object valueData1 = row[ data.fieldnrs[ i ] ];
+            findColumn = meta.getFieldStream()[ i ];
             // find the returnRowMeta based on the field in the fieldLookup list
             ValueMetaInterface v2 = null;
             Object valueData2 = null;
             // Fix for PDI-8122
             // See if it's already been computed.
-            returnRowColNum = columnLookupArray[i];
+            returnRowColNum = columnLookupArray[ i ];
             if ( returnRowColNum == -1 ) {
               // It hasn't been found yet - search the list and make sure we're comparing
               // the right column to the right column.
               for ( int j = 2; j < data.returnRowMeta.size(); j++ ) { // starting at 2 because I know that 0 and 1 are
-                                                                      // poked in by Kettle.
+                // poked in by Kettle.
                 v2 = data.returnRowMeta.getValueMeta( j );
                 if ( ( v2.getName() != null ) && ( v2.getName().equalsIgnoreCase( findColumn ) ) ) { // is this the
-                                                                                                     // right column?
-                  columnLookupArray[i] = j; // yes - record the "j" into the columnLookupArray at [i] for the next time
-                                            // through the loop
-                  valueData2 = returnRow[j]; // get the valueData2 for comparison
+                  // right column?
+                  columnLookupArray[ i ] =
+                    j; // yes - record the "j" into the columnLookupArray at [i] for the next time
+                  // through the loop
+                  valueData2 = returnRow[ j ]; // get the valueData2 for comparison
                   break; // get outta here.
                 } else {
                   // Reset to null because otherwise, we'll get a false finding at the end.
@@ -639,13 +640,13 @@ public class DimensionLookup extends BaseStep implements StepInterface {
             } else {
               // We have a value in the columnLookupArray - use the value stored there.
               v2 = data.returnRowMeta.getValueMeta( returnRowColNum );
-              valueData2 = returnRow[returnRowColNum];
+              valueData2 = returnRow[ returnRowColNum ];
             }
             if ( v2 == null ) {
               // If we made it here, then maybe someone tweaked the XML in the transformation
               // and we're matching a stream column to a column that doesn't really exist. Throw an exception.
               throw new KettleStepException( BaseMessages.getString(
-                PKG, "DimensionLookup.Exception.ErrorDetectedInComparingFields", meta.getFieldStream()[i] ) );
+                PKG, "DimensionLookup.Exception.ErrorDetectedInComparingFields", meta.getFieldStream()[ i ] ) );
             }
 
             try {
@@ -660,12 +661,12 @@ public class DimensionLookup extends BaseStep implements StepInterface {
             }
 
             // Field flagged for insert: insert
-            if ( cmp != 0 && meta.getFieldUpdate()[i] == DimensionLookupMeta.TYPE_UPDATE_DIM_INSERT ) {
+            if ( cmp != 0 && meta.getFieldUpdate()[ i ] == DimensionLookupMeta.TYPE_UPDATE_DIM_INSERT ) {
               insert = true;
             }
 
             // Field flagged for punchthrough
-            if ( cmp != 0 && meta.getFieldUpdate()[i] == DimensionLookupMeta.TYPE_UPDATE_DIM_PUNCHTHROUGH ) {
+            if ( cmp != 0 && meta.getFieldUpdate()[ i ] == DimensionLookupMeta.TYPE_UPDATE_DIM_PUNCHTHROUGH ) {
               punch = true;
             }
 
@@ -765,8 +766,8 @@ public class DimensionLookup extends BaseStep implements StepInterface {
           incrementLinesUpdated();
         }
 
-        returnRow = new Object[data.returnRowMeta.size()];
-        returnRow[0] = technicalKey;
+        returnRow = new Object[ data.returnRowMeta.size() ];
+        returnRow[ 0 ] = technicalKey;
         if ( isRowLevel() ) {
           logRowlevel( BaseMessages.getString( PKG, "DimensionLookup.Log.TechnicalKey" ) + technicalKey );
         }
@@ -783,7 +784,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
     // First copy the input row values to the output..
     //
     for ( int i = 0; i < rowMeta.size(); i++ ) {
-      outputRow[i] = row[i];
+      outputRow[ i ] = row[ i ];
     }
 
     int outputIndex = rowMeta.size();
@@ -791,7 +792,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
 
     // Then the technical key...
     //
-    if ( data.returnRowMeta.getValueMeta( 0 ).isBigNumber() && returnRow[0] instanceof Long ) {
+    if ( data.returnRowMeta.getValueMeta( 0 ).isBigNumber() && returnRow[ 0 ] instanceof Long ) {
       if ( isDebug() ) {
         log.logDebug( "Changing the type of the technical key from TYPE_BIGNUMBER to an TYPE_INTEGER" );
       }
@@ -800,7 +801,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
         tkValueMeta, ValueMetaInterface.TYPE_INTEGER ) );
     }
 
-    outputRow[outputIndex++] = data.returnRowMeta.getInteger( returnRow, inputIndex++ );
+    outputRow[ outputIndex++ ] = data.returnRowMeta.getInteger( returnRow, inputIndex++ );
 
     // skip the version in the input
     inputIndex++;
@@ -809,7 +810,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
     // don't return date from-to fields, they can be returned when explicitly
     // specified in lookup fields.
     while ( inputIndex < returnRow.length && outputIndex < outputRow.length ) {
-      outputRow[outputIndex] = returnRow[inputIndex];
+      outputRow[ outputIndex ] = returnRow[ inputIndex ];
       outputIndex++;
       inputIndex++;
     }
@@ -855,13 +856,13 @@ public class DimensionLookup extends BaseStep implements StepInterface {
     if ( !Utils.isEmpty( meta.getFieldLookup() ) ) {
       for ( int i = 0; i < meta.getFieldLookup().length; i++ ) {
         // Don't retrieve the fields without input
-        if ( !Utils.isEmpty( meta.getFieldLookup()[i] )
-          && !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[i] ) ) {
-          sql += ", " + databaseMeta.quoteField( meta.getFieldLookup()[i] );
+        if ( !Utils.isEmpty( meta.getFieldLookup()[ i ] )
+          && !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[ i ] ) ) {
+          sql += ", " + databaseMeta.quoteField( meta.getFieldLookup()[ i ] );
 
-          if ( !Utils.isEmpty( meta.getFieldStream()[i] )
-            && !meta.getFieldLookup()[i].equals( meta.getFieldStream()[i] ) ) {
-            sql += " AS " + databaseMeta.quoteField( meta.getFieldStream()[i] );
+          if ( !Utils.isEmpty( meta.getFieldStream()[ i ] )
+            && !meta.getFieldLookup()[ i ].equals( meta.getFieldStream()[ i ] ) ) {
+            sql += " AS " + databaseMeta.quoteField( meta.getFieldStream()[ i ] );
           }
         }
       }
@@ -877,8 +878,8 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       if ( i != 0 ) {
         sql += " AND ";
       }
-      sql += databaseMeta.quoteField( meta.getKeyLookup()[i] ) + " = ? ";
-      data.lookupRowMeta.addValueMeta( rowMeta.getValueMeta( data.keynrs[i] ) );
+      sql += databaseMeta.quoteField( meta.getKeyLookup()[ i ] ) + " = ? ";
+      data.lookupRowMeta.addValueMeta( rowMeta.getValueMeta( data.keynrs[ i ] ) );
     }
 
     String dateFromField = databaseMeta.quoteField( meta.getDateFrom() );
@@ -928,10 +929,11 @@ public class DimensionLookup extends BaseStep implements StepInterface {
    * version of the entry.
    */
   public Long dimInsert( RowMetaInterface inputRowMeta, Object[] row, Long technicalKey, boolean newEntry,
-    Long versionNr, Date dateFrom, Date dateTo ) throws KettleException {
+                         Long versionNr, Date dateFrom, Date dateTo ) throws KettleException {
     DatabaseMeta databaseMeta = meta.getDatabaseMeta();
 
-    if ( data.prepStatementInsert == null && data.prepStatementUpdate == null ) { // first time: construct prepared statement
+    if ( data.prepStatementInsert == null
+      && data.prepStatementUpdate == null ) { // first time: construct prepared statement
       RowMetaInterface insertRowMeta = new RowMeta();
 
       /*
@@ -946,9 +948,9 @@ public class DimensionLookup extends BaseStep implements StepInterface {
 
       if ( !isAutoIncrement() ) {
         sql += databaseMeta.quoteField( meta.getKeyField() ) + ", "; // NO
-                                                                     // AUTOINCREMENT
+        // AUTOINCREMENT
         insertRowMeta.addValueMeta( data.outputRowMeta.getValueMeta( inputRowMeta.size() ) ); // the first return value
-                                                                                              // after the input
+        // after the input
       } else {
         if ( databaseMeta.needsPlaceHolder() ) {
           sql += "0, "; // placeholder on informix!
@@ -964,17 +966,17 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       insertRowMeta.addValueMeta( new ValueMetaDate( meta.getDateTo() ) );
 
       for ( int i = 0; i < meta.getKeyLookup().length; i++ ) {
-        sql += ", " + databaseMeta.quoteField( meta.getKeyLookup()[i] );
-        insertRowMeta.addValueMeta( inputRowMeta.getValueMeta( data.keynrs[i] ) );
+        sql += ", " + databaseMeta.quoteField( meta.getKeyLookup()[ i ] );
+        insertRowMeta.addValueMeta( inputRowMeta.getValueMeta( data.keynrs[ i ] ) );
       }
 
       for ( int i = 0; i < meta.getFieldLookup().length; i++ ) {
         // Ignore last_version, last_updated etc, they are handled below (at the
         // back of the row).
         //
-        if ( !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[i] ) ) {
-          sql += ", " + databaseMeta.quoteField( meta.getFieldLookup()[i] );
-          insertRowMeta.addValueMeta( inputRowMeta.getValueMeta( data.fieldnrs[i] ) );
+        if ( !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[ i ] ) ) {
+          sql += ", " + databaseMeta.quoteField( meta.getFieldLookup()[ i ] );
+          insertRowMeta.addValueMeta( inputRowMeta.getValueMeta( data.fieldnrs[ i ] ) );
         }
       }
 
@@ -982,13 +984,13 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       //
       for ( int i = 0; i < meta.getFieldUpdate().length; i++ ) {
         ValueMetaInterface valueMeta = null;
-        switch ( meta.getFieldUpdate()[i] ) {
+        switch ( meta.getFieldUpdate()[ i ] ) {
           case DimensionLookupMeta.TYPE_UPDATE_DATE_INSUP:
           case DimensionLookupMeta.TYPE_UPDATE_DATE_INSERTED:
-            valueMeta = new ValueMetaDate( meta.getFieldLookup()[i] );
+            valueMeta = new ValueMetaDate( meta.getFieldLookup()[ i ] );
             break;
           case DimensionLookupMeta.TYPE_UPDATE_LAST_VERSION:
-            valueMeta = new ValueMetaBoolean( meta.getFieldLookup()[i] );
+            valueMeta = new ValueMetaBoolean( meta.getFieldLookup()[ i ] );
             break;
           default:
             break;
@@ -1013,7 +1015,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       for ( int i = 0; i < meta.getFieldLookup().length; i++ ) {
         // Ignore last_version, last_updated, etc. These are handled below...
         //
-        if ( !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[i] ) ) {
+        if ( !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[ i ] ) ) {
           sql += ", ?";
         }
       }
@@ -1021,7 +1023,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       // The special update fields...
       //
       for ( int i = 0; i < meta.getFieldUpdate().length; i++ ) {
-        switch ( meta.getFieldUpdate()[i] ) {
+        switch ( meta.getFieldUpdate()[ i ] ) {
           case DimensionLookupMeta.TYPE_UPDATE_DATE_INSUP:
           case DimensionLookupMeta.TYPE_UPDATE_DATE_INSERTED:
           case DimensionLookupMeta.TYPE_UPDATE_LAST_VERSION:
@@ -1066,13 +1068,13 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       //
       for ( int i = 0; i < meta.getFieldUpdate().length; i++ ) {
         ValueMetaInterface valueMeta = null;
-        switch ( meta.getFieldUpdate()[i] ) {
+        switch ( meta.getFieldUpdate()[ i ] ) {
           case DimensionLookupMeta.TYPE_UPDATE_DATE_INSUP:
           case DimensionLookupMeta.TYPE_UPDATE_DATE_UPDATED:
-            valueMeta = new ValueMetaDate( meta.getFieldLookup()[i] );
+            valueMeta = new ValueMetaDate( meta.getFieldLookup()[ i ] );
             break;
           case DimensionLookupMeta.TYPE_UPDATE_LAST_VERSION:
-            valueMeta = new ValueMetaBoolean( meta.getFieldLookup()[i] );
+            valueMeta = new ValueMetaBoolean( meta.getFieldLookup()[ i ] );
             break;
           default:
             break;
@@ -1088,8 +1090,8 @@ public class DimensionLookup extends BaseStep implements StepInterface {
         if ( i > 0 ) {
           sql_upd += "AND   ";
         }
-        sql_upd += databaseMeta.quoteField( meta.getKeyLookup()[i] ) + " = ?" + Const.CR;
-        updateRowMeta.addValueMeta( inputRowMeta.getValueMeta( data.keynrs[i] ) );
+        sql_upd += databaseMeta.quoteField( meta.getKeyLookup()[ i ] ) + " = ?" + Const.CR;
+        updateRowMeta.addValueMeta( inputRowMeta.getValueMeta( data.keynrs[ i ] ) );
       }
       sql_upd += "AND   " + databaseMeta.quoteField( meta.getVersionField() ) + " = ? ";
       updateRowMeta.addValueMeta( new ValueMetaInteger( meta.getVersionField() ) );
@@ -1105,63 +1107,63 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       data.updateRowMeta = updateRowMeta;
     }
 
-    Object[] insertRow = new Object[data.insertRowMeta.size()];
+    Object[] insertRow = new Object[ data.insertRowMeta.size() ];
     int insertIndex = 0;
     if ( !isAutoIncrement() ) {
-      insertRow[insertIndex++] = technicalKey;
+      insertRow[ insertIndex++ ] = technicalKey;
     }
 
     // Caller is responsible for setting proper version number depending
     // on if newEntry == true
-    insertRow[insertIndex++] = versionNr;
+    insertRow[ insertIndex++ ] = versionNr;
 
     switch ( data.startDateChoice ) {
       case DimensionLookupMeta.START_DATE_ALTERNATIVE_NONE:
-        insertRow[insertIndex++] = dateFrom;
+        insertRow[ insertIndex++ ] = dateFrom;
         break;
       case DimensionLookupMeta.START_DATE_ALTERNATIVE_SYSDATE:
         // use the time the step execution begins as the date from (passed in as dateFrom).
         // before, the current system time was used. this caused an exclusion of the row in the
         // lookup portion of the step that uses this 'valueDate' and not the current time.
         // the result was multiple inserts for what should have been 1 [PDI-4317]
-        insertRow[insertIndex++] = dateFrom;
+        insertRow[ insertIndex++ ] = dateFrom;
         break;
       case DimensionLookupMeta.START_DATE_ALTERNATIVE_START_OF_TRANS:
-        insertRow[insertIndex++] = getTrans().getStartDate();
+        insertRow[ insertIndex++ ] = getTrans().getStartDate();
         break;
       case DimensionLookupMeta.START_DATE_ALTERNATIVE_NULL:
-        insertRow[insertIndex++] = null;
+        insertRow[ insertIndex++ ] = null;
         break;
       case DimensionLookupMeta.START_DATE_ALTERNATIVE_COLUMN_VALUE:
-        insertRow[insertIndex++] = inputRowMeta.getDate( row, data.startDateFieldIndex );
+        insertRow[ insertIndex++ ] = inputRowMeta.getDate( row, data.startDateFieldIndex );
         break;
       default:
         throw new KettleStepException( BaseMessages.getString(
           PKG, "DimensionLookup.Exception.IllegalStartDateSelection", Integer.toString( data.startDateChoice ) ) );
     }
 
-    insertRow[insertIndex++] = dateTo;
+    insertRow[ insertIndex++ ] = dateTo;
 
     for ( int i = 0; i < data.keynrs.length; i++ ) {
-      insertRow[insertIndex++] = row[data.keynrs[i]];
+      insertRow[ insertIndex++ ] = row[ data.keynrs[ i ] ];
     }
     for ( int i = 0; i < data.fieldnrs.length; i++ ) {
-      if ( data.fieldnrs[i] >= 0 ) {
+      if ( data.fieldnrs[ i ] >= 0 ) {
         // Ignore last_version, last_updated, etc. These are handled below...
         //
-        insertRow[insertIndex++] = row[data.fieldnrs[i]];
+        insertRow[ insertIndex++ ] = row[ data.fieldnrs[ i ] ];
       }
     }
     // The special update fields...
     //
     for ( int i = 0; i < meta.getFieldUpdate().length; i++ ) {
-      switch ( meta.getFieldUpdate()[i] ) {
+      switch ( meta.getFieldUpdate()[ i ] ) {
         case DimensionLookupMeta.TYPE_UPDATE_DATE_INSUP:
         case DimensionLookupMeta.TYPE_UPDATE_DATE_INSERTED:
-          insertRow[insertIndex++] = new Date();
+          insertRow[ insertIndex++ ] = new Date();
           break;
         case DimensionLookupMeta.TYPE_UPDATE_LAST_VERSION:
-          insertRow[insertIndex++] = Boolean.TRUE;
+          insertRow[ insertIndex++ ] = Boolean.TRUE;
           break; // Always the last version on insert.
         default:
           break;
@@ -1199,24 +1201,24 @@ public class DimensionLookup extends BaseStep implements StepInterface {
        * UPDATE d_customer SET dateto = val_datfrom , last_updated = <now> , last_version = false WHERE keylookup[] =
        * keynrs[] AND versionfield = val_version - 1 ;
        */
-      Object[] updateRow = new Object[data.updateRowMeta.size()];
+      Object[] updateRow = new Object[ data.updateRowMeta.size() ];
       int updateIndex = 0;
 
       switch ( data.startDateChoice ) {
         case DimensionLookupMeta.START_DATE_ALTERNATIVE_NONE:
-          updateRow[updateIndex++] = dateFrom;
+          updateRow[ updateIndex++ ] = dateFrom;
           break;
         case DimensionLookupMeta.START_DATE_ALTERNATIVE_SYSDATE:
-          updateRow[updateIndex++] = new Date();
+          updateRow[ updateIndex++ ] = new Date();
           break;
         case DimensionLookupMeta.START_DATE_ALTERNATIVE_START_OF_TRANS:
-          updateRow[updateIndex++] = getTrans().getCurrentDate();
+          updateRow[ updateIndex++ ] = getTrans().getCurrentDate();
           break;
         case DimensionLookupMeta.START_DATE_ALTERNATIVE_NULL:
-          updateRow[updateIndex++] = null;
+          updateRow[ updateIndex++ ] = null;
           break;
         case DimensionLookupMeta.START_DATE_ALTERNATIVE_COLUMN_VALUE:
-          updateRow[updateIndex++] = inputRowMeta.getDate( row, data.startDateFieldIndex );
+          updateRow[ updateIndex++ ] = inputRowMeta.getDate( row, data.startDateFieldIndex );
           break;
         default:
           throw new KettleStepException( BaseMessages.getString(
@@ -1226,15 +1228,15 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       // The special update fields...
       //
       for ( int i = 0; i < meta.getFieldUpdate().length; i++ ) {
-        switch ( meta.getFieldUpdate()[i] ) {
+        switch ( meta.getFieldUpdate()[ i ] ) {
           case DimensionLookupMeta.TYPE_UPDATE_DATE_INSUP:
-            updateRow[updateIndex++] = new Date();
+            updateRow[ updateIndex++ ] = new Date();
             break;
           case DimensionLookupMeta.TYPE_UPDATE_LAST_VERSION:
-            updateRow[updateIndex++] = Boolean.FALSE;
+            updateRow[ updateIndex++ ] = Boolean.FALSE;
             break; // Never the last version on this update
           case DimensionLookupMeta.TYPE_UPDATE_DATE_UPDATED:
-            updateRow[updateIndex++] = new Date();
+            updateRow[ updateIndex++ ] = new Date();
             break;
           default:
             break;
@@ -1242,10 +1244,10 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       }
 
       for ( int i = 0; i < data.keynrs.length; i++ ) {
-        updateRow[updateIndex++] = row[data.keynrs[i]];
+        updateRow[ updateIndex++ ] = row[ data.keynrs[ i ] ];
       }
 
-      updateRow[updateIndex++] = versionNr - 1;
+      updateRow[ updateIndex++ ] = versionNr - 1;
 
       if ( isRowLevel() ) {
         logRowlevel( "UPDATE using rupd=" + data.updateRowMeta.getString( updateRow ) );
@@ -1278,7 +1280,8 @@ public class DimensionLookup extends BaseStep implements StepInterface {
     return log.isDebug();
   }
 
-  public void dimUpdate( RowMetaInterface rowMeta, Object[] row, Long dimkey, Date valueDate ) throws KettleDatabaseException {
+  public void dimUpdate( RowMetaInterface rowMeta, Object[] row, Long dimkey, Date valueDate )
+    throws KettleDatabaseException {
     if ( data.prepStatementDimensionUpdate == null ) {
       // first time: construct prepared statement
       //
@@ -1292,15 +1295,15 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       String sql = "UPDATE " + data.schemaTable + Const.CR + "SET ";
       boolean comma = false;
       for ( int i = 0; i < meta.getFieldLookup().length; i++ ) {
-        if ( !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[i] ) ) {
+        if ( !DimensionLookupMeta.isUpdateTypeWithoutArgument( meta.isUpdate(), meta.getFieldUpdate()[ i ] ) ) {
           if ( comma ) {
             sql += ", ";
           } else {
             sql += "  ";
           }
           comma = true;
-          sql += meta.getDatabaseMeta().quoteField( meta.getFieldLookup()[i] ) + " = ?" + Const.CR;
-          data.dimensionUpdateRowMeta.addValueMeta( rowMeta.getValueMeta( data.fieldnrs[i] ) );
+          sql += meta.getDatabaseMeta().quoteField( meta.getFieldLookup()[ i ] ) + " = ?" + Const.CR;
+          data.dimensionUpdateRowMeta.addValueMeta( rowMeta.getValueMeta( data.fieldnrs[ i ] ) );
         }
       }
 
@@ -1308,10 +1311,10 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       //
       for ( int i = 0; i < meta.getFieldUpdate().length; i++ ) {
         ValueMetaInterface valueMeta = null;
-        switch ( meta.getFieldUpdate()[i] ) {
+        switch ( meta.getFieldUpdate()[ i ] ) {
           case DimensionLookupMeta.TYPE_UPDATE_DATE_INSUP:
           case DimensionLookupMeta.TYPE_UPDATE_DATE_UPDATED:
-            valueMeta = new ValueMetaDate( meta.getFieldLookup()[i] );
+            valueMeta = new ValueMetaDate( meta.getFieldLookup()[ i ] );
             break;
           default:
             break;
@@ -1345,26 +1348,26 @@ public class DimensionLookup extends BaseStep implements StepInterface {
 
     // Assemble information
     // New
-    Object[] dimensionUpdateRow = new Object[data.dimensionUpdateRowMeta.size()];
+    Object[] dimensionUpdateRow = new Object[ data.dimensionUpdateRowMeta.size() ];
     int updateIndex = 0;
     for ( int i = 0; i < data.fieldnrs.length; i++ ) {
       // Ignore last_version, last_updated, etc. These are handled below...
       //
-      if ( data.fieldnrs[i] >= 0 ) {
-        dimensionUpdateRow[updateIndex++] = row[data.fieldnrs[i]];
+      if ( data.fieldnrs[ i ] >= 0 ) {
+        dimensionUpdateRow[ updateIndex++ ] = row[ data.fieldnrs[ i ] ];
       }
     }
     for ( int i = 0; i < meta.getFieldUpdate().length; i++ ) {
-      switch ( meta.getFieldUpdate()[i] ) {
+      switch ( meta.getFieldUpdate()[ i ] ) {
         case DimensionLookupMeta.TYPE_UPDATE_DATE_INSUP:
         case DimensionLookupMeta.TYPE_UPDATE_DATE_UPDATED:
-          dimensionUpdateRow[updateIndex++] = valueDate;
+          dimensionUpdateRow[ updateIndex++ ] = valueDate;
           break;
         default:
           break;
       }
     }
-    dimensionUpdateRow[updateIndex++] = dimkey;
+    dimensionUpdateRow[ updateIndex++ ] = dimkey;
 
     data.db.setValues( data.dimensionUpdateRowMeta, dimensionUpdateRow, data.prepStatementDimensionUpdate );
     data.db.insertRow( data.prepStatementDimensionUpdate );
@@ -1385,25 +1388,25 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       sql_upd += "SET ";
       boolean first = true;
       for ( int i = 0; i < meta.getFieldLookup().length; i++ ) {
-        if ( meta.getFieldUpdate()[i] == DimensionLookupMeta.TYPE_UPDATE_DIM_PUNCHTHROUGH ) {
+        if ( meta.getFieldUpdate()[ i ] == DimensionLookupMeta.TYPE_UPDATE_DIM_PUNCHTHROUGH ) {
           if ( !first ) {
             sql_upd += ", ";
           } else {
             sql_upd += "  ";
           }
           first = false;
-          sql_upd += databaseMeta.quoteField( meta.getFieldLookup()[i] ) + " = ?" + Const.CR;
-          data.punchThroughRowMeta.addValueMeta( rowMeta.getValueMeta( data.fieldnrs[i] ) );
+          sql_upd += databaseMeta.quoteField( meta.getFieldLookup()[ i ] ) + " = ?" + Const.CR;
+          data.punchThroughRowMeta.addValueMeta( rowMeta.getValueMeta( data.fieldnrs[ i ] ) );
         }
       }
       // The special update fields...
       //
       for ( int i = 0; i < meta.getFieldUpdate().length; i++ ) {
         ValueMetaInterface valueMeta = null;
-        switch ( meta.getFieldUpdate()[i] ) {
+        switch ( meta.getFieldUpdate()[ i ] ) {
           case DimensionLookupMeta.TYPE_UPDATE_DATE_INSUP:
           case DimensionLookupMeta.TYPE_UPDATE_DATE_UPDATED:
-            valueMeta = new ValueMetaDate( meta.getFieldLookup()[i] );
+            valueMeta = new ValueMetaDate( meta.getFieldLookup()[ i ] );
             break;
           default:
             break;
@@ -1419,8 +1422,8 @@ public class DimensionLookup extends BaseStep implements StepInterface {
         if ( i > 0 ) {
           sql_upd += "AND   ";
         }
-        sql_upd += databaseMeta.quoteField( meta.getKeyLookup()[i] ) + " = ?" + Const.CR;
-        data.punchThroughRowMeta.addValueMeta( rowMeta.getValueMeta( data.keynrs[i] ) );
+        sql_upd += databaseMeta.quoteField( meta.getKeyLookup()[ i ] ) + " = ?" + Const.CR;
+        data.punchThroughRowMeta.addValueMeta( rowMeta.getValueMeta( data.keynrs[ i ] ) );
       }
 
       try {
@@ -1432,31 +1435,31 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       }
     }
 
-    Object[] punchThroughRow = new Object[data.punchThroughRowMeta.size()];
+    Object[] punchThroughRow = new Object[ data.punchThroughRowMeta.size() ];
     int punchIndex = 0;
 
     for ( int i = 0; i < meta.getFieldLookup().length; i++ ) {
-      if ( meta.getFieldUpdate()[i] == DimensionLookupMeta.TYPE_UPDATE_DIM_PUNCHTHROUGH ) {
-        punchThroughRow[punchIndex++] = row[data.fieldnrs[i]];
+      if ( meta.getFieldUpdate()[ i ] == DimensionLookupMeta.TYPE_UPDATE_DIM_PUNCHTHROUGH ) {
+        punchThroughRow[ punchIndex++ ] = row[ data.fieldnrs[ i ] ];
       }
     }
     for ( int i = 0; i < meta.getFieldUpdate().length; i++ ) {
-      switch ( meta.getFieldUpdate()[i] ) {
+      switch ( meta.getFieldUpdate()[ i ] ) {
         case DimensionLookupMeta.TYPE_UPDATE_DATE_INSUP:
         case DimensionLookupMeta.TYPE_UPDATE_DATE_UPDATED:
-          punchThroughRow[punchIndex++] = new Date();
+          punchThroughRow[ punchIndex++ ] = new Date();
           break;
         default:
           break;
       }
     }
     for ( int i = 0; i < data.keynrs.length; i++ ) {
-      punchThroughRow[punchIndex++] = row[data.keynrs[i]];
+      punchThroughRow[ punchIndex++ ] = row[ data.keynrs[ i ] ];
     }
 
     // UPDATE VALUES
     data.db.setValues( data.punchThroughRowMeta, punchThroughRow, data.prepStatementPunchThrough ); // set values for
-                                                                                                    // update
+    // update
     data.db.insertRow( data.prepStatementPunchThrough ); // do the actual punch through update
   }
 
@@ -1464,40 +1467,36 @@ public class DimensionLookup extends BaseStep implements StepInterface {
    * Keys: - natural key fields Values: - Technical key - lookup fields / extra fields (allows us to compare or
    * retrieve) - Date_from - Date_to
    *
-   * @param row
-   *          The input row
-   * @param technicalKey
-   *          the technical key value
-   * @param valueDateFrom
-   *          the start of valid date range
-   * @param valueDateTo
-   *          the end of the valid date range
+   * @param row           The input row
+   * @param technicalKey  the technical key value
+   * @param valueDateFrom the start of valid date range
+   * @param valueDateTo   the end of the valid date range
    * @return the values to store in the cache as a row.
    */
   private Object[] getCacheValues( RowMetaInterface rowMeta, Object[] row, Long technicalKey, Long valueVersion,
-    Date valueDateFrom, Date valueDateTo ) {
+                                   Date valueDateFrom, Date valueDateTo ) {
     if ( data.cacheValueRowMeta == null ) {
       return null; // nothing is in the cache.
     }
 
-    Object[] cacheValues = new Object[data.cacheValueRowMeta.size()];
+    Object[] cacheValues = new Object[ data.cacheValueRowMeta.size() ];
     int cacheIndex = 0;
 
-    cacheValues[cacheIndex++] = technicalKey;
+    cacheValues[ cacheIndex++ ] = technicalKey;
 
-    cacheValues[cacheIndex++] = valueVersion;
+    cacheValues[ cacheIndex++ ] = valueVersion;
 
     for ( int i = 0; i < data.fieldnrs.length; i++ ) {
       // Ignore last_version, last_updated, etc. These are handled below...
       //
-      if ( data.fieldnrs[i] >= 0 ) {
-        cacheValues[cacheIndex++] = row[data.fieldnrs[i]];
+      if ( data.fieldnrs[ i ] >= 0 ) {
+        cacheValues[ cacheIndex++ ] = row[ data.fieldnrs[ i ] ];
       }
     }
 
-    cacheValues[cacheIndex++] = valueDateFrom;
+    cacheValues[ cacheIndex++ ] = valueDateFrom;
 
-    cacheValues[cacheIndex++] = valueDateTo;
+    cacheValues[ cacheIndex++ ] = valueDateTo;
 
     return cacheValues;
   }
@@ -1505,7 +1504,7 @@ public class DimensionLookup extends BaseStep implements StepInterface {
   /**
    * Adds a row to the cache In case we are doing updates, we need to store the complete rows from the database. These
    * are the values we need to store
-   *
+   * <p>
    * Key: - natural key fields Value: - Technical key - lookup fields / extra fields (allows us to compare or retrieve)
    * - Date_from - Date_to
    *
@@ -1592,13 +1591,14 @@ public class DimensionLookup extends BaseStep implements StepInterface {
     }
 
     if ( isRowLevel() ) {
-      logRowlevel( "Cache store: key=" + keyValues + "    values=" + returnValues );
+      logRowlevel(
+        "Cache store: key=" + Arrays.toString( keyValues ) + "    values=" + Arrays.toString( returnValues ) );
     }
   }
 
   /**
    * @return the cache value row metadata. The items that are cached is basically the return row metadata:<br>
-   *         - Technical key (Integer) - Version (Integer) -
+   * - Technical key (Integer) - Version (Integer) -
    */
   private RowMetaInterface assembleCacheValueRowMeta() {
     RowMetaInterface cacheRowMeta = data.returnRowMeta.clone();
@@ -1629,8 +1629,8 @@ public class DimensionLookup extends BaseStep implements StepInterface {
       // See if the dateValue is between the from and to date ranges...
       // The last 2 values are from and to
       long time = dateValue.getTime();
-      long from = ( (Date) row[row.length - 2] ).getTime();
-      long to = ( (Date) row[row.length - 1] ).getTime();
+      long from = ( (Date) row[ row.length - 2 ] ).getTime();
+      long to = ( (Date) row[ row.length - 1 ] ).getTime();
       if ( time >= from && time < to ) { // sanity check to see if we have the right version
         if ( isRowLevel() ) {
           logRowlevel( "Cache hit: key="

--- a/engine/src/main/java/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
@@ -623,8 +623,6 @@ public class ExcelOutput extends BaseStep implements StepInterface {
       for ( int currentRowNumber = 0; currentRowNumber < templateWorkbookSheetRows; currentRowNumber++ ) {
         Cell[] templateWorkbookSheetRow = templateWorkbookSheet.getRow( currentRowNumber );
         Cell[] targetWorkbookSheetRow = targetWorkbookSheet.getRow( currentRowNumber );
-        templateWorkbookSheetRow.toString();
-        targetWorkbookSheetRow.toString();
         if ( templateWorkbookSheetRow.length > targetWorkbookSheetRow.length ) {
           return false;
         }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/execprocess/ExecProcess.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/execprocess/ExecProcess.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.pentaho.di.core.Const;
@@ -233,9 +234,9 @@ public class ExecProcess extends BaseStep implements StepInterface {
         processresult.setExistStatus( p.exitValue() );
       }
     } catch ( IOException ioe ) {
-      throw new KettleException( "IO exception while running the process " + process + "!", ioe );
+      throw new KettleException( "IO exception while running the process " + Arrays.toString( process ) + "!", ioe );
     } catch ( InterruptedException ie ) {
-      throw new KettleException( "Interrupted exception while running the process " + process + "!", ie );
+      throw new KettleException( "Interrupted exception while running the process " + Arrays.toString( process ) + "!", ie );
     } catch ( Exception e ) {
       throw new KettleException( e );
     } finally {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/file/BaseFileInputMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/file/BaseFileInputMeta.java
@@ -24,6 +24,7 @@ package org.pentaho.di.trans.steps.file;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import org.pentaho.di.core.fileinput.FileInputList;
 import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.variables.VariableSpace;
@@ -124,7 +125,8 @@ public abstract class BaseFileInputMeta<A extends BaseFileInputAdditionalField, 
   public abstract String getEncoding();
 
   public boolean isAcceptingFilenames() {
-    return inputFiles == null ? null : inputFiles.acceptingFilenames;
+    Preconditions.checkNotNull( inputFiles );
+    return inputFiles.acceptingFilenames;
   }
 
   public String getAcceptingStepName() {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/formula/Formula.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/formula/Formula.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,6 +23,7 @@
 package org.pentaho.di.trans.steps.formula;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Date;
 
 import org.pentaho.di.core.Const;
@@ -97,14 +98,14 @@ public class Formula extends BaseStep implements StepInterface {
     }
 
     if ( log.isRowLevel() ) {
-      logRowlevel( "Read row #" + getLinesRead() + " : " + r );
+      logRowlevel( "Read row #" + getLinesRead() + " : " + Arrays.toString( r ) );
     }
 
     Object[] outputRowData = calcFields( getInputRowMeta(), r );
     putRow( data.outputRowMeta, outputRowData ); // copy row to possible alternate rowset(s).
 
     if ( log.isRowLevel() ) {
-      logRowlevel( "Wrote row #" + getLinesWritten() + " : " + r );
+      logRowlevel( "Wrote row #" + getLinesWritten() + " : " + Arrays.toString( r ) );
     }
     if ( checkFeedback( getLinesRead() ) ) {
       logBasic( "Linenr " + getLinesRead() );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/ldapinput/LDAPConnection.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/ldapinput/LDAPConnection.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,6 +24,7 @@ package org.pentaho.di.trans.steps.ldapinput;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -243,7 +244,7 @@ public class LDAPConnection {
         nrCtl++;
         if ( log.isDebug() ) {
           log.logDebug( BaseMessages
-            .getString( "LDAPInput.Log.SortingKeys", getSortingAttributesKeys().toString() ) );
+            .getString( "LDAPInput.Log.SortingKeys", Arrays.toString( getSortingAttributesKeys() ) ) );
         }
       }
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/mergerows/MergeRows.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/mergerows/MergeRows.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.mergerows;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.pentaho.di.core.Const;
@@ -82,7 +83,8 @@ public class MergeRows extends BaseStep implements StepInterface {
 
       //rowSetWhenIdentical is use in case the comparison is IDENTICAL.
       //this should be the "Comparison" stream but can be the "Reference" stream for backward compatibility (PDI-736)
-      String useRefWhenIdenticalVar = Const.NVL( System.getProperty( Const.KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL ), "N" );
+      String useRefWhenIdenticalVar = Const
+        .NVL( System.getProperty( Const.KETTLE_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL ), "N" );
       if ( "N".equalsIgnoreCase( useRefWhenIdenticalVar ) ) {
         //use the reference stream (as per documentation)
         useRefWhenIdentical = false;
@@ -101,13 +103,13 @@ public class MergeRows extends BaseStep implements StepInterface {
 
       if ( data.one != null ) {
         // Find the key indexes:
-        data.keyNrs = new int[meta.getKeyFields().length];
+        data.keyNrs = new int[ meta.getKeyFields().length ];
         for ( int i = 0; i < data.keyNrs.length; i++ ) {
-          data.keyNrs[i] = data.oneRowSet.getRowMeta().indexOfValue( meta.getKeyFields()[i] );
-          if ( data.keyNrs[i] < 0 ) {
+          data.keyNrs[ i ] = data.oneRowSet.getRowMeta().indexOfValue( meta.getKeyFields()[ i ] );
+          if ( data.keyNrs[ i ] < 0 ) {
             String message =
               BaseMessages.getString( PKG, "MergeRows.Exception.UnableToFindFieldInReferenceStream", meta
-                .getKeyFields()[i] );
+                .getKeyFields()[ i ] );
             logError( message );
             throw new KettleStepException( message );
           }
@@ -115,13 +117,13 @@ public class MergeRows extends BaseStep implements StepInterface {
       }
 
       if ( data.two != null ) {
-        data.valueNrs = new int[meta.getValueFields().length];
+        data.valueNrs = new int[ meta.getValueFields().length ];
         for ( int i = 0; i < data.valueNrs.length; i++ ) {
-          data.valueNrs[i] = data.twoRowSet.getRowMeta().indexOfValue( meta.getValueFields()[i] );
-          if ( data.valueNrs[i] < 0 ) {
+          data.valueNrs[ i ] = data.twoRowSet.getRowMeta().indexOfValue( meta.getValueFields()[ i ] );
+          if ( data.valueNrs[ i ] < 0 ) {
             String message =
               BaseMessages.getString( PKG, "MergeRows.Exception.UnableToFindFieldInReferenceStream", meta
-                .getValueFields()[i] );
+                .getValueFields()[ i ] );
             logError( message );
             throw new KettleStepException( message );
           }
@@ -130,7 +132,8 @@ public class MergeRows extends BaseStep implements StepInterface {
     }
 
     if ( log.isRowLevel() ) {
-      logRowlevel( BaseMessages.getString( PKG, "MergeRows.Log.DataInfo", data.one + "" ) + data.two );
+      logRowlevel( BaseMessages.getString( PKG, "MergeRows.Log.DataInfo",
+        Arrays.toString( data.one ) + "" ) + Arrays.toString( data.two ) );
     }
 
     if ( data.one == null && data.two == null ) {
@@ -248,9 +251,9 @@ public class MergeRows extends BaseStep implements StepInterface {
   /**
    * Checks whether 2 template rows are compatible for the mergestep.
    *
-   * @param referenceRow
+   * @param referenceRowMeta
    *          Reference row
-   * @param compareRow
+   * @param compareRowMeta
    *          Row to compare to
    *
    * @return true when templates are compatible.

--- a/engine/src/main/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkDataOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkDataOutput.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -108,6 +108,7 @@ public class OraBulkDataOutput {
     return buf.toString();
   }
 
+  @SuppressWarnings( "ArrayToString" )
   public void writeLine( RowMetaInterface mi, Object[] row ) throws KettleException {
     if ( first ) {
       first = false;
@@ -198,6 +199,7 @@ public class OraBulkDataOutput {
           case ValueMetaInterface.TYPE_BINARY:
             byte[] byt = mi.getBinary( row, number );
             outbuf.append( "<startlob>" );
+            // TODO REVIEW - implicit .toString
             outbuf.append( byt );
             outbuf.append( "<endlob>" );
             break;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/reservoirsampling/ReservoirSampling.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/reservoirsampling/ReservoirSampling.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.reservoirsampling;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.pentaho.di.core.Const;
@@ -152,7 +153,7 @@ public class ReservoirSampling extends BaseStep implements StepInterface {
     }
 
     if ( log.isRowLevel() ) {
-      logRowlevel( "Read row #" + getLinesRead() + " : " + r );
+      logRowlevel( "Read row #" + getLinesRead() + " : " + Arrays.toString( r ) );
     }
 
     if ( checkFeedback( getLinesRead() ) ) {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/script/ScriptAddedFunctions.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/script/ScriptAddedFunctions.java
@@ -1739,10 +1739,10 @@ public class ScriptAddedFunctions {
        * Signal.getMessage() + "\")"); } catch (IOException Signal) { new RuntimeException("Error while reading file \""
        * + fileName + "\" (reason: \"" + Signal.getMessage() + "\")" ); }
        */
-      new RuntimeException( "Error while reading file \""
+      throw new RuntimeException( "Error while reading file \""
         + fileName + "\" (reason: \"" + Signal.getMessage() + "\")" );
     } catch ( ScriptException Signal ) {
-      new RuntimeException( "Error while reading file \""
+      throw new RuntimeException( "Error while reading file \""
         + fileName + "\" (reason: \"" + Signal.getMessage() + "\")" );
     } finally {
       try {
@@ -1966,12 +1966,12 @@ public class ScriptAddedFunctions {
           if ( fileObject.exists() ) {
             if ( fileObject.getType() == FileType.FILE ) {
               if ( !fileObject.delete() ) {
-                new RuntimeException( "We can not delete file [" + (String) ArgList[0] + "]!" );
+                throw new RuntimeException( "We can not delete file [" + (String) ArgList[0] + "]!" );
               }
             }
 
           } else {
-            new RuntimeException( "file [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "file [" + ArgList[0] + "] can not be found!" );
           }
         } catch ( IOException e ) {
           throw new RuntimeException( "The function call deleteFile is not valid." );
@@ -2005,7 +2005,7 @@ public class ScriptAddedFunctions {
           if ( !fileObject.exists() ) {
             fileObject.createFolder();
           } else {
-            new RuntimeException( "folder [" + (String) ArgList[0] + "] already exist!" );
+            throw new RuntimeException( "folder [" + ArgList[0] + "] already exist!" );
           }
         } catch ( IOException e ) {
           throw new RuntimeException( "The function call createFolder is not valid." );
@@ -2057,7 +2057,7 @@ public class ScriptAddedFunctions {
 
             }
           } else {
-            new RuntimeException( "file to copy [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "file to copy [" + ArgList[0] + "] can not be found!" );
           }
         } catch ( IOException e ) {
           throw new RuntimeException( "The function call copyFile throw an error : " + e.toString() );
@@ -2103,10 +2103,10 @@ public class ScriptAddedFunctions {
             if ( file.getType().equals( FileType.FILE ) ) {
               filesize = file.getContent().getSize();
             } else {
-              new RuntimeException( "[" + (String) ArgList[0] + "] is not a file!" );
+              throw new RuntimeException( "[" + ArgList[0] + "] is not a file!" );
             }
           } else {
-            new RuntimeException( "file [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "file [" + ArgList[0] + "] can not be found!" );
           }
           return filesize;
         } catch ( IOException e ) {
@@ -2146,10 +2146,10 @@ public class ScriptAddedFunctions {
             if ( file.getType().equals( FileType.FILE ) ) {
               isafile = true;
             } else {
-              new RuntimeException( "[" + (String) ArgList[0] + "] is not a file!" );
+              throw new RuntimeException( "[" + ArgList[0] + "] is not a file!" );
             }
           } else {
-            new RuntimeException( "file [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "file [" + ArgList[0] + "] can not be found!" );
           }
           return isafile;
         } catch ( IOException e ) {
@@ -2189,10 +2189,10 @@ public class ScriptAddedFunctions {
             if ( file.getType().equals( FileType.FOLDER ) ) {
               isafolder = true;
             } else {
-              new RuntimeException( "[" + (String) ArgList[0] + "] is not a folder!" );
+              throw new RuntimeException( "[" + ArgList[0] + "] is not a folder!" );
             }
           } else {
-            new RuntimeException( "folder [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "folder [" + ArgList[0] + "] can not be found!" );
           }
           return isafolder;
         } catch ( IOException e ) {
@@ -2229,10 +2229,10 @@ public class ScriptAddedFunctions {
           file = KettleVFS.getFileObject( (String) ArgList[0] );
           String Filename = null;
           if ( file.exists() ) {
-            Filename = file.getName().getBaseName().toString();
+            Filename = file.getName().getBaseName();
 
           } else {
-            new RuntimeException( "file [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "file [" + ArgList[0] + "] can not be found!" );
           }
 
           return Filename;
@@ -2270,10 +2270,10 @@ public class ScriptAddedFunctions {
           file = KettleVFS.getFileObject( (String) ArgList[0] );
           String Extension = null;
           if ( file.exists() ) {
-            Extension = file.getName().getExtension().toString();
+            Extension = file.getName().getExtension();
 
           } else {
-            new RuntimeException( "file [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "file [" + ArgList[0] + "] can not be found!" );
           }
 
           return Extension;
@@ -2314,7 +2314,7 @@ public class ScriptAddedFunctions {
             foldername = KettleVFS.getFilename( file.getParent() );
 
           } else {
-            new RuntimeException( "file [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "file [" + ArgList[0] + "] can not be found!" );
           }
 
           return foldername;
@@ -2361,7 +2361,7 @@ public class ScriptAddedFunctions {
             lastmodifiedtime = dateFormat.format( lastmodifiedtimedate );
 
           } else {
-            new RuntimeException( "file [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "file [" + ArgList[0] + "] can not be found!" );
           }
 
           return lastmodifiedtime;
@@ -2500,7 +2500,7 @@ public class ScriptAddedFunctions {
 
             }
           } else {
-            new RuntimeException( "file to move [" + (String) ArgList[0] + "] can not be found!" );
+            throw new RuntimeException( "file to move [" + ArgList[0] + "] can not be found!" );
           }
         } catch ( IOException e ) {
           throw new RuntimeException( "The function call moveFile throw an error : " + e.toString() );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesAddedFunctions.java
@@ -1600,7 +1600,7 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
         String sArg1 = Context.toString( ArgList[0] );
         // PDI-1276 Function getEnvironmentVar() does not work for user defined variables.
         // check if the system property exists, and if it does not, try getting a Kettle var instead
-        if ( System.getProperties().contains( sArg1 ) ) {
+        if ( System.getProperties().containsValue( sArg1 ) ) {
           sRC = System.getProperty( sArg1, "" );
         } else {
           Object scmo = actualObject.get( "_step_", actualObject );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/synchronizeaftermerge/SynchronizeAfterMerge.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/synchronizeaftermerge/SynchronizeAfterMerge.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -109,7 +109,7 @@ public class SynchronizeAfterMerge extends BaseStep implements StepInterface {
          */
 
         if ( log.isRowLevel() ) {
-          logRowlevel( BaseMessages.getString( PKG, "SynchronizeAfterMerge.InsertRow", row.toString() ) );
+          logRowlevel( BaseMessages.getString( PKG, "SynchronizeAfterMerge.InsertRow", Arrays.toString( row ) ) );
         }
 
         // The values to insert are those in the update section

--- a/engine/src/main/java/org/pentaho/di/trans/steps/tableinput/TableInputMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/tableinput/TableInputMeta.java
@@ -244,7 +244,7 @@ public class TableInputMeta extends BaseStepMeta implements StepMetaInterface {
         StreamInterface infoStream = getStepIOMeta().getInfoStreams().get( 0 );
         if ( !Utils.isEmpty( infoStream.getStepname() ) ) {
           param = true;
-          if ( info.length >= 0 && info[0] != null ) {
+          if ( info.length > 0 && info[0] != null ) {
             paramRowMeta = info[0];
             paramData = RowDataUtil.allocateRowData( paramRowMeta.size() );
           }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/terafast/TeraFast.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/terafast/TeraFast.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -227,6 +227,7 @@ public class TeraFast extends AbstractStep implements StepInterface {
    * @throws KettleException
    *           ...
    */
+  @SuppressWarnings( "ArrayToString" )
   public void writeToDataFile( RowMetaInterface rowMetaInterface, Object[] row ) throws KettleException {
     // Write the data to the output
     ValueMetaInterface valueMeta = null;
@@ -268,6 +269,7 @@ public class TeraFast extends AbstractStep implements StepInterface {
             break;
           case ValueMetaInterface.TYPE_BINARY:
             byte[] byt = rowMetaInterface.getBinary( row, i );
+            // REVIEW - this does an implicit byt.toString, which can't be what was intended.
             dataFilePrintStream.print( byt );
             break;
           default:

--- a/engine/src/main/java/org/pentaho/di/trans/steps/univariatestats/UnivariateStats.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/univariatestats/UnivariateStats.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,6 +23,7 @@
 package org.pentaho.di.trans.steps.univariatestats;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -62,34 +63,26 @@ public class UnivariateStats extends BaseStep implements StepInterface {
   /**
    * Creates a new <code>UnivariateStats</code> instance.
    *
-   * @param stepMeta
-   *          holds the step's meta data
-   * @param stepDataInterface
-   *          holds the step's temporary data
-   * @param copyNr
-   *          the number assigned to the step
-   * @param transMeta
-   *          meta data for the transformation
-   * @param trans
-   *          a <code>Trans</code> value
+   * @param stepMeta          holds the step's meta data
+   * @param stepDataInterface holds the step's temporary data
+   * @param copyNr            the number assigned to the step
+   * @param transMeta         meta data for the transformation
+   * @param trans             a <code>Trans</code> value
    */
   public UnivariateStats( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
-    Trans trans ) {
+                          Trans trans ) {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
 
   /**
    * Process an incoming row of data.
    *
-   * @param smi
-   *          a <code>StepMetaInterface</code> value
-   * @param sdi
-   *          a <code>StepDataInterface</code> value
+   * @param smi a <code>StepMetaInterface</code> value
+   * @param sdi a <code>StepDataInterface</code> value
    * @return a <code>boolean</code> value
-   * @exception KettleException
-   *              if an error occurs
+   * @throws KettleException if an error occurs
    */
-  @SuppressWarnings( { "unchecked" } )
+  @SuppressWarnings ( { "unchecked" } )
   public boolean processRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
 
     m_meta = (UnivariateStatsMeta) smi;
@@ -124,19 +117,19 @@ public class UnivariateStats extends BaseStep implements StepInterface {
       m_meta.getFields( m_data.getOutputRowMeta(), getStepname(), null, null, this, repository, metaStore );
 
       // Set up data cache for calculating median/percentiles
-      m_dataCache = new ArrayList[m_meta.getNumFieldsToProcess()];
+      m_dataCache = new ArrayList[ m_meta.getNumFieldsToProcess() ];
 
       // Initialize the step meta data
-      FieldIndex[] fi = new FieldIndex[m_meta.getNumFieldsToProcess()];
+      FieldIndex[] fi = new FieldIndex[ m_meta.getNumFieldsToProcess() ];
 
       m_data.setFieldIndexes( fi );
 
       // allocate the field indexes in the data class and meta stats functions
       // in the step meta
       for ( int i = 0; i < m_meta.getNumFieldsToProcess(); i++ ) {
-        UnivariateStatsMetaFunction usmf = m_meta.getInputFieldMetaFunctions()[i];
+        UnivariateStatsMetaFunction usmf = m_meta.getInputFieldMetaFunctions()[ i ];
         //CHECKSTYLE:Indentation:OFF
-        m_data.getFieldIndexes()[i] = new FieldIndex();
+        m_data.getFieldIndexes()[ i ] = new FieldIndex();
 
         // check that this univariate stats computation has been
         // defined on an input field
@@ -148,7 +141,7 @@ public class UnivariateStats extends BaseStep implements StepInterface {
               + usmf.getSourceFieldName() + "' for stats calc #" + ( i + 1 ) );
           }
 
-          FieldIndex tempData = m_data.getFieldIndexes()[i];
+          FieldIndex tempData = m_data.getFieldIndexes()[ i ];
 
           tempData.m_columnIndex = fieldIndex;
 
@@ -167,7 +160,7 @@ public class UnivariateStats extends BaseStep implements StepInterface {
           // requested
 
           if ( usmf.getCalcMedian() || usmf.getCalcPercentile() >= 0 ) {
-            m_dataCache[i] = new ArrayList<Number>();
+            m_dataCache[ i ] = new ArrayList<Number>();
           }
         } else {
           throw new KettleException( "There is no input field specified for stats calc #" + ( i + 1 ) );
@@ -177,15 +170,15 @@ public class UnivariateStats extends BaseStep implements StepInterface {
 
     for ( int i = 0; i < m_meta.getNumFieldsToProcess(); i++ ) {
 
-      UnivariateStatsMetaFunction usmf = m_meta.getInputFieldMetaFunctions()[i];
+      UnivariateStatsMetaFunction usmf = m_meta.getInputFieldMetaFunctions()[ i ];
       if ( !Utils.isEmpty( usmf.getSourceFieldName() ) ) {
-        FieldIndex tempData = m_data.getFieldIndexes()[i];
+        FieldIndex tempData = m_data.getFieldIndexes()[ i ];
 
         ValueMetaInterface metaI = getInputRowMeta().getValueMeta( tempData.m_columnIndex );
 
         Number input = null;
         try {
-          input = metaI.getNumber( r[tempData.m_columnIndex] );
+          input = metaI.getNumber( r[ tempData.m_columnIndex ] );
         } catch ( Exception ex ) {
           // quietly ignore -- assume missing for anything not
           // parsable as a number
@@ -194,7 +187,7 @@ public class UnivariateStats extends BaseStep implements StepInterface {
 
           // add to the cache?
           if ( usmf.getCalcMedian() || usmf.getCalcPercentile() >= 0 ) {
-            m_dataCache[i].add( input );
+            m_dataCache[ i ].add( input );
           }
 
           // update stats
@@ -214,7 +207,7 @@ public class UnivariateStats extends BaseStep implements StepInterface {
     }
 
     if ( log.isRowLevel() ) {
-      logRowlevel( "Read row #" + getLinesRead() + " : " + r );
+      logRowlevel( "Read row #" + getLinesRead() + " : " + Arrays.toString( r ) );
     }
 
     if ( checkFeedback( getLinesRead() ) ) {
@@ -233,23 +226,23 @@ public class UnivariateStats extends BaseStep implements StepInterface {
     int totalNumOutputFields = 0;
 
     for ( int i = 0; i < m_meta.getNumFieldsToProcess(); i++ ) {
-      UnivariateStatsMetaFunction usmf = m_meta.getInputFieldMetaFunctions()[i];
+      UnivariateStatsMetaFunction usmf = m_meta.getInputFieldMetaFunctions()[ i ];
 
       if ( !Utils.isEmpty( usmf.getSourceFieldName() ) ) {
         totalNumOutputFields += usmf.numberOfMetricsRequested();
       }
     }
 
-    Object[] result = new Object[totalNumOutputFields];
+    Object[] result = new Object[ totalNumOutputFields ];
     int index = 0;
     for ( int i = 0; i < m_meta.getNumFieldsToProcess(); i++ ) {
-      UnivariateStatsMetaFunction usmf = m_meta.getInputFieldMetaFunctions()[i];
+      UnivariateStatsMetaFunction usmf = m_meta.getInputFieldMetaFunctions()[ i ];
 
       if ( !Utils.isEmpty( usmf.getSourceFieldName() ) ) {
-        Object[] tempOut = m_data.getFieldIndexes()[i].generateOutputValues( usmf, m_dataCache[i] );
+        Object[] tempOut = m_data.getFieldIndexes()[ i ].generateOutputValues( usmf, m_dataCache[ i ] );
 
         for ( int j = 0; j < tempOut.length; j++ ) {
-          result[index++] = tempOut[j];
+          result[ index++ ] = tempOut[ j ];
         }
       }
     }
@@ -260,10 +253,8 @@ public class UnivariateStats extends BaseStep implements StepInterface {
   /**
    * Initialize the step.
    *
-   * @param smi
-   *          a <code>StepMetaInterface</code> value
-   * @param sdi
-   *          a <code>StepDataInterface</code> value
+   * @param smi a <code>StepMetaInterface</code> value
+   * @param sdi a <code>StepDataInterface</code> value
    * @return a <code>boolean</code> value
    */
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {

--- a/engine/src/test/java/org/pentaho/di/trans/steps/excelinput/staxpoi/StaxPoiSheetTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/excelinput/staxpoi/StaxPoiSheetTest.java
@@ -53,13 +53,13 @@ import org.pentaho.di.core.spreadsheet.KSheet;
 public class StaxPoiSheetTest {
 
   private static final String BP_SHEET = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
-      + "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" "
-      + "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
-      + "%s"
-      + "</worksheet>";
+    + "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" "
+    + "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+    + "%s"
+    + "</worksheet>";
 
   private static final String SHEET_DATE_NO_V = String.format( BP_SHEET,
-      " <dimension ref=\"A1:A3\"/>"
+    " <dimension ref=\"A1:A3\"/>"
       + " <sheetData>"
       + "   <row r=\"1\" spans=\"1:1\">"
       + "     <c r=\"A1\" s=\"1\" t=\"s\"><v>0</v></c>"
@@ -73,7 +73,7 @@ public class StaxPoiSheetTest {
       + " </sheetData>" );
 
   private static final String SHEET_1 = String.format( BP_SHEET,
-      " <dimension ref=\"B2:F5\"/>"
+    " <dimension ref=\"B2:F5\"/>"
       + " <sheetData>"
       + "  <row r=\"2\" spans=\"2:6\"><c r=\"B2\" t=\"s\"><v>0</v></c><c r=\"C2\" t=\"s\"><v>1</v></c>"
       + "    <c r=\"D2\" t=\"s\"><v>2</v></c><c r=\"E2\" t=\"s\"><v>3</v></c><c r=\"F2\" t=\"s\"><v>4</v></c></row>"
@@ -89,87 +89,88 @@ public class StaxPoiSheetTest {
 
   private static final String SHEET_INLINE_STRINGS = String.format( BP_SHEET,
     "<dimension ref=\"A1:B3\"/>"
-    + "<sheetViews>"
-    +   "<sheetView tabSelected=\"1\" workbookViewId=\"0\" rightToLeft=\"false\">"
-    +     "<selection activeCell=\"C5\" sqref=\"C5\"/>"
-    +   "</sheetView>"
-    + "</sheetViews>"
-    + "<sheetFormatPr defaultRowHeight=\"15\"/>"
-    + "<sheetData>"
-    +   "<row outlineLevel=\"0\" r=\"1\">"
-    +     "<c r=\"A1\" s=\"0\" t=\"inlineStr\"><is><t>Test1</t></is></c>"
-    +     "<c r=\"B1\" s=\"0\" t=\"inlineStr\"><is><t>Test2</t></is></c>"
-    +   "</row>"
-    +   "<row outlineLevel=\"0\" r=\"2\">"
-    +     "<c r=\"A2\" s=\"0\" t=\"inlineStr\"><is><t>value 1 1</t></is></c>"
-    +     "<c r=\"B2\" s=\"0\" t=\"inlineStr\"><is><t>value 2 1</t></is></c>"
-    +   "</row>"
-    +   "<row outlineLevel=\"0\" r=\"3\">"
-    +     "<c r=\"A3\" s=\"0\" t=\"inlineStr\"><is><t>value 1 2</t></is></c>"
-    +     "<c r=\"B3\" s=\"0\" t=\"inlineStr\"><is><t>value 2 2</t></is></c>"
-    +   "</row>"
-    + "</sheetData>" );
+      + "<sheetViews>"
+      + "<sheetView tabSelected=\"1\" workbookViewId=\"0\" rightToLeft=\"false\">"
+      + "<selection activeCell=\"C5\" sqref=\"C5\"/>"
+      + "</sheetView>"
+      + "</sheetViews>"
+      + "<sheetFormatPr defaultRowHeight=\"15\"/>"
+      + "<sheetData>"
+      + "<row outlineLevel=\"0\" r=\"1\">"
+      + "<c r=\"A1\" s=\"0\" t=\"inlineStr\"><is><t>Test1</t></is></c>"
+      + "<c r=\"B1\" s=\"0\" t=\"inlineStr\"><is><t>Test2</t></is></c>"
+      + "</row>"
+      + "<row outlineLevel=\"0\" r=\"2\">"
+      + "<c r=\"A2\" s=\"0\" t=\"inlineStr\"><is><t>value 1 1</t></is></c>"
+      + "<c r=\"B2\" s=\"0\" t=\"inlineStr\"><is><t>value 2 1</t></is></c>"
+      + "</row>"
+      + "<row outlineLevel=\"0\" r=\"3\">"
+      + "<c r=\"A3\" s=\"0\" t=\"inlineStr\"><is><t>value 1 2</t></is></c>"
+      + "<c r=\"B3\" s=\"0\" t=\"inlineStr\"><is><t>value 2 2</t></is></c>"
+      + "</row>"
+      + "</sheetData>" );
 
   private static final String SHEET_NO_USED_RANGE_SPECIFIED = String.format( BP_SHEET,
-      "<dimension ref=\"A1\" />"
-          +"<sheetViews>"
-          + "<sheetView tabSelected=\"1\" workbookViewId=\"0\">"
-          +   "<selection/>"
-          + "</sheetView>"
-          +"</sheetViews>"
-          +"<sheetFormatPr defaultRowHeight=\"12.750000\" customHeight=\"true\"/>"
-          +"<sheetData>"
-          + "<row r=\"2\">"
-          +   "<c r=\"A2\" s=\"9\" t=\"s\">"
-          +     "<v>0</v>"
-          +   "</c><c r=\"B2\" s=\"9\" t=\"s\">"
-          +     "<v>0</v>"
-          +   "</c><c r=\"C2\" s=\"9\" t=\"s\">"
-          +     "<v>1</v>"
-          +   "</c><c r=\"D2\" s=\"9\" t=\"s\">"
-          +     "<v>2</v>"
-          +   "</c><c r=\"E2\" s=\"9\" t=\"s\">"
-          +     "<v>3</v>"
-          +   "</c>"
-          + "</row>"
-          + "<row r=\"3\">"
-          +   "<c r=\"A3\" s=\"11\" t=\"s\">"
-          +     "<v>4</v>"
-          +   "</c><c r=\"B3\" s=\"11\" t=\"s\">"
-          +     "<v>4</v>"
-          +   "</c><c r=\"C3\" s=\"11\" t=\"s\">"
-          +     "<v>5</v>"
-          +   "</c><c r=\"D3\" s=\"12\">"
-          +     "<v>2623</v>"
-          +   "</c><c r=\"E3\" s=\"11\" t=\"s\">"
-          +     "<v>6</v>"
-          +   "</c>"
-          + "</row>"
-          +"</sheetData>");
+    "<dimension ref=\"A1\" />"
+      + "<sheetViews>"
+      + "<sheetView tabSelected=\"1\" workbookViewId=\"0\">"
+      + "<selection/>"
+      + "</sheetView>"
+      + "</sheetViews>"
+      + "<sheetFormatPr defaultRowHeight=\"12.750000\" customHeight=\"true\"/>"
+      + "<sheetData>"
+      + "<row r=\"2\">"
+      + "<c r=\"A2\" s=\"9\" t=\"s\">"
+      + "<v>0</v>"
+      + "</c><c r=\"B2\" s=\"9\" t=\"s\">"
+      + "<v>0</v>"
+      + "</c><c r=\"C2\" s=\"9\" t=\"s\">"
+      + "<v>1</v>"
+      + "</c><c r=\"D2\" s=\"9\" t=\"s\">"
+      + "<v>2</v>"
+      + "</c><c r=\"E2\" s=\"9\" t=\"s\">"
+      + "<v>3</v>"
+      + "</c>"
+      + "</row>"
+      + "<row r=\"3\">"
+      + "<c r=\"A3\" s=\"11\" t=\"s\">"
+      + "<v>4</v>"
+      + "</c><c r=\"B3\" s=\"11\" t=\"s\">"
+      + "<v>4</v>"
+      + "</c><c r=\"C3\" s=\"11\" t=\"s\">"
+      + "<v>5</v>"
+      + "</c><c r=\"D3\" s=\"12\">"
+      + "<v>2623</v>"
+      + "</c><c r=\"E3\" s=\"11\" t=\"s\">"
+      + "<v>6</v>"
+      + "</c>"
+      + "</row>"
+      + "</sheetData>" );
+
   @Test
   public void testNullDateCell() throws Exception {
     // cell had null value instead of being null
     final String sheetId = "1";
     final String sheetName = "Sheet 1";
     XSSFReader reader = mockXSSFReader( sheetId, SHEET_DATE_NO_V,
-        mockSharedStringsTable( "Some Date" ),
-        mockStylesTable(
-          Collections.singletonMap( 2, 165 ),
-          Collections.singletonMap( 165, "M/D/YYYY" ) ) );
+      mockSharedStringsTable( "Some Date" ),
+      mockStylesTable(
+        Collections.singletonMap( 2, 165 ),
+        Collections.singletonMap( 165, "M/D/YYYY" ) ) );
     StaxPoiSheet spSheet = spy( new StaxPoiSheet( reader, sheetName, sheetId ) );
     doReturn( true ).when( spSheet ).isDateCell( any() );
-    KCell cell = spSheet.getRow( 1 )[0];
+    KCell cell = spSheet.getRow( 1 )[ 0 ];
     assertNotNull( cell );
     assertEquals( KCellType.DATE, cell.getType() );
-    cell = spSheet.getRow( 2 )[0];
+    cell = spSheet.getRow( 2 )[ 0 ];
     assertNull( "cell must be null", cell );
   }
 
   @Test
   public void testEmptySheet() throws Exception {
     XSSFReader reader = mockXSSFReader( "sheet1", SHEET_EMPTY,
-        mock( SharedStringsTable.class ),
-        mock( StylesTable.class ) );
+      mock( SharedStringsTable.class ),
+      mock( StylesTable.class ) );
     // check no exceptions
     StaxPoiSheet sheet = new StaxPoiSheet( reader, "empty", "sheet1" );
     for ( int j = 0; j < sheet.getRows(); j++ ) {
@@ -181,18 +182,18 @@ public class StaxPoiSheetTest {
   public void testReadSameRow() throws Exception {
     KSheet sheet1 = getSampleSheet();
     KCell[] row = sheet1.getRow( 3 );
-    assertEquals( "Two", row[1].getValue() );
+    assertEquals( "Two", row[ 1 ].getValue() );
     row = sheet1.getRow( 3 );
-    assertEquals( "Two", row[1].getValue() );
+    assertEquals( "Two", row[ 1 ].getValue() );
   }
 
   @Test
   public void testReadRowRA() throws Exception {
     KSheet sheet1 = getSampleSheet();
     KCell[] row = sheet1.getRow( 4 );
-    assertEquals( "Three", row[1].getValue() );
+    assertEquals( "Three", row[ 1 ].getValue() );
     row = sheet1.getRow( 2 );
-    assertEquals( "One", row[1].getValue() );
+    assertEquals( "One", row[ 1 ].getValue() );
   }
 
   @Test
@@ -225,40 +226,40 @@ public class StaxPoiSheetTest {
     assertEquals( 5, sheet1.getRows() );
 
     KCell[] row = sheet1.getRow( 2 );
-    assertEquals( KCellType.LABEL, row[1].getType() );
-    assertEquals( "One", row[1].getValue() );
-    assertEquals( KCellType.DATE, row[2].getType() );
-    assertEquals( new Date( 1283817600000L ), row[2].getValue() );
-    assertEquals( KCellType.NUMBER, row[3].getType() );
-    assertEquals( Double.valueOf( "75" ), row[3].getValue() );
-    assertEquals( KCellType.BOOLEAN, row[4].getType() );
-    assertEquals( Boolean.TRUE, row[4].getValue() );
-    assertEquals( KCellType.NUMBER_FORMULA, row[5].getType() );
-    assertEquals( Double.valueOf( "75" ), row[5].getValue() );
+    assertEquals( KCellType.LABEL, row[ 1 ].getType() );
+    assertEquals( "One", row[ 1 ].getValue() );
+    assertEquals( KCellType.DATE, row[ 2 ].getType() );
+    assertEquals( new Date( 1283817600000L ), row[ 2 ].getValue() );
+    assertEquals( KCellType.NUMBER, row[ 3 ].getType() );
+    assertEquals( Double.valueOf( "75" ), row[ 3 ].getValue() );
+    assertEquals( KCellType.BOOLEAN, row[ 4 ].getType() );
+    assertEquals( Boolean.TRUE, row[ 4 ].getValue() );
+    assertEquals( KCellType.NUMBER_FORMULA, row[ 5 ].getType() );
+    assertEquals( Double.valueOf( "75" ), row[ 5 ].getValue() );
 
     row = sheet1.getRow( 3 );
-    assertEquals( KCellType.LABEL, row[1].getType() );
-    assertEquals( "Two", row[1].getValue() );
-    assertEquals( KCellType.DATE, row[2].getType() );
-    assertEquals( new Date( 1283904000000L ), row[2].getValue() );
-    assertEquals( KCellType.NUMBER, row[3].getType() );
-    assertEquals( Double.valueOf( "42" ), row[3].getValue() );
-    assertEquals( KCellType.BOOLEAN, row[4].getType() );
-    assertEquals( Boolean.FALSE, row[4].getValue() );
-    assertEquals( KCellType.NUMBER_FORMULA, row[5].getType() );
-    assertEquals( Double.valueOf( "117" ), row[5].getValue() );
+    assertEquals( KCellType.LABEL, row[ 1 ].getType() );
+    assertEquals( "Two", row[ 1 ].getValue() );
+    assertEquals( KCellType.DATE, row[ 2 ].getType() );
+    assertEquals( new Date( 1283904000000L ), row[ 2 ].getValue() );
+    assertEquals( KCellType.NUMBER, row[ 3 ].getType() );
+    assertEquals( Double.valueOf( "42" ), row[ 3 ].getValue() );
+    assertEquals( KCellType.BOOLEAN, row[ 4 ].getType() );
+    assertEquals( Boolean.FALSE, row[ 4 ].getValue() );
+    assertEquals( KCellType.NUMBER_FORMULA, row[ 5 ].getType() );
+    assertEquals( Double.valueOf( "117" ), row[ 5 ].getValue() );
 
     row = sheet1.getRow( 4 );
-    assertEquals( KCellType.LABEL, row[1].getType() );
-    assertEquals( "Three", row[1].getValue() );
-    assertEquals( KCellType.DATE, row[2].getType() );
-    assertEquals( new Date( 1283990400000L ), row[2].getValue() );
-    assertEquals( KCellType.NUMBER, row[3].getType() );
-    assertEquals( Double.valueOf( "93" ), row[3].getValue() );
-    assertEquals( KCellType.BOOLEAN, row[4].getType() );
-    assertEquals( Boolean.TRUE, row[4].getValue() );
-    assertEquals( KCellType.NUMBER_FORMULA, row[5].getType() );
-    assertEquals( Double.valueOf( "210" ), row[5].getValue() );
+    assertEquals( KCellType.LABEL, row[ 1 ].getType() );
+    assertEquals( "Three", row[ 1 ].getValue() );
+    assertEquals( KCellType.DATE, row[ 2 ].getType() );
+    assertEquals( new Date( 1283990400000L ), row[ 2 ].getValue() );
+    assertEquals( KCellType.NUMBER, row[ 3 ].getType() );
+    assertEquals( Double.valueOf( "93" ), row[ 3 ].getValue() );
+    assertEquals( KCellType.BOOLEAN, row[ 4 ].getType() );
+    assertEquals( Boolean.TRUE, row[ 4 ].getValue() );
+    assertEquals( KCellType.NUMBER_FORMULA, row[ 5 ].getType() );
+    assertEquals( Double.valueOf( "210" ), row[ 5 ].getValue() );
 
     try {
       row = sheet1.getRow( 5 );
@@ -271,14 +272,15 @@ public class StaxPoiSheetTest {
   private StaxPoiSheet getSampleSheet() throws Exception {
     String sheetId = "sheet1";
     XSSFReader reader = mockXSSFReader( sheetId, SHEET_1,
-        mockSharedStringsTable(
-            "Col1Label", "Col2Date", "Col3Number", "Col4Boolean", "Col5NumFormula", "One", "Two", "Three" ),
-        mockStylesTable( Collections.singletonMap( 1, 14 ), Collections.<Integer, String>emptyMap() ) );
+      mockSharedStringsTable(
+        "Col1Label", "Col2Date", "Col3Number", "Col4Boolean", "Col5NumFormula", "One", "Two", "Three" ),
+      mockStylesTable( Collections.singletonMap( 1, 14 ), Collections.<Integer, String>emptyMap() ) );
     return new StaxPoiSheet( reader, "Sheet 1", sheetId );
   }
 
   private XSSFReader mockXSSFReader( final String sheetId,
-      final String sheetContent, final SharedStringsTable sst, final StylesTable styles ) throws Exception {
+                                     final String sheetContent, final SharedStringsTable sst, final StylesTable styles )
+    throws Exception {
     XSSFReader reader = mock( XSSFReader.class );
     when( reader.getSharedStringsTable() ).thenReturn( sst );
     when( reader.getStylesTable() ).thenReturn( styles );
@@ -290,11 +292,12 @@ public class StaxPoiSheetTest {
     return reader;
   }
 
-  private StylesTable mockStylesTable( final Map<Integer, Integer> styleToNumFmtId, final Map<Integer, String> numFmts ) {
+  private StylesTable mockStylesTable( final Map<Integer, Integer> styleToNumFmtId,
+                                       final Map<Integer, String> numFmts ) {
     StylesTable styles = mock( StylesTable.class );
     when( styles.getCellXfAt( any( Integer.class ) ) ).then( new Answer<CTXf>() {
       public CTXf answer( InvocationOnMock invocation ) throws Throwable {
-        int style = (int) invocation.getArguments()[0];
+        int style = (int) invocation.getArguments()[ 0 ];
         Integer numFmtId = styleToNumFmtId.get( style );
         if ( numFmtId != null ) {
           CTXf ctxf = CTXf.Factory.newInstance();
@@ -307,7 +310,7 @@ public class StaxPoiSheetTest {
     } );
     when( styles.getNumberFormatAt( any( Short.class ) ) ).then( new Answer<String>() {
       public String answer( InvocationOnMock invocation ) throws Throwable {
-        return numFmts.get( (Short) invocation.getArguments()[0] );
+        return numFmts.get( invocation.getArguments()[ 0 ] );
       }
     } );
     return styles;
@@ -332,20 +335,20 @@ public class StaxPoiSheetTest {
       mock( StylesTable.class ) );
     StaxPoiSheet spSheet = new StaxPoiSheet( reader, sheetName, sheetId );
     KCell[] rowCells = spSheet.getRow( 0 );
-    assertEquals( "Test1", rowCells[0].getValue() );
-    assertEquals( KCellType.STRING_FORMULA, rowCells[0].getType() );
-    assertEquals( "Test2", rowCells[1].getValue() );
-    assertEquals( KCellType.STRING_FORMULA, rowCells[1].getType() );
+    assertEquals( "Test1", rowCells[ 0 ].getValue() );
+    assertEquals( KCellType.STRING_FORMULA, rowCells[ 0 ].getType() );
+    assertEquals( "Test2", rowCells[ 1 ].getValue() );
+    assertEquals( KCellType.STRING_FORMULA, rowCells[ 1 ].getType() );
     rowCells = spSheet.getRow( 1 );
-    assertEquals( "value 1 1", rowCells[0].getValue() );
-    assertEquals( KCellType.STRING_FORMULA, rowCells[0].getType() );
-    assertEquals( "value 2 1", rowCells[1].getValue() );
-    assertEquals( KCellType.STRING_FORMULA, rowCells[1].getType() );
+    assertEquals( "value 1 1", rowCells[ 0 ].getValue() );
+    assertEquals( KCellType.STRING_FORMULA, rowCells[ 0 ].getType() );
+    assertEquals( "value 2 1", rowCells[ 1 ].getValue() );
+    assertEquals( KCellType.STRING_FORMULA, rowCells[ 1 ].getType() );
     rowCells = spSheet.getRow( 2 );
-    assertEquals( "value 1 2", rowCells[0].getValue() );
-    assertEquals( KCellType.STRING_FORMULA, rowCells[0].getType() );
-    assertEquals( "value 2 2", rowCells[1].getValue() );
-    assertEquals( KCellType.STRING_FORMULA, rowCells[1].getType() );
+    assertEquals( "value 1 2", rowCells[ 0 ].getValue() );
+    assertEquals( KCellType.STRING_FORMULA, rowCells[ 0 ].getType() );
+    assertEquals( "value 2 2", rowCells[ 1 ].getValue() );
+    assertEquals( KCellType.STRING_FORMULA, rowCells[ 1 ].getType() );
   }
 
   // The row and column bounds of all cells in the worksheet are specified in ref attribute of Dimension tag in sheet
@@ -357,8 +360,10 @@ public class StaxPoiSheetTest {
     final String sheetId = "1";
     final String sheetName = "Sheet 1";
     SharedStringsTable sharedStringsTableMock =
-        mockSharedStringsTable( "Report ID", "Report ID", "Approval Status", "Total Report Amount", "Policy", "ReportIdValue_1", "ReportIdValue_1", "ApprovalStatusValue_1", "PolicyValue_1" );
-    XSSFReader reader = mockXSSFReader( sheetId, SHEET_NO_USED_RANGE_SPECIFIED, sharedStringsTableMock, mock( StylesTable.class ) );
+      mockSharedStringsTable( "Report ID", "Report ID", "Approval Status", "Total Report Amount", "Policy",
+        "ReportIdValue_1", "ReportIdValue_1", "ApprovalStatusValue_1", "PolicyValue_1" );
+    XSSFReader reader =
+      mockXSSFReader( sheetId, SHEET_NO_USED_RANGE_SPECIFIED, sharedStringsTableMock, mock( StylesTable.class ) );
     StaxPoiSheet spSheet = new StaxPoiSheet( reader, sheetName, sheetId );
     // The first row is empty - it should have empty rowCells
     KCell[] rowCells = spSheet.getRow( 0 );
@@ -368,16 +373,16 @@ public class StaxPoiSheetTest {
     assertEquals( 0, rowCells.length );
     // The row3 - is the first row with data - validating it
     rowCells = spSheet.getRow( 2 );
-    assertEquals( KCellType.LABEL, rowCells[0].getType() );
-    assertEquals( "ReportIdValue_1", rowCells[0].getValue() );
-    assertEquals( KCellType.LABEL, rowCells[1].getType() );
-    assertEquals( "ReportIdValue_1", rowCells[1].getValue() );
-    assertEquals( KCellType.LABEL, rowCells[2].getType() );
-    assertEquals( "ApprovalStatusValue_1", rowCells[2].getValue() );
-    assertEquals( KCellType.NUMBER, rowCells[3].getType() );
-    assertEquals( 2623.0, rowCells[3].getValue() );
-    assertEquals( KCellType.LABEL, rowCells[4].getType() );
-    assertEquals( "PolicyValue_1", rowCells[4].getValue() );
+    assertEquals( KCellType.LABEL, rowCells[ 0 ].getType() );
+    assertEquals( "ReportIdValue_1", rowCells[ 0 ].getValue() );
+    assertEquals( KCellType.LABEL, rowCells[ 1 ].getType() );
+    assertEquals( "ReportIdValue_1", rowCells[ 1 ].getValue() );
+    assertEquals( KCellType.LABEL, rowCells[ 2 ].getType() );
+    assertEquals( "ApprovalStatusValue_1", rowCells[ 2 ].getValue() );
+    assertEquals( KCellType.NUMBER, rowCells[ 3 ].getType() );
+    assertEquals( 2623.0, rowCells[ 3 ].getValue() );
+    assertEquals( KCellType.LABEL, rowCells[ 4 ].getType() );
+    assertEquals( "PolicyValue_1", rowCells[ 4 ].getValue() );
   }
 
 }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
@@ -206,7 +207,8 @@ public class IngresVectorwiseTest {
     }
   }
 
-  // @Test
+  @Test
+  @Ignore
   public void testVWLoadMocker() {
     String cmd =
       "java -cp . -Duser.dir=" + VWLoadMocker.class.getProtectionDomain().getCodeSource().getLocation().getPath()

--- a/engine/src/test/java/org/pentaho/di/www/GetJobStatusServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/GetJobStatusServletTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -154,7 +154,7 @@ public class GetJobStatusServletTest {
 
     verify( cacheMock, times( 2 ) ).get( logId, 0 );
     verify( cacheMock, times( 1 ) ).put( eq( logId ), anyString(), eq( 0 ) );
-    verify( mockJob.getLogChannel(), times( 1 ) );
+    verify( mockJob, times( 1 ) ).getLogChannel();
 
   }
 }

--- a/engine/src/test/java/org/pentaho/di/www/GetTransStatusServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/GetTransStatusServletTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -149,7 +149,7 @@ public class GetTransStatusServletTest {
 
     verify( cacheMock, times( 2 ) ).get( logId, 0 );
     verify( cacheMock, times( 1 ) ).put( eq( logId ), anyString(), eq( 0 ) );
-    verify( mockTrans.getLogChannel(), times( 1 ) );
+    verify( mockTrans, times( 1 ) ).getLogChannel();
 
   }
 


### PR DESCRIPTION
https://github.com/google/error-prone

Specifically, these 5 categories of errors:

[NullTernary] This conditional expression may evaluate to null, which will result in an NPE when the result is unboxed.
    (see http://errorprone.info/bugpattern/NullTernary)

[ArrayToString] Calling toString on an array does not provide useful information
    (see http://errorprone.info/bugpattern/ArrayToString)

[SizeGreaterThanOrEqualsZero] Comparison of a size >= 0 is always true, did you intend to check for non-emptiness?
    (see http://errorprone.info/bugpattern/SizeGreaterThanOrEqualsZero)

[InfiniteRecursion] This method always recurses, and will cause a StackOverflowError
    (see http://errorprone.info/bugpattern/InfiniteRecursion)

[DeadException] Exception created but not thrown
    (see http://errorprone.info/bugpattern/DeadException)