### PR TITLE
[BACKLOG-24617] Adding support for serialization of InjectionDeep lists

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -1936,7 +1936,7 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
     this.privateDatabases = privateDatabases;
   }
 
-  public void saveSharedObjects() throws KettleException {
+  @Override public void saveSharedObjects() throws KettleException {
     try {
       // Load all the shared objects...
       String soFile = environmentSubstitute( sharedObjectsFile );
@@ -2092,7 +2092,7 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
     return this.versioningEnabled;
   }
 
-  private class RunOptions {
+  private static class RunOptions {
     boolean clearingLog;
     boolean safeModeEnabled;
 

--- a/engine/src/main/java/org/pentaho/di/core/EngineMetaInterface.java
+++ b/engine/src/main/java/org/pentaho/di/core/EngineMetaInterface.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -36,24 +36,24 @@ public interface EngineMetaInterface extends RepositoryElementInterface {
    *
    * @param filename
    */
-  public void setFilename( String filename );
+  void setFilename( String filename );
 
   /**
    * Gets the name.
    *
    * @return name
    */
-  public String getName();
+  @Override String getName();
 
   /**
    * Builds a name for this. If no name is yet set, create the name from the filename.
    */
-  public void nameFromFilename();
+  void nameFromFilename();
 
   /**
    * Clears the changed flag of this.
    */
-  public void clearChanged();
+  void clearChanged();
 
   /**
    * Gets the XML representation.
@@ -64,33 +64,33 @@ public interface EngineMetaInterface extends RepositoryElementInterface {
    * @see org.pentaho.di.core.xml.XMLInterface#getXML()
    */
 
-  public String getXML() throws KettleException;
+  String getXML() throws KettleException;
 
   /**
    * Gets the file type.
    *
    * @return the file type
    */
-  public String getFileType();
+  String getFileType();
 
   /**
    * Gets the filter names.
    */
-  public String[] getFilterNames();
+  String[] getFilterNames();
 
   /**
    * Gets the filter extensions.
    *
    * @return the filter extensions
    */
-  public String[] getFilterExtensions();
+  String[] getFilterExtensions();
 
   /**
    * Gets the default extension.
    *
    * @return default extension
    */
-  public String getDefaultExtension();
+  String getDefaultExtension();
 
   /**
    * Set the database ID for this in the repository.
@@ -98,100 +98,99 @@ public interface EngineMetaInterface extends RepositoryElementInterface {
    * @param id
    *          the database ID for this in the repository
    */
-  public void setObjectId( ObjectId id );
+  @Override void setObjectId( ObjectId id );
 
   /**
    * Gets the date the transformation was created.
    *
    * @return the date the transformation was created
    */
-  public Date getCreatedDate();
+  Date getCreatedDate();
 
   /**
    * Sets the date the transformation was created.
    *
-   * @param createdDate
+   * @param date
    *          The creation date to set
    */
-  public void setCreatedDate( Date date );
+  void setCreatedDate( Date date );
 
   /**
    * Returns whether or not the this can be saved.
    *
    * @return
    */
-  public boolean canSave();
+  boolean canSave();
 
   /**
    * Gets the user by whom this was created.
    *
    * @return the user by whom this was created
    */
-  public String getCreatedUser();
+  String getCreatedUser();
 
   /**
    * Sets the user by whom this was created.
    *
-   * @param createdUser
+   * @param createduser
    *          The user to set
    */
-  public void setCreatedUser( String createduser );
+  void setCreatedUser( String createduser );
 
   /**
    * Gets the date this was modified.
    *
    * @return the date this was modified
    */
-  public Date getModifiedDate();
+  Date getModifiedDate();
 
   /**
    * Sets the date this was modified.
    *
-   * @param modifiedDate
+   * @param date
    *          The modified date to set
    */
-  public void setModifiedDate( Date date );
+  void setModifiedDate( Date date );
 
   /**
    * Sets the user who last modified this.
    *
-   * @param modifiedUser
+   * @param user
    *          The user name to set
    */
-  public void setModifiedUser( String user );
+  void setModifiedUser( String user );
 
   /**
    * Gets the user who last modified this.
    *
    * @return the user who last modified this
    */
-  public String getModifiedUser();
+  String getModifiedUser();
 
   /**
    * Gets the repository element type.
    *
    * @return the repository element type
    */
-  public RepositoryDirectoryInterface getRepositoryDirectory();
+  @Override RepositoryDirectoryInterface getRepositoryDirectory();
 
   /**
    * Get the filename (if any).
    *
    * @return the filename
    */
-  public String getFilename();
+  String getFilename();
 
   /**
    * Saves shared objects, including databases, steps, partition schemas, slave servers, and cluster schemas, to a file.
    *
-   * @throws KettleException
    */
-  public void saveSharedObjects() throws KettleException;
+  void saveSharedObjects() throws KettleException;
 
   /**
    * Sets the internal kettle variables.
    */
-  public void setInternalKettleVariables();
+  void setInternalKettleVariables();
 
   /**
    * Set versioning enabled
@@ -199,7 +198,7 @@ public interface EngineMetaInterface extends RepositoryElementInterface {
    * @param versioningEnabled
    *          is versioning enabled
    */
-  public default void setVersioningEnabled( Boolean versioningEnabled ) {
+  default void setVersioningEnabled( Boolean versioningEnabled ) {
     // Default implementation does nothing
   }
 
@@ -208,7 +207,7 @@ public interface EngineMetaInterface extends RepositoryElementInterface {
    *
    * @return is versioning enabled
    */
-  public default Boolean getVersioningEnabled() {
+  default Boolean getVersioningEnabled() {
     return null;
   }
 

--- a/engine/src/main/java/org/pentaho/di/core/util/serialization/StepMetaProps.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/serialization/StepMetaProps.java
@@ -44,6 +44,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.groupingBy;
@@ -189,6 +190,8 @@ public class StepMetaProps {
       Object o = injector.getPropVal( stepMeta, prop.getName() );
       if ( o instanceof List ) {
         ret = (List<Object>) o;
+      } else if ( o instanceof Object[] ) {
+        ret = asList( (Object[]) o );
       } else {
         ret = singletonList( o );
       }
@@ -267,11 +270,9 @@ public class StepMetaProps {
    * Represents a named grouping of properties, corresponding to a metadata injection group.
    */
   private static class PropGroup {
-    @XmlAttribute
-    String name;
+    @XmlAttribute String name;
 
-    @XmlElement ( name = "property" )
-    List<Prop> props;
+    @XmlElement ( name = "property" ) List<Prop> props;
 
     @SuppressWarnings ( "unused" )
     public PropGroup() {
@@ -292,14 +293,10 @@ public class StepMetaProps {
    * Values are captured as a List<Object> to consistently handle both List properties and single items.
    */
   private static class Prop {
-    @XmlAttribute
-    String group;
+    @XmlAttribute String group;
+    @XmlAttribute String name;
 
-    @XmlAttribute
-    String name;
-
-    @XmlElement ( name = "value" )
-    List<Object> value = new ArrayList<>();
+    @XmlElement ( name = "value" ) List<Object> value = new ArrayList<>();
 
     @SuppressWarnings ( "unused" )
     public Prop() {

--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -334,7 +334,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
 
       // create the class
       // Try to instantiate this one...
-      Job job = (Job) jobClass.newInstance();
+      Job job = (Job) jobClass.getDeclaredConstructor().newInstance();
 
       // Done!
       return job;
@@ -358,7 +358,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
   /**
    * Threads main loop: called by Thread.start();
    */
-  public void run() {
+  @Override public void run() {
 
     ExecutorService heartbeat = null; // this job's heartbeat scheduled executor
 
@@ -793,7 +793,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
           threadEntries.add( nextEntry );
 
           Runnable runnable = new Runnable() {
-            public void run() {
+            @Override public void run() {
               try {
                 Result threadResult = execute( nr + 1, newResult, nextEntry, jobEntryCopy, nextComment );
                 threadResults.add( threadResult );
@@ -976,7 +976,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
 
       try {
         // See if we have to add a batch id...
-        Long id_batch = new Long( 1 );
+        Long id_batch = 1L;
         if ( jobMeta.getJobLogTable().isBatchIdUsed() ) {
           id_batch = logcon.getNextBatchId( ldb, schemaName, tableName, jobLogTable.getKeyField().getFieldName() );
           setBatchId( id_batch.longValue() );
@@ -1012,7 +1012,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
         if ( intervalInSeconds > 0 ) {
           final Timer timer = new Timer( getName() + " - interval logging timer" );
           TimerTask timerTask = new TimerTask() {
-            public void run() {
+            @Override public void run() {
               try {
                 endProcessing();
               } catch ( Exception e ) {
@@ -1028,7 +1028,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
           timer.schedule( timerTask, intervalInSeconds * 1000, intervalInSeconds * 1000 );
 
           addJobListener( new JobAdapter() {
-            public void jobFinished( Job job ) {
+            @Override public void jobFinished( Job job ) {
               timer.cancel();
             }
           } );
@@ -1038,7 +1038,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
         // log record...
         //
         addJobListener( new JobAdapter() {
-          public void jobFinished( Job job ) throws KettleException {
+          @Override public void jobFinished( Job job ) throws KettleException {
             try {
               endProcessing();
             } catch ( KettleJobException e ) {
@@ -1065,7 +1065,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
     JobEntryLogTable jobEntryLogTable = jobMeta.getJobEntryLogTable();
     if ( jobEntryLogTable.isDefined() ) {
       addJobListener( new JobAdapter() {
-        public void jobFinished( Job job ) throws KettleException {
+        @Override public void jobFinished( Job job ) throws KettleException {
           try {
             writeJobEntryLogInformation();
           } catch ( KettleException e ) {
@@ -1083,7 +1083,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
     if ( channelLogTable.isDefined() ) {
       addJobListener( new JobAdapter() {
 
-        public void jobFinished( Job job ) throws KettleException {
+        @Override public void jobFinished( Job job ) throws KettleException {
           try {
             writeLogChannelInformation();
           } catch ( KettleException e ) {
@@ -1467,7 +1467,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#copyVariablesFrom(org.pentaho.di.core.variables.VariableSpace)
    */
-  public void copyVariablesFrom( VariableSpace space ) {
+  @Override public void copyVariablesFrom( VariableSpace space ) {
     variables.copyVariablesFrom( space );
   }
 
@@ -1476,7 +1476,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#environmentSubstitute(java.lang.String)
    */
-  public String environmentSubstitute( String aString ) {
+  @Override public String environmentSubstitute( String aString ) {
     return variables.environmentSubstitute( aString );
   }
 
@@ -1485,11 +1485,11 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#environmentSubstitute(java.lang.String[])
    */
-  public String[] environmentSubstitute( String[] aString ) {
+  @Override public String[] environmentSubstitute( String[] aString ) {
     return variables.environmentSubstitute( aString );
   }
 
-  public String fieldSubstitute( String aString, RowMetaInterface rowMeta, Object[] rowData )
+  @Override public String fieldSubstitute( String aString, RowMetaInterface rowMeta, Object[] rowData )
     throws KettleValueException {
     return variables.fieldSubstitute( aString, rowMeta, rowData );
   }
@@ -1499,7 +1499,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#getParentVariableSpace()
    */
-  public VariableSpace getParentVariableSpace() {
+  @Override public VariableSpace getParentVariableSpace() {
     return variables.getParentVariableSpace();
   }
 
@@ -1509,7 +1509,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    * @see
    * org.pentaho.di.core.variables.VariableSpace#setParentVariableSpace(org.pentaho.di.core.variables.VariableSpace)
    */
-  public void setParentVariableSpace( VariableSpace parent ) {
+  @Override public void setParentVariableSpace( VariableSpace parent ) {
     variables.setParentVariableSpace( parent );
   }
 
@@ -1518,7 +1518,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#getVariable(java.lang.String, java.lang.String)
    */
-  public String getVariable( String variableName, String defaultValue ) {
+  @Override public String getVariable( String variableName, String defaultValue ) {
     return variables.getVariable( variableName, defaultValue );
   }
 
@@ -1527,7 +1527,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#getVariable(java.lang.String)
    */
-  public String getVariable( String variableName ) {
+  @Override public String getVariable( String variableName ) {
     return variables.getVariable( variableName );
   }
 
@@ -1536,7 +1536,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#getBooleanValueOfVariable(java.lang.String, boolean)
    */
-  public boolean getBooleanValueOfVariable( String variableName, boolean defaultValue ) {
+  @Override public boolean getBooleanValueOfVariable( String variableName, boolean defaultValue ) {
     if ( !Utils.isEmpty( variableName ) ) {
       String value = environmentSubstitute( variableName );
       if ( !Utils.isEmpty( value ) ) {
@@ -1552,7 +1552,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    * @see
    * org.pentaho.di.core.variables.VariableSpace#initializeVariablesFrom(org.pentaho.di.core.variables.VariableSpace)
    */
-  public void initializeVariablesFrom( VariableSpace parent ) {
+  @Override public void initializeVariablesFrom( VariableSpace parent ) {
     variables.initializeVariablesFrom( parent );
   }
 
@@ -1561,7 +1561,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#listVariables()
    */
-  public String[] listVariables() {
+  @Override public String[] listVariables() {
     return variables.listVariables();
   }
 
@@ -1570,7 +1570,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#setVariable(java.lang.String, java.lang.String)
    */
-  public void setVariable( String variableName, String variableValue ) {
+  @Override public void setVariable( String variableName, String variableValue ) {
     variables.setVariable( variableName, variableValue );
   }
 
@@ -1579,7 +1579,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#shareVariablesWith(org.pentaho.di.core.variables.VariableSpace)
    */
-  public void shareVariablesWith( VariableSpace space ) {
+  @Override public void shareVariablesWith( VariableSpace space ) {
     variables = space;
   }
 
@@ -1588,7 +1588,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.variables.VariableSpace#injectVariables(java.util.Map)
    */
-  public void injectVariables( Map<String, String> prop ) {
+  @Override public void injectVariables( Map<String, String> prop ) {
     variables.injectVariables( prop );
   }
 
@@ -1744,7 +1744,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    * @see org.pentaho.di.core.parameters.NamedParams#addParameterDefinition(java.lang.String, java.lang.String,
    * java.lang.String)
    */
-  public void addParameterDefinition( String key, String defValue, String description ) throws DuplicateParamException {
+  @Override public void addParameterDefinition( String key, String defValue, String description ) throws DuplicateParamException {
     namedParams.addParameterDefinition( key, defValue, description );
   }
 
@@ -1753,7 +1753,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.parameters.NamedParams#getParameterDescription(java.lang.String)
    */
-  public String getParameterDescription( String key ) throws UnknownParamException {
+  @Override public String getParameterDescription( String key ) throws UnknownParamException {
     return namedParams.getParameterDescription( key );
   }
 
@@ -1762,7 +1762,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.parameters.NamedParams#getParameterDefault(java.lang.String)
    */
-  public String getParameterDefault( String key ) throws UnknownParamException {
+  @Override public String getParameterDefault( String key ) throws UnknownParamException {
     return namedParams.getParameterDefault( key );
   }
 
@@ -1771,7 +1771,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.parameters.NamedParams#getParameterValue(java.lang.String)
    */
-  public String getParameterValue( String key ) throws UnknownParamException {
+  @Override public String getParameterValue( String key ) throws UnknownParamException {
     return namedParams.getParameterValue( key );
   }
 
@@ -1780,7 +1780,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.parameters.NamedParams#listParameters()
    */
-  public String[] listParameters() {
+  @Override public String[] listParameters() {
     return namedParams.listParameters();
   }
 
@@ -1789,7 +1789,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    *
    * @see org.pentaho.di.core.parameters.NamedParams#setParameterValue(java.lang.String, java.lang.String)
    */
-  public void setParameterValue( String key, String value ) throws UnknownParamException {
+  @Override public void setParameterValue( String key, String value ) throws UnknownParamException {
     namedParams.setParameterValue( key, value );
   }
 

--- a/engine/src/main/java/org/pentaho/di/trans/TransAdapter.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransAdapter.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,14 +32,14 @@ import org.pentaho.di.core.exception.KettleException;
  */
 public class TransAdapter implements TransListener {
 
-  public void transStarted( Trans trans ) throws KettleException {
+  @Override public void transStarted( Trans trans ) throws KettleException {
 
   }
 
-  public void transActive( Trans trans ) {
+  @Override public void transActive( Trans trans ) {
   }
 
-  public void transFinished( Trans trans ) throws KettleException {
+  @Override public void transFinished( Trans trans ) throws KettleException {
   }
 
 }

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -320,10 +320,10 @@ public class TransMeta extends AbstractMeta
         .getString( PKG, "TransMeta.TransformationType.SingleThreaded" ) );
 
     /** The code corresponding to the transformation type. */
-    private String code;
+    private final String code;
 
     /** The description of the transformation type. */
-    private String description;
+    private final String description;
 
     /**
      * Instantiates a new transformation type.
@@ -333,7 +333,7 @@ public class TransMeta extends AbstractMeta
      * @param description
      *          the description
      */
-    private TransformationType( String code, String description ) {
+    TransformationType( String code, String description ) {
       this.code = code;
       this.description = description;
     }
@@ -5554,7 +5554,7 @@ public class TransMeta extends AbstractMeta
     setChanged();
   }
 
-  protected List<SharedObjectInterface> getAllSharedObjects() {
+  @Override protected List<SharedObjectInterface> getAllSharedObjects() {
     List<SharedObjectInterface> shared = super.getAllSharedObjects();
     shared.addAll( steps );
     shared.addAll( partitionSchemas );

--- a/engine/src/main/java/org/pentaho/di/trans/step/BaseStep.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/BaseStep.java
@@ -3210,32 +3210,32 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
 
     r.addValueMeta( new ValueMetaNumber(
       BaseMessages.getString( PKG, "BaseStep.ColumnName.Copy" ) ) );
-    data[ nr ] = new Double( copynr );
+    data[ nr ] = (double) copynr;
     nr++;
 
     r.addValueMeta( new ValueMetaNumber(
       BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesReaded" ) ) );
-    data[ nr ] = new Double( lines_read );
+    data[ nr ] = (double) lines_read;
     nr++;
 
     r.addValueMeta( new ValueMetaNumber(
       BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesWritten" ) ) );
-    data[ nr ] = new Double( lines_written );
+    data[ nr ] = (double) lines_written;
     nr++;
 
     r.addValueMeta( new ValueMetaNumber(
       BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesUpdated" ) ) );
-    data[ nr ] = new Double( lines_updated );
+    data[ nr ] = (double) lines_updated;
     nr++;
 
     r.addValueMeta( new ValueMetaNumber(
       BaseMessages.getString( PKG, "BaseStep.ColumnName.LinesSkipped" ) ) );
-    data[ nr ] = new Double( lines_skipped );
+    data[ nr ] = (double) lines_skipped;
     nr++;
 
     r.addValueMeta( new ValueMetaNumber(
       BaseMessages.getString( PKG, "BaseStep.ColumnName.Errors" ) ) );
-    data[ nr ] = new Double( errors );
+    data[ nr ] = (double) errors;
     nr++;
 
     r.addValueMeta( new ValueMetaDate( "start_date" ) );
@@ -4396,7 +4396,7 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
       return handleGetRowFrom( rowSet );
     }
 
-    public void putRowTo( RowMetaInterface rowMeta, Object[] row, RowSet rowSet ) throws KettleStepException {
+    @Override public void putRowTo( RowMetaInterface rowMeta, Object[] row, RowSet rowSet ) throws KettleStepException {
       handlePutRowTo( rowMeta, row, rowSet );
     }
 

--- a/engine/src/main/java/org/pentaho/di/trans/step/BaseStepData.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/BaseStepData.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -120,7 +120,7 @@ public abstract class BaseStepData implements StepDataInterface {
    * @param status
    *          the new status.
    */
-  public void setStatus( StepExecutionStatus status ) {
+  @Override public void setStatus( StepExecutionStatus status ) {
     this.status = status;
   }
 
@@ -129,7 +129,7 @@ public abstract class BaseStepData implements StepDataInterface {
    *
    * @return the status of the step data
    */
-  public StepExecutionStatus getStatus() {
+  @Override public StepExecutionStatus getStatus() {
     return status;
   }
 
@@ -138,7 +138,7 @@ public abstract class BaseStepData implements StepDataInterface {
    *
    * @return true, if is empty
    */
-  public boolean isEmpty() {
+  @Override public boolean isEmpty() {
     return status == StepExecutionStatus.STATUS_EMPTY;
   }
 
@@ -147,7 +147,7 @@ public abstract class BaseStepData implements StepDataInterface {
    *
    * @return true, if is initialising
    */
-  public boolean isInitialising() {
+  @Override public boolean isInitialising() {
     return status == StepExecutionStatus.STATUS_INIT;
   }
 
@@ -156,7 +156,7 @@ public abstract class BaseStepData implements StepDataInterface {
    *
    * @return true, if is running
    */
-  public boolean isRunning() {
+  @Override public boolean isRunning() {
     return status == StepExecutionStatus.STATUS_RUNNING;
   }
 
@@ -165,7 +165,7 @@ public abstract class BaseStepData implements StepDataInterface {
    *
    * @return true, if is idle
    */
-  public boolean isIdle() {
+  @Override public boolean isIdle() {
     return status == StepExecutionStatus.STATUS_IDLE;
   }
 
@@ -174,7 +174,7 @@ public abstract class BaseStepData implements StepDataInterface {
    *
    * @return true, if is finished
    */
-  public boolean isFinished() {
+  @Override public boolean isFinished() {
     return status == StepExecutionStatus.STATUS_FINISHED;
   }
 
@@ -192,7 +192,7 @@ public abstract class BaseStepData implements StepDataInterface {
    *
    * @return true, if is disposed
    */
-  public boolean isDisposed() {
+  @Override public boolean isDisposed() {
     return status == StepExecutionStatus.STATUS_DISPOSED;
   }
 }

--- a/engine/src/main/java/org/pentaho/di/trans/step/StepInterface.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/StepInterface.java
@@ -350,7 +350,7 @@ public interface StepInterface extends VariableSpace, HasLogChannelInterface {
   /**
    * @return the logging channel for this step
    */
-  public LogChannelInterface getLogChannel();
+  @Override public LogChannelInterface getLogChannel();
 
   /**
    * @param usingThreadPriorityManagment

--- a/engine/src/main/java/org/pentaho/di/trans/steps/cubeinput/CubeInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/cubeinput/CubeInput.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -55,7 +55,7 @@ public class CubeInput extends BaseStep implements StepInterface {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
 
-  public boolean processRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
+  @Override public boolean processRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
 
     if ( first ) {
       first = false;
@@ -90,7 +90,7 @@ public class CubeInput extends BaseStep implements StepInterface {
     return true;
   }
 
-  public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
+  @Override public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (CubeInputMeta) smi;
     data = (CubeInputData) sdi;
 
@@ -126,7 +126,7 @@ public class CubeInput extends BaseStep implements StepInterface {
     return false;
   }
 
-  public void dispose( StepMetaInterface smi, StepDataInterface sdi ) {
+  @Override public void dispose( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (CubeInputMeta) smi;
     data = (CubeInputData) sdi;
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/cubeinput/CubeInputMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/cubeinput/CubeInputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -73,7 +73,7 @@ public class CubeInputMeta extends BaseStepMeta implements StepMetaInterface {
     super(); // allocate BaseStepMeta
   }
 
-  public void loadXML( Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore ) throws KettleXMLException {
+  @Override public void loadXML( Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore ) throws KettleXMLException {
     readData( stepnode );
   }
 
@@ -131,7 +131,7 @@ public class CubeInputMeta extends BaseStepMeta implements StepMetaInterface {
     this.addfilenameresult = addfilenameresult;
   }
 
-  public Object clone() {
+  @Override public Object clone() {
     CubeInputMeta retval = (CubeInputMeta) super.clone();
     return retval;
   }
@@ -148,14 +148,14 @@ public class CubeInputMeta extends BaseStepMeta implements StepMetaInterface {
     }
   }
 
-  public void setDefault() {
+  @Override public void setDefault() {
     filename = "file";
     rowLimit = "0";
     addfilenameresult = false;
   }
 
-  public void getFields( RowMetaInterface r, String name, RowMetaInterface[] info, StepMeta nextStep,
-    VariableSpace space, Repository repository, IMetaStore metaStore ) throws KettleStepException {
+  @Override public void getFields( RowMetaInterface r, String name, RowMetaInterface[] info, StepMeta nextStep,
+                                   VariableSpace space, Repository repository, IMetaStore metaStore ) throws KettleStepException {
     GZIPInputStream fis = null;
     DataInputStream dis = null;
     try {
@@ -189,7 +189,7 @@ public class CubeInputMeta extends BaseStepMeta implements StepMetaInterface {
     }
   }
 
-  public String getXML() {
+  @Override public String getXML() {
     StringBuilder retval = new StringBuilder( 300 );
 
     retval.append( "    <file>" ).append( Const.CR );
@@ -201,7 +201,7 @@ public class CubeInputMeta extends BaseStepMeta implements StepMetaInterface {
     return retval.toString();
   }
 
-  public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases ) throws KettleException {
+  @Override public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases ) throws KettleException {
     try {
       filename = rep.getStepAttributeString( id_step, "file_name" );
       try {
@@ -218,7 +218,7 @@ public class CubeInputMeta extends BaseStepMeta implements StepMetaInterface {
     }
   }
 
-  public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
+  @Override public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
     try {
       rep.saveStepAttribute( id_transformation, id_step, "file_name", filename );
       rep.saveStepAttribute( id_transformation, id_step, "limit", rowLimit );
@@ -230,9 +230,9 @@ public class CubeInputMeta extends BaseStepMeta implements StepMetaInterface {
     }
   }
 
-  public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta,
-    RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
-    Repository repository, IMetaStore metaStore ) {
+  @Override public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta,
+                               RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info, VariableSpace space,
+                               Repository repository, IMetaStore metaStore ) {
     CheckResult cr;
 
     cr =
@@ -241,12 +241,12 @@ public class CubeInputMeta extends BaseStepMeta implements StepMetaInterface {
     remarks.add( cr );
   }
 
-  public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int cnr, TransMeta tr,
-    Trans trans ) {
+  @Override public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int cnr, TransMeta tr,
+                                          Trans trans ) {
     return new CubeInput( stepMeta, stepDataInterface, cnr, tr, trans );
   }
 
-  public StepDataInterface getStepData() {
+  @Override public StepDataInterface getStepData() {
     return new CubeInputData();
   }
 
@@ -262,8 +262,8 @@ public class CubeInputMeta extends BaseStepMeta implements StepMetaInterface {
    *
    * @return the filename of the exported resource
    */
-  public String exportResources( VariableSpace space, Map<String, ResourceDefinition> definitions,
-    ResourceNamingInterface resourceNamingInterface, Repository repository, IMetaStore metaStore ) throws KettleException {
+  @Override public String exportResources( VariableSpace space, Map<String, ResourceDefinition> definitions,
+                                           ResourceNamingInterface resourceNamingInterface, Repository repository, IMetaStore metaStore ) throws KettleException {
     try {
       // The object that we're modifying here is a copy of the original!
       // So let's change the filename from relative to absolute by grabbing the file object...

--- a/engine/src/main/java/org/pentaho/di/trans/steps/script/ScriptDummy.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/script/ScriptDummy.java
@@ -263,7 +263,7 @@ public class ScriptDummy implements StepInterface {
     return null;
   }
 
-  public LogChannelInterface getLogChannel() {
+  @Override public LogChannelInterface getLogChannel() {
     return null;
   }
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesModDummy.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/scriptvalues_mod/ScriptValuesModDummy.java
@@ -268,7 +268,7 @@ public class ScriptValuesModDummy implements StepInterface {
     return null;
   }
 
-  public LogChannelInterface getLogChannel() {
+  @Override public LogChannelInterface getLogChannel() {
     return null;
   }
 

--- a/engine/src/main/java/org/pentaho/di/www/AddTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/AddTransServlet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -258,7 +258,7 @@ public class AddTransServlet extends BaseHttpServlet implements CartePluginInter
         // are done with this transformation.
         //
         trans.addTransListener( new TransAdapter() {
-          public void transFinished( Trans trans ) {
+          @Override public void transFinished( Trans trans ) {
             repository.disconnect();
           }
         } );

--- a/engine/src/main/java/org/pentaho/di/www/BaseJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/BaseJobServlet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -166,7 +166,7 @@ public abstract class BaseJobServlet extends BodyHttpServlet {
       // The repository connection is open: make sure we disconnect from the repository once we
       // are done with this transformation.
       trans.addTransListener( new TransAdapter() {
-        public void transFinished( Trans trans ) {
+        @Override public void transFinished( Trans trans ) {
           repository.disconnect();
         }
       } );

--- a/engine/src/main/java/org/pentaho/di/www/ExecuteTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/ExecuteTransServlet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -279,7 +279,7 @@ public class ExecuteTransServlet extends BaseHttpServlet implements CartePluginI
         // are done with this transformation.
         //
         trans.addTransListener( new TransAdapter() {
-          public void transFinished( Trans trans ) {
+          @Override public void transFinished( Trans trans ) {
             repository.disconnect();
           }
         } );

--- a/engine/src/main/java/org/pentaho/di/www/jaxrs/TransformationResource.java
+++ b/engine/src/main/java/org/pentaho/di/www/jaxrs/TransformationResource.java
@@ -258,7 +258,7 @@ public class TransformationResource {
         // are done with this transformation.
         //
         trans.addTransListener( new TransAdapter() {
-          public void transFinished( Trans trans ) {
+          @Override public void transFinished( Trans trans ) {
             repository.disconnect();
           }
         } );

--- a/engine/src/test/java/org/pentaho/di/core/util/serialization/MetaXmlSerializerTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/util/serialization/MetaXmlSerializerTest.java
@@ -27,6 +27,9 @@ import org.junit.Test;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.trans.steps.file.BaseFileField;
+import org.pentaho.di.trans.steps.file.BaseFileInputFiles;
+import org.pentaho.di.trans.steps.fileinput.text.TextFileInputMeta;
 
 import java.util.Collections;
 
@@ -68,5 +71,27 @@ public class MetaXmlSerializerTest {
     assertThat( deserializedMeta, equalTo( fooMeta ) );
   }
 
+
+  @Test public void testTextFileInputRoundTrip() {
+    // TextFileInputMeta is one of the most complex, including arrays under @InjectionDeep.
+    TextFileInputMeta fileInputMeta = new TextFileInputMeta();
+    fileInputMeta.inputFields = new BaseFileField[] {
+      new BaseFileField( "foo", 0, 10 ),
+      new BaseFileField( "bar", 0, 10 )
+    };
+    fileInputMeta.inputFiles = new BaseFileInputFiles();
+    final String[] fileNames = { "file1.txt", "file2.tsv" };
+    fileInputMeta.inputFiles.fileName = fileNames;
+
+    TextFileInputMeta rehydratedMeta = new TextFileInputMeta();
+
+    StepMetaProps props = StepMetaProps.from( fileInputMeta );
+    MetaXmlSerializer.deserialize( MetaXmlSerializer.serialize( props ) )
+      .to( rehydratedMeta );
+
+    assertThat( rehydratedMeta.inputFields[ 0 ].getName(), equalTo( "foo" ) );
+    assertThat( rehydratedMeta.inputFields[ 1 ].getName(), equalTo( "bar" ) );
+    assertThat( rehydratedMeta.inputFiles.fileName, equalTo( fileNames ) );
+  }
 
 }

--- a/engine/src/test/java/org/pentaho/di/core/util/serialization/StepMetaPropsTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/util/serialization/StepMetaPropsTest.java
@@ -41,6 +41,7 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.streaming.common.BaseStreamStepMeta;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -52,98 +53,6 @@ import static org.junit.Assert.assertThat;
 
 public class StepMetaPropsTest {
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
-
-
-  @InjectionSupported ( localizationPrefix = "stuff", groups = { "stuffGroup" } ) static class FooMeta
-    extends BaseStreamStepMeta {
-
-    @Sensitive
-    @Injection ( name = "FIELD1", group = "stuffGroup" ) String field1 = "default";
-    @Injection ( name = "FIELD2", group = "stuffGroup" ) int field2 = 123;
-
-    @Sensitive
-    @Injection ( name = "PassVerd" ) String password = "should.be.encrypted";
-
-
-    @Injection ( name = "ALIST" ) List<String> alist = new ArrayList<>();
-
-    @Sensitive
-    @Injection ( name = "SECURELIST" ) List<String> securelist = new ArrayList<>();
-
-    @Injection ( name = "BOOLEANLIST" ) List<Boolean> blist = new ArrayList<>();
-    @Injection ( name = "IntList" ) List<Integer> ilist = new ArrayList<>();
-
-    @InjectionDeep SoooDeep deep = new SoooDeep();
-
-    static class SoooDeep {
-      @Injection ( name = "DEEP_FLAG" ) boolean isItDeep = true;
-      @Injection ( name = "DEPTH" ) int howDeep = 1000;
-      @Injection ( name = "DEEP_LIST " ) List<String> deepList = new ArrayList<>();
-
-      @Sensitive
-      @Injection ( name = "DEEP_PASSWORD" ) String password = "p@ssword";
-
-      @Override public boolean equals( Object o ) {
-        if ( this == o ) {
-          return true;
-        }
-        if ( o == null || getClass() != o.getClass() ) {
-          return false;
-        }
-        SoooDeep soooDeep = (SoooDeep) o;
-        return isItDeep == soooDeep.isItDeep && howDeep == soooDeep.howDeep;
-      }
-
-      @Override public int hashCode() {
-        return Objects.hashCode( isItDeep, howDeep );
-      }
-    }
-
-
-    @Override
-    public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr,
-                                  TransMeta transMeta,
-                                  Trans trans ) {
-      return null;
-    }
-
-    @Override public StepDataInterface getStepData() {
-      return null;
-    }
-
-    @Override public boolean equals( Object o ) {
-      if ( this == o ) {
-        return true;
-      }
-      if ( o == null || getClass() != o.getClass() ) {
-        return false;
-      }
-      FooMeta fooMeta = (FooMeta) o;
-      return field2 == fooMeta.field2
-        && Objects.equal( field1, fooMeta.field1 )
-        && Objects.equal( password, fooMeta.password )
-        && Objects.equal( alist, fooMeta.alist )
-        && Objects.equal( securelist, fooMeta.securelist )
-        && Objects.equal( blist, fooMeta.blist )
-        && Objects.equal( ilist, fooMeta.ilist )
-        && Objects.equal( deep, fooMeta.deep );
-    }
-
-    @Override public int hashCode() {
-      return Objects.hashCode( field1, field2, password, alist, securelist, blist, ilist, deep );
-    }
-
-    @Override public String toString() {
-      return String
-        .format( "FooMeta{%nfield1='%s', %nfield2=%d, %nalist=%s, %nblist=%s, %nilist=%s}",
-          field1, field2, alist, blist, ilist );
-    }
-
-    @Override public RowMeta getRowMeta( String origin, VariableSpace space ) {
-      return null;
-    }
-  }
-
 
   @Before
   public void before() throws KettleException {
@@ -277,5 +186,173 @@ public class StepMetaPropsTest {
     return foo;
   }
 
+  @InjectionSupported ( localizationPrefix = "stuff", groups = { "stuffGroup" } ) static class FooMeta
+    extends BaseStreamStepMeta {
 
+    @Sensitive
+    @Injection ( name = "FIELD1", group = "stuffGroup" ) String field1 = "default";
+    @Injection ( name = "FIELD2", group = "stuffGroup" ) int field2 = 123;
+
+    @Sensitive
+    @Injection ( name = "PassVerd" ) String password = "should.be.encrypted";
+
+
+    @Injection ( name = "ALIST" ) List<String> alist = new ArrayList<>();
+
+    @Sensitive
+    @Injection ( name = "SECURELIST" ) List<String> securelist = new ArrayList<>();
+
+    @Injection ( name = "BOOLEANLIST" ) List<Boolean> blist = new ArrayList<>();
+    @Injection ( name = "IntList" ) List<Integer> ilist = new ArrayList<>();
+
+    @InjectionDeep SoooDeep deep = new SoooDeep();
+
+    static class SoooDeep {
+      @Injection ( name = "DEEP_FLAG" ) boolean isItDeep = true;
+      @Injection ( name = "DEPTH" ) int howDeep = 1000;
+      @Injection ( name = "DEEP_LIST " ) List<String> deepList = new ArrayList<>();
+
+      @Sensitive
+      @Injection ( name = "DEEP_PASSWORD" ) String password = "p@ssword";
+
+      @Override public boolean equals( Object o ) {
+        if ( this == o ) {
+          return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+          return false;
+        }
+        SoooDeep soooDeep = (SoooDeep) o;
+        return isItDeep == soooDeep.isItDeep && howDeep == soooDeep.howDeep;
+      }
+
+      @Override public int hashCode() {
+        return Objects.hashCode( isItDeep, howDeep );
+      }
+    }
+
+    // list and array of deep injection
+    // these varieties are trickier than lists of @Injection, since each list item
+    // is a composite of meta properties.
+    @InjectionDeep List<DeepListable> deepListables = new ArrayList<>();
+    @InjectionDeep DeepArrayable[] deepArrayable = new DeepArrayable[ 2 ];
+
+    {
+      this.deepListables.add( new DeepListable( "foo", "bar" ) );
+      this.deepListables.add( new DeepListable( "foo2", "bar2" ) );
+      deepArrayable[ 0 ] = new DeepArrayable( "afoo", "abar" );
+      deepArrayable[ 1 ] = new DeepArrayable( "afoo2", "abar2" );
+    }
+
+    static class DeepListable {
+      DeepListable( String item, String item2 ) {
+        this.item = item;
+        this.item2 = item2;
+      }
+
+      @Override public boolean equals( Object o ) {
+        if ( this == o ) {
+          return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+          return false;
+        }
+        DeepListable that = (DeepListable) o;
+        return java.util.Objects.equals( item, that.item )
+          && java.util.Objects.equals( item2, that.item2 );
+      }
+
+      @Override public int hashCode() {
+        return java.util.Objects.hash( item, item2 );
+      }
+
+      @Injection ( name = "ITEM" ) String item;
+      @Injection ( name = "ITEM2" ) String item2;
+    }
+
+    static class DeepArrayable {
+      DeepArrayable( String item, String item2 ) {
+        this.item = item;
+        this.item2 = item2;
+      }
+
+      @Override public boolean equals( Object o ) {
+        if ( this == o ) {
+          return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+          return false;
+        }
+        DeepArrayable that = (DeepArrayable) o;
+        return java.util.Objects.equals( item, that.item )
+          && java.util.Objects.equals( item2, that.item2 );
+      }
+
+      @Override public int hashCode() {
+        return java.util.Objects.hash( item, item2 );
+      }
+
+      @Injection ( name = "AITEM" ) String item;
+      @Injection ( name = "AITEM2" ) String item2;
+    }
+
+
+    @Override
+    public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr,
+                                  TransMeta transMeta,
+                                  Trans trans ) {
+      return null;
+    }
+
+    @Override public StepDataInterface getStepData() {
+      return null;
+    }
+
+    @Override public boolean equals( Object o ) {
+      if ( this == o ) {
+        return true;
+      }
+      if ( o == null || getClass() != o.getClass() ) {
+        return false;
+      }
+      FooMeta fooMeta = (FooMeta) o;
+      return field2 == fooMeta.field2
+        && java.util.Objects.equals( field1, fooMeta.field1 )
+        && java.util.Objects.equals( password, fooMeta.password )
+        && java.util.Objects.equals( alist, fooMeta.alist )
+        && java.util.Objects.equals( securelist, fooMeta.securelist )
+        && java.util.Objects.equals( blist, fooMeta.blist )
+        && java.util.Objects.equals( ilist, fooMeta.ilist )
+        && java.util.Objects.equals( deep, fooMeta.deep )
+        && java.util.Objects.equals( deepListables, fooMeta.deepListables )
+        && Arrays.equals( deepArrayable, fooMeta.deepArrayable );
+    }
+
+    @Override public int hashCode() {
+      int result =
+        java.util.Objects.hash( field1, field2, password, alist, securelist, blist, ilist, deep, deepListables );
+      result = 31 * result + Arrays.hashCode( deepArrayable );
+      return result;
+    }
+
+    @Override public String toString() {
+      final StringBuilder sb = new StringBuilder( "FooMeta{" );
+      sb.append( "field1='" ).append( field1 ).append( '\'' );
+      sb.append( ", \nfield2=" ).append( field2 );
+      sb.append( ", \npassword='" ).append( password ).append( '\'' );
+      sb.append( ", \nalist=" ).append( alist );
+      sb.append( ", \nsecurelist=" ).append( securelist );
+      sb.append( ", \nblist=" ).append( blist );
+      sb.append( ", \nilist=" ).append( ilist );
+      sb.append( ", \ndeep=" ).append( deep );
+      sb.append( ", \ndeepListables=" ).append( deepListables );
+      sb.append( ", \ndeepArrayable=" ).append( Arrays.toString( deepArrayable ) );
+      sb.append( '}' );
+      return sb.toString();
+    }
+
+    @Override public RowMeta getRowMeta( String origin, VariableSpace space ) {
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
and arrays.

This involves a change to BeanInjector.getPropVal, which now walks
down the full list of BeanLevelInfos, specially handling LIST and
ARRAY.

Also fixes a handful of compiler warnings, mostly involving missing
@override.

Files changed for injectiondeep support are just these 3:
BeanInjector
MetaXmlSerializerTest
StepMetaPropsTest

https://jira.pentaho.com/browse/BACKLOG-24617