### PR TITLE
[SP-4586] Backport of PDI-17215 - REST Client step ignore Content-Typ…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
@@ -152,6 +152,7 @@ public class Rest extends BaseStep implements StepInterface {
         logDebug( BaseMessages.getString( PKG, "Rest.Log.ConnectingToURL", webResource.getURI() ) );
       }
       WebResource.Builder builder = webResource.getRequestBuilder();
+      String contentType = null; // media type override, if not null
       if ( data.useHeaders ) {
         // Add headers
         for ( int i = 0; i < data.nrheader; i++ ) {
@@ -159,6 +160,9 @@ public class Rest extends BaseStep implements StepInterface {
 
           // unsure if an already set header will be returned to builder
           builder = builder.header( data.headerNames[i], value );
+          if ( "Content-Type".equals( data.headerNames[i] ) ) {
+            contentType = value;
+          }
           if ( isDebug() ) {
             logDebug( BaseMessages.getString( PKG, "Rest.Log.HeaderValue", data.headerNames[i], value ) );
           }
@@ -178,9 +182,17 @@ public class Rest extends BaseStep implements StepInterface {
         if ( data.method.equals( RestMeta.HTTP_METHOD_GET ) ) {
           response = builder.get( ClientResponse.class );
         } else if ( data.method.equals( RestMeta.HTTP_METHOD_POST ) ) {
-          response = builder.type( data.mediaType ).post( ClientResponse.class, entityString );
+          if ( null != contentType ) {
+            response = builder.type( contentType ).post( ClientResponse.class, entityString );
+          } else {
+            response = builder.type( data.mediaType ).post( ClientResponse.class, entityString );
+          }
         } else if ( data.method.equals( RestMeta.HTTP_METHOD_PUT ) ) {
-          response = builder.type( data.mediaType ).put( ClientResponse.class, entityString );
+          if ( null != contentType ) {
+            response = builder.type( contentType ).put( ClientResponse.class, entityString );
+          } else {
+            response = builder.type( data.mediaType ).put( ClientResponse.class, entityString );
+          }
         } else if ( data.method.equals( RestMeta.HTTP_METHOD_DELETE ) ) {
           response = builder.delete( ClientResponse.class );
         } else if ( data.method.equals( RestMeta.HTTP_METHOD_HEAD ) ) {
@@ -188,7 +200,11 @@ public class Rest extends BaseStep implements StepInterface {
         } else if ( data.method.equals( RestMeta.HTTP_METHOD_OPTIONS ) ) {
           response = builder.options( ClientResponse.class );
         } else if ( data.method.equals( RestMeta.HTTP_METHOD_PATCH ) ) {
-          response = builder.type( data.mediaType ).method( RestMeta.HTTP_METHOD_PATCH, ClientResponse.class, entityString );
+          if ( null != contentType ) {
+            response = builder.type( contentType ).method( RestMeta.HTTP_METHOD_PATCH, ClientResponse.class, entityString );
+          } else {
+            response = builder.type( data.mediaType ).method( RestMeta.HTTP_METHOD_PATCH, ClientResponse.class, entityString );
+          }
         } else {
           throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.UnknownMethod", data.method ) );
         }


### PR DESCRIPTION
…e header (8.1 Suite)

Backport of: #5301

Did't include the changes in the `DELETE` verb since it isn't an entity enclosing method.
For details see work done in PDI-16909 - https://github.com/pentaho-lmartins/pentaho-kettle/commit/ea95425741fdc8f28b397a95d4e162a5c606b109.

Only `PUT`, `POST` and `PATCH` are entity enclosing methods, i.e. verbs that can carry data in the body of the HTTP request.

@ricardosilva88 