### PR TITLE
[SP-4607] Backport of BACKLOG-25556 - Text File Output: When "Accept …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputMeta.java
@@ -764,7 +764,7 @@ public class TextFileOutputMeta extends BaseFileOutputMeta implements StepMetaIn
   public String buildFilename( String filename, String extension, VariableSpace space, int stepnr, String partnr,
                                int splitnr, boolean ziparchive, TextFileOutputMeta meta ) {
 
-    final String realFileName = space.environmentSubstitute( fileName );
+    final String realFileName = space.environmentSubstitute( filename );
     final String realExtension = space.environmentSubstitute( extension );
     return super.buildFilename( space, realFileName, realExtension, Integer.toString( stepnr ), partnr, Integer
       .toString( splitnr ), new Date(), ziparchive, true, meta );


### PR DESCRIPTION
…filename from field" is checked and Filename field is blank; output file is not created. (8.1 Suite)