### PR TITLE
[PDI-17495] Load File Content step throws exception after row fields …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/loadfileinput/LoadFileInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/loadfileinput/LoadFileInput.java
@@ -331,7 +331,7 @@ public class LoadFileInput extends BaseStep implements StepInterface {
     try {
       // Create new row or clone
       if ( meta.getIsInFields() ) {
-        outputRowData = data.readrow.clone();
+        outputRowData = copyOrCloneArrayFromLoadFile( outputRowData, data.readrow );
       }
 
       // Read fields...
@@ -505,6 +505,21 @@ public class LoadFileInput extends BaseStep implements StepInterface {
       }
     }
     super.dispose( smi, sdi );
+  }
+
+  protected Object[] copyOrCloneArrayFromLoadFile( Object[] outputRowData, Object[] readrow ) {
+    // if readrow array is shorter than outputRowData reserved space, then we can not clone it because we have to
+    // preserve the outputRowData reserved space. Clone, creates a new array with a new length, equals to the
+    // readRow length and with that set we lost our outputRowData reserved space - needed for future additions.
+    // The equals case works in both clauses, but arraycopy is up to 5 times faster for smaller arrays.
+    if ( readrow.length <= outputRowData.length ) {
+      System.arraycopy( readrow, 0, outputRowData, 0, readrow.length );
+    } else {
+      // if readrow array is longer than outputRowData reserved space, then we can only clone it.
+      // Copy does not work here and will return an error since we are trying to copy a bigger array into a shorter one.
+      outputRowData = readrow.clone();
+    }
+    return outputRowData;
   }
 
 }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/loadfileinput/LoadFileInputTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/loadfileinput/LoadFileInputTest.java
@@ -387,4 +387,41 @@ public class LoadFileInputTest {
     assertNotNull( stepLoadFileInput.getOneRow() );
     assertArrayEquals( IOUtils.toByteArray( getFile( "pentaho_splash.png" ).getContent().getInputStream() ), stepLoadFileInput.data.filecontent );
   }
+
+  @Test
+  public void testCopyOrCloneArrayFromLoadFileWithSmallerSizedReadRowArray() {
+    int size = 5;
+    Object[] rowData = new Object[ size ];
+    Object[] readrow = new Object[ size - 1 ];
+    LoadFileInput loadFileInput = mock( LoadFileInput.class );
+
+    Mockito.when( loadFileInput.copyOrCloneArrayFromLoadFile( rowData, readrow ) ).thenCallRealMethod();
+
+    assertEquals( 5,  loadFileInput.copyOrCloneArrayFromLoadFile( rowData, readrow ).length );
+  }
+
+  @Test
+  public void testCopyOrCloneArrayFromLoadFileWithBiggerSizedReadRowArray() {
+    int size = 5;
+    Object[] rowData = new Object[ size ];
+    Object[] readrow = new Object[ size + 1 ];
+    LoadFileInput loadFileInput = mock( LoadFileInput.class );
+
+    Mockito.when( loadFileInput.copyOrCloneArrayFromLoadFile( rowData, readrow ) ).thenCallRealMethod();
+
+    assertEquals( 6,  loadFileInput.copyOrCloneArrayFromLoadFile( rowData, readrow ).length );
+  }
+
+  @Test
+  public void testCopyOrCloneArrayFromLoadFileWithSameSizedReadRowArray() {
+    int size = 5;
+    Object[] rowData = new Object[ size ];
+    Object[] readrow = new Object[ size ];
+    LoadFileInput loadFileInput = mock( LoadFileInput.class );
+
+    Mockito.when( loadFileInput.copyOrCloneArrayFromLoadFile( rowData, readrow ) ).thenCallRealMethod();
+
+    assertEquals( 5,  loadFileInput.copyOrCloneArrayFromLoadFile( rowData, readrow ).length );
+  }
+
 }


### PR DESCRIPTION
…are changed

This is an arraycopy vs clone issue. We have to use both of them depending of our execution context.
Having some rules in mind:
- We can only copy an equal length or smaller array into another.
- Using clone we have to be careful if we had initial reserved more space, because with clone, it sets the length of our final array to the length of the array we are cloning from.

This PR also fixes PDI-13264.

@mbatchelor @bmorrise     