### PR TITLE
[PDI-17303] Job Executor does not read parameter values from fields

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
@@ -364,6 +364,22 @@ public class JobExecutor extends BaseStep implements StepInterface {
     // Set parameters, when fields are used take the first row in the set.
     //
     JobExecutorParameters parameters = meta.getParameters();
+
+    String value;
+
+    for ( int i = 0; i < parameters.getVariable().length; i++ ) {
+      String fieldName = parameters.getField()[i];
+      if ( !Utils.isEmpty( fieldName ) ) {
+        int idx = getInputRowMeta().indexOfValue( fieldName );
+        if ( idx < 0 ) {
+          throw new KettleException( BaseMessages.getString(
+            PKG, "JobExecutor.Exception.UnableToFindField", fieldName ) );
+        }
+        value = data.groupBuffer.get( 0 ).getString( i, "" );
+        this.setVariable( parameters.getVariable()[ i ], value );
+      }
+    }
+
     StepWithMappingMeta.activateParams( data.executorJob, data.executorJob, this, data.executorJob.listParameters(),
       parameters.getVariable(), parameters.getInput() );
   }


### PR DESCRIPTION
Fixing a regression introduced in PDI-16844. Including again the lost logic for fieldname parameters in JobExecutor: https://github.com/ppatricio/pentaho-kettle/blame/5682a8b08389bff683703af22f6af21f5cb41ded/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java

@pentaho-lmartins @pamval @bmorrise @mbatchelor 