### PR TITLE
[PDI-17644] - StaxPoiSheet.java creates additional object with null

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/excelinput/staxpoi/StaxPoiSheet.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/excelinput/staxpoi/StaxPoiSheet.java
@@ -268,11 +268,11 @@ public class StaxPoiSheet implements KSheet {
       if ( content != null ) {
         KCellType kcType = getCellType( cellType, cellStyle, isFormula );
         setCells( cells, undefinedColIndex, columnIndex, new StaxPoiCell( parseValue( kcType, content ), kcType, currentRow ) );
-        undefinedColIndex = columnIndex + 1;
       } else {
         // else let cell be null
         setCells( cells, undefinedColIndex, columnIndex, null );
       }
+        undefinedColIndex = columnIndex + 1;
     }
     return cells.toArray( new StaxPoiCell[cells.size()] );
   }


### PR DESCRIPTION
Empty Cell creates an additional Object with null in the cells field.
Problem Scenario:
Consider an Excel (xlsx with POI Streaming) file with 5 columns.
Header1,Header2,Header3,Header4,Header5
Data11,Data12,Data13,Data14,Data15                      => cells arraylist holds 5 objects [Data11,Data12,Data13,Data14,Data15] =>Correct
Data21,Data22,,Data24,Data25                                 => cells arraylist holds 6 objects [Data21,Data22,null,null,Data24,Data25] =>Wrong

Solution:
undefinedColIndex must be incremented always.