### PR TITLE
[BACKLOG-23973] AEL - Inside Unique Row step,Ktr hangs if the Redirect duplicate row is unchecked but there is error handling step

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/uniquerows/UniqueRowsDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/uniquerows/UniqueRowsDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/uniquerows/UniqueRowsDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/uniquerows/UniqueRowsDialog.java
@@ -475,8 +475,9 @@ public class UniqueRowsDialog extends BaseStepDialog implements StepDialogInterf
       IntStream.range( 0, hops.size() )
         .filter( hopInd -> {
           TransHopMeta hop = hops.get( hopInd );
-          return ( hop.isErrorHop() &&
-            hop.getFromStep().getStepID().equals( this.input.getParentStepMeta().getStepID() ) );
+          return (
+            hop.isErrorHop()
+            && hop.getFromStep().getStepID().equals( this.input.getParentStepMeta().getStepID() ) );
         } )
         .forEach( hopInd -> this.transMeta.removeTransHop( hopInd ) );
     }

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/uniquerows/UniqueRowsDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/uniquerows/UniqueRowsDialog.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.MessageDialogWithToggle;
@@ -54,6 +55,7 @@ import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.trans.TransHopMeta;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepDialogInterface;
@@ -465,6 +467,18 @@ public class UniqueRowsDialog extends BaseStepDialog implements StepDialogInterf
       md.open();
       props.setCustomParameter( STRING_SORT_WARNING_PARAMETER, md.getToggleState() ? "N" : "Y" );
       props.saveProps();
+    }
+
+    // Remove any error hops coming out of UniqueRows when Reject Duplicate Rows checkbox is unselected.
+    if ( wRejectDuplicateRow.getSelection() == false ) {
+      List<TransHopMeta> hops = this.transMeta.getTransHops();
+      IntStream.range( 0, hops.size() )
+        .filter( hopInd -> {
+          TransHopMeta hop = hops.get( hopInd );
+          return ( hop.isErrorHop() &&
+            hop.getFromStep().getStepID().equals( this.input.getParentStepMeta().getStepID() ) );
+        } )
+        .forEach( hopInd -> this.transMeta.removeTransHop( hopInd ) );
     }
 
     dispose();


### PR DESCRIPTION
Fixed https://jira.pentaho.com/browse/BACKLOG-23973 for both Kettle and AEL by removing the error hops when the "Reject Duplicate Rows" is unselected. 