### PR TITLE
FTB: Errors while building StepWithMappingMetaTest / OutOfMemoryError in ExtensionPointIntegrationTest

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -536,6 +536,13 @@
 
   <build>
     <plugins>
+     <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkMode>always</forkMode>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>

--- a/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
@@ -56,6 +56,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.pentaho.di.resource.ResourceNamingInterface;
+import org.pentaho.metastore.api.IMetaStore;
 
 
 /**
@@ -147,7 +149,7 @@ public class StepWithMappingMetaTest {
     String testName = "test";
     PowerMockito.mockStatic( StepWithMappingMeta.class );
     when( StepWithMappingMeta.loadMappingMeta( any(), any(), any(), any() ) ).thenReturn( transMeta );
-    when( transMeta.exportResources( any(), anyMap(), any(), any(), any() ) ).thenReturn( testName );
+    when( transMeta.exportResources( any(VariableSpace.class), anyMap(), any(ResourceNamingInterface.class), any(Repository.class), any(IMetaStore.class) ) ).thenReturn( testName );
 
     stepWithMappingMeta.exportResources( null, null, null, null, null );
     verify( transMeta ).setFilename( "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + testName );


### PR DESCRIPTION
This PR contains fixes to errors occcuring while building/testing PDI:

- StepDataInterface is not compile due to a cast error involving Mockito's any()

- ExtensionPointIntegrationTest fails with OutOfMemoryError. This can be avoided by forcing Surefire to fork always.