### PR TITLE
7.1--fix the bug which is about multiple chars of delimiter

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
@@ -292,7 +292,12 @@ public class CsvInputData extends BaseStepData implements StepDataInterface {
   }
 
   boolean delimiterFound() {
-    return delimiterMatcher.matchesPattern( byteBuffer, endBuffer, delimiter );
+	boolean result = delimiterMatcher.matchesPattern(byteBuffer, bufferSize, endBuffer, delimiter);
+	
+	if (result)
+			endBuffer = endBuffer - delimiter.length + 1;
+		
+    return result;
   }
 
   boolean enclosureFound() {

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/EmptyPatternMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/EmptyPatternMatcher.java
@@ -24,8 +24,8 @@ package org.pentaho.di.trans.steps.csvinput;
 
 public class EmptyPatternMatcher implements PatternMatcherInterface {
 
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern ) {
-    return false;
-  }
+	public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] patter) {		
+		return false;
+	}
 
 }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/MultiBytePatternMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/MultiBytePatternMatcher.java
@@ -23,15 +23,26 @@
 package org.pentaho.di.trans.steps.csvinput;
 
 public class MultiBytePatternMatcher implements PatternMatcherInterface {
-
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern ) {
+  private int continueToMatchIndex = 0;
+  
+  public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] pattern) {
+    // every time only match one char
     int start = location;
-    for ( int i = 0; i < pattern.length; i++ ) {
-      if ( source[start + i] != pattern[i] ) {
-        return false;
-      }
-    }
-    return true;
-  }
 
+    if (start >= sourceSize)
+        return false;
+
+    if (source[start] != pattern[continueToMatchIndex]) {
+        continueToMatchIndex = 0;
+        return false;
+    } else {
+        continueToMatchIndex++;
+    }
+
+    if (continueToMatchIndex == pattern.length) {
+        continueToMatchIndex = 0;
+        return true;
+    } else
+        return false;
+    }
 }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/PatternMatcherInterface.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/PatternMatcherInterface.java
@@ -23,5 +23,7 @@
 package org.pentaho.di.trans.steps.csvinput;
 
 public interface PatternMatcherInterface {
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern );
+	// sourceSize
+	public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] pattern);
+
 }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/SingleBytePatternMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/SingleBytePatternMatcher.java
@@ -24,8 +24,8 @@ package org.pentaho.di.trans.steps.csvinput;
 
 public class SingleBytePatternMatcher implements PatternMatcherInterface {
 
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern ) {
-    return source[location] == pattern[0];
-  }
+	public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] pattern) {
+		return source[location] == pattern[0];
+	}
 
 }


### PR DESCRIPTION
when the multiple chars of delimiter (such as @|@) happened to be divided into two buffers, the data is read incorrectly in CSVinput node.

for example: set the NIO buffer to 10 and set delimiter as '@|@' in the CSVInput node, and the file has only one line as following:
a@|@aaaa@|@aaa@|@aaaa@|@aaaaa@|@

Get the fields automatically and click preview data, then you will see the bug.


![1](https://user-images.githubusercontent.com/13728060/46091199-e7c5bc00-c1e4-11e8-8d32-c54114077f09.png)

![2](https://user-images.githubusercontent.com/13728060/46091232-f4e2ab00-c1e4-11e8-97d3-9cce121b75a1.png)

