### PR TITLE
[PDI-17656] Use internalization key instead of hardcode

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/core/widget/ConditionEditor.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/widget/ConditionEditor.java
@@ -543,7 +543,7 @@ public class ConditionEditor extends Composite {
       case AREA_SUBCONDITION:
         mPop = new Menu( widget );
         MenuItem miEdit = new MenuItem( mPop, SWT.CASCADE );
-        miEdit.setText( "Edit condition" );
+        miEdit.setText( BaseMessages.getString( PKG, "ConditionEditor.EditCondition.Label" ) );
         miEdit.addSelectionListener( new SelectionAdapter() {
           @Override
           public void widgetSelected( SelectionEvent e ) {


### PR DESCRIPTION
This patch originally came from @Valeran86 to HiromuHota/pentaho-kettle as HiromuHota/pentaho-kettle#121 but I think it should be merged to the upstream.