### PR TITLE
PDI-12648: Encode tag content using Encode.forXmlContent()

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/xml/XMLHandler.java
+++ b/core/src/main/java/org/pentaho/di/core/xml/XMLHandler.java
@@ -798,7 +798,7 @@ public class XMLHandler {
 
     if ( val != null && val.length() > 0 ) {
       value.append( '>' );
-      value.append( Encode.forXml( val ) );
+      value.append( Encode.forXmlContent( val ) );
 
       value.append( "</" );
       value.append( Encode.forXml( tag ) );

--- a/core/src/test/java/org/pentaho/di/core/xml/XMLHandlerUnitTest.java
+++ b/core/src/test/java/org/pentaho/di/core/xml/XMLHandlerUnitTest.java
@@ -224,7 +224,7 @@ public class XMLHandlerUnitTest {
     String expectedStrAfterConversion = "<[value_start (&#34;&#39;&lt;&amp;&gt;) value_end] "
       + "[value_start (&#34;&#39;&lt;&amp;&gt;) value_end]=\""
       + "[value_start (&#34;&#39;&lt;&amp;>) value_end]\" >"
-      + "[value_start (&#34;&#39;&lt;&amp;&gt;) value_end]"
+      + "[value_start (\"'&lt;&amp;&gt;) value_end]"
       + "</[value_start (&#34;&#39;&lt;&amp;&gt;) value_end]>";
     String result = XMLHandler.addTagValue( testString, testString, false, testString, testString );
     assertEquals( expectedStrAfterConversion, result );


### PR DESCRIPTION
Current PDI version remove line breaks from XML tag values. This is especially true for any SQL step since any change is not trackable anymore through SCM. It will always show one line with the SQL being changed.

The source of the issue lies in the over-careful approach to encoding the XML values: Currently it use Encode.forXml() which is meant to be used for everything inside XML tags. The more lenient Encode.forXmlContent() will not touch line breaks.

This was reported as PDI-12648 which was closed unfortunately before the issue was fixed.

