### PR TITLE
[PDI-17343] Job Transformation Step does not receive parameters from …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -886,7 +886,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
         transMeta.clearParameters();
         String[] parameterNames = transMeta.listParameters();
 
-        prepareFieldNamesParameters( parameterNames, parameterFieldNames, namedParam, this );
+        prepareFieldNamesParameters( parameters, parameterFieldNames, parameterValues, namedParam, this );
 
         StepWithMappingMeta.activateParams( transMeta, transMeta, this, parameterNames,
           parameters, parameterValues );
@@ -1699,16 +1699,30 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
     }
   }
 
-  public void prepareFieldNamesParameters( String[] parameterNames, String[] parameterFieldNames,
+  public void prepareFieldNamesParameters( String[] parameters, String[] parameterFieldNames, String[] parameterValues,
                                                     NamedParams namedParam, JobEntryTrans jobEntryTrans )
     throws UnknownParamException {
-    for ( int idx = 0; idx < parameterNames.length; idx++ ) {
+    for ( int idx = 0; idx < parameters.length; idx++ ) {
       // Grab the parameter value set in the Trans job entry
+      // Set fieldNameParameter only if exists and if it is not declared any staticValue( parameterValues array )
       //
-      String thisValue = namedParam.getParameterValue( parameterNames[ idx ] );
-
-      if ( !Utils.isEmpty( thisValue ) && !Utils.isEmpty( Const.trim( parameterFieldNames[ idx ] ) ) ) {
-        jobEntryTrans.setVariable( parameterNames[ idx ], thisValue );
+      String thisValue = namedParam.getParameterValue( parameters[ idx ] );
+      // Set value only if is not empty at namedParam and exists in parameterFieldNames
+      if ( !Utils.isEmpty( thisValue ) && idx < parameterFieldNames.length ) {
+        // If exists then ask if is not empty
+        if ( !Utils.isEmpty( Const.trim( parameterFieldNames[ idx ] ) ) ) {
+          // If is not empty then we have to ask if it exists too in parameterValues array, since the values in
+          // parameterValues prevail over parameterFieldNames
+          if ( idx < parameterValues.length ) {
+            // If is empty at parameterValues array, then we can finally add that variable with that value
+            if ( Utils.isEmpty( Const.trim( parameterValues[ idx ] ) ) ) {
+              jobEntryTrans.setVariable( parameters[ idx ], thisValue );
+            }
+          } else {
+            // Or if not in parameterValues then we can add that variable with that value too
+            jobEntryTrans.setVariable( parameters[ idx ], thisValue );
+          }
+        }
       }
     }
   }

--- a/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
@@ -231,12 +231,18 @@ public class JobEntryTransTest {
   @Test
   public void testPrepareFieldNamesParameters() throws UnknownParamException {
     // array of params
-    String[] parameterNames = new String[1];
+    String[] parameterNames = new String[2];
     parameterNames[0] = "param1";
+    parameterNames[1] = "param2";
 
     // array of fieldNames params
     String[] parameterFieldNames = new String[1];
     parameterFieldNames[0] = "StreamParam1";
+
+    // array of parameterValues params
+    String[] parameterValues = new String[2];
+    parameterValues[1] = "ValueParam2";
+
 
     JobEntryTrans jet = new JobEntryTrans();
     VariableSpace variableSpace = new Variables();
@@ -244,11 +250,13 @@ public class JobEntryTransTest {
 
     //at this point StreamColumnNameParams are already inserted in namedParams
     NamedParams namedParam = Mockito.mock( NamedParamsDefault.class );
-    Mockito.doReturn( "value1" ).when( namedParam ).getParameterValue(  Mockito.anyObject() );
+    Mockito.doReturn( "value1" ).when( namedParam ).getParameterValue(  "param1" );
+    Mockito.doReturn( "value2" ).when( namedParam ).getParameterValue(  "param2" );
 
-    jet.prepareFieldNamesParameters( parameterNames, parameterFieldNames, namedParam, jet );
+    jet.prepareFieldNamesParameters( parameterNames, parameterFieldNames, parameterValues, namedParam, jet );
 
     Assert.assertEquals( "value1", jet.getVariable( "param1" ) );
+    Assert.assertEquals( null, jet.getVariable( "param2" ) );
   }
 
   @Test


### PR DESCRIPTION
…fields

Fix to the #5513 PR, The array of Fieldnames and staticValues parameters needs to be checked since it's not always guaranteed that the "idx" will match between them

@pentaho-lmartins 