### PR TITLE
The bug of CsvInput which is about multiple chars of delimiter--7.1

### DIFF
--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
@@ -292,7 +292,12 @@ public class CsvInputData extends BaseStepData implements StepDataInterface {
   }
 
   boolean delimiterFound() {
-    return delimiterMatcher.matchesPattern( byteBuffer, endBuffer, delimiter );
+	boolean result = delimiterMatcher.matchesPattern(byteBuffer, bufferSize, endBuffer, delimiter);
+	
+	if (result)
+			endBuffer = endBuffer - delimiter.length + 1;
+		
+    return result;
   }
 
   boolean enclosureFound() {

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/CsvInputData.java
@@ -301,7 +301,7 @@ public class CsvInputData extends BaseStepData implements StepDataInterface {
   }
 
   boolean enclosureFound() {
-    return enclosureMatcher.matchesPattern( byteBuffer, endBuffer, enclosure );
+    return enclosureMatcher.matchesPattern( byteBuffer, bufferSize, endBuffer, enclosure );
   }
 
   boolean endOfBuffer() {

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/EmptyPatternMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/EmptyPatternMatcher.java
@@ -24,8 +24,8 @@ package org.pentaho.di.trans.steps.csvinput;
 
 public class EmptyPatternMatcher implements PatternMatcherInterface {
 
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern ) {
-    return false;
-  }
+	public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] patter) {		
+		return false;
+	}
 
 }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/MultiBytePatternMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/MultiBytePatternMatcher.java
@@ -23,15 +23,26 @@
 package org.pentaho.di.trans.steps.csvinput;
 
 public class MultiBytePatternMatcher implements PatternMatcherInterface {
-
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern ) {
+  private int continueToMatchIndex = 0;
+  
+  public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] pattern) {
+    // every time only match one char
     int start = location;
-    for ( int i = 0; i < pattern.length; i++ ) {
-      if ( source[start + i] != pattern[i] ) {
-        return false;
-      }
-    }
-    return true;
-  }
 
+    if (start >= sourceSize)
+        return false;
+
+    if (source[start] != pattern[continueToMatchIndex]) {
+        continueToMatchIndex = 0;
+        return false;
+    } else {
+        continueToMatchIndex++;
+    }
+
+    if (continueToMatchIndex == pattern.length) {
+        continueToMatchIndex = 0;
+        return true;
+    } else
+        return false;
+    }
 }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/PatternMatcherInterface.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/PatternMatcherInterface.java
@@ -23,5 +23,7 @@
 package org.pentaho.di.trans.steps.csvinput;
 
 public interface PatternMatcherInterface {
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern );
+	// sourceSize
+	public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] pattern);
+
 }

--- a/engine/src/org/pentaho/di/trans/steps/csvinput/SingleBytePatternMatcher.java
+++ b/engine/src/org/pentaho/di/trans/steps/csvinput/SingleBytePatternMatcher.java
@@ -24,8 +24,8 @@ package org.pentaho.di.trans.steps.csvinput;
 
 public class SingleBytePatternMatcher implements PatternMatcherInterface {
 
-  public boolean matchesPattern( byte[] source, int location, byte[] pattern ) {
-    return source[location] == pattern[0];
-  }
+	public boolean matchesPattern(byte[] source, int sourceSize, int location, byte[] pattern) {
+		return source[location] == pattern[0];
+	}
 
 }


### PR DESCRIPTION
When the multiple chars of delimiter (such as @|@) happened to be divided into two buffers, the data is read incorrectly in CSVinput node.

for example: set the NIO buffer to 10 and set delimiter as '@|@' in the CSVInput node, and the file has only one line as following:

a@|@aaaa@|@aaa@|@aaaa@|@aaaaa@|@
 
Get the fields automatically and click preview data, then you will see the bug.z
 
when the multiple chars of delimiter (such as @|@) happened to be divided into two buffers, the data is read incorrectly in CSVinput node.
for example: set the NIO buffer to 10 and set delimiter as '@|@' in the CSVInput node, and the file has only one line as following:
a@|@aaaa@|@aaa@|@aaaa@|@aaaaa@|@

Get the fields automatically and click preview data, then you will see the bug.

![untitled](https://user-images.githubusercontent.com/13728060/47250981-61f10580-d45e-11e8-82a4-2f48a2f5dab6.png)

![untitled2](https://user-images.githubusercontent.com/13728060/47250984-674e5000-d45e-11e8-8ad4-69adccf5d0b6.png)
