### PR TITLE
[BACKLOG-25015] Refactor: StepMetaInferface holds a new default metho…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/step/StepMetaInterface.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/StepMetaInterface.java
@@ -755,4 +755,17 @@ public interface StepMetaInterface {
   default boolean passDataToServletOutput() {
     return false;
   }
+
+  /**
+   * Allows for someone to fetch the related TransMeta object. Returns null if not found (or not implemented)
+   * @param stepMeta StepMetaInterface object
+   * @param rep Repository object
+   * @param metastore metastore object
+   * @param space VariableSpace
+   * @return the associated TransMeta object, or null if not found (or not implemented)
+   * @throws KettleException should something go wrong
+   */
+  default TransMeta fetchTransMeta( StepMetaInterface stepMeta, Repository rep, IMetaStore metastore, VariableSpace space ) throws KettleException {
+    return null; // default
+  }
 }

--- a/plugins/meta-inject/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
+++ b/plugins/meta-inject/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -491,6 +491,13 @@ public class MetaInjectMeta extends BaseStepMeta implements StepMetaInterface, S
    */
   public void setSpecificationMethod( ObjectLocationSpecificationMethod specificationMethod ) {
     this.specificationMethod = specificationMethod;
+  }
+
+  @Override
+  public TransMeta fetchTransMeta( StepMetaInterface stepMeta, Repository rep, IMetaStore metastore, VariableSpace space ) throws KettleException {
+    return ( stepMeta != null && stepMeta instanceof MetaInjectMeta )
+        ? loadTransformationMeta( (MetaInjectMeta) stepMeta, rep, metastore, space ) : null;
+
   }
 
   @Deprecated


### PR DESCRIPTION
…d interface, which will allows for the decoupling of PDI-data-refinery from ETL Metadata injection step

- Refactor: `StepMetaInferface` holds a new default method interface, which will allow for decoupling of PDI-data-refinery from ETL Metadata injection step
- Also makes it so that any `StepMetaInterface`, should they care to implement `fetchTransMeta()`,  could potentially become a drillable Step

Should be merged alongside https://github.com/pentaho/pentaho-data-refinery/pull/115

@pentaho/rogueone @kurtwalker @tmcsantos @mdamour1976 