### PR TITLE
[PDI-13055] CSV File Input step: Get Fields incorrectly reverse field…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1124,6 +1124,9 @@ public class Const {
   // See PDI-17203 for details
   public static final String KETTLE_COMPATIBILITY_XML_OUTPUT_NULL_VALUES = "KETTLE_COMPATIBILITY_XML_OUTPUT_NULL_VALUES";
 
+  // See PDI-13055 for details
+  public static final String KETTLE_COMPATIBILITY_LENGTH_VALIDATION_USES_BYTES = "KETTLE_COMPATIBILITY_LENGTH_VALIDATION_USES_BYTES";
+
   /**
    * The XML file that contains the list of native import rules
    */

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
@@ -1200,4 +1200,11 @@ public interface DatabaseInterface extends Cloneable {
     return "";
   }
 
+  /**
+   * @return true if database supports the default char length validation
+   */
+  default boolean supportsGetLengthByChar() {
+    return true;
+  }
+
 }

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
@@ -2930,6 +2930,13 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   }
 
   /**
+   * @return true if database supports the default char length validation
+   */
+  public boolean supportsGetLengthByChar() {
+    return databaseInterface.supportsGetLengthByChar();
+  }
+
+  /**
    * Get the SQL to insert a new empty unknown record in a dimension.
    *
    * @param schemaTable

--- a/core/src/main/java/org/pentaho/di/core/database/OracleDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/OracleDatabaseMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -677,5 +677,9 @@ public class OracleDatabaseMeta extends BaseDatabaseMeta implements DatabaseInte
    */
   public void setStrictBigNumberInterpretation( boolean strictBigNumberInterpretation ) {
     getAttributes().setProperty( STRICT_BIGNUMBER_INTERPRETATION, strictBigNumberInterpretation ? "Y" : "N" );
+  }
+
+  @Override public boolean supportsGetLengthByChar() {
+    return false;
   }
 }

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -526,6 +526,51 @@ public class ValueMetaBase implements ValueMetaInterface {
   }
 
   /**
+   *
+   * @return get length in bytes (dealing with special characters)
+   */
+  int getLengthInBytes( String value ) {
+    int total = 0;
+    try {
+      for ( int i = 0; i < value.length(); i++ ) {
+        String c = new String( new char[] {value.charAt( i )} );
+        int length = c.getBytes( "UTF-8" ).length;
+        total += length;
+      }
+      return total;
+
+    } catch ( UnsupportedEncodingException e ) {
+      return value.length();
+    }
+  }
+
+  /**
+   *
+   * @return get length in bytes (if const is defined or database only supports char validation ) or chars (default
+   * except for Oracle Databases)
+   */
+
+  int getLengthInCharOrBytes( String string, DatabaseMeta databaseMeta )  {
+    String val = EnvUtil.getSystemProperty( Const.KETTLE_COMPATIBILITY_LENGTH_VALIDATION_USES_BYTES );
+    int total = string.length();
+    if ( val != null ) {
+      boolean usesBytes = convertStringToBoolean( Const.NVL( val, "N" ) );
+      // if const is defined and it's true, then use bytes
+      if ( usesBytes ) {
+        total = getLengthInBytes( string );
+      }
+    } else {
+      // if const is not defined then check the default databaseConfiguration
+      boolean databaseSupportsChar = databaseMeta.supportsGetLengthByChar();
+      if ( !databaseSupportsChar ) {
+        total = getLengthInBytes( string );
+      }
+    }
+    return total;
+  }
+
+
+  /**
    * @return the name
    */
   @Override
@@ -5357,7 +5402,8 @@ public class ValueMetaBase implements ValueMetaInterface {
               setLength( databaseMeta.getMaxTextFieldLength() );
             }
             String string = getString( data );
-            int len = string.length();
+            //int len = string.length(); - changed to support length in char or bytes
+            int len = getLengthInCharOrBytes( string, databaseMeta );
             int maxlen = isLengthInvalidOrZero() ? len : getLength();
             if ( len <= maxlen ) {
               preparedStatement.setString( index, string );

--- a/core/src/main/java/org/pentaho/di/core/util/StringEvaluator.java
+++ b/core/src/main/java/org/pentaho/di/core/util/StringEvaluator.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -254,6 +254,7 @@ public class StringEvaluator {
       maxLength = value.length();
     }
   }
+
 
   private void evaluatePrecision( String value ) {
     int p = determinePrecision( value );

--- a/core/src/test/java/org/pentaho/di/core/util/StringEvaluatorTest.java
+++ b/core/src/test/java/org/pentaho/di/core/util/StringEvaluatorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
 import java.util.*;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;


### PR DESCRIPTION
…s length
This is a special characters related issue.
Since my suggested workaround could be massive in some cases, when we have to deal with multiple tables with multiple rows, drop them all and recreate again could be a not easy and danger solution. So I provide a possible solution to ensure we deal differently when we have to deal with special characters in both ways, bytes and chars.
In that way this PR creates a new compatibility flag where users can now choose from reading a string length by char or byte before inserting it to a database, and if that Const is not defined, then it uses a new configuration at "DatabaseInterface" in which Oracle (in "OracleDatabaseMeta") is defined by default with bytes. The Const value **overwrites** the default value in "OracleDatabaseMeta".
This means that if configured right, Kettle i'll not stop executing, neither giving the ORA error, but instead use the actual logic in "ValueMetaBase", providing now the already existing message:
 ValueMetaBase - Truncating 2 symbols of original message in 'CONTACTFIRSTNAME' field

@pentaho-lmartins @mbatchelor @bmorrise 


