### PR TITLE
PDI-17607 - Upgrade to ElasticSearch 6.3.0

### DIFF
--- a/plugins/elasticsearch-bulk-insert/assemblies/plugin/assembly/assembly.xml
+++ b/plugins/elasticsearch-bulk-insert/assemblies/plugin/assembly/assembly.xml
@@ -26,11 +26,13 @@
       <outputDirectory>elasticsearch-bulk-insert-plugin/lib</outputDirectory>
       <scope>runtime</scope>
       <useTransitiveDependencies>true</useTransitiveDependencies>
+      <!-- 
       <includes>
         <include>com.wcohen:com.wcohen.secondstring:jar</include>
         <include>commons-cli:commons-cli:jar</include>
         <include>com.ning:compress-lzf:jar</include>
         <include>org.elasticsearch:elasticsearch:jar</include>
+        <include>org.elasticsearch.client:transport:jar</include>
         <include>com.google.guava:guava:jar</include>
         <include>org.hdrhistogram:HdrHistogram:jar</include>
         <include>com.carrotsearch:hppc:jar</include>
@@ -60,6 +62,11 @@
         <include>com.spatial4j:spatial4j:jar</include>
         <include>com.tdunning:t-digest:jar</include>
       </includes>
+       -->
+       
+       <excludes>
+          <exclude>org.pentaho.di.plugins:elasticsearch-bulk-insert-core:jar</exclude>
+       </excludes>
     </dependencySet>
   </dependencySets>
 </assembly>

--- a/plugins/elasticsearch-bulk-insert/core/pom.xml
+++ b/plugins/elasticsearch-bulk-insert/core/pom.xml
@@ -21,54 +21,70 @@
     <timestamp>${maven.build.timestamp}</timestamp>
     <build.description>${project.description}</build.description>
     <maven.build.timestamp.format>yyyy/MM/dd hh:mm</maven.build.timestamp.format>
+    <elasticsearch.version>6.3.0</elasticsearch.version>
   </properties>
   
   <dependencies>
     <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch</artifactId>
