### PR TITLE
[PDI-17620] Error message when a sub-transformation is not defined is…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1263,6 +1263,10 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
     String realTransName = "";
     String realDirectory = "/";
 
+    if ( StringUtils.isBlank( transPath ) ) {
+      throw new KettleException( BaseMessages.getString( PKG, "JobTrans.Exception.MissingTransFileName" ) );
+    }
+
     int index = transPath.lastIndexOf( RepositoryFile.SEPARATOR );
     if ( index != -1 ) {
       realTransName = transPath.substring( index + 1 );


### PR DESCRIPTION
… not clear

PDI-17532 - removed the JobTrans.Exception.MissingTransFileName message declared in BACKLOG-21756. This PR insert it again.

@pentaho-lmartins 