### PR TITLE
[BACKLOG-22946] Override the getFileName method to return the path to…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMeta.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.streaming.common;
 
+import com.google.common.base.Strings;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.exception.KettleException;
@@ -146,6 +147,11 @@ public abstract class BaseStreamStepMeta extends StepWithMappingMeta implements 
         BaseMessages.getString( PKG, "BaseStreamStepMeta.CheckResult.NoBatchDefined" ),
         stepMeta ) );
     }
+  }
+
+  @Override
+  public String getFileName() {
+    return ( Strings.isNullOrEmpty( this.fileName ) ? this.getTransformationPath() : this.fileName );
   }
 
   @Override

--- a/engine/src/test/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMetaTest.java
@@ -308,6 +308,21 @@ public class BaseStreamStepMetaTest {
     assertEquals( "someName", stuffStreamMeta.getTransformationPath() );
   }
 
+  @Test
+  public void testGetFileName() {
+    meta = new StuffStreamMeta();
+    String testPathName = "transformationPathName";
+    String testFileName = "testFileName";
+
+    // verify that when the fileName is not set, we get the transformation path
+    meta.setTransformationPath( testPathName );
+    assertThat( meta.getFileName(), equalTo( testPathName ) );
+
+    // verify that when the fileName is set, we get it
+    meta.setFileName( testFileName );
+    assertThat( meta.getFileName(), equalTo( testFileName ) );
+  }
+
   // Checks that a serialization->deserialization does not alter meta fields
   private void testRoundTrip( BaseStreamStepMeta thisMeta ) {
     StuffStreamMeta startingMeta = (StuffStreamMeta) thisMeta;


### PR DESCRIPTION
… the subtransformation if filename is null.