### PR TITLE
[BACKLOG-22526][CLEANUP] Promoting current spring-security.version to…

### DIFF
--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -66,7 +66,6 @@
 
         <!-- Spring -->
         <springframework4.version>4.3.2.RELEASE</springframework4.version>
-        <springframework4-security.version>4.1.5.RELEASE</springframework4-security.version>
     </properties>
 
     <dependencies>
@@ -540,7 +539,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>${springframework4-security.version}</version>
+            <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
         </dependency>
 
         <!-- Other third-party dependencies -->

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -65,7 +65,6 @@
 
     <!-- Spring -->
     <springframework4.version>4.3.2.RELEASE</springframework4.version>
-    <springframework4-security.version>4.1.5.RELEASE</springframework4-security.version>
   </properties>
 
   <dependencies>
@@ -539,7 +538,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${springframework4-security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
     </dependency>
 
     <!-- Other third-party dependencies -->

--- a/plugins/pur/core/pom.xml
+++ b/plugins/pur/core/pom.xml
@@ -39,7 +39,6 @@
 
     <!-- Test dependencies -->
     <spring.framework.version>3.2.10.RELEASE</spring.framework.version>
-    <spring.security.version>4.1.3.RELEASE</spring.security.version>
     <spring.webflow.version>2.4.4.RELEASE</spring.webflow.version>
     <se-jcr.version>0.9</se-jcr.version>
     <jcr.version>2.0</jcr.version>
@@ -323,13 +322,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
… maven-parent-pom

**Notes**
- This is not changing the current version
  - we are merely promoting it to maven-parent-pom as a cleanup + centralization effort
- Wingman **will** fail on these
  - the referenced dependency property version `spring-security.version` is not yet in play 
  - see related PR adding it to maven-parent-pom: https://github.com/pentaho/maven-parent-poms/pull/71

@pentaho/rogueone @pentaho-lmartins

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅

**List of PRs:**
- https://github.com/pentaho/maven-parent-poms/pull/71
- https://github.com/pentaho/marketplace/pull/153
- https://github.com/pentaho/pentaho-platform/pull/4231
- https://github.com/pentaho/pentaho-platform-ee/pull/1278
- https://github.com/pentaho/pentaho-kettle/pull/5752
- https://github.com/pentaho/pentaho-reporting/pull/1181
- https://github.com/pentaho/pdi-ee-plugin/pull/362
- https://github.com/pentaho/pentaho-osgi-bundles/pull/289
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/116
- https://github.com/pentaho/pentaho-metadata-editor/pull/130
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40