### PR TITLE
fix the bug which is about the multiple chars of delimiter 

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
@@ -292,7 +292,12 @@ public class CsvInputData extends BaseStepData implements StepDataInterface {
   }
 
   boolean delimiterFound() {
-    return delimiterMatcher.matchesPattern( byteBuffer, endBuffer, delimiter );
+	boolean result = delimiterMatcher.matchesPattern(byteBuffer, bufferSize, endBuffer, delimiter);
+	
+	if (result)
+			endBuffer = endBuffer - delimiter.length + 1;
+		
+    return result;
   }
 
   boolean enclosureFound() {

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/EmptyPatternMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/EmptyPatternMatcher.java
@@ -24,8 +24,8 @@ package org.pentaho.di.trans.steps.csvinput;
 
 public class EmptyPatternMatcher implements PatternMatcherInterface {
 
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern ) {
-    return false;
-  }
+	public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] patter) {		
+		return false;
+	}
 
 }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/PatternMatcherInterface.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/PatternMatcherInterface.java
@@ -23,5 +23,7 @@
 package org.pentaho.di.trans.steps.csvinput;
 
 public interface PatternMatcherInterface {
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern );
+	// sourceSize
+	public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] pattern);
+
 }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/SingleBytePatternMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/SingleBytePatternMatcher.java
@@ -24,8 +24,8 @@ package org.pentaho.di.trans.steps.csvinput;
 
 public class SingleBytePatternMatcher implements PatternMatcherInterface {
 
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern ) {
-    return source[location] == pattern[0];
-  }
+	public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] pattern) {
+		return source[location] == pattern[0];
+	}
 
 }


### PR DESCRIPTION
when the multiple chars of delimiter (such as @|@) happened to be divided into two buffers, the data is read incorrectly in CSVinput node.
For example one file with only one line:
a@|@aaaa@|@aaa@|@aaaa@|@aaaaa@|@

Set the NIO buffer size to 10 and the delimiter as '@|@' to a CSVinput, get fields automatically and preview the data, then you will see the bug.

![1](https://user-images.githubusercontent.com/13728060/46090676-cca67c80-c1e3-11e8-906d-b58ce2e99343.png)

![2](https://user-images.githubusercontent.com/13728060/46090683-d334f400-c1e3-11e8-810b-e7c249a36180.png)


