### PR TITLE
[SP-4680] - Backport of PDI-17632 - TextFileOutput has major typo cau…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -284,7 +284,7 @@ public class TextFileOutput extends BaseStep implements StepInterface {
     int flushInterval = 0;
     if ( var != null ) {
       try {
-        Integer.parseInt( var );
+        flushInterval = Integer.parseInt( var );
       } catch ( Exception ex ) {
         // Do nothing
       }


### PR DESCRIPTION
…sing a performance issue - flushInterval setting ignored (8.1 Suite)

* Backport of PDI-17632 - TextFileOutput has major typo causing a performance issue - flushInterval setting ignored (8.1 Suite)

@smmribeiro , @LeonardoCoelho71950 