### PR TITLE
[PDI-17577] Text File Output Step 2-5 Times Slower in V8.1 than V6.1

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -445,7 +445,7 @@ public class TextFileOutput extends BaseStep implements StepInterface {
 
     Object[] row = getRow(); // This also waits for a row to be finished.
 
-    if ( ( row != null ) && ( ( meta.getOutputFields().length == 0 ) || first ) ) {
+    if ( row != null  && first ) {
       data.outputRowMeta = getInputRowMeta().clone();
     }
 


### PR DESCRIPTION
@pentaho-lmartins @mbatchelor @bmorrise @lucboudreau 

This issue was introduced in PDI-13987, which caused the inputRowMeta to be cloned for each row processed. It was then changed again to check for the outputfields lenght in BACKLOG-16118, which continues to clone the rowMeta for each row. This fix makes the code similar what it was in 6.1 before PDI-13987. 
The removal of the outputfields length check has no effect in the correction done in BACKLOG-16118 (meaning, the expected result still occurs).