### PR TITLE
[PPP-4108] Use of vulnerable component jackson-databind-2.8.8.jar, ja…

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -544,6 +544,16 @@
 
     <!-- Other third-party dependencies -->
     <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-jaxb-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>apache-log4j-extras</artifactId>
       <version>${apache-log4j-extras}</version>


### PR DESCRIPTION
…ckson-databind-2.9.2.jar, jackson-mapper-asl-1.9.2.jar CVE-2017-7525, CVE-2017-15095, CVE-2017-15095

Due to a regression found in DET - Publish Model, we need to add **jackson-jaxrs-json-provider** and **jackson-jaxrs-base** back to `data-integration/lib`. These libraries were there before PPP-4108.

Since these are not transitive dependencies of `kettle-engine`, I figure this is the best place to add them. In #5485 these were removed from: https://github.com/pentaho/pentaho-kettle/pull/5485/files#diff-2648864198c6f1a9221ce8ac97fe85bcL686

@graimundo @pamval