### PR TITLE
[BACKLOG-24662] As a Foundry Service developer, I want to make sure t…

### DIFF
--- a/assemblies/core/static/src/main/resources/spoon.sh
+++ b/assemblies/core/static/src/main/resources/spoon.sh
@@ -140,7 +140,7 @@ case `uname -s` in
             HASWEBKITGTK=`ldconfig -p | grep webkitgtk-1.0`
             export LIBWEBKITGTK="$HASWEBKITGTK"
             export JavaScriptCoreUseJIT=0
-            if [ -z "$HASWEBKITGTK" ]; then
+            if [ -z "$HASWEBKITGTK" ] && [ "1" != "$SKIP_WEBKITGTK_CHECK" ]; then
               echo "#######################################################################"
               echo "WARNING:  no libwebkitgtk-1.0 detected, some features will be unavailable"
               echo "    Consider installing the package with apt-get or yum."

--- a/assemblies/static/src/main/resources/spoon.sh
+++ b/assemblies/static/src/main/resources/spoon.sh
@@ -140,7 +140,7 @@ case `uname -s` in
             HASWEBKITGTK=`ldconfig -p | grep webkitgtk-1.0`
             export LIBWEBKITGTK="$HASWEBKITGTK"
             export JavaScriptCoreUseJIT=0
-            if [ -z "$HASWEBKITGTK" ]; then
+            if [ -z "$HASWEBKITGTK" ] && [ "1" != "$SKIP_WEBKITGTK_CHECK" ]; then
               echo "#######################################################################"
               echo "WARNING:  no libwebkitgtk-1.0 detected, some features will be unavailable"
               echo "    Consider installing the package with apt-get or yum."


### PR DESCRIPTION
…he builds of my services rely on the nexus docker registry and all its capabilities

- adding a check to bypass libwebkitgtk check
  - **default/fallback behaviour is the same as always, which is to not skip** the check/message
  - libwebkitgtk is solely for UI (SWT) based actions; pdi-service / pdi-job are for headless ETL execution

```
REPOSITORY                        IMAGE ID           CREATED              SIZE
pdi-service-original              2590e54bee59       10 minutes ago       987MB
pdi-service-no-libwebkitgtk       12fb858ca09d       6 minutes ago        725MB
```

To be merged alongside https://github.com/pentaho/pentaho-ee/pull/1450

@pentaho/rogueone 