-      <version>2.2.0</version>
+	    <groupId>org.elasticsearch</groupId>
+	    <artifactId>elasticsearch</artifactId>
+	    <version>${elasticsearch.version}</version>
+	    <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.elasticsearch.client</groupId>
+        <artifactId>transport</artifactId>
+        <version>${elasticsearch.version}</version>
+        <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-engine</artifactId>
       <version>${pdi.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-core</artifactId>
       <version>${pdi.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-ui-swt</artifactId>
       <version>${pdi.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.swt</groupId>
       <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
       <version>4.6</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>jface</artifactId>
       <version>3.3.0-I20070606-0010</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-engine</artifactId>
       <classifier>tests</classifier>
       <version>${pdi.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>

--- a/plugins/elasticsearch-bulk-insert/core/src/main/java/org/pentaho/di/trans/steps/elasticsearchbulk/ElasticSearchBulk.java
+++ b/plugins/elasticsearch-bulk-insert/core/src/main/java/org/pentaho/di/trans/steps/elasticsearchbulk/ElasticSearchBulk.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,6 +23,7 @@
 package org.pentaho.di.trans.steps.elasticsearchbulk;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -33,21 +34,21 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
-import org.elasticsearch.action.ListenableActionFuture;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.index.IndexRequest.OpType;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.node.Node;
-import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowDataUtil;
@@ -61,6 +62,7 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
+import org.pentaho.di.trans.steps.elasticsearchbulk.ElasticSearchBulkMeta.Server;
 
 /**
  * Does bulk insert of data into ElasticSearch
@@ -77,7 +79,6 @@ public class ElasticSearchBulk extends BaseStep implements StepInterface {
 
   TransportClient tc;
 
-  private Node node;
   private Client client;
   private String index;
   private String type;
@@ -106,7 +107,7 @@ public class ElasticSearchBulk extends BaseStep implements StepInterface {
   private Map<String, String> columnsToJson;
   private boolean hasFields;
 
-  private IndexRequest.OpType opType = OpType.CREATE;
+  private IndexRequest.OpType opType = org.elasticsearch.action.DocWriteRequest.OpType.CREATE;
 
   public ElasticSearchBulk( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
       Trans trans ) {
@@ -332,7 +333,9 @@ public class ElasticSearchBulk extends BaseStep implements StepInterface {
 
   private boolean processBatch( boolean makeNew ) throws KettleStepException {
 
-    ListenableActionFuture<BulkResponse> actionFuture = currentRequest.execute();
+    
+    
+    ActionFuture<BulkResponse> actionFuture = currentRequest.execute();
     boolean responseOk = false;
 
     BulkResponse response = null;
@@ -467,26 +470,29 @@ public class ElasticSearchBulk extends BaseStep implements StepInterface {
   }
 
   private void initClient() throws UnknownHostException {
-    Settings.Builder settingsBuilder = Settings.builder();
-    settingsBuilder.put( Settings.Builder.EMPTY_SETTINGS ); // keep default classloader
-    settingsBuilder.put( meta.getSettingsMap() );
-    // Settings settings = settingsBuilder.build();
-    TransportClient.Builder tClientBuilder = TransportClient.builder().settings( settingsBuilder );
 
-    if ( !meta.servers.isEmpty() ) {
-      node = null;
-      TransportClient tClient = tClientBuilder.build();
-      for ( ElasticSearchBulkMeta.Server s : meta.servers ) {
-        tClient.addTransportAddress( s.getAddr() );
-      }
-      client = tClient;
-    } else {
-      NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder();
-      nodeBuilder.settings( settingsBuilder );
-      node = nodeBuilder.client( true ).node(); // this node will not hold data
-      client = node.client();
-      node.start();
+    
+    
+    Settings.Builder settingsBuilder = Settings.builder();
+    settingsBuilder.put( Settings.Builder.EMPTY_SETTINGS );
+    meta.getSettingsMap().entrySet().stream().forEach( 
+        (s) -> settingsBuilder.put( s.getKey(), environmentSubstitute( s.getValue() ) ) );
+
+    PreBuiltTransportClient tClient = new PreBuiltTransportClient( settingsBuilder.build() );
+
+    for ( Server server : meta.getServers() ) {
+      tClient.addTransportAddress( new TransportAddress( 
+             InetAddress.getByName( environmentSubstitute(server.getAddress() ) ), 
+             server.getPort() ) );
     }
+    
+    client = tClient;
+    
+    /** With the upgrade to elasticsearch 6.3.0, removed the NodeBuilder,
+     *  which was removed from the elasticsearch 5.0 API, see:
+     *  https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_java_api_changes.html#_nodebuilder_removed
+     */
+      
   }
 
   private void disposeClient() {
@@ -494,9 +500,7 @@ public class ElasticSearchBulk extends BaseStep implements StepInterface {
     if ( client != null ) {
       client.close();
     }
-    if ( node != null ) {
-      node.close();
-    }
+
 
   }
 

--- a/plugins/elasticsearch-bulk-insert/core/src/main/java/org/pentaho/di/trans/steps/elasticsearchbulk/ElasticSearchBulkMeta.java
+++ b/plugins/elasticsearch-bulk-insert/core/src/main/java/org/pentaho/di/trans/steps/elasticsearchbulk/ElasticSearchBulkMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,8 +22,6 @@
 
 package org.pentaho.di.trans.steps.elasticsearchbulk;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,7 +30,6 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
@@ -45,8 +42,8 @@ import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -386,8 +383,7 @@ public class ElasticSearchBulkMeta extends BaseStepMeta implements StepMetaInter
   public void getFields( RowMetaInterface r, String name, RowMetaInterface[] info, StepMeta nextStep,
       VariableSpace space, Repository repository, IMetaStore metaStore ) throws KettleStepException {
     if ( StringUtils.isNotBlank( this.getIdOutField() ) ) {
-      ValueMetaInterface valueMeta =
-          new ValueMeta( space.environmentSubstitute( this.getIdOutField() ), ValueMetaInterface.TYPE_STRING );
+      ValueMetaInterface valueMeta = new ValueMetaString( space.environmentSubstitute( this.getIdOutField() ) );
       valueMeta.setOrigin( name );
       // add if doesn't exist
       if ( !r.exists( valueMeta ) ) {
@@ -768,7 +764,7 @@ public class ElasticSearchBulkMeta extends BaseStepMeta implements StepMetaInter
 
   public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int cnr, TransMeta transMeta,
       Trans trans ) {
-    return new ElasticSearchBulk( stepMeta, stepDataInterface, cnr, transMeta, trans );
+      return new ElasticSearchBulk( stepMeta, stepDataInterface, cnr, transMeta, trans );
   }
 
   public StepDataInterface getStepData() {
@@ -785,9 +781,14 @@ public class ElasticSearchBulkMeta extends BaseStepMeta implements StepMetaInter
     @Injection( name = "PORT" )
     public int port;
 
-    public InetSocketTransportAddress getAddr() throws UnknownHostException {
-      return new InetSocketTransportAddress( InetAddress.getByName( address ), port );
+    public String getAddress() {
+      return address;
     }
+    
+    public int getPort() {
+      return port;
+    }
+    
   }
 
   public static class Field {

--- a/plugins/elasticsearch-bulk-insert/core/src/main/java/org/pentaho/di/ui/trans/steps/elasticsearchbulk/ElasticSearchBulkDialog.java
+++ b/plugins/elasticsearch-bulk-insert/core/src/main/java/org/pentaho/di/ui/trans/steps/elasticsearchbulk/ElasticSearchBulkDialog.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.ui.trans.steps.elasticsearchbulk;
 
+import java.net.InetAddress;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
@@ -50,7 +51,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.elasticsearch.action.ListenableActionFuture;
+import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequestBuilder;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequestBuilder;
@@ -58,14 +59,12 @@ import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRespon
 import org.elasticsearch.action.admin.indices.recovery.RecoveryRequestBuilder;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.NoNodeAvailableException;
-import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
-import org.elasticsearch.node.Node;
-import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.exception.KettleException;
@@ -75,6 +74,7 @@ import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepDialogInterface;
 import org.pentaho.di.trans.steps.elasticsearchbulk.ElasticSearchBulkMeta;
+import org.pentaho.di.trans.steps.elasticsearchbulk.ElasticSearchBulkMeta.Server;
 import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.core.widget.ColumnInfo;
 import org.pentaho.di.ui.core.widget.LabelComboVar;
@@ -221,7 +221,7 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
     wCancel = new Button( shell, SWT.PUSH );
     wCancel.setText( BaseMessages.getString( PKG, "System.Button.Cancel" ) );
 
-    setButtonPositions( new Button[]{ wOK, wCancel }, margin, null );
+    setButtonPositions( new Button[] { wOK, wCancel }, margin, null );
 
     fdTabFolder = new FormData();
     fdTabFolder.left = new FormAttachment( 0, 0 );
@@ -335,16 +335,14 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
 
     // Index
     wIndex =
-      new LabelTextVar( transMeta, wIndexGroup,
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Index.Label" ),
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Index.Tooltip" ) );
+        new LabelTextVar( transMeta, wIndexGroup, BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Index.Label" ),
+            BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Index.Tooltip" ) );
     wIndex.addModifyListener( lsMod );
 
     // Type
     wType =
-      new LabelTextVar( transMeta, wIndexGroup,
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Type.Label" ),
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Type.Tooltip" ) );
+        new LabelTextVar( transMeta, wIndexGroup, BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Type.Label" ),
+            BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Type.Tooltip" ) );
     wType.addModifyListener( lsMod );
 
     // Test button
@@ -359,10 +357,10 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
       }
     } );
 
-    Control[] connectionControls = new Control[]{ wIndex, wType };
+    Control[] connectionControls = new Control[] { wIndex, wType };
     placeControls( wIndexGroup, connectionControls );
 
-    BaseStepDialog.positionBottomButtons( wIndexGroup, new Button[]{ wTest }, Const.MARGIN, wType );
+    BaseStepDialog.positionBottomButtons( wIndexGroup, new Button[] { wTest }, Const.MARGIN, wType );
 
     fdIndexGroup = new FormData();
     fdIndexGroup.left = new FormAttachment( 0, Const.MARGIN );
@@ -395,21 +393,20 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
       }
     } );
 
-    setButtonPositions( new Button[]{ wTestCl }, Const.MARGIN, null );
+    setButtonPositions( new Button[] { wTestCl }, Const.MARGIN, null );
 
     ColumnInfo[] columnsMeta = new ColumnInfo[2];
     columnsMeta[0] =
-      new ColumnInfo(
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.ServersTab.Address.Column" ),
-        ColumnInfo.COLUMN_TYPE_TEXT, false );
+        new ColumnInfo( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.ServersTab.Address.Column" ),
+            ColumnInfo.COLUMN_TYPE_TEXT, false );
+    columnsMeta[0].setUsingVariables( true );
     columnsMeta[1] =
-      new ColumnInfo(
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.ServersTab.Port.Column" ),
-        ColumnInfo.COLUMN_TYPE_TEXT, true );
+        new ColumnInfo( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.ServersTab.Port.Column" ),
+            ColumnInfo.COLUMN_TYPE_TEXT, true );
 
     wServers =
-      new TableView(
-        transMeta, wServersComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, columnsMeta, 1, lsMod, props );
+        new TableView( transMeta, wServersComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, columnsMeta, 1, lsMod,
+            props );
     FormData fdServers = new FormData();
     fdServers.left = new FormAttachment( 0, Const.MARGIN );
     fdServers.top = new FormAttachment( 0, Const.MARGIN );
@@ -441,17 +438,16 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
 
     ColumnInfo[] columnsMeta = new ColumnInfo[2];
     columnsMeta[0] =
-      new ColumnInfo(
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.SettingsTab.Property.Column" ),
-        ColumnInfo.COLUMN_TYPE_TEXT, false );
+        new ColumnInfo( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.SettingsTab.Property.Column" ),
+            ColumnInfo.COLUMN_TYPE_TEXT, false );
     columnsMeta[1] =
-      new ColumnInfo(
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.SettingsTab.Value.Column" ),
-        ColumnInfo.COLUMN_TYPE_TEXT, false );
+        new ColumnInfo( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.SettingsTab.Value.Column" ),
+            ColumnInfo.COLUMN_TYPE_TEXT, false );
+    columnsMeta[1].setUsingVariables( true );
 
     wSettings =
-      new TableView(
-        transMeta, wSettingsComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, columnsMeta, 1, lsMod, props );
+        new TableView( transMeta, wSettingsComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, columnsMeta, 1, lsMod,
+            props );
     FormData fdServers = new FormData();
     fdServers.left = new FormAttachment( 0, Const.MARGIN );
     fdServers.top = new FormAttachment( 0, Const.MARGIN );
@@ -494,25 +490,22 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
     };
     wGet.addListener( SWT.Selection, lsGet );
 
-    setButtonPositions( new Button[]{ wGet }, Const.MARGIN, null );
+    setButtonPositions( new Button[] { wGet }, Const.MARGIN, null );
 
     final int fieldsRowCount = model.getFields().size();
 
-    String[] names = this.fieldNames != null ? this.fieldNames : new String[]{ "" };
+    String[] names = this.fieldNames != null ? this.fieldNames : new String[] { "" };
     ColumnInfo[] columnsMeta = new ColumnInfo[2];
     columnsMeta[0] =
-      new ColumnInfo(
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.NameColumn.Column" ),
-        ColumnInfo.COLUMN_TYPE_CCOMBO, names, false );
+        new ColumnInfo( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.NameColumn.Column" ),
+            ColumnInfo.COLUMN_TYPE_CCOMBO, names, false );
     columnsMeta[1] =
-      new ColumnInfo(
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TargetNameColumn.Column" ),
-        ColumnInfo.COLUMN_TYPE_TEXT, false );
+        new ColumnInfo( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TargetNameColumn.Column" ),
+            ColumnInfo.COLUMN_TYPE_TEXT, false );
 
     wFields =
-      new TableView(
-        transMeta, wFieldsComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, columnsMeta, fieldsRowCount,
-        lsMod, props );
+        new TableView( transMeta, wFieldsComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, columnsMeta, fieldsRowCount,
+            lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, Const.MARGIN );
@@ -547,9 +540,8 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
 
     // Timeout
     wTimeOut =
-      new LabelTimeComposite( wSettingsGroup,
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TimeOut.Label" ),
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TimeOut.Tooltip" ) );
+        new LabelTimeComposite( wSettingsGroup, BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TimeOut.Label" ),
+            BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TimeOut.Tooltip" ) );
     props.setLook( wTimeOut );
     wTimeOut.addModifyListener( lsMod );
 
@@ -583,9 +575,9 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
 
     // ID input
     wIdInField =
-      new LabelComboVar( transMeta, wSettingsGroup,
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.IdField.Label" ),
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.IdField.Tooltip" ) );
+        new LabelComboVar( transMeta, wSettingsGroup, BaseMessages.getString( PKG,
+            "ElasticSearchBulkDialog.IdField.Label" ), BaseMessages.getString( PKG,
+                "ElasticSearchBulkDialog.IdField.Tooltip" ) );
     props.setLook( wIdInField );
     wIdInField.getComboWidget().setEditable( true );
     wIdInField.addModifyListener( lsMod );
@@ -638,9 +630,9 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
 
     // ID out field
     wIdOutField =
-      new LabelTextVar( transMeta, wSettingsGroup,
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.IdOutField.Label" ),
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.IdOutField.Tooltip" ) );
+        new LabelTextVar( transMeta, wSettingsGroup, BaseMessages.getString( PKG,
+            "ElasticSearchBulkDialog.IdOutField.Label" ), BaseMessages.getString( PKG,
+                "ElasticSearchBulkDialog.IdOutField.Tooltip" ) );
     props.setLook( wIdOutField );
     wIdOutField.setEnabled( wUseOutput.getSelection() );
     wIdOutField.addModifyListener( lsMod );
@@ -668,9 +660,9 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
 
     // Json field
     wJsonField =
-      new LabelComboVar( transMeta, wSettingsGroup,
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.JsonField.Label" ),
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.JsonField.Tooltip" ) );
+        new LabelComboVar( transMeta, wSettingsGroup, BaseMessages.getString( PKG,
+            "ElasticSearchBulkDialog.JsonField.Label" ), BaseMessages.getString( PKG,
+                "ElasticSearchBulkDialog.JsonField.Tooltip" ) );
     wJsonField.getComboWidget().setEditable( true );
     props.setLook( wJsonField );
     wJsonField.addModifyListener( lsMod );
@@ -686,9 +678,8 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
     wJsonField.setEnabled( wIsJson.getSelection() );
 
     Control[] settingsControls =
-      new Control[]{
-        wlBatchSize, wBatchSize, wlStopOnError, wStopOnError, wTimeOut, wIdInField, wlIsOverwrite,
-        wIsOverwrite, wlUseOutput, wUseOutput, wIdOutField, wlIsJson, wIsJson, wJsonField };
+        new Control[] { wlBatchSize, wBatchSize, wlStopOnError, wStopOnError, wTimeOut, wIdInField, wlIsOverwrite,
+          wIsOverwrite, wlUseOutput, wUseOutput, wIdOutField, wlIsJson, wIsJson, wJsonField };
     placeControls( wSettingsGroup, settingsControls );
 
     fdSettingsGroup = new FormData();
@@ -715,9 +706,8 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
           fieldNames = r.getFieldNames();
         }
       } catch ( KettleException ke ) {
-        new ErrorDialog( shell,
-          BaseMessages.getString( PKG, "ElasticSearchBulkDialog.FailedToGetFields.DialogTitle" ),
-          BaseMessages.getString( PKG, "ElasticSearchBulkDialog.FailedToGetFields.DialogMessage" ), ke );
+        new ErrorDialog( shell, BaseMessages.getString( PKG, "ElasticSearchBulkDialog.FailedToGetFields.DialogTitle" ),
+            BaseMessages.getString( PKG, "ElasticSearchBulkDialog.FailedToGetFields.DialogMessage" ), ke );
         return new String[0];
       }
     }
@@ -729,11 +719,11 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
     try {
       RowMetaInterface r = transMeta.getPrevStepFields( stepname );
       if ( r != null ) {
-        BaseStepDialog.getFieldsFromPrevious( r, table, 1, new int[]{ 1, 2 }, null, 0, 0, null );
+        BaseStepDialog.getFieldsFromPrevious( r, table, 1, new int[] { 1, 2 }, null, 0, 0, null );
       }
     } catch ( KettleException ke ) {
       new ErrorDialog( shell, BaseMessages.getString( PKG, "System.Dialog.GetFieldsFailed.Title" ), BaseMessages
-        .getString( PKG, "System.Dialog.GetFieldsFailed.Message" ), ke );
+          .getString( PKG, "System.Dialog.GetFieldsFailed.Message" ), ke );
     }
   }
 
@@ -775,7 +765,8 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
   /**
    * Read the data from the ElasticSearchBulkMeta object and show it in this dialog.
    *
-   * @param in The ElasticSearchBulkMeta object to obtain the data from.
+   * @param in
+   *          The ElasticSearchBulkMeta object to obtain the data from.
    */
   public void getData( ElasticSearchBulkMeta in ) {
     wIndex.setText( Const.NVL( in.getIndex(), "" ) );
@@ -837,9 +828,8 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
     try {
       toModel( model );
     } catch ( KettleException e ) {
-      new ErrorDialog( shell,
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.ErrorValidateData.DialogTitle" ),
-        BaseMessages.getString( PKG, "ElasticSearchBulkDialog.ErrorValidateData.DialogMessage" ), e );
+      new ErrorDialog( shell, BaseMessages.getString( PKG, "ElasticSearchBulkDialog.ErrorValidateData.DialogTitle" ),
+          BaseMessages.getString( PKG, "ElasticSearchBulkDialog.ErrorValidateData.DialogMessage" ), e );
     }
     dispose();
   }
@@ -900,90 +890,70 @@ public class ElasticSearchBulkDialog extends BaseStepDialog implements StepDialo
 
   private void test( TestType testType ) {
 
-    // Save off the thread's context class loader to restore after the test
-    ClassLoader originalClassloader = Thread.currentThread().getContextClassLoader();
-
-    // Now ensure that the thread's context class loader is the plugin's classloader
-    Thread.currentThread().setContextClassLoader( this.getClass().getClassLoader() );
-
-    Client client = null;
-    Node node = null;
     try {
 
       ElasticSearchBulkMeta tempMeta = new ElasticSearchBulkMeta();
       toModel( tempMeta );
 
-      Settings.Builder settingsBuilder = Settings.settingsBuilder();
-      settingsBuilder.put( Settings.Builder.EMPTY_SETTINGS ); // keep default classloader
-      settingsBuilder.put( tempMeta.getSettingsMap() );
-      TransportClient.Builder tClientBuilder = TransportClient.builder().settings( settingsBuilder );
+      // if ( !tempMeta.getServers().isEmpty() ) {
 
-      if ( !tempMeta.getServers().isEmpty() ) {
-        node = null;
-        TransportClient tClient = tClientBuilder.build();
-        for ( ElasticSearchBulkMeta.Server s : tempMeta.getServers() ) {
-          tClient.addTransportAddress( s.getAddr() );
+      Settings.Builder settingsBuilder = Settings.builder();
+      settingsBuilder.put( Settings.Builder.EMPTY_SETTINGS );
+      tempMeta.getSettingsMap().entrySet().stream().forEach( 
+          (s) -> settingsBuilder.put( s.getKey(), transMeta.environmentSubstitute( s.getValue() ) ) );
+      
+
+      try (PreBuiltTransportClient client = new PreBuiltTransportClient( settingsBuilder.build() )) {
+
+        for ( Server server : tempMeta.getServers() ) {
+
+          client.addTransportAddress( new TransportAddress( 
+                 InetAddress.getByName( transMeta.environmentSubstitute(server.getAddress() ) ), 
+                 server.getPort() ) );
+
         }
-        client = tClient;
-      } else {
-        NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder();
-        nodeBuilder.settings( settingsBuilder );
-        node = nodeBuilder.client( true ).node();
-        client = node.client();
-        node.start();
-      }
 
-      AdminClient admin = client.admin();
+        AdminClient admin = client.admin();
 
-      switch ( testType ) {
-        case INDEX:
-          if ( StringUtils.isBlank( tempMeta.getIndex() ) ) {
-            showError( BaseMessages.getString( PKG, "ElasticSearchBulk.Error.NoIndex" ) );
+        switch ( testType ) {
+          case INDEX:
+            if ( StringUtils.isBlank( tempMeta.getIndex() ) ) {
+              showError( BaseMessages.getString( PKG, "ElasticSearchBulk.Error.NoIndex" ) );
+              break;
+            }
+            // First check to see if the index exists
+            IndicesExistsRequestBuilder indicesExistBld = admin.indices().prepareExists( tempMeta.getIndex() );
+            IndicesExistsResponse indicesExistResponse = indicesExistBld.execute().get();
+            if ( !indicesExistResponse.isExists() ) {
+              showError( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Error.NoIndex" ) );
+              return;
+            }
+
+            RecoveryRequestBuilder indicesBld = admin.indices().prepareRecoveries( tempMeta.getIndex() );
+            ActionFuture<RecoveryResponse> lafInd = indicesBld.execute();
+            String shards = "" + lafInd.get().getSuccessfulShards() + "/" + lafInd.get().getTotalShards();
+            showMessage( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TestIndex.TestOK", shards ) );
             break;
-          }
-          // First check to see if the index exists
-          IndicesExistsRequestBuilder indicesExistBld = admin.indices().prepareExists( tempMeta.getIndex() );
-          IndicesExistsResponse indicesExistResponse = indicesExistBld.execute().get();
-          if ( !indicesExistResponse.isExists() ) {
-            showError( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Error.NoIndex" ) );
-            return;
-          }
+          case CLUSTER:
+            ClusterStateRequestBuilder clusterBld = admin.cluster().prepareState();
+            ActionFuture<ClusterStateResponse> lafClu = clusterBld.execute();
+            ClusterStateResponse cluResp = lafClu.actionGet();
+            String name = cluResp.getClusterName().value();
+            ClusterState cluState = cluResp.getState();
+            int numNodes = cluState.getNodes().getSize();
+            showMessage( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TestCluster.TestOK", name, numNodes ) );
+            break;
+          default:
+            break;
+        }
 
-          RecoveryRequestBuilder indicesBld = admin.indices().prepareRecoveries( tempMeta.getIndex() );
-          ListenableActionFuture<RecoveryResponse> lafInd = indicesBld.execute();
-          String shards = "" + lafInd.get().getSuccessfulShards() + "/" + lafInd.get().getTotalShards();
-          showMessage( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TestIndex.TestOK", shards ) );
-          break;
-        case CLUSTER:
-          ClusterStateRequestBuilder clusterBld = admin.cluster().prepareState();
-          ListenableActionFuture<ClusterStateResponse> lafClu = clusterBld.execute();
-          ClusterStateResponse cluResp = lafClu.actionGet();
-          String name = cluResp.getClusterName().value();
-          ClusterState cluState = cluResp.getState();
-          int numNodes = cluState.getNodes().size();
-          showMessage( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.TestCluster.TestOK", name, numNodes ) );
-          break;
-        default:
-          break;
       }
-    } catch ( NoNodeAvailableException e ) {
-      showError( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Error.NoNodesFound" ) );
-    } catch ( MasterNotDiscoveredException e ) {
+
+    } catch ( NoNodeAvailableException | MasterNotDiscoveredException e ) {
       showError( BaseMessages.getString( PKG, "ElasticSearchBulkDialog.Error.NoNodesFound" ) );
     } catch ( Exception e ) {
       showError( e.getLocalizedMessage() );
-    } finally {
-      if ( client != null ) {
-        client.close();
-      }
-      if ( node != null ) {
-        node.close();
-      }
-    }
-
-    // Restore the original classloader
-    Thread.currentThread().setContextClassLoader( originalClassloader );
-
+    } 
   }
 
   private void showError( String message ) {

--- a/plugins/elasticsearch-bulk-insert/core/src/test/java/org/pentaho/di/trans/steps/elasticsearchbulk/ElasticSearchBulkMetaTest.java
+++ b/plugins/elasticsearch-bulk-insert/core/src/test/java/org/pentaho/di/trans/steps/elasticsearchbulk/ElasticSearchBulkMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleValueException;
@@ -230,9 +230,9 @@ public class ElasticSearchBulkMetaTest {
   }
 
   public class InetSocketTransportAddressFieldLoadSaveValidator implements
-      FieldLoadSaveValidator<InetSocketTransportAddress> {
+      FieldLoadSaveValidator<TransportAddress> {
     @Override
-    public InetSocketTransportAddress getTestObject() {
+    public TransportAddress getTestObject() {
       byte[] randomIP;
       // Test IPv4 and IPv6 addresses
       if ( new Random().nextBoolean() ) {
@@ -242,15 +242,15 @@ public class ElasticSearchBulkMetaTest {
       }
       new Random().nextBytes( randomIP );
       try {
-        return new InetSocketTransportAddress( InetAddress.getByAddress( randomIP ), new Random().nextInt( 65536 ) );
+        return new TransportAddress( InetAddress.getByAddress( randomIP ), new Random().nextInt( 65536 ) );
       } catch ( UnknownHostException e ) {
-        return new InetSocketTransportAddress( InetAddress.getLoopbackAddress(), new Random().nextInt( 65536 ) );
+        return new TransportAddress( InetAddress.getLoopbackAddress(), new Random().nextInt( 65536 ) );
       }
     }
 
     @Override
-    public boolean validateTestObject( InetSocketTransportAddress testObject, Object actual ) {
-      return testObject.equals( (InetSocketTransportAddress) actual );
+    public boolean validateTestObject( TransportAddress testObject, Object actual ) {
+      return testObject.equals( (TransportAddress) actual );
     }
   }
 


### PR DESCRIPTION
Important note, which is listed in the code:

With the upgrade to elasticsearch 6.3.0, removed the NodeBuilder,
which was removed from the elasticsearch 5.0 API, see:

https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_java_api_changes.html#_nodebuilder_removed

