### PR TITLE
[TEST] Increasing PanTest, KitchenTest, PanIT, KitchenIT

### DIFF
--- a/engine/src/it/java/org/pentaho/di/kitchen/KitchenIT.java
+++ b/engine/src/it/java/org/pentaho/di/kitchen/KitchenIT.java
@@ -24,15 +24,21 @@ package org.pentaho.di.kitchen;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.pentaho.di.pan.Pan;
+import org.pentaho.di.base.CommandExecutorCodes;
+import org.pentaho.di.core.Result;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
 import java.security.Permission;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class KitchenIT {
 
@@ -53,13 +59,13 @@ public class KitchenIT {
   private static final String EXPECTED_PARAMS_PASSED_ALONG = BASE_PATH + "expected_params_passed_along";
 
   private static final String[] KTRS_EXPECTED_COMPLETE_WITH_SUCCESS = new String[] {
-          "runs_well_hello_world.kjb"
+    "runs_well_hello_world.kjb"
   };
 
   private static final String[] KTRS_EXPECTED_COMPLETE_WITH_FAILURE = new String[] {
-          "fail_on_exec_hello_world.kjb",
-          "fail_on_prep_hello_world.kjb",
-          "missing_referenced_ktr.kjb"
+    "fail_on_exec_hello_world.kjb",
+    "fail_on_prep_hello_world.kjb",
+    "missing_referenced_ktr.kjb"
   };
 
   @Before
@@ -137,6 +143,10 @@ public class KitchenIT {
         assertTrue( logFileContent.contains( JOB_EXEC_RESULT_FALSE ) );
         assertTrue( logFileContent.contains( FAILED_JOB_EXEC_PATTERN ) );
 
+        Result result = Kitchen.getCommandExecutor().getResult();
+        assertNotNull( result );
+        assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.ERRORS_DURING_PROCESSING.getCode() );
+
       } finally {
         // sanitize
         File f = new File( logFileFullPath );
@@ -172,6 +182,10 @@ public class KitchenIT {
         assertTrue( logFileContent.contains( JOB_EXEC_RESULT_TRUE ) );
         assertFalse( logFileContent.contains( FAILED_JOB_EXEC_PATTERN ) );
 
+        Result result = Kitchen.getCommandExecutor().getResult();
+        assertNotNull( result );
+        assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.SUCCESS.getCode() );
+
       } finally {
         // sanitize
         File f = new File( logFileFullPath );
@@ -203,11 +217,11 @@ public class KitchenIT {
     try {
 
       Kitchen.main( new String[] {
-              "/file:" + testKJBFullPath,
-              "/level:Basic",
-              "/logfile:" + logFileFullPath,
-              "/param:" + param1Name + "=" + param1Val,
-              "/param:" + param2Name + "=" + param2Val
+        "/file:" + testKJBFullPath,
+        "/level:Basic",
+        "/logfile:" + logFileFullPath,
+        "/param:" + param1Name + "=" + param1Val,
+        "/param:" + param2Name + "=" + param2Val
       } );
 
     } catch ( SecurityException e ) {
@@ -219,6 +233,10 @@ public class KitchenIT {
       assertTrue( logFileContent.contains( EXPECTED_OUTPUT ) );
       assertTrue( logFileContent.contains( JOB_EXEC_RESULT_TRUE ) );
       assertFalse( logFileContent.contains( FAILED_JOB_EXEC_PATTERN ) );
+
+      Result result = Kitchen.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.SUCCESS.getCode() );
 
     } finally {
       // sanitize

--- a/engine/src/it/java/org/pentaho/di/pan/PanIT.java
+++ b/engine/src/it/java/org/pentaho/di/pan/PanIT.java
@@ -24,21 +24,25 @@ package org.pentaho.di.pan;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.Result;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.util.FileUtil;
 import org.pentaho.di.core.util.Utils;
 
-import java.io.*;
-import java.net.URL;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
 import java.security.Permission;
-import java.util.Enumeration;
-import java.util.Random;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class PanIT {
@@ -107,6 +111,10 @@ public class PanIT {
 
       assertTrue( !logFileContent.contains( FAILED_TO_INITIALIZE_ERROR_PATTERN ) &&  errorCount == 0 );
 
+      Result result = Pan.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Pan.SUCCESS.getCode() );
+
     } finally {
       // sanitize
       File f = new File( logFileFullPath );
@@ -140,6 +148,10 @@ public class PanIT {
       int errorCount = parseErrorCount( logFileContent );
 
       assertTrue( !logFileContent.contains( FAILED_TO_INITIALIZE_ERROR_PATTERN ) &&  errorCount == 0 );
+
+      Result result = Pan.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Pan.SUCCESS.getCode() );
 
     } finally {
       // sanitize
@@ -177,6 +189,10 @@ public class PanIT {
 
         assertTrue( logFileContent.contains( FAILED_TO_INITIALIZE_ERROR_PATTERN ) ||  errorCount > 0 );
 
+        Result result = Pan.getCommandExecutor().getResult();
+        assertNotNull( result );
+        assertEquals( result.getExitStatus(), CommandExecutorCodes.Pan.ERRORS_DURING_PROCESSING.getCode() );
+
       } finally {
         // sanitize
         File f = new File( logFileFullPath );
@@ -213,6 +229,10 @@ public class PanIT {
         int errorCount = parseErrorCount( logFileContent );
 
         assertTrue( !logFileContent.contains( FAILED_TO_INITIALIZE_ERROR_PATTERN ) &&  errorCount == 0 );
+
+        Result result = Pan.getCommandExecutor().getResult();
+        assertNotNull( result );
+        assertEquals( result.getExitStatus(), CommandExecutorCodes.Pan.SUCCESS.getCode() );
 
       } finally {
         // sanitize
@@ -263,6 +283,10 @@ public class PanIT {
 
       assertTrue( !logFileContent.contains( FAILED_TO_INITIALIZE_ERROR_PATTERN ) && errorCount == 0 );
       assertTrue( logFileContent.contains( EXPECTED_OUTPUT ) );
+
+      Result result = Pan.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Pan.SUCCESS.getCode() );
 
     } finally {
       // sanitize

--- a/engine/src/main/java/org/pentaho/di/base/AbstractBaseCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractBaseCommandExecutor.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.Result;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleSecurityException;
@@ -52,6 +53,13 @@ public abstract class AbstractBaseCommandExecutor {
   private LogChannelInterface log;
   private Class<?> pkgClazz;
   DelegatingMetaStore metaStore;
+
+  private Result result = new Result();
+
+  protected Result exitWithStatus( final int exitStatus ) {
+    getResult().setExitStatus( exitStatus );
+    return getResult();
+  }
 
   public DelegatingMetaStore createDefaultMetastore() throws MetaStoreException {
     DelegatingMetaStore metaStore = new DelegatingMetaStore();
@@ -217,5 +225,13 @@ public abstract class AbstractBaseCommandExecutor {
 
   public void setDateFormat( SimpleDateFormat dateFormat ) {
     this.dateFormat = dateFormat;
+  }
+
+  public Result getResult() {
+    return result;
+  }
+
+  public void setResult( Result result ) {
+    this.result = result;
   }
 }

--- a/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Future;
 
 import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.Result;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.KettleEnvironment;
@@ -241,7 +242,7 @@ public class Kitchen {
 
     // Start the action...
     //
-    int returnCode = CommandExecutorCodes.Kitchen.SUCCESS.getCode();
+    Result result = new Result();
 
     try {
 
@@ -256,14 +257,14 @@ public class Kitchen {
         }
       }
 
-      returnCode = getCommandExecutor().execute( optionRepname.toString(), optionNorep.toString(), optionUsername.toString(),
+      result = getCommandExecutor().execute( optionRepname.toString(), optionNorep.toString(), optionUsername.toString(),
             optionTrustUser.toString(), optionPassword.toString(), optionDirname.toString(), optionFilename.toString(), optionJobname.toString(), optionListjobs.toString(),
             optionListdir.toString(), optionExport.toString(), initialDir.toString(), optionListrep.toString(), optionListParam.toString(),
             optionParams, customOptions, args.toArray( new String[ args.size() ] ) );
 
     } catch ( Throwable t ) {
       t.printStackTrace();
-      returnCode = CommandExecutorCodes.Pan.UNEXPECTED_ERROR.getCode();
+      result.setExitStatus( CommandExecutorCodes.Pan.UNEXPECTED_ERROR.getCode() );
 
     } finally {
       if ( fileAppender != null ) {
@@ -272,7 +273,7 @@ public class Kitchen {
       }
     }
 
-    exitJVM( returnCode );
+    exitJVM( result.getExitStatus() );
 
   }
 

--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.Result;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.KettleEnvironment;
@@ -227,13 +228,13 @@ public class Pan {
         }
       }
 
-      int returnCode = getCommandExecutor().execute( optionRepname.toString(), optionNorep.toString(), optionUsername.toString(),
+      Result result = getCommandExecutor().execute( optionRepname.toString(), optionNorep.toString(), optionUsername.toString(),
               optionTrustUser.toString(), optionPassword.toString(), optionDirname.toString(), optionFilename.toString(), optionJarFilename.toString(),
               optionTransname.toString(), optionListtrans.toString(), optionListdir.toString(), optionExprep.toString(),
               initialDir.toString(), optionListrep.toString(), optionSafemode.toString(), optionMetrics.toString(),
               optionListParam.toString(), optionParams, args.toArray( new String[ args.size() ] ) );
 
-      exitJVM( returnCode );
+      exitJVM( result.getExitStatus() );
 
     } catch ( Throwable t ) {
       t.printStackTrace();

--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
@@ -25,7 +25,9 @@ package org.pentaho.di.kitchen;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.Result;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleSecurityException;
 import org.pentaho.di.job.Job;
@@ -40,6 +42,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.security.Permission;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyBoolean;
@@ -142,6 +145,10 @@ public class KitchenTest {
       assertTrue( sysOutContent.toString().contains( TEST_REPO_DUMMY_NAME ) );
       assertTrue( sysOutContent.toString().contains( TEST_REPO_DUMMY_DESC ) );
 
+      Result result = Kitchen.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode() );
+
     } finally {
       // sanitize
 
@@ -187,6 +194,10 @@ public class KitchenTest {
       assertTrue( sysOutContent.toString().contains( DUMMY_DIR_1 ) );
       assertTrue( sysOutContent.toString().contains( DUMMY_DIR_2 ) );
 
+      Result result = Kitchen.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode() );
+
     } finally {
       // sanitize
 
@@ -230,6 +241,10 @@ public class KitchenTest {
 
       assertTrue( sysOutContent.toString().contains( DUMMY_JOB_1 ) );
       assertTrue( sysOutContent.toString().contains( DUMMY_JOB_2 ) );
+
+      Result result = Kitchen.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode() );
 
     } finally {
       // sanitize

--- a/engine/src/test/java/org/pentaho/di/pan/PanTest.java
+++ b/engine/src/test/java/org/pentaho/di/pan/PanTest.java
@@ -27,7 +27,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.Result;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleSecurityException;
 import org.pentaho.di.core.parameters.NamedParams;
@@ -47,6 +49,7 @@ import java.security.Permission;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
@@ -160,6 +163,10 @@ public class PanTest {
       assertTrue( sysOutContent.toString().contains( TEST_REPO_DUMMY_NAME ) );
       assertTrue( sysOutContent.toString().contains( TEST_REPO_DUMMY_DESC ) );
 
+      Result result = Pan.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Pan.SUCCESS.getCode() );
+
     } finally {
       // sanitize
 
@@ -205,6 +212,10 @@ public class PanTest {
       assertTrue( sysOutContent.toString().contains( DUMMY_DIR_1 ) );
       assertTrue( sysOutContent.toString().contains( DUMMY_DIR_2 ) );
 
+      Result result = Pan.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Pan.SUCCESS.getCode() );
+
     } finally {
       // sanitize
 
@@ -248,6 +259,10 @@ public class PanTest {
 
       assertTrue( sysOutContent.toString().contains( DUMMY_TRANS_1 ) );
       assertTrue( sysOutContent.toString().contains( DUMMY_TRANS_2 ) );
+
+      Result result = Pan.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Pan.SUCCESS.getCode() );
 
     } finally {
       // sanitize


### PR DESCRIPTION
- Expanding unit tests for PanTest, KitchenTest, PanIT, KitchenIT, testing the `exitStatus` returned within `org.pentaho.di.core.Result` 
  - further tests be done, testing further data returned within `org.pentaho.di.core.Result`
- `PanCommandExecutor` / `KitchenCommandExecutor` now return `org.pentaho.di.core.Result` obj instead of the `exitStatus` int primitive value
- `exitStatus` int primitive value is found in `Result.getExitStatus()`
- checkstyle fixes
  - single-line imports instead of `*`
  - deleted unused imports
  - checkstyle issues

### To test Pan / Kitchen

- `mvn clean verify -Dtest=PanTest -DrunITs -Dit.test=PanIT`
- `mvn clean verify -Dtest=KitchenTest -DrunITs -Dit.test=KitchenIT`


To be merged alongside

@pentaho/rogueone please review