### PR TITLE
[PDI-17353] OutOfMemory exception while play with DET for Geo viz

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/SlaveStepCopyPartitionDistribution.java
+++ b/engine/src/main/java/org/pentaho/di/trans/SlaveStepCopyPartitionDistribution.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -274,5 +275,22 @@ public class SlaveStepCopyPartitionDistribution {
    */
   public void setOriginalPartitionSchemas( List<PartitionSchema> originalPartitionSchemas ) {
     this.originalPartitionSchemas = originalPartitionSchemas;
+  }
+
+  @Override
+  public boolean equals( Object o ) {
+    if ( this == o ) {
+      return true;
+    }
+    if ( o == null || getClass() != o.getClass() ) {
+      return false;
+    }
+    SlaveStepCopyPartitionDistribution that = (SlaveStepCopyPartitionDistribution) o;
+    return Objects.equals( distribution, that.distribution ) && Objects.equals( originalPartitionSchemas, that.originalPartitionSchemas );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash( distribution, originalPartitionSchemas );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/SlaveStepCopyPartitionDistributionTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/SlaveStepCopyPartitionDistributionTest.java
@@ -1,0 +1,97 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Assert;
+import org.pentaho.di.partition.PartitionSchema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SlaveStepCopyPartitionDistributionTest {
+
+    private SlaveStepCopyPartitionDistribution slaveStep;
+
+    @Before
+    public void setup() {
+
+        slaveStep = new SlaveStepCopyPartitionDistribution();
+    }
+
+    @Test
+    public void equalsNullTest() {
+
+        Assert.assertFalse( slaveStep.equals( null ) );
+    }
+
+    @Test
+    public void equalsDifferentClassesTest() {
+
+        Assert.assertFalse( slaveStep.equals( Integer.valueOf(5) ) );
+    }
+
+    @Test
+    public void equalsSameInstanceTest() {
+
+        Assert.assertTrue( slaveStep.equals( slaveStep ) );
+    }
+
+    @Test
+    public void equalsDifferentStepsTest() {
+
+        SlaveStepCopyPartitionDistribution other = new SlaveStepCopyPartitionDistribution();
+        List<PartitionSchema> schemas = new ArrayList<>();
+        schemas.add( new PartitionSchema() );
+        other.setOriginalPartitionSchemas( schemas );
+        Assert.assertFalse( slaveStep.equals( other ) );
+    }
+
+    @Test
+    public void equalsTest(){
+
+        Assert.assertTrue( slaveStep.equals( new SlaveStepCopyPartitionDistribution() ) );
+    }
+
+    @Test
+    public void hashCodeEqualsTest() {
+
+        SlaveStepCopyPartitionDistribution other = new SlaveStepCopyPartitionDistribution();
+
+        Assert.assertEquals( slaveStep.hashCode(), other.hashCode() );
+    }
+
+    @Test
+    public void hashCodeDifferentTest() {
+
+        SlaveStepCopyPartitionDistribution other = new SlaveStepCopyPartitionDistribution();
+        List<PartitionSchema> schemas = new ArrayList<>();
+        PartitionSchema schema = new PartitionSchema();
+        schema.setName( "Test" );
+        schemas.add( schema );
+        other.setOriginalPartitionSchemas( schemas );
+
+        Assert.assertNotEquals( slaveStep.hashCode(), other.hashCode() );
+
+    }
+}


### PR DESCRIPTION
@pentaho-lmartins 

The problem is that the DataService cache increases exponentially and the number of instances of RowMetaAndData in memory also increase with every change done. This was confirmed using Java VisualVM looking at the memory spent and heapdump. It was seen this exponential increase of RowMetaAndData.

The problem resides with the fact that the stored key in the cache relies on getCacheVersion() of TransMeta.java

The getCacheVersion() then relies on the hashCode each TransMeta member. The problem is that one of its members SlaveStepCopyPartitionDistribution did not have hashCode() implemented.

This caused that each run of the transformation would store everytime new RowMetaAndData even if no change was done in the Transformation.

implementing the missing hashCode in SlaveStepCopyPartitionDistribution corrects the getCacheVersion() of TransMeta to return a correct hashCode.

With this correction it was seen with Java VisualVM that RowMetaAndData instances in memory now don't increase exponentially.