### PR TITLE
[BACKLOG-26150] Correction to the fix for BACKLOG-25967.  In the case…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/util/serialization/BaseSerializingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/serialization/BaseSerializingMeta.java
@@ -80,15 +80,20 @@ public abstract class BaseSerializingMeta extends BaseStepMeta implements StepMe
    * Creates a copy of this stepMeta with variables globally substituted.
    */
   public StepMetaInterface withVariables( VariableSpace variables ) {
-    BaseSerializingMeta newInstance = null;
-    try {
-      newInstance = this.getClass().newInstance();
-    } catch ( IllegalAccessException | InstantiationException e ) {
-      throw new IllegalStateException( e );
-    }
     return StepMetaProps
       .from( this )
       .withVariables( variables )
-      .to( newInstance );
+      .to( (StepMetaInterface) this.copyObject() );
+  }
+
+  /**
+   * This is intended to act the way clone should (return a fully independent copy of the original).  This method
+   * name was chosen in order to force any subclass that wants to use withVariables to implement a proper clone
+   * override, but let others ignore it.
+   *
+   * @return a copy of this object
+   */
+  public BaseSerializingMeta copyObject() {
+    throw new UnsupportedOperationException( "This method must be overridden if you use withVariables." );
   }
 }

--- a/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsConsumerMeta.java
+++ b/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsConsumerMeta.java
@@ -51,7 +51,7 @@ import static org.pentaho.di.core.ObjectLocationSpecificationMethod.FILENAME;
 public class JmsConsumerMeta extends BaseStreamStepMeta {
 
   @InjectionDeep
-  public final JmsDelegate jmsDelegate;
+  public JmsDelegate jmsDelegate;
 
   @VisibleForTesting
   public JmsConsumerMeta() {
@@ -84,4 +84,9 @@ public class JmsConsumerMeta extends BaseStreamStepMeta {
     return new GenericStepData();
   }
 
+  @Override public JmsConsumerMeta copyObject() {
+    JmsConsumerMeta newClone = (JmsConsumerMeta) this.clone();
+    newClone.jmsDelegate = new JmsDelegate( this.jmsDelegate );
+    return newClone;
+  }
 }

--- a/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsDelegate.java
+++ b/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsDelegate.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.di.trans.step.jms;
 
-
 import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -105,6 +104,36 @@ public class JmsDelegate {
   public JmsDelegate( List<JmsProvider> jmsProviders ) {
     super();
     this.jmsProviders = jmsProviders;
+  }
+
+  public JmsDelegate( JmsDelegate orig ) {
+    super();
+    this.jmsProviders = orig.jmsProviders;
+    this.destinationName = orig.destinationName;
+    this.ibmUrl = orig.ibmUrl;
+    this.ibmUsername  = orig.ibmUsername;
+    this.ibmPassword = orig.ibmPassword;
+    this.amqUrl = orig.amqUrl;
+    this.amqUsername = orig.amqUsername;
+    this.amqPassword = orig.amqPassword;
+    this.connectionType = orig.connectionType;
+    this.destinationType = orig.destinationType;
+    this.receiveTimeout = orig.receiveTimeout;
+    this.messageField = orig.messageField;
+    this.destinationField = orig.destinationField;
+    this.sslEnabled = orig.sslEnabled;
+    this.sslKeystorePath = orig.sslKeystorePath;
+    this.sslKeystoreType = orig.sslKeystoreType;
+    this.sslKeystorePassword = orig.sslKeystorePassword;
+    this.sslTruststorePath = orig.sslTruststorePath;
+    this.sslTruststoreType = orig.sslTruststoreType;
+    this.sslTruststorePassword = orig.sslTruststorePassword;
+    this.sslContextAlgorithm = orig.sslContextAlgorithm;
+    this.sslCipherSuite = orig.sslCipherSuite;
+    this.ibmSslFipsRequired = orig.ibmSslFipsRequired;
+    this.amqSslProvider = orig.amqSslProvider;
+    this.amqSslVerifyHost = orig.amqSslVerifyHost;
+    this.amqSslTrustAll = orig.amqSslTrustAll;
   }
 
   Destination getDestination( ) {

--- a/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsProducerMeta.java
+++ b/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsProducerMeta.java
@@ -81,7 +81,7 @@ public class JmsProducerMeta extends BaseSerializingMeta implements StepMetaInte
   public static final String JMS_TYPE = "JMS_TYPE";
 
   @InjectionDeep
-  public final JmsDelegate jmsDelegate;
+  public JmsDelegate jmsDelegate;
 
   @Injection( name = FIELD_TO_SEND )
   private String fieldToSend = "";
@@ -253,5 +253,13 @@ public class JmsProducerMeta extends BaseSerializingMeta implements StepMetaInte
       new StepOption( JMS_CORRELATION_ID, getString( PKG, "JmsDialog.Options.JMS_CORRELATION_ID" ), jmsCorrelationId ),
       new StepOption( JMS_TYPE, getString( PKG, "JmsDialog.Options.JMS_TYPE" ), jmsType )
     );
+  }
+
+  @Override public JmsProducerMeta copyObject() {
+    JmsProducerMeta newClone = (JmsProducerMeta) this.clone();
+    newClone.jmsDelegate = new JmsDelegate( this.jmsDelegate );
+    newClone.propertyNames = new ArrayList<>( this.propertyNames );
+    newClone.propertyValues = new ArrayList<>( this.propertyValues );
+    return newClone;
   }
 }

--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerMeta.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerMeta.java
@@ -399,4 +399,12 @@ public class MQTTConsumerMeta extends BaseStreamStepMeta implements StepMetaInte
         cleanSession, storageLevel, serverUris, mqttVersion, automaticReconnect );
   }
 
+  @Override public MQTTConsumerMeta copyObject() {
+    MQTTConsumerMeta newClone = (MQTTConsumerMeta) this.clone();
+    newClone.topics = new ArrayList<>( this.topics );
+    newClone.sslKeys = new ArrayList<>( this.sslKeys );
+    newClone.sslValues = new ArrayList<>( this.sslValues );
+    return newClone;
+  }
+
 }

--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTProducerMeta.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTProducerMeta.java
@@ -283,4 +283,10 @@ public class MQTTProducerMeta extends BaseSerializingMeta implements StepMetaInt
       .toString();
   }
 
+  @Override public MQTTProducerMeta copyObject() {
+    MQTTProducerMeta newClone = (MQTTProducerMeta) this.clone();
+    newClone.sslKeys = new ArrayList<>( this.sslKeys );
+    newClone.sslValues = new ArrayList<>( this.sslValues );
+    return newClone;
+  }
 }


### PR DESCRIPTION
… of JMS and the JmsDelegate, we don't want a new instance of the jmsProviders list.  This implements a proper clone of the metas for all derivatives of the BaseSerializingMeta with that exception.