### PR TITLE
[BACKLOG-24046] Implement streamlined volume directory structure

### DIFF
--- a/assemblies/core/client/pom.xml
+++ b/assemblies/core/client/pom.xml
@@ -22,6 +22,13 @@
         <pentaho-karaf.version>9.0.0.0-SNAPSHOT</pentaho-karaf.version>
         <pentaho-launcher.version>9.0.0.0-SNAPSHOT</pentaho-launcher.version>
         <oss-licenses.version>9.0.0.0-SNAPSHOT</oss-licenses.version>
+
+        <!-- swt -->
+        <org.eclipse.swt.gtk.linux.x86.version>4.3.2</org.eclipse.swt.gtk.linux.x86.version>
+        <org.eclipse.swt.gtk.linux.x86_64.version>4.3.2</org.eclipse.swt.gtk.linux.x86_64.version>
+        <org.eclipse.swt.win32.win32.x86.version>4.6</org.eclipse.swt.win32.win32.x86.version>
+        <org.eclipse.swt.win32.win32.x86_64.version>4.6</org.eclipse.swt.win32.win32.x86_64.version>
+        <org.eclipse.swt.cocoa.macosx.x86_64.version>4.6</org.eclipse.swt.cocoa.macosx.x86_64.version>
     </properties>
 
     <dependencies>
@@ -76,18 +83,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.pentaho.adaptive</groupId>
-            <artifactId>pdi-websocket-daemon-assembly</artifactId>
-            <version>${ael.version}</version>
-            <type>zip</type>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>pentaho</groupId>
             <artifactId>pentaho-application-launcher</artifactId>
             <version>${pentaho-launcher.version}</version>
@@ -103,6 +98,32 @@
             <artifactId>oss-licenses</artifactId>
             <version>${oss-licenses.version}</version>
             <type>zip</type>
+        </dependency>
+        <!-- swt -->
+        <dependency>
+          <groupId>org.eclipse.swt</groupId>
+          <artifactId>org.eclipse.swt.gtk.linux.x86</artifactId>
+          <version>${org.eclipse.swt.gtk.linux.x86.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.swt</groupId>
+          <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
+          <version>${org.eclipse.swt.gtk.linux.x86_64.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.swt</groupId>
+          <artifactId>org.eclipse.swt.win32.win32.x86</artifactId>
+          <version>${org.eclipse.swt.win32.win32.x86.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.swt</groupId>
+          <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
+          <version>${org.eclipse.swt.win32.win32.x86_64.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.swt</groupId>
+          <artifactId>org.eclipse.swt.cocoa.macosx.x86_64</artifactId>
+          <version>${org.eclipse.swt.cocoa.macosx.x86_64.version}</version>
         </dependency>
     </dependencies>
 
@@ -130,23 +151,6 @@
                             <excludes>**/etc-pan/*.cfg,**/etc-kitchen/*.cfg,**/etc-scale/*.cfg</excludes>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>add-pdi-daemon</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.pentaho.adaptive</groupId>
-                                    <artifactId>pdi-websocket-daemon-assembly</artifactId>
-                                    <type>zip</type>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>${assembly.dir}</outputDirectory>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <!-- post processing -->
@@ -163,7 +167,6 @@
                             <target>
                                 <echo message="Moving unpacked dependencies to the right place..."/>
                                 <move file="${assembly.dir}/system/pentaho-karaf-assembly" tofile="${assembly.dir}/system/karaf" failonerror="false"/>
-                                <move file="${assembly.dir}/pdi-websocket-daemon" tofile="${assembly.dir}/adaptive-execution" failonerror="false"/>
                             </target>
                         </configuration>
                     </execution>

--- a/assemblies/core/client/src/assembly/assembly.xml
+++ b/assemblies/core/client/src/assembly/assembly.xml
@@ -29,6 +29,52 @@
       <useTransitiveDependencies>false</useTransitiveDependencies>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
+    <!-- swt -->
+    <dependencySet>
+      <includes>
+        <include>org.eclipse.swt:*.linux.x86</include>
+      </includes>
+      <outputDirectory>libswt/linux/x86</outputDirectory>
+      <outputFileNameMapping>swt.jar</outputFileNameMapping>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <includes>
+        <include>org.eclipse.swt:*.linux.x86_64</include>
+      </includes>
+      <outputDirectory>libswt/linux/x86_64</outputDirectory>
+      <outputFileNameMapping>swt.jar</outputFileNameMapping>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <includes>
+        <include>org.eclipse.swt:*.win32.x86</include>
+      </includes>
+      <outputDirectory>libswt/win32</outputDirectory>
+      <outputFileNameMapping>swt.jar</outputFileNameMapping>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <includes>
+        <include>org.eclipse.swt:*.win32.x86_64</include>
+      </includes>
+      <outputDirectory>libswt/win64</outputDirectory>
+      <outputFileNameMapping>swt.jar</outputFileNameMapping>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <includes>
+        <include>org.eclipse.swt:*.macosx.x86_64</include>
+      </includes>
+      <outputDirectory>libswt/osx64</outputDirectory>
+      <outputFileNameMapping>swt.jar</outputFileNameMapping>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
     <!-- licenses -->
     <dependencySet>
       <includes>
@@ -43,16 +89,6 @@
       <outputDirectory>.</outputDirectory>
       <useTransitiveDependencies>false</useTransitiveDependencies>
       <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
-    <!-- jdbc drivers -->
-    <dependencySet>
-      <includes>
-        <include>pentaho:pdi-dataservice-driver-bundle:zip</include>
-      </includes>
-      <outputDirectory>Data Service JDBC Driver</outputDirectory>
-      <useTransitiveDependencies>false</useTransitiveDependencies>
-      <useProjectArtifact>false</useProjectArtifact>
-      <outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
     <!-- application launcher -->
     <dependencySet>


### PR DESCRIPTION
- Adding "classic" PDI plugins ( via mounted-volumes ) is causing errors when being registered in pdi-core with

> ERROR (version 9.0.0.0-102, build 9.0.0.0-102 from 2018-07-04 10.16.57 by buildguy) : java.lang.ClassNotFoundException: org.pentaho.di.ui.
(...)

This is due to the fact that PDI plugins are ( sadly ) still tightly coupled to kettle-ui classes, which in turn are coupled to `swt` libs. 
So `data-integration/libswt` ( ~ 10 MB ) must continue on being bundled as part of pdi-core.

Also: removed unused / unneeded content from pdi-core's assembly process, namely
- `data-integration/Data Service JDBC Driver` ( ~ 13 MB )
- `data-integration/adaptive-execution` ( ~ 20 MB ) 

Should be merged alongside pdi-core-ee's assembly changes: https://github.com/pentaho/pentaho-ee/pull/1346

@pentaho/rogueone please review/process

CC'ing @flbrino 
