### PR TITLE
[PDI-17295] Switch / Case step is not working as expected when input …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/switchcase/SwitchCase.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/switchcase/SwitchCase.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.switchcase;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -81,6 +82,9 @@ public class SwitchCase extends BaseStep implements StepInterface {
     // Perhaps there is some conversion needed.
     //
     Object lookupData = data.valueMeta.convertData( data.inputValueMeta, r[data.fieldIndex] );
+
+    // could not use byte[] as key in Maps, so we need to convert it to his specific hashCode for comparisons
+    lookupData = prepareObjectType( lookupData );
 
     // Determine the output set of rowset to use...
     Set<RowSet> rowSetSet = ( data.valueMeta.isNull( lookupData ) ) ? data.nullRowSetSet : data.outputMap.get( lookupData );
@@ -193,6 +197,9 @@ public class SwitchCase extends BaseStep implements StepInterface {
           if ( data.valueMeta.isNull( value ) ) {
             data.nullRowSetSet.add( rowSet );
           } else {
+            // could not use byte[] as key in Maps, so we need to convert it to his specific hashCode for future
+            // comparisons
+            value = prepareObjectType( value );
             data.outputMap.put( value, rowSet );
           }
         } catch ( Exception e ) {
@@ -214,4 +221,9 @@ public class SwitchCase extends BaseStep implements StepInterface {
       throw new KettleException( e );
     }
   }
+
+  protected static Object prepareObjectType( Object o ) {
+    return ( o instanceof byte[] ) ?  Arrays.hashCode( (byte[]) o ) :  o;
+  }
+
 }

--- a/engine/src/test/resources/org/pentaho/di/trans/steps/switchcase/SwitchCaseBinaryTest.xml
+++ b/engine/src/test/resources/org/pentaho/di/trans/steps/switchcase/SwitchCaseBinaryTest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<step>
+	<name>Switch &#x2f; Case</name>
+	<type>SwitchCase</type>
+	<description />
+	<distribute>Y</distribute>
+	<custom_distribution />
+	<copies>1</copies>
+	<partitioning>
+		<method>none</method>
+		<schema_name />
+	</partitioning>
+	<fieldname>num</fieldname>
+	<use_contains>N</use_contains>
+	<case_value_type>Binary</case_value_type>
+	<case_value_format />
+	<case_value_decimal />
+	<case_value_group />
+	<default_target_step>def_1</default_target_step>
+	<cases>
+		<case>
+			<value>1</value>
+			<target_step>f1</target_step>
+		</case>
+		<case>
+			<value>1</value>
+			<target_step>f1 Copy</target_step>
+		</case>
+		<case>
+			<value>0</value>
+			<target_step>f0</target_step>
+		</case>
+		<case>
+			<value />
+			<target_step>null_1_copy</target_step>
+		</case>
+		<case>
+			<value />
+			<target_step>null_1</target_step>
+		</case>
+	</cases>
+</step>


### PR DESCRIPTION
…data is of Binary type.
There was a problem when validating binary values to match in the SwitchCase Step. When testing if a binary was on our "SwitchCase values to match" map, a byte[] was inserted as key in the SwitchCase Map and using byte[] as key, results on bad comparison results. So we need to convert it to it's specific/unique hashCode and using it instead, as comparator.

@ricardosilva88  @pentaho-lmartins @mbatchelor 