### PR TITLE
[PDI-17343] Job Transformation Step does not receive parameters from …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -36,6 +36,7 @@ import org.pentaho.di.core.extension.ExtensionPointHandler;
 import org.pentaho.di.core.extension.KettleExtensionPoint;
 import org.pentaho.di.core.listeners.CurrentDirectoryChangedListener;
 import org.pentaho.di.core.listeners.impl.EntryCurrentDirectoryChangedListener;
+import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.Result;
@@ -884,6 +885,9 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
         //
         transMeta.clearParameters();
         String[] parameterNames = transMeta.listParameters();
+
+        prepareFieldNamesParameters( parameterNames, parameterFieldNames, namedParam, this );
+
         StepWithMappingMeta.activateParams( transMeta, transMeta, this, parameterNames,
           parameters, parameterValues );
         boolean doFallback = true;
@@ -1692,6 +1696,20 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       variables.setParentVariableSpace( parentJobMeta );
     } else if ( previous != null ) {
       previous.removeCurrentDirectoryChangedListener( currentDirListener );
+    }
+  }
+
+  public void prepareFieldNamesParameters( String[] parameterNames, String[] parameterFieldNames,
+                                                    NamedParams namedParam, JobEntryTrans jobEntryTrans )
+    throws UnknownParamException {
+    for ( int idx = 0; idx < parameterNames.length; idx++ ) {
+      // Grab the parameter value set in the Trans job entry
+      //
+      String thisValue = namedParam.getParameterValue( parameterNames[ idx ] );
+
+      if ( !Utils.isEmpty( thisValue ) && !Utils.isEmpty( Const.trim( parameterFieldNames[ idx ] ) ) ) {
+        jobEntryTrans.setVariable( parameterNames[ idx ], thisValue );
+      }
     }
   }
 

--- a/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
@@ -54,6 +54,9 @@ import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.parameters.NamedParams;
+import org.pentaho.di.core.parameters.NamedParamsDefault;
+import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.job.Job;
@@ -223,6 +226,29 @@ public class JobEntryTransTest {
 
     verify( transMeta ).setFilename( "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + testName );
     verify( jobEntryTrans ).setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
+  }
+
+  @Test
+  public void testPrepareFieldNamesParameters() throws UnknownParamException {
+    // array of params
+    String[] parameterNames = new String[1];
+    parameterNames[0] = "param1";
+
+    // array of fieldNames params
+    String[] parameterFieldNames = new String[1];
+    parameterFieldNames[0] = "StreamParam1";
+
+    JobEntryTrans jet = new JobEntryTrans();
+    VariableSpace variableSpace = new Variables();
+    jet.copyVariablesFrom( variableSpace );
+
+    //at this point StreamColumnNameParams are already inserted in namedParams
+    NamedParams namedParam = Mockito.mock( NamedParamsDefault.class );
+    Mockito.doReturn( "value1" ).when( namedParam ).getParameterValue(  Mockito.anyObject() );
+
+    jet.prepareFieldNamesParameters( parameterNames, parameterFieldNames, namedParam, jet );
+
+    Assert.assertEquals( "value1", jet.getVariable( "param1" ) );
   }
 
   @Test


### PR DESCRIPTION
…fields

The Stream Column Name parameters were not being considered for activation since the refactoring done in PDI-16844. I had to add that logic again using the parameterFiledNames array for that purpose.

@pentaho-lmartins @pamval @bmorrise @mbatchelor 