### PR TITLE
[PDI-17340] 8.0 Execute transformation fails when sub-job name has .k…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/jobexecutor/JobExecutorDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/jobexecutor/JobExecutorDialog.java
@@ -448,10 +448,6 @@ public class JobExecutorDialog extends BaseStepDialog implements StepDialogInter
         if ( Utils.isEmpty( filename ) ) {
           return;
         }
-        if ( filename.endsWith( ".kjb" ) ) {
-          filename = filename.replace( ".kjb", "" );
-          wPath.setText( filename );
-        }
         String transPath = transMeta.environmentSubstitute( filename );
         String realJobname = transPath;
         String realDirectory = "";

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
@@ -449,10 +449,6 @@ public class TransExecutorDialog extends BaseStepDialog implements StepDialogInt
         if ( Utils.isEmpty( filename ) ) {
           return;
         }
-        if ( filename.endsWith( ".ktr" ) ) {
-          filename = filename.replace( ".ktr", "" );
-          wPath.setText( filename );
-        }
         String transPath = transMeta.environmentSubstitute( filename );
         String realTransname = transPath;
         String realDirectory = "";


### PR DESCRIPTION
…jb extension - 6.1 Does Not

This complements #5433 and fixes an inconsistency between `JobEntryJob` and `JobExecutor`.
Since we now check for the presence of the extension, we don't need to remove it when present.

@mbatchelor @bmorrise @pamval 