### PR TITLE
[PDI-17278] Repository Job Fails Using Variable to Run Local Job

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/ObjectLocationSpecificationMethod.java
+++ b/core/src/main/java/org/pentaho/di/core/ObjectLocationSpecificationMethod.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,8 +23,10 @@
 package org.pentaho.di.core;
 
 public enum ObjectLocationSpecificationMethod {
-  FILENAME( "filename", "Filename" ), REPOSITORY_BY_NAME( "rep_name", "Specify by name in repository" ),
-    REPOSITORY_BY_REFERENCE( "rep_ref", "Specify by reference in repository" );
+  FILENAME( "filename", "Filename" ),
+  REPOSITORY_BY_NAME( "rep_name", "Specify by name in repository" ),
+  @Deprecated // this is no longer supported in the UI, only in code with jobs/transformations created prior to 7.0
+  REPOSITORY_BY_REFERENCE( "rep_ref", "Specify by reference in repository" );
 
   private String code;
   private String description;

--- a/core/src/main/java/org/pentaho/di/core/util/StringUtil.java
+++ b/core/src/main/java/org/pentaho/di/core/util/StringUtil.java
@@ -613,4 +613,47 @@ public class StringUtil {
       return obj.toString().toLowerCase();
     }
   }
+
+  /**
+   * Removes all instances of the specified character from the start of the given {@link String}.
+   *
+   * @param source the {@link String} to trim
+   * @param c the character to remove from the {@link String}
+   * @return a new string with all instances of the specified character removed from the start
+   */
+  public static String trimStart( final String source, char c ) {
+    if ( source == null ) {
+      return null;
+    }
+
+    int length = source.length();
+    int index = 0;
+
+    while ( index < length && source.charAt( index ) == c ) {
+      index++;
+    }
+
+    return source.substring( index );
+  }
+
+  /**
+   * Removes all instances of the specified character from the end of the given {@link String}.
+   *
+   * @param source the {@link String} to trim
+   * @param c the character to remove from the {@link String}
+   * @return a new string with all instances of the specified character removed from the end
+   */
+  public static String trimEnd( final String source, char c ) {
+    if ( source == null ) {
+      return null;
+    }
+
+    int index = source.length();
+
+    while ( index > 0 && source.charAt( index - 1 ) == c ) {
+      index--;
+    }
+
+    return source.substring( 0, index );
+  }
 }

