### PR TITLE
[SP-4367] Backport of PPP-4108 - Use of vulnerable component jackson-…

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -544,6 +544,16 @@
 
     <!-- Other third-party dependencies -->
     <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-jaxb-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>apache-log4j-extras</artifactId>
       <version>${apache-log4j-extras}</version>


### PR DESCRIPTION
…databind-2.8.8.jar, jackson-databind-2.9.2.jar, jackson-mapper-asl-1.9.2.jar CVE-2017-7525, CVE-2017-15095, CVE-2017-15095 (8.1 Suite)

Backport of #5633 to 8.1.0.2 branch.

@ricardosilva88 @cravobranco