### PR TITLE
Revert [BACKLOG-25015] Meta-inject - Move step to Kettle plugin system

### DIFF
--- a/assemblies/plugins/pom.xml
+++ b/assemblies/plugins/pom.xml
@@ -35,7 +35,6 @@
     <pentaho-googledrive-vfs-plugin.version>${project.version}</pentaho-googledrive-vfs-plugin.version>
     <google-bigquery-plugin.version>${project.version}</google-bigquery-plugin.version>
     <elasticsearch-bulk-insert-plugin.version>${project.version}</elasticsearch-bulk-insert-plugin.version>
-    <meta-inject-plugin.version>${project.version}</meta-inject-plugin.version>
     <pdi-xml-plugin.version>9.0.0.0-SNAPSHOT</pdi-xml-plugin.version>
     <pdi-json-plugin.version>9.0.0.0-SNAPSHOT</pdi-json-plugin.version>
     <pdi-sap-plugin.version>9.0.0.0-SNAPSHOT</pdi-sap-plugin.version>
@@ -376,18 +375,6 @@
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>pdi-pur-plugin</artifactId>
       <version>${pdi-pur-plugin.version}</version>
-      <type>zip</type>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho.di.plugins</groupId>
-      <artifactId>meta-inject-plugin</artifactId>
-      <version>${meta-inject-plugin.version}</version>
       <type>zip</type>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
The metadata-injection de-OSGification process, while working fine on Spoon, is *not* working on AEL

In light of that - and given that there is no clear strategy yet on how non-OSGi kettle plugins ( that live outside kettle-engine ) can work on AEL - it’s safer to revert the changes done, and keep metadata-injection OSGified for the time being.

@pentaho/rogueone @kurtwalker @mdamour1976 @tmcsantos @hbfernandes 

To be merged alongside
- https://github.com/pentaho/pentaho-ee/pull/1457
- https://github.com/pentaho/pentaho-kettle/pull/5712
- https://github.com/pentaho/pentaho-karaf-assembly/pull/475

**Please hold off merging until there's a say so by @mdamour1976 or @kurtwalker**