--- a/core/src/test/java/org/pentaho/di/core/util/StringUtilTest.java
+++ b/core/src/test/java/org/pentaho/di/core/util/StringUtilTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Test class for the basic functionality of StringUtil.
@@ -191,5 +192,35 @@ public class StringUtilTest extends TestCase {
     public String toString() {
       return string;
     }
+  }
+
+  @Test
+  public void testTrimStart_Single() {
+    assertEquals( "file/path/", StringUtil.trimStart( "/file/path/", '/' ) );
+  }
+
+  @Test
+  public void testTrimStart_Many() {
+    assertEquals( "file/path/", StringUtil.trimStart( "////file/path/", '/' ) );
+  }
+
+  @Test
+  public void testTrimStart_None() {
+    assertEquals( "file/path/", StringUtil.trimStart( "file/path/", '/' ) );
+  }
+
+  @Test
+  public void testTrimEnd_Single() {
+    assertEquals( "/file/path", StringUtil.trimEnd( "/file/path/", '/' ) );
+  }
+
+  @Test
+  public void testTrimEnd_Many() {
+    assertEquals( "/file/path", StringUtil.trimEnd( "/file/path///", '/' ) );
+  }
+
+  @Test
+  public void testTrimEnd_None() {
+    assertEquals( "/file/path", StringUtil.trimEnd( "/file/path", '/' ) );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/job/entries/job/JobEntryJobTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/job/JobEntryJobTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,16 +23,18 @@
 package org.pentaho.di.job.entries.job;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.verifyNew;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -40,143 +42,468 @@ import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.database.DatabaseMeta;
-import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.util.CurrentDirectoryResolver;
 import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryDirectoryInterface;
+import org.pentaho.di.repository.StringObjectId;
 import org.pentaho.di.resource.ResourceNamingInterface;
 import org.pentaho.metastore.api.IMetaStore;
-import org.w3c.dom.Document;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.w3c.dom.Node;
-import org.xml.sax.SAXException;
 
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( JobEntryJob.class )
 public class JobEntryJobTest {
 
-  private final String JOB_ENTRY_JOB_NAME = "JobEntryJobName";
-  private final String JOB_ENTRY_FILE_NAME = "JobEntryFileName";
-  private final String JOB_ENTRY_FILE_DIRECTORY = "JobEntryFileDirectory";
-  private final String JOB_ENTRY_DESCRIPTION = "JobEntryDescription";
+  private final String JOB_ENTRY_JOB_NAME = "My Job";
+  private final StringObjectId JOB_ENTRY_JOB_OBJECT_ID = new StringObjectId( "00x1" );
+  private final String JOB_ENTRY_FILE_NAME = "job.kjb";
+  private final String JOB_ENTRY_FILE_DIRECTORY = "/public/test";
+  private final String JOB_ENTRY_FILE_PATH = "/home/ljm/job.kjb";
+  private final String JOB_ENTRY_DESCRIPTION = "This is yet another job";
 
-  //prepare xml for use
-  public Node getEntryNode( boolean includeJobname, ObjectLocationSpecificationMethod method )
-    throws ParserConfigurationException, SAXException, IOException {
-    JobEntryJob jobEntryJob = getJobEntryJob();
-    jobEntryJob.setDescription( JOB_ENTRY_DESCRIPTION );
-    jobEntryJob.setFileName( JOB_ENTRY_FILE_NAME );
-    jobEntryJob.setDirectory( JOB_ENTRY_FILE_DIRECTORY );
-    if ( includeJobname ) {
-      jobEntryJob.setJobName( JOB_ENTRY_FILE_NAME );
-    }
-    if ( method != null ) {
-      jobEntryJob.setSpecificationMethod( method );
-    }
-    String string = "<job>" + jobEntryJob.getXML() + "</job>";
-    InputStream stream = new ByteArrayInputStream( string.getBytes( StandardCharsets.UTF_8 ) );
-    DocumentBuilder db;
-    Document doc;
-    db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-    doc = db.parse( stream );
-    Node entryNode = doc.getFirstChild();
-    return entryNode;
-  }
+  private Repository repository = mock( Repository.class );
+  private List<DatabaseMeta> databases = mock( List.class );
+  private List<SlaveServer> servers = mock( List.class );
+  private IMetaStore store = mock( IMetaStore.class );
+  private VariableSpace space = mock( VariableSpace.class );
+  private CurrentDirectoryResolver resolver = mock( CurrentDirectoryResolver.class );
+  private RepositoryDirectoryInterface rdi = mock( RepositoryDirectoryInterface.class );
+  private RepositoryDirectoryInterface directory = mock( RepositoryDirectoryInterface.class );
 
-  private JobEntryJob getJobEntryJob() {
-    JobEntryJob jobEntryJob = new JobEntryJob( JOB_ENTRY_JOB_NAME );
-    return jobEntryJob;
-  }
+  @Before
+  public void setUp() throws Exception {
+    doReturn( true ).when( repository ).isConnected();
+    doReturn( null ).when( repository ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( rdi ).when( repository ).loadRepositoryDirectoryTree();
+    doReturn( directory ).when( rdi ).findDirectory( JOB_ENTRY_FILE_DIRECTORY );
+    doReturn( directory ).when( rdi ).findDirectory( "/home/admin/folder" );
 
-  @SuppressWarnings( "unchecked" )
-  private void testJobEntry( Repository rep, boolean includeJobName, ObjectLocationSpecificationMethod method,
-      ObjectLocationSpecificationMethod expectedMethod )
-    throws KettleXMLException, ParserConfigurationException, SAXException, IOException {
-    List<DatabaseMeta> databases = mock( List.class );
-    List<SlaveServer> slaveServers = mock( List.class );
-    IMetaStore metaStore = mock( IMetaStore.class );
-    JobEntryJob jobEntryJob = getJobEntryJob();
-    jobEntryJob.loadXML( getEntryNode( includeJobName, method ), databases, slaveServers, rep, metaStore );
-    assertEquals( "If we connect to repository then we use rep_name method",
-        expectedMethod, jobEntryJob.getSpecificationMethod() );
+    doReturn( null ).when( space ).environmentSubstitute( anyString() );
+    doReturn( "" ).when( space ).environmentSubstitute( "" );
+    doReturn( JOB_ENTRY_FILE_PATH ).when( space ).environmentSubstitute( JOB_ENTRY_FILE_PATH );
+    doReturn( JOB_ENTRY_FILE_NAME ).when( space ).environmentSubstitute( JOB_ENTRY_FILE_NAME );
+    doReturn( JOB_ENTRY_FILE_DIRECTORY ).when( space ).environmentSubstitute( JOB_ENTRY_FILE_DIRECTORY );
+    doReturn( "hdfs://server/path/" ).when( space ).environmentSubstitute( "${hdfs}" );
+    doReturn( "/home/admin/folder/job.kjb" ).when( space ).environmentSubstitute( "${repositoryfullfilepath}" );
+    doReturn( "/home/admin/folder/" ).when( space ).environmentSubstitute( "${repositorypath}" );
+    doReturn( "job.kjb" ).when( space ).environmentSubstitute( "${jobname}" );
+    doReturn( "job" ).when( space ).environmentSubstitute( "job" );
+
+    doCallRealMethod().when( resolver ).normalizeSlashes( anyString() );
+    doReturn( space ).when( resolver ).resolveCurrentDirectory(
+      any( ObjectLocationSpecificationMethod.class ), any( VariableSpace.class ), any( Repository.class ), any( Job.class ), anyString() );
+
+    whenNew( CurrentDirectoryResolver.class ).withNoArguments().thenReturn( resolver );
+    whenNew( JobMeta.class ).withAnyArguments().thenReturn( mock( JobMeta.class ) );
   }
 
   /**
-   * BACKLOG-179 - Exporting/Importing Jobs breaks Transformation specification when using "Specify by reference"
-   * 
-   * Test checks that we choose different {@link ObjectLocationSpecificationMethod} when connection to
-   * {@link Repository} and disconnected. 
-   * 
-   * <b>Important!</b> You must rewrite test when change import logic
-   * 
-   * @throws KettleXMLException
-   * @throws IOException
-   * @throws SAXException
-   * @throws ParserConfigurationException
+   * When disconnected from the repository and {@link JobEntryJob} contains no info,
+   * default to {@link ObjectLocationSpecificationMethod}.{@code FILENAME}
    */
   @Test
-  public void testChooseSpecMethodByRepositoryConnectionStatus()
-    throws KettleXMLException, ParserConfigurationException, SAXException, IOException {
-    Repository rep = mock( Repository.class );
-    when( rep.isConnected() ).thenReturn( true );
+  public void testNotConnectedLoad_NoInfo() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadXML( getNode( jej ), databases, servers, null, store );
 
-    // 000
-    // not connected, no jobname, no method
-    testJobEntry( null, false, null, ObjectLocationSpecificationMethod.FILENAME );
+    assertEquals( ObjectLocationSpecificationMethod.FILENAME, jej.getSpecificationMethod() );
+  }
 
-    // 001
-    // not connected, no jobname, REPOSITORY_BY_REFERENCE method
-    testJobEntry( null, false, ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE, ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
-    // not connected, no jobname, REPOSITORY_BY_NAME method
-    testJobEntry( null, false, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
-    // not connected, no jobname, FILENAME method
-    testJobEntry( null, false, ObjectLocationSpecificationMethod.FILENAME, ObjectLocationSpecificationMethod.FILENAME );
+  /**
+   * When disconnected from the repository and {@link JobEntryJob} references a child job by {@link ObjectId},
+   * this reference will be invalid to run such job.
+   * Default to {@link ObjectLocationSpecificationMethod}.{@code FILENAME} with a {@code null} file path.
+   */
+  @Test
+  public void testNotConnectedLoad_RepByRef() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setSpecificationMethod( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
+    jej.setJobObjectId( JOB_ENTRY_JOB_OBJECT_ID );
+    jej.loadXML( getNode( jej ), databases, servers, null, store );
+    jej.getJobMeta( null, store, space );
 
-    // 010
-    // not connected, jobname, no method
-    testJobEntry( null, true, null, ObjectLocationSpecificationMethod.FILENAME );
+    assertEquals( ObjectLocationSpecificationMethod.FILENAME, jej.getSpecificationMethod() );
+    verifyNew( JobMeta.class ).withArguments( space, null, null, store, null );
+  }
 
-    // 011
-    // not connected, jobname, REPOSITORY_BY_REFERENCE method
-    testJobEntry( null, true, ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE, ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
-    // not connected, jobname, REPOSITORY_BY_NAME method
-    testJobEntry( null, true, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
-    // not connected, jobname, FILENAME method
-    testJobEntry( null, true, ObjectLocationSpecificationMethod.FILENAME, ObjectLocationSpecificationMethod.FILENAME );
+  /**
+   * When disconnected from the repository and {@link JobEntryJob} references a child job by name,
+   * this reference will be invalid to run such job.
+   * Default to {@link ObjectLocationSpecificationMethod}.{@code FILENAME} with a {@code null} file path.
+   */
+  @Test
+  public void testNotConnectedLoad_RepByName() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setSpecificationMethod( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
+    jej.setJobName( JOB_ENTRY_FILE_NAME );
+    jej.setDirectory( JOB_ENTRY_FILE_DIRECTORY );
+    jej.loadXML( getNode( jej ), databases, servers, null, store );
+    jej.getJobMeta( null, store, space );
 
-    // 100
-    // connected, no jobname, no method
-    testJobEntry( rep, false, null, ObjectLocationSpecificationMethod.FILENAME );
+    assertEquals( ObjectLocationSpecificationMethod.FILENAME, jej.getSpecificationMethod() );
+    verifyNew( JobMeta.class ).withArguments( space, null, null, store, null );
+  }
 
-    // 101
-    // connected, no jobname, REPOSITORY_BY_REFERENCE method
-    testJobEntry( rep, false, ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE, ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
-    // connected, no jobname, REPOSITORY_BY_NAME method
-    testJobEntry( rep, false, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
-    // connected, no jobname, FILENAME method
-    testJobEntry( rep, false, ObjectLocationSpecificationMethod.FILENAME, ObjectLocationSpecificationMethod.FILENAME );
+  /**
+   * When disconnected from the repository and {@link JobEntryJob} references a child job by file path,
+   * {@link ObjectLocationSpecificationMethod} will be {@code FILENAME}.
+   */
+  @Test
+  public void testNotConnectedLoad_Filename() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+    jej.setFileName( JOB_ENTRY_FILE_PATH );
+    jej.loadXML( getNode( jej ), databases, servers, null, store );
+    jej.getJobMeta( null, store, space );
 
-    // 110  
-    // connected, jobname, no method
-    testJobEntry( rep, true, null, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
+    assertEquals( ObjectLocationSpecificationMethod.FILENAME, jej.getSpecificationMethod() );
+    verifyNew( JobMeta.class ).withArguments( space, JOB_ENTRY_FILE_PATH, null, store, null );
+  }
 
-    // 111
-    // connected, jobname, REPOSITORY_BY_REFERENCE method
-    testJobEntry( rep, true, ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
-    // connected, jobname, REPOSITORY_BY_NAME method
-    testJobEntry( rep, true, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
-    // connected, jobname, FILENAME method    
-    testJobEntry( rep, true, ObjectLocationSpecificationMethod.FILENAME, ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
+  /**
+   * When connected to the repository and {@link JobEntryJob} contains no info,
+   * default to {@link ObjectLocationSpecificationMethod}.{@code REPOSITORY_BY_NAME}
+   */
+  @Test
+  public void testConnectedImport_NoInfo() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadXML( getNode( jej ), databases, servers, repository, store );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, jej.getSpecificationMethod() );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by {@link ObjectId},
+   * keep {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_REFERENCE}.
+   * Load the job from the repository using the specified {@link ObjectId}.
+   */
+  @Test
+  public void testConnectedImport_RepByRef() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setSpecificationMethod( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
+    jej.setJobObjectId( JOB_ENTRY_JOB_OBJECT_ID );
+    jej.loadXML( getNode( jej ), databases, servers, repository, store );
+    jej.getJobMeta( repository, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE, jej.getSpecificationMethod() );
+    verify( repository, times( 1 ) ).loadJob( JOB_ENTRY_JOB_OBJECT_ID, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by name,
+   * keep {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_NAME}.
+   * Load the job from the repository using the specified job name and directory.
+   */
+  @Test
+  public void testConnectedImport_RepByName() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setSpecificationMethod( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
+    jej.setJobName( JOB_ENTRY_FILE_NAME );
+    jej.setDirectory( JOB_ENTRY_FILE_DIRECTORY );
+    jej.loadXML( getNode( jej ), databases, servers, repository, store );
+    jej.getJobMeta( repository, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, jej.getSpecificationMethod() );
+    verify( repository, times( 1 ) ).loadJob( JOB_ENTRY_FILE_NAME, directory, null, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by file path,
+   * keep {@link ObjectLocationSpecificationMethod} as {@code FILENAME}.
+   * Load the job from the repository using the specified file path.
+   */
+  @Test
+  public void testConnectedImport_Filename() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+    jej.setFileName( JOB_ENTRY_FILE_PATH );
+    jej.loadXML( getNode( jej ), databases, servers, repository, store );
+    jej.getJobMeta( repository, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.FILENAME, jej.getSpecificationMethod() );
+    verifyNew( JobMeta.class ).withArguments( space, JOB_ENTRY_FILE_PATH, repository, store, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by {@link ObjectId},
+   * guess {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_REFERENCE}.
+   * Load the job from the repository using the specified {@link ObjectId}.
+   */
+  @Test
+  public void testConnectedImport_RepByRef_Guess() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setJobObjectId( JOB_ENTRY_JOB_OBJECT_ID );
+    jej.loadXML( getNode( jej ), databases, servers, repository, store );
+    jej.getJobMeta( repository, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE, jej.getSpecificationMethod() );
+    verify( repository, times( 1 ) ).loadJob( JOB_ENTRY_JOB_OBJECT_ID, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by name,
+   * keep {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_NAME}.
+   * Load the job from the repository using the specified job name and directory.
+   */
+  @Test
+  public void testConnectedImport_RepByName_Guess() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setJobName( JOB_ENTRY_FILE_NAME );
+    jej.setDirectory( JOB_ENTRY_FILE_DIRECTORY );
+    jej.loadXML( getNode( jej ), databases, servers, repository, store );
+    jej.getJobMeta( repository, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, jej.getSpecificationMethod() );
+    verify( repository, times( 1 ) ).loadJob( JOB_ENTRY_FILE_NAME, directory, null, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by file path,
+   * guess {@link ObjectLocationSpecificationMethod} as {@code FILENAME}.
+   * Load the job from the repository using the specified file path.
+   */
+  @Test
+  public void testConnectedImport_Filename_Guess() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setFileName( JOB_ENTRY_FILE_PATH );
+    jej.loadXML( getNode( jej ), databases, servers, repository, store );
+    jej.getJobMeta( repository, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.FILENAME, jej.getSpecificationMethod() );
+    verifyNew( JobMeta.class ).withArguments( space, JOB_ENTRY_FILE_PATH, repository, store, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} contains no info,
+   * default to {@link ObjectLocationSpecificationMethod}.{@code REPOSITORY_BY_NAME}
+   */
+  @Test
+  public void testConnectedLoad_NoInfo() throws Exception {
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( repository, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, jej.getSpecificationMethod() );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by {@link ObjectId},
+   * keep {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_REFERENCE}.
+   * Load the job from the repository using the specified {@link ObjectId}.
+   */
+  @Test
+  public void testConnectedLoad_RepByRef() throws Exception {
+    Repository myrepo = mock( Repository.class );
+    doReturn( true ).when( myrepo ).isConnected();
+    doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( "rep_ref" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "specification_method" );
+    doReturn( JOB_ENTRY_JOB_OBJECT_ID.toString() ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "job_object_id" );
+
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( myrepo, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+    jej.getJobMeta( myrepo, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE, jej.getSpecificationMethod() );
+    verify( myrepo, times( 1 ) ).loadJob( JOB_ENTRY_JOB_OBJECT_ID, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by name,
+   * keep {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_NAME}.
+   * Load the job from the repository using the specified job name and directory.
+   */
+  @Test
+  public void testConnectedLoad_RepByName() throws Exception {
+    Repository myrepo = mock( Repository.class );
+    doReturn( true ).when( myrepo ).isConnected();
+    doReturn( rdi ).when( myrepo ).loadRepositoryDirectoryTree();
+    doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( "rep_name" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "specification_method" );
+    doReturn( JOB_ENTRY_FILE_NAME ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "name" );
+    doReturn( JOB_ENTRY_FILE_DIRECTORY ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "dir_path" );
+
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( myrepo, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+    jej.getJobMeta( myrepo, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, jej.getSpecificationMethod() );
+    verify( myrepo, times( 1 ) ).loadJob( JOB_ENTRY_FILE_NAME, directory, null, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by file path,
+   * keep {@link ObjectLocationSpecificationMethod} as {@code FILENAME}.
+   * Load the job from the repository using the specified file path.
+   */
+  @Test
+  public void testConnectedLoad_Filename() throws Exception {
+    Repository myrepo = mock( Repository.class );
+    doReturn( true ).when( myrepo ).isConnected();
+    doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( "filename" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "specification_method" );
+    doReturn( JOB_ENTRY_FILE_PATH ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "file_name" );
+
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( myrepo, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+    jej.getJobMeta( myrepo, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.FILENAME, jej.getSpecificationMethod() );
+    verifyNew( JobMeta.class ).withArguments( space, JOB_ENTRY_FILE_PATH, myrepo, store, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by name,
+   * keep {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_NAME}.
+   * Load the job from the repository using the specified job name and directory.
+   */
+  @Test
+  public void testConnectedLoad_RepByName_HDFS() throws Exception {
+    Repository myrepo = mock( Repository.class );
+    doReturn( true ).when( myrepo ).isConnected();
+    doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( "rep_name" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "specification_method" );
+    doReturn( "job" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "name" );
+    doReturn( "${hdfs}" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "dir_path" );
+
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( myrepo, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+    jej.getJobMeta( myrepo, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, jej.getSpecificationMethod() );
+    verifyNew( JobMeta.class ).withArguments( space, "hdfs://server/path/job.kjb", myrepo, store, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by name using a single parameter,
+   * keep {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_NAME}.
+   * Load the job from the repository using the specified job name and directory.
+   */
+  @Test
+  public void testConnectedLoad_RepByName_SingleParameter() throws Exception {
+    Repository myrepo = mock( Repository.class );
+    doReturn( true ).when( myrepo ).isConnected();
+    doReturn( rdi ).when( myrepo ).loadRepositoryDirectoryTree();
+    doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( "rep_name" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "specification_method" );
+    doReturn( "${repositoryfullfilepath}" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "name" );
+
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( myrepo, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+    jej.getJobMeta( myrepo, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, jej.getSpecificationMethod() );
+    verify( myrepo, times( 1 ) ).loadJob( "job.kjb", directory, null, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by name using multiple parameters,
+   * keep {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_NAME}.
+   * Load the job from the repository using the specified job name and directory.
+   */
+  @Test
+  public void testConnectedLoad_RepByName_MultipleParameters() throws Exception {
+    Repository myrepo = mock( Repository.class );
+    doReturn( true ).when( myrepo ).isConnected();
+    doReturn( rdi ).when( myrepo ).loadRepositoryDirectoryTree();
+    doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( "rep_name" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "specification_method" );
+    doReturn( "${jobname}" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "name" );
+    doReturn( "${repositorypath}" ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "dir_path" );
+
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( myrepo, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+    jej.getJobMeta( myrepo, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, jej.getSpecificationMethod() );
+    verify( myrepo, times( 1 ) ).loadJob( "job.kjb", directory, null, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by {@link ObjectId},
+   * guess {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_REFERENCE}.
+   * Load the job from the repository using the specified {@link ObjectId}.
+   */
+  @Test
+  public void testConnectedLoad_RepByRef_Guess() throws Exception {
+    Repository myrepo = mock( Repository.class );
+    doReturn( true ).when( myrepo ).isConnected();
+    doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( JOB_ENTRY_JOB_OBJECT_ID.toString() ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "job_object_id" );
+
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( myrepo, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+    jej.getJobMeta( myrepo, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE, jej.getSpecificationMethod() );
+    verify( myrepo, times( 1 ) ).loadJob( JOB_ENTRY_JOB_OBJECT_ID, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by name,
+   * guess {@link ObjectLocationSpecificationMethod} as {@code REPOSITORY_BY_NAME}.
+   * Load the job from the repository using the specified job name and directory.
+   */
+  @Test
+  public void testConnectedLoad_RepByName_Guess() throws Exception {
+    Repository myrepo = mock( Repository.class );
+    doReturn( true ).when( myrepo ).isConnected();
+    doReturn( rdi ).when( myrepo ).loadRepositoryDirectoryTree();
+    doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( JOB_ENTRY_FILE_NAME ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "name" );
+    doReturn( JOB_ENTRY_FILE_DIRECTORY ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "dir_path" );
+
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( myrepo, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+    jej.getJobMeta( myrepo, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME, jej.getSpecificationMethod() );
+    verify( myrepo, times( 1 ) ).loadJob( JOB_ENTRY_FILE_NAME, directory, null, null );
+  }
+
+  /**
+   * When connected to the repository and {@link JobEntryJob} references a child job by file path,
+   * guess {@link ObjectLocationSpecificationMethod} as {@code FILENAME}.
+   * Load the job from the repository using the specified file path.
+   */
+  @Test
+  public void testConnectedLoad_Filename_Guess() throws Exception {
+    Repository myrepo = mock( Repository.class );
+    doReturn( true ).when( myrepo ).isConnected();
+    doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
+    doReturn( JOB_ENTRY_FILE_PATH ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "file_name" );
+
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.loadRep( myrepo, store, JOB_ENTRY_JOB_OBJECT_ID, databases, servers );
+    jej.getJobMeta( myrepo, store, space );
+
+    assertEquals( ObjectLocationSpecificationMethod.FILENAME, jej.getSpecificationMethod() );
+    verifyNew( JobMeta.class ).withArguments( space, JOB_ENTRY_FILE_PATH, myrepo, store, null );
+  }
+
+  private Node getNode( JobEntryJob jej ) throws Exception {
+    String string = "<job>" + jej.getXML() + "</job>";
+    InputStream stream = new ByteArrayInputStream( string.getBytes( StandardCharsets.UTF_8 ) );
+    DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    return db.parse( stream ).getFirstChild();
   }
 
   @Test
   public void testCurrDirListener() throws Exception {
     JobMeta meta = mock( JobMeta.class );
-    JobEntryJob jej = getJobEntryJob();
+    JobEntryJob jej = new JobEntryJob( JOB_ENTRY_JOB_NAME );
     jej.setParentJobMeta( null );
     jej.setParentJobMeta( meta );
     jej.setParentJobMeta( null );
@@ -186,19 +513,19 @@ public class JobEntryJobTest {
 
   @Test
   public void testExportResources() throws Exception {
-    JobEntryJob jobEntryJob = spy( getJobEntryJob() );
-    JobMeta jobMeta = mock( JobMeta.class );
+    JobMeta meta = mock( JobMeta.class );
+    JobEntryJob jej = spy( new JobEntryJob( JOB_ENTRY_JOB_NAME ) );
+    jej.setDescription( JOB_ENTRY_DESCRIPTION );
 
-    String testName = "test";
+    doReturn( meta ).when( jej ).getJobMeta(
+      any( Repository.class ), any( IMetaStore.class ), any( VariableSpace.class ) );
+    doReturn( JOB_ENTRY_JOB_NAME ).when( meta ).exportResources(
+      any( JobMeta.class ), any( Map.class ), any( ResourceNamingInterface.class ),
+      any( Repository.class ), any( IMetaStore.class ) );
 
-    doReturn( jobMeta ).when( jobEntryJob ).getJobMeta( any( Repository.class ),
-            any( IMetaStore.class ), any( VariableSpace.class ) );
-    when( jobMeta.exportResources( any( JobMeta.class ), any( Map.class ), any( ResourceNamingInterface.class ),
-            any( Repository.class ), any( IMetaStore.class ) ) ).thenReturn( testName );
+    jej.exportResources( null, null, null, null, null );
 
-    jobEntryJob.exportResources( null, null, null, null, null );
-
-    verify( jobMeta ).setFilename( "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + testName );
-    verify( jobEntryJob ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+    verify( meta ).setFilename( "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + JOB_ENTRY_JOB_NAME );
+    verify( jej ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
   }
 }

--- a/ui/src/test/java/org/pentaho/di/ui/job/entries/job/JobEntryJobDialogTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/job/entries/job/JobEntryJobDialogTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,26 +22,115 @@
 
 package org.pentaho.di.ui.job.entries.job;
 
+import org.eclipse.swt.widgets.Shell;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.di.core.ObjectLocationSpecificationMethod;
+import org.pentaho.di.core.logging.LoggingRegistry;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entries.job.JobEntryJob;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.ui.core.PropsUI;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 /**
  * @author Vadim_Polynkov
  */
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( { PropsUI.class, LoggingRegistry.class } )
 public class JobEntryJobDialogTest {
 
   private static final String FILE_NAME =  "TestJob.kjb";
 
-  JobEntryJobDialog dialog;
+  private JobEntryJobDialog dialog;
+  private JobEntryJob job = mock( JobEntryJob.class );
+
+  @Before
+  public void setUp() {
+    mockStatic( PropsUI.class );
+    when( PropsUI.getInstance() ).thenReturn( mock( PropsUI.class ) );
+
+    LoggingRegistry logging = mock( LoggingRegistry.class );
+    doReturn( null ).when( logging ).registerLoggingSource( anyObject() );
+
+    mockStatic( LoggingRegistry.class );
+    when( LoggingRegistry.getInstance() ).thenReturn( logging );
+
+    dialog = spy( new JobEntryJobDialog( mock( Shell.class ), job, mock( Repository.class ), mock( JobMeta.class ) ) );
+    doReturn( "My Job" ).when( dialog ).getName();
+    doNothing().when( dialog ).getInfo( job );
+    doNothing().when( dialog ).getData();
+    doNothing().when( dialog ).dispose();
+  }
 
   @Test
   public void testEntryName() {
-    dialog = mock( JobEntryJobDialog.class );
-    doCallRealMethod().when( dialog ).getEntryName( any() );
-    assertEquals( dialog.getEntryName( FILE_NAME ), "${Internal.Entry.Current.Directory}/" + FILE_NAME );
+    assertEquals( "${Internal.Entry.Current.Directory}/" + FILE_NAME, dialog.getEntryName( FILE_NAME ) );
+  }
+
+  @Test
+  public void testSetChanged_OK() {
+    doReturn( "/path/job.kjb" ).when( dialog ).getPath();
+
+    dialog.ok();
+    verify( job, times( 1 ) ).setChanged();
+  }
+
+  @Test
+  public void testSpecificationMethod_ConnectedRepositoryByName() {
+    doReturn( "/path/job.kjb" ).when( dialog ).getPath();
+
+    dialog.ok();
+    verify( job, times( 1 ) ).setSpecificationMethod( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
+  }
+
+  @Test
+  public void testSpecificationMethod_ConnectedFilename() {
+    doReturn( "file:///path/job.kjb" ).when( dialog ).getPath();
+
+    dialog.ok();
+    verify( job, times( 1 ) ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+  }
+
+  @Test
+  public void testSpecificationMethod_ConnectedFilenameZip() {
+    doReturn( "zip:file:///path/job.kjb" ).when( dialog ).getPath();
+
+    dialog.ok();
+    verify( job, times( 1 ) ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+  }
+
+  @Test
+  public void testSpecificationMethod_ConnectedFilenameHDFS() {
+    doReturn( "hdfs://path/job.kjb" ).when( dialog ).getPath();
+
+    dialog.ok();
+    verify( job, times( 1 ) ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+  }
+
+  @Test
+  public void testSpecificationMethod_NotConnectedFilename() {
+    JobEntryJobDialog nc = spy( new JobEntryJobDialog( mock( Shell.class ), job, null, mock( JobMeta.class ) ) );
+    doReturn( "My Job" ).when( nc ).getName();
+    doReturn( "/path/job.kjb" ).when( nc ).getPath();
+    doNothing().when( nc ).getInfo( job );
+    doNothing().when( nc ).getData();
+    doNothing().when( nc ).dispose();
+
+    nc.ok();
+    verify( job, times( 1 ) ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
   }
 }


### PR DESCRIPTION
Maybe I went too far with the code changes, but there was some logic to handle use cases we should not be supporting. The new code makes much more sense to me while still running all possible configurations of `JobEntryJob` created prior to 7.0, namely, when it was possible to specify a child job by repository name, repository object id and file system filename.

Please review and let me know if you think we should be supporting any other use cases.
See use cases in the comment blocks [here](https://github.com/pentaho-lmartins/pentaho-kettle/blob/d24e413b66c7dab188d83ee8aab054ad6ac6949c/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java#L369-L377) and [here](https://github.com/pentaho-lmartins/pentaho-kettle/blob/d24e413b66c7dab188d83ee8aab054ad6ac6949c/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java#L466-L473).

There are 20 test cases in `JobEntryJobTest` to cover all the options I could think of.

@mbatchelor @pamval @bmorrise @pmalves 