### PR TITLE
[BACKLOG-26358] Fixes issue that allowed users to create folders with…

### DIFF
--- a/plugins/file-open-save/core/src/main/javascript/app/services/data.service.js
+++ b/plugins/file-open-save/core/src/main/javascript/app/services/data.service.js
@@ -106,7 +106,7 @@ define(
         }
 
         function search(path, value) {
-          return _httpGet([baseUrl, "search", encodeURIComponent(path), encodeURIComponent(value)].join("/"));
+          return _httpGet([baseUrl, "search", encodeURIComponent(path), _checkAndEncodeURIComponent(value)].join("/"));
         }
 
         /**
@@ -151,9 +151,9 @@ define(
          */
         function saveFile(path, name, fileName, override) {
           if (fileName === null) {
-            return _httpGet([baseUrl, "saveFile", encodeURIComponent(path), encodeURIComponent(name), override].join("/"));
+            return _httpGet([baseUrl, "saveFile", encodeURIComponent(path), _checkAndEncodeURIComponent(name), override].join("/"));
           }
-          return _httpGet([baseUrl, "saveFile", encodeURIComponent(path), encodeURIComponent(name), encodeURIComponent(fileName), override].join("/"));
+          return _httpGet([baseUrl, "saveFile", encodeURIComponent(path), _checkAndEncodeURIComponent(name), _checkAndEncodeURIComponent(fileName), override].join("/"));
         }
 
         /**
@@ -168,10 +168,10 @@ define(
         function checkForSecurityOrDupeIssues(path, name, fileName, override) {
           if (fileName === null) {
             return _httpGet([baseUrl, "checkForSecurityOrDupeIssues",
-              encodeURIComponent(path), encodeURIComponent(name), override].join("/"));
+              encodeURIComponent(path), _checkAndEncodeURIComponent(name), override].join("/"));
           }
           return _httpGet([baseUrl, "checkForSecurityOrDupeIssues",
-            encodeURIComponent(path), encodeURIComponent(name), encodeURIComponent(fileName), override].join("/"));
+            encodeURIComponent(path), _checkAndEncodeURIComponent(name), _checkAndEncodeURIComponent(fileName), override].join("/"));
         }
 
         /**
@@ -247,7 +247,7 @@ define(
          * @return {Promise} - a promise resolved once data is returned
          */
         function create(parent, name) {
-          return _httpPost([baseUrl, "create", encodeURIComponent(parent), encodeURIComponent(name)].join("/"), null);
+          return _httpPost([baseUrl, "create", encodeURIComponent(parent), _checkAndEncodeURIComponent(name)].join("/"), null);
         }
 
         /**
@@ -261,7 +261,7 @@ define(
          */
         function remove(id, name, path, type) {
           return _httpDelete([baseUrl, "remove",
-            encodeURIComponent(id), encodeURIComponent(name), encodeURIComponent(path), type].join("/"));
+            encodeURIComponent(id), _checkAndEncodeURIComponent(name), encodeURIComponent(path), type].join("/"));
         }
 
         /**
@@ -348,6 +348,14 @@ define(
             url += "?v=" + value;
           }
           return url;
+        }
+
+        function _checkAndEncodeURIComponent(strToCheck) {
+          if (strToCheck != null && (strToCheck.indexOf("\\") >= 0 || strToCheck.indexOf("/") >= 0)) {
+            return strToCheck;
+          }
+
+          return encodeURIComponent(strToCheck);
         }
       }
     });


### PR DESCRIPTION
… special slash characters

This seems to be caused due to https://github.com/pentaho/pentaho-kettle/pull/5821

I'm not sure if this is really the best solution but this solution should mimic it's old behavior. Right now the only characters that shouldn't be allowed are '/' and '\\'.

Since the validation of the folder name string is happening client-side, my thoughts were to update the javascript to check for any slash characters. If it detects them, it passes the string on normally (without URL encoding) and fails like it used to. If the string is fine, it will encode it as was updated in PR #5821  . Please let me know if this makes sense.