### PR TITLE
[PDI-17387] The import script should not be blocked from loading repo…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/imp/Import.java
+++ b/engine/src/main/java/org/pentaho/di/imp/Import.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -66,6 +66,8 @@ public class Import {
 
   public static final String STRING_IMPORT = "Import";
   public static final String ROOT_DIRECTORY = "/";
+  public static final String PUBLIC_DIRECTORY = "public";
+  public static final String HOME_DIRECTORY = "home";
 
   private static class ImportFeedback implements RepositoryImportFeedbackInterface, HasOverwritePrompter {
     private final LogChannelInterface log;
@@ -350,12 +352,6 @@ public class Import {
     SimpleDateFormat df = new SimpleDateFormat( "yyyy/MM/dd HH:mm:ss.SSS" );
     start = new Date(  );
     int returnCode = 0;
-
-    if ( ROOT_DIRECTORY.equals( optionDirname.toString() ) ) {
-      log.logError( BaseMessages.getString( PKG, "Import.Error.TargetDirectoryIsRootDirectory" ) );
-      exitJVM( 1 );
-    }
-
     try {
       RepositoryDirectoryInterface tree = repository.loadRepositoryDirectoryTree();
 

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
@@ -376,9 +376,16 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
   @Override
   public RepositoryDirectoryInterface createRepositoryDirectory( final RepositoryDirectoryInterface parentDirectory,
                                                                  final String directoryPath ) throws KettleException {
+    // allow new folders only inside Home and Public directory, else - provide UI message
     try {
-      if ( parentDirectory.isRoot() ) {
-        throw new IllegalArgumentException();
+      // if parentDirectory is root then we have to check if the defined directory is valid ( only Public and Home folders are allowed )
+      if ( parentDirectory.isRoot()
+        &&
+          ( directoryPath.equals( Import.ROOT_DIRECTORY )
+            ||
+          ( !directoryPath.startsWith( Import.HOME_DIRECTORY ) && !directoryPath.startsWith( Import.PUBLIC_DIRECTORY ) )
+          ) ) {
+        throw new KettleException( BaseMessages.getString( PKG, "PurRepository.invalidRepositoryDirectory", directoryPath ) );
       }
 
       RepositoryDirectoryInterface refreshedParentDir = findDirectory( parentDirectory.getPath() );
@@ -3350,6 +3357,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
       throw new KettleException( BaseMessages.getString( PKG, "PurRepository.fileCannotBeSavedInRootDirectory",
         element.getName() + element.getRepositoryElementType().getExtension() ) );
     }
+
     if ( saveSharedObjects ) {
       objectTransformer.saveSharedObjects( element, versionComment );
     }

--- a/plugins/pur/core/src/main/resources/org/pentaho/di/repository/pur/messages/messages_en_US.properties
+++ b/plugins/pur/core/src/main/resources/org/pentaho/di/repository/pur/messages/messages_en_US.properties
@@ -60,9 +60,8 @@ PurRepositoryExporter.ERROR_EXPORT=Error exporting "{0}" from directory ["{1}"].
 PurRepositoryExporter.ERROR_EXPORT_ITEM=Exported entity "{0}" is not satisfied following rule(s):
 PurRepositoryExporter.ERROR_EXPORT_ITEM_RULE= - "{0}" ;
 PurRepository.fileCannotBeSavedInRootDirectory=The file "{0}" cannot be saved in the <root> '/' directory.
-
+PurRepository.invalidRepositoryDirectory=The folder "{0}" cannot be created. Files can only be saved in the /home and /public folders, please select one and try again.
 PurRepositoryExporter.DETAILED_USED_BATCH_SIZE=Using batch size of "{0}".
-
 PurRepositoryExporter.BASIC_EXPORT_FROM=Exporting "{0}" "{1}" from directory ["{2}"].
 PurRepositoryConnector.CreateServiceProvider.Start=Creating security provider
 PurRepositoryConnector.CreateServiceProvider.End=Security provider created

--- a/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/PurRepositoryUnitTest.java
+++ b/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/PurRepositoryUnitTest.java
@@ -67,6 +67,7 @@ import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -536,4 +537,80 @@ public class PurRepositoryUnitTest extends RepositoryTestLazySupport {
 
     assertEquals( "/home/admin/trans.ktr", pur.getPath( "trans.ktr", rdi, RepositoryObjectType.TRANSFORMATION ) );
   }
+
+  @Test
+  public void testCreateValidRepositoryDirectoryForRootHomeFolder() throws KettleException {
+    RepositoryDirectoryInterface treeMocked = mock( RepositoryDirectoryInterface.class );
+    PurRepository repository = mock( PurRepository.class );
+    LazyUnifiedRepositoryDirectory lazy = mock( LazyUnifiedRepositoryDirectory.class );
+    String newDirectory = "home/admin1";
+    //if root then we can create any folder at home or public folders
+    when( treeMocked.isRoot() ).thenReturn( true );
+    when( treeMocked.getPath() ).thenReturn( newDirectory );
+    when( repository.findDirectory( anyString() ) ).thenReturn( lazy );
+    when( repository.createRepositoryDirectory( treeMocked, newDirectory ) ).thenCallRealMethod();
+
+    assertEquals( "/home/admin1", repository.createRepositoryDirectory( treeMocked, newDirectory ).getPath() );
+  }
+
+  @Test
+  public void testCreateValidRepositoryDirectoryForRootPublicFolder() throws KettleException {
+    RepositoryDirectoryInterface treeMocked = mock( RepositoryDirectoryInterface.class );
+    PurRepository repository = mock( PurRepository.class );
+    LazyUnifiedRepositoryDirectory lazy = mock( LazyUnifiedRepositoryDirectory.class );
+    String newDirectory = "public/admin1";
+    //if root then we can create any folder at home or public folders
+    when( treeMocked.isRoot() ).thenReturn( true );
+    when( treeMocked.getPath() ).thenReturn( newDirectory );
+    when( repository.findDirectory( anyString() ) ).thenReturn( lazy );
+    when( repository.createRepositoryDirectory( treeMocked, newDirectory ) ).thenCallRealMethod();
+
+    assertEquals( "/public/admin1", repository.createRepositoryDirectory( treeMocked, newDirectory ).getPath() );
+  }
+
+  @Test( expected = KettleException.class )
+  public void testCreateInvalidRepositoryDirectoryForRootAnyOtherFolders() throws KettleException {
+    RepositoryDirectoryInterface treeMocked = mock( RepositoryDirectoryInterface.class );
+    PurRepository repository = mock( PurRepository.class );
+    LazyUnifiedRepositoryDirectory lazy = mock( LazyUnifiedRepositoryDirectory.class );
+    String newDirectory = "dummy/admin1";
+    //if root then we can ony create folders at home or public folders
+    when( treeMocked.isRoot() ).thenReturn( true );
+    when( treeMocked.getPath() ).thenReturn( newDirectory );
+    when( repository.findDirectory( anyString() ) ).thenReturn( lazy );
+    when( repository.createRepositoryDirectory( treeMocked, newDirectory ) ).thenCallRealMethod();
+
+    assertNull( repository.createRepositoryDirectory( treeMocked, newDirectory ).getPath() );
+  }
+
+  @Test( expected = KettleException.class )
+  public void testCreateInvalidRepositoryDirectoryForRoot() throws KettleException {
+    RepositoryDirectoryInterface treeMocked = mock( RepositoryDirectoryInterface.class );
+    PurRepository repository = mock( PurRepository.class );
+    LazyUnifiedRepositoryDirectory lazy = mock( LazyUnifiedRepositoryDirectory.class );
+    String newDirectory = "admin1";
+    //if root then we can ony create folders at home or public folders
+    when( treeMocked.isRoot() ).thenReturn( true );
+    when( treeMocked.getPath() ).thenReturn( newDirectory );
+    when( repository.findDirectory( anyString() ) ).thenReturn( lazy );
+    when( repository.createRepositoryDirectory( treeMocked, newDirectory ) ).thenCallRealMethod();
+
+    assertNull( repository.createRepositoryDirectory( treeMocked, newDirectory ).getPath() );
+  }
+
+  @Test
+  public void testCreateValidRepositoryDirectoryForNotRoot() throws KettleException {
+    RepositoryDirectoryInterface treeMocked = mock( RepositoryDirectoryInterface.class );
+    PurRepository repository = mock( PurRepository.class );
+    LazyUnifiedRepositoryDirectory lazy = mock( LazyUnifiedRepositoryDirectory.class );
+    String newDirectory = "admin1";
+    //if not root then we can create any folder
+    when( treeMocked.isRoot() ).thenReturn( false );
+    when( treeMocked.getPath() ).thenReturn( newDirectory );
+    when( repository.findDirectory( anyString() ) ).thenReturn( lazy );
+    when( repository.createRepositoryDirectory( treeMocked, newDirectory ) ).thenCallRealMethod();
+
+    assertEquals( "/admin1", repository.createRepositoryDirectory( treeMocked, newDirectory ).getPath() );
+  }
+
 }


### PR DESCRIPTION
…sitory exports to the root of the repository

This PR fixes the issue that always give an error if user selects Root for the destination path. ( Introduced in PDI-16591). Now it considers the full path ( destination path + path defined in file to import ) instead of validating only the destination path.
It was added a new error message when the user tries to create a new directory at root level. For instance if you choose / as destination path and your repository file to import has a directory attribute like /anyFolderName/filename this will invoke the new message, since it is not valid path. You can only save to the "home" and "public" folders, at root level.

@mbatchelor @bmorrise @kcruzada 