### PR TITLE
[BACKLOG-26378] - limiting streaming ReplayProcessor buffer size to 1000

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/streaming/common/BlockingQueueStreamSource.java
+++ b/engine/src/main/java/org/pentaho/di/trans/streaming/common/BlockingQueueStreamSource.java
@@ -53,7 +53,7 @@ public abstract class BlockingQueueStreamSource<T> implements StreamSource<T> {
 
   private final AtomicBoolean paused = new AtomicBoolean( false );
 
-  private final FlowableProcessor<T> publishProcessor = ReplayProcessor.create();
+  private final FlowableProcessor<T> publishProcessor = ReplayProcessor.createWithSize( 1000 );
   protected final BaseStreamStep streamStep;
 
   // binary semaphore used to block acceptance of rows when paused


### PR DESCRIPTION
We poll kafka records 1000 at a time, so this should leave enough buffer in case we've read rows from kafka before the rxjava window has been constructed

master PR
https://github.com/pentaho/pentaho-kettle/pull/5951