### PR TITLE
[PDI-17436] Scheduling a transformation more than once causes the log…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -286,21 +286,14 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
   }
 
   public Job( Repository repository, JobMeta jobMeta ) {
-    this( repository, jobMeta, null, null );
+    this( repository, jobMeta, null );
   }
 
   public Job( Repository repository, JobMeta jobMeta, LoggingObjectInterface parentLogging ) {
-    this( repository, jobMeta, parentLogging, null );
-  }
-
-  private Job( Repository repository, JobMeta jobMeta, LoggingObjectInterface parentLogging, String containerObjectId ) {
     this.rep = repository;
     this.jobMeta = jobMeta;
+    this.containerObjectId = jobMeta.getContainerObjectId();
     this.parentLoggingObject = parentLogging;
-
-    if ( containerObjectId != null ) {
-      this.containerObjectId = containerObjectId;
-    }
 
     init();
 
@@ -309,16 +302,9 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
     this.log = new LogChannel( this, parentLogging );
     this.logLevel = log.getLogLevel();
 
-    if ( containerObjectId == null ) {
+    if ( this.containerObjectId == null ) {
       this.containerObjectId = log.getContainerObjectId();
     }
-  }
-
-  /**
-   * Create a new Job instance with a given container Id, which can be the Carte object Id.
-   */
-  public Job( Repository repository, JobMeta jobMeta, String containerObjectId ) {
-    this( repository, jobMeta, null, containerObjectId );
   }
 
   public Job() {

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -592,6 +592,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
   public Trans( TransMeta transMeta, LoggingObjectInterface parent ) {
     this();
     this.transMeta = transMeta;
+    this.containerObjectId = transMeta.getContainerObjectId();
+
     setParent( parent );
 
     initializeVariablesFrom( transMeta );
@@ -613,7 +615,10 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
 
     this.log = new LogChannel( this, parent );
     this.logLevel = log.getLogLevel();
-    this.containerObjectId = log.getContainerObjectId();
+
+    if ( this.containerObjectId == null ) {
+      this.containerObjectId = log.getContainerObjectId();
+    }
 
     if ( log.isDetailed() ) {
       log.logDetailed( BaseMessages.getString( PKG, "Trans.Log.TransformationIsPreloaded" ) );

--- a/engine/src/test/java/org/pentaho/di/job/JobTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/JobTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -107,7 +108,9 @@ public class JobTest {
     JobMeta meta = mock( JobMeta.class );
 
     String carteId = UUID.randomUUID().toString();
-    Job job = new Job( repository, meta, carteId );
+    doReturn( carteId ).when( meta ).getContainerObjectId();
+
+    Job job = new Job( repository, meta );
 
     assertEquals( carteId, job.getContainerObjectId() );
   }
@@ -134,11 +137,17 @@ public class JobTest {
   @Test
   public void testTwoJobsGetDifferentLogChannelIdWithDifferentCarteId() {
     Repository repository = mock( Repository.class );
-    JobMeta meta = mock( JobMeta.class );
+    JobMeta meta1 = mock( JobMeta.class );
+    JobMeta meta2 = mock( JobMeta.class );
 
-    // third parameter is the Carte object Id
-    Job job1 = new Job( repository, meta, UUID.randomUUID().toString() );
-    Job job2 = new Job( repository, meta, UUID.randomUUID().toString() );
+    String carteId1 = UUID.randomUUID().toString();
+    String carteId2 = UUID.randomUUID().toString();
+
+    doReturn( carteId1 ).when( meta1 ).getContainerObjectId();
+    doReturn( carteId2 ).when( meta2 ).getContainerObjectId();
+
+    Job job1 = new Job( repository, meta1 );
+    Job job2 = new Job( repository, meta2 );
 
     assertNotEquals( job1.getContainerObjectId(), job2.getContainerObjectId() );
     assertNotEquals( job1.getLogChannelId(), job2.getLogChannelId() );


### PR DESCRIPTION
…s to display incorrectly

This reverts/reworks some of the work done in https://github.com/pentaho/pentaho-kettle/pull/5584 and includes the same fix for transformations.

Merge this before: https://github.com/pentaho/pdi-platform-plugin/pull/64

@cravobranco @ricardosilva88 