### PR TITLE
[PDI-17362] Not possible pass a fixed value to a sub transformation

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -225,6 +225,10 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
     if ( mappingVariables != null ) {
       for ( int i = 0; i < mappingVariables.length; i++ ) {
         parameters.put( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
+        //If inputField value is not empty then create it in variableSpace of step(Parent)
+        if ( !Utils.isEmpty( Const.trim( parent.environmentSubstitute( inputFields[ i ] ) ) ) ) {
+          parent.setVariable( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
+        }
       }
     }
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
@@ -335,39 +335,6 @@ public class TransExecutor extends BaseStep implements StepInterface {
     }
     /////////////////////////////////////////////
 
-    /////////////////////////////////////////////
-    //If "Fields to use" ARE NOT provided and "Inherit all variables from transformation" IS checked.
-    boolean isFieldsToUseEmpty = true;
-    for ( int i = 0; i < fieldsToUse.size(); i++ ) {
-      if ( fieldsToUse.get( i ) != null ) {
-        isFieldsToUseEmpty = false;
-        break;
-      }
-    }
-    if ( parameters.isInheritingAllVariables() && isFieldsToUseEmpty ) {
-      //Check for parameter matches in the TRANSFORMATION TO EXECUTE parameters.
-      if ( getExecutorTrans().listParameters() != null ) {
-        List<String> transformationToExecuteParameters = Arrays.asList( getExecutorTrans().listParameters() );
-        for ( int i = 0; i < parameters.getVariable().length; i++ ) {
-          if ( transformationToExecuteParameters.contains( parameters.getVariable()[i] ) ) {
-            resolvingValuesMap.put( parameters.getVariable()[i],
-                getExecutorTrans().getParameterDefault( parameters.getVariable()[i] ) );
-          }
-        }
-      }
-      //Check for parameter matches in THIS transformation parameters.
-      if ( getTrans().listParameters() != null ) {
-        List<String> transformationParameters = Arrays.asList( getTrans().listParameters() );
-        for ( int i = 0; i < parameters.getVariable().length; i++ ) {
-          if ( transformationParameters.contains( parameters.getVariable()[i] ) ) {
-            resolvingValuesMap
-                .put( parameters.getVariable()[i], getTrans().getParameterValue( parameters.getVariable()[i] ) );
-          }
-        }
-      }
-    }
-    /////////////////////////////////////////////
-
     //Transform the values of the resolvingValuesMap into a String array "inputFieldValues" to be passed as parameter..
     String[] inputFieldValues = new String[parameters.getVariable().length];
     for ( int i = 0; i < parameters.getVariable().length; i++ ) {

--- a/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
@@ -253,6 +253,7 @@ public class StepWithMappingMetaTest {
     String childValue = "childValue";
     String paramOverwrite = "paramOverwrite";
     String parentValue = "parentValue";
+    String stepValue= "stepValue";
 
     VariableSpace parent = new Variables();
     parent.setVariable( paramOverwrite, parentValue );
@@ -262,10 +263,11 @@ public class StepWithMappingMetaTest {
 
     String[] parameters = childVariableSpace.listParameters();
     StepWithMappingMeta.activateParams( childVariableSpace, childVariableSpace, parent,
-      parameters, new String[] { childParam, paramOverwrite }, new String[] { childValue, childValue } );
+      parameters, new String[] { childParam, paramOverwrite }, new String[] { childValue, stepValue } );
 
     Assert.assertEquals( childValue, childVariableSpace.getVariable( childParam ) );
-    Assert.assertEquals( parentValue, childVariableSpace.getVariable( paramOverwrite ) );
+    // the step parameter prevails
+    Assert.assertEquals( stepValue, childVariableSpace.getVariable( paramOverwrite ) );
   }
 
   @Test


### PR DESCRIPTION
Fix to ensure the main rules validated by Jens:
-	In case of same parameters in parent, step and child, the value of step parameter prevails.
-	In case of same parameters in parent and child only, the value of parent parameter prevails.

Some code were removed since that logic is already granted at StepWithMappingMeta.java - loadMappingMeta (https://github.com/ppatricio/pentaho-kettle/blob/eb0e00c59188b0e4e6d62388f040e75a92532b70/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java#L209)
