### PR TITLE
[TEST] Adding helper methods to CommandExecutorCodes.Pan / CommandExe…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/CommandExecutorCodes.java
+++ b/engine/src/main/java/org/pentaho/di/base/CommandExecutorCodes.java
@@ -22,6 +22,8 @@
 
 package org.pentaho.di.base;
 
+import java.util.Arrays;
+
 /**
  * @link https://help.pentaho.com/Documentation/8.0/Products/Data_Integration/Command_Line_Tools
  */
@@ -64,6 +66,19 @@ public class CommandExecutorCodes {
     public void setDescription( String description ) {
       this.description = description;
     }
+
+    public static Pan getByCode( final int code ) {
+      return Arrays.asList( Pan.values() ).stream()
+          .filter( pan -> pan.getCode() == code )
+          .findAny().orElse( null );
+    }
+
+    public static boolean isFailedExecution( final int code ) {
+      return Pan.UNEXPECTED_ERROR.getCode() == code
+          || Pan.UNABLE_TO_PREP_INIT_TRANS.getCode() == code
+          || Pan.COULD_NOT_LOAD_TRANS.getCode() == code
+          || Pan.ERROR_LOADING_STEPS_PLUGINS.getCode() == code;
+    }
   }
 
   /**
@@ -101,6 +116,18 @@ public class CommandExecutorCodes {
 
     public void setDescription( String description ) {
       this.description = description;
+    }
+
+    public static Kitchen getByCode( final int code ) {
+      return Arrays.asList( Kitchen.values() ).stream()
+          .filter( kitchen -> kitchen.getCode() == code )
+          .findAny().orElse( null );
+    }
+
+    public static boolean isFailedExecution( final int code ) {
+      return Kitchen.UNEXPECTED_ERROR.getCode() == code
+          || Kitchen.COULD_NOT_LOAD_JOB.getCode() == code
+          || Kitchen.ERROR_LOADING_STEPS_PLUGINS.getCode() == code;
     }
   }
 }

--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
@@ -98,8 +98,8 @@ public class KitchenTest {
     assertNull( CommandExecutorCodes.Kitchen.getByCode( 9999 ) );
     assertNotNull( CommandExecutorCodes.Kitchen.getByCode( 0 ) );
 
-    assertEquals( CommandExecutorCodes.Kitchen.UNEXPECTED_ERROR, CommandExecutorCodes.Pan.getByCode( 2 ) );
-    assertEquals( CommandExecutorCodes.Kitchen.CMD_LINE_PRINT, CommandExecutorCodes.Pan.getByCode( 9 ) );
+    assertEquals( CommandExecutorCodes.Kitchen.UNEXPECTED_ERROR, CommandExecutorCodes.Kitchen.getByCode( 2 ) );
+    assertEquals( CommandExecutorCodes.Kitchen.CMD_LINE_PRINT, CommandExecutorCodes.Kitchen.getByCode( 9 ) );
 
     assertEquals( "The job ran without a problem", CommandExecutorCodes.Kitchen.getByCode( 0 ).getDescription() );
     assertEquals( "The job couldn't be loaded from XML or the Repository", CommandExecutorCodes.Kitchen.getByCode( 7 ).getDescription() );

--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
@@ -42,9 +42,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.security.Permission;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
@@ -88,6 +90,24 @@ public class KitchenTest {
     mockRepositoryMeta = null;
     mockRepository = null;
     mockRepositoryDirectory = null;
+  }
+
+  @Test
+  public void testKitchenStatusCodes() throws Exception {
+
+    assertNull( CommandExecutorCodes.Kitchen.getByCode( 9999 ) );
+    assertNotNull( CommandExecutorCodes.Kitchen.getByCode( 0 ) );
+
+    assertEquals( CommandExecutorCodes.Kitchen.UNEXPECTED_ERROR, CommandExecutorCodes.Pan.getByCode( 2 ) );
+    assertEquals( CommandExecutorCodes.Kitchen.CMD_LINE_PRINT, CommandExecutorCodes.Pan.getByCode( 9 ) );
+
+    assertEquals( "The job ran without a problem", CommandExecutorCodes.Kitchen.getByCode( 0 ).getDescription() );
+    assertEquals( "The job couldn't be loaded from XML or the Repository", CommandExecutorCodes.Kitchen.getByCode( 7 ).getDescription() );
+
+    assertTrue( CommandExecutorCodes.Kitchen.isFailedExecution( CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode() ) );
+    assertTrue( CommandExecutorCodes.Kitchen.isFailedExecution( CommandExecutorCodes.Kitchen.ERROR_LOADING_STEPS_PLUGINS.getCode() ) );
+    assertFalse( CommandExecutorCodes.Kitchen.isFailedExecution( CommandExecutorCodes.Kitchen.SUCCESS.getCode() ) );
+    assertFalse( CommandExecutorCodes.Kitchen.isFailedExecution( CommandExecutorCodes.Kitchen.ERRORS_DURING_PROCESSING.getCode() ) );
   }
 
   @Test

--- a/engine/src/test/java/org/pentaho/di/pan/PanTest.java
+++ b/engine/src/test/java/org/pentaho/di/pan/PanTest.java
@@ -47,9 +47,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.security.Permission;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
@@ -98,6 +100,24 @@ public class PanTest {
     mockRepositoryMeta = null;
     mockRepository = null;
     mockRepositoryDirectory = null;
+  }
+
+  @Test
+  public void testPanStatusCodes() throws Exception {
+
+    assertNull( CommandExecutorCodes.Pan.getByCode( 9999 ) );
+    assertNotNull( CommandExecutorCodes.Pan.getByCode( 0 ) );
+
+    assertEquals( CommandExecutorCodes.Pan.UNEXPECTED_ERROR, CommandExecutorCodes.Pan.getByCode( 2 ) );
+    assertEquals( CommandExecutorCodes.Pan.CMD_LINE_PRINT, CommandExecutorCodes.Pan.getByCode( 9 ) );
+
+    assertEquals( "The transformation ran without a problem", CommandExecutorCodes.Pan.getByCode( 0 ).getDescription() );
+    assertEquals( "The transformation couldn't be loaded from XML or the Repository", CommandExecutorCodes.Pan.getByCode( 7 ).getDescription() );
+
+    assertTrue( CommandExecutorCodes.Pan.isFailedExecution( CommandExecutorCodes.Pan.COULD_NOT_LOAD_TRANS.getCode() ) );
+    assertTrue( CommandExecutorCodes.Pan.isFailedExecution( CommandExecutorCodes.Pan.ERROR_LOADING_STEPS_PLUGINS.getCode() ) );
+    assertFalse( CommandExecutorCodes.Pan.isFailedExecution( CommandExecutorCodes.Pan.SUCCESS.getCode() ) );
+    assertFalse( CommandExecutorCodes.Pan.isFailedExecution( CommandExecutorCodes.Pan.ERRORS_DURING_PROCESSING.getCode() ) );
   }
 
   @Test


### PR DESCRIPTION
…cutorCodes.Kitchen, as well as unit tests for those

### To test Pan / Kitchen

- `mvn clean verify -Dtest=PanTest -DrunITs -Dit.test=PanIT`
- `mvn clean verify -Dtest=KitchenTest -DrunITs -Dit.test=KitchenIT`

@pentaho/rogueone 