### PR TITLE
[BACKLOG-26374] steps creating field name conflicts

### DIFF
--- a/core/src/test/java/org/pentaho/di/core/row/RowMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/RowMetaTest.java
@@ -214,6 +214,23 @@ public class RowMetaTest {
     assertEquals( "Original is still the same (name)", 1, rowMeta.indexOfValue( "dup" ) );
     assertEquals( "Renaming happened", 2, rowMeta.indexOfValue( "dup_1" ) );
   }
+  
+  @Test
+  public void testInsertValueMetaDup() throws Exception {
+    rowMeta.addValueMeta( 1, new ValueMetaInteger( integer.getName() ) );
+    assertEquals( "inserted", 4, rowMeta.size() );
+    assertEquals( "rename new", "integer_1", rowMeta.getValueMeta( 1 ).getName() );
+    rowMeta.addValueMeta( new ValueMetaInteger( integer.getName() ) );
+    assertEquals( "rename after", "integer_2", rowMeta.getValueMeta( 4 ).getName() );
+  }
+
+  @Test
+  public void testRemoveValueMetaDup() throws Exception {
+    rowMeta.removeValueMeta( date.getName() );
+    assertEquals( "removed", 2, rowMeta.size() );
+    rowMeta.addValueMeta( new ValueMetaInteger( integer.getName() ) );
+    assertEquals( "rename after", "integer_1", rowMeta.getValueMeta( 2 ).getName() );
+  }
 
   @Test
   public void testSetValueMetaNullName() throws KettlePluginException {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesMeta.java
@@ -411,6 +411,8 @@ public class SelectValuesMeta extends BaseStepMeta implements StepMetaInterface 
           if ( !v.getName().equals( metaChange.getRename() ) && !Utils.isEmpty( metaChange.getRename() ) ) {
             v.setName( metaChange.getRename() );
             v.setOrigin( name );
+            // need to reinsert to check name conflicts
+            inputRowMeta.setValueMeta( idx, v );
           }
           // Change the type?
           if ( metaChange.getType() != ValueMetaInterface.TYPE_NONE && v.getType() != metaChange.getType() ) {

--- a/engine/src/test/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -36,6 +36,9 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
 import org.pentaho.di.trans.steps.loadsave.validator.ArrayLoadSaveValidator;
@@ -71,8 +74,8 @@ public class SelectValuesMetaTest {
     fieldLoadSaveValidatorTypeMap.put( SelectField[].class.getCanonicalName(), new ArrayLoadSaveValidator<SelectField>(
         new SelectFieldLoadSaveValidator( selectField ), 2 ) );
 
-    LoadSaveTester tester =
-        new LoadSaveTester( SelectValuesMeta.class, attributes, new HashMap<String, String>(),
+    LoadSaveTester<SelectValuesMeta> tester =
+        new LoadSaveTester<>( SelectValuesMeta.class, attributes, new HashMap<String, String>(),
             new HashMap<String, String>(), new HashMap<String, FieldLoadSaveValidator<?>>(),
             fieldLoadSaveValidatorTypeMap );
 
@@ -208,6 +211,21 @@ public class SelectValuesMetaTest {
   @Test
   public void getSelectPrecision() {
     assertArrayEquals( new int[0], selectValuesMeta.getSelectPrecision() );
+  }
+
+  @Test
+  public void testMetaDataFieldsRenameConflict() throws Exception {
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMetaString( "A" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "B" ) );
+
+    SelectMetadataChange change = new SelectMetadataChange( selectValuesMeta );
+    change.setName( "A" );
+    change.setRename( "B" );
+    selectValuesMeta.setMeta( new SelectMetadataChange[] { change } );
+
+    selectValuesMeta.getMetadataFields( rowMeta, "select values", null );
+    assertEquals( "rename conflict", "B_1", rowMeta.getValueMeta( 0 ).getName() );
   }
 
   public static class SelectFieldLoadSaveValidator implements FieldLoadSaveValidator<SelectField> {

--- a/engine/src/test/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/selectvalues/SelectValuesTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.runner.RunWith;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.RowSet;


### PR DESCRIPTION
repeated field names could arise after inserting or deleting value metas
select values not checking for conflicts when renaming