### PR TITLE
[BACKLOG-26444] Additional data lineage support for ETL Metadata Injection step

### DIFF
--- a/plugins/meta-inject/src/main/java/org/pentaho/di/ui/trans/steps/metainject/analyzer/MetaInjectAnalyzer.java
+++ b/plugins/meta-inject/src/main/java/org/pentaho/di/ui/trans/steps/metainject/analyzer/MetaInjectAnalyzer.java
@@ -22,7 +22,10 @@
 
 package org.pentaho.di.ui.trans.steps.metainject.analyzer;
 
+import com.tinkerpop.blueprints.Vertex;
 import org.apache.commons.lang.StringUtils;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -38,7 +41,6 @@ import org.pentaho.metaverse.api.analyzer.kettle.step.IClonableStepAnalyzer;
 import org.pentaho.metaverse.api.analyzer.kettle.step.StepAnalyzer;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -59,9 +61,8 @@ public class MetaInjectAnalyzer extends StepAnalyzer<MetaInjectMeta> {
 
     final Set<StepField> usedFields = new HashSet();
 
-    final Map<TargetStepAttribute, SourceStepField> fieldMappings = meta.getTargetSourceMapping();
     final Iterator<Map.Entry<TargetStepAttribute, SourceStepField>> fieldMappingsIter
-      = fieldMappings.entrySet().iterator();
+      = meta.getTargetSourceMapping().entrySet().iterator();
     while ( fieldMappingsIter.hasNext() ) {
       final Map.Entry<TargetStepAttribute, SourceStepField> entry = fieldMappingsIter.next();
       final SourceStepField value = entry.getValue();
@@ -87,166 +88,146 @@ public class MetaInjectAnalyzer extends StepAnalyzer<MetaInjectMeta> {
       parentTransMeta.environmentSubstitute( meta.getStreamTargetStepname() ) );
     rootNode.setProperty( "runResultingTransformation", !meta.isNoExecution() );
 
-    final TransMeta subTransMeta = KettleAnalyzerUtil.getSubTransMeta( meta );
+    KettleAnalyzerUtil.analyze( this, parentTransMeta, meta, rootNode );
+  }
 
-    final IMetaverseNode subTransNode = getNode( subTransMeta.getName(), DictionaryConst.NODE_TYPE_TRANS,
-      descriptor.getNamespace(), null, null );
-    subTransNode.setProperty( DictionaryConst.PROPERTY_PATH,
-      KettleAnalyzerUtil.getSubTransMetaPath( meta, subTransMeta ) );
-    subTransNode.setLogicalIdGenerator( DictionaryConst.LOGICAL_ID_GENERATOR_DOCUMENT );
-
-    metaverseBuilder.addLink( rootNode, DictionaryConst.LINK_EXECUTES, subTransNode );
-
-    // look at the mdi mappings to mimic the steps within the sub transformation
-    final Map<String, IMetaverseNode> subTransSteps = new HashMap();
-    final Map<String, IMetaverseNode> subTransFields = new HashMap();
-
-    // create a node for the source step - we will need it later
-    if ( StringUtils.isNotBlank( sourceStepName ) ) {
-      final IMetaverseNode sourceStepNode = getVirtualNode( sourceStepName, DictionaryConst.NODE_TYPE_TRANS_STEP,
-        descriptor.getNamespace(), sourceStepName, subTransSteps );
-      // it does not matter what the step type, we just need this property to exist
-      sourceStepNode.setProperty( DictionaryConst.PROPERTY_STEP_TYPE, "N/A" );
-      metaverseBuilder.addLink( subTransNode, DictionaryConst.LINK_CONTAINS, sourceStepNode );
+  private List<String> getOutputFieldNames( final TransMeta transMeta, final String stepName ) {
+    final Map<String, RowMetaInterface> targetFieldsMap = getOutputRowMetaInterfaces( transMeta,
+      transMeta.findStep( stepName ), null, false );
+    final List<String> targetFieldNames = new ArrayList();
+    if ( targetFieldsMap != null ) {
+      final List<ValueMetaInterface> fieldValues = targetFieldsMap.values().iterator().next().getValueMetaList();
+      for ( final ValueMetaInterface fieldValue : fieldValues ) {
+        targetFieldNames.add( fieldValue.getName() );
+      }
     }
+    return targetFieldNames;
+  }
 
-    final Map<TargetStepAttribute, SourceStepField> fieldMappings = meta.getTargetSourceMapping();
-    final Iterator<Map.Entry<TargetStepAttribute, SourceStepField>> fieldMappingsIter
-      = fieldMappings.entrySet().iterator();
+  @Override
+  public void postAnalyze( final MetaInjectMeta meta )
+    throws MetaverseAnalyzerException {
 
-    boolean streaming = false;
+    final String transformationPath = parentTransMeta.environmentSubstitute( meta.getFileName() );
+
+    final TransMeta subTransMeta = KettleAnalyzerUtil.getSubTransMeta( meta );
+    subTransMeta.setFilename( transformationPath );
+
+    // get the vertex corresponding to this step
+    final Vertex stepVertex = findStepVertex( parentTransMeta, parentStepMeta.getName() );
+
     // are we streaming data directly from an injector step to a template step?
-    if ( !StringUtil.isEmpty( meta.getStreamSourceStepname() ) && !StringUtil.isEmpty(
-      meta.getStreamTargetStepname() ) ) {
-      streaming = true;
+    if ( !StringUtil.isEmpty( meta.getStreamSourceStepname() )
+      && !StringUtil.isEmpty( meta.getStreamTargetStepname() ) ) {
+      // get the field names flowing from the stream source step into the template ktr's streaming target
+      // step directly and the output fields of the streamTargetStepVertex, and create "derives" links between the
+      // pairs at each index - we look at the outputRowMeta rather than just finding the vertices in the graph,
+      // because we need to preserve field order, and the gtraph might give us the field Vertices out of order;
+      // the returned maps might contain multiple key-value pairs for multiple steps, but the values in all should be
+      // the same, so we can graph the first value we encounter
+      final List<String> sourceFieldNames = getOutputFieldNames( parentTransMeta, meta.getStreamSourceStepname() );
+      final List<String> targetFieldNames = getOutputFieldNames( subTransMeta, meta.getStreamTargetStepname() );
 
-      final IMetaverseNode streamTargetStepNode = getVirtualNode( meta.getStreamTargetStepname(),
-        DictionaryConst.NODE_TYPE_TRANS_STEP, descriptor.getNamespace(), meta.getStreamTargetStepname(),
-        subTransSteps );
-      metaverseBuilder.addLink( subTransNode, DictionaryConst.LINK_CONTAINS, streamTargetStepNode );
-
-      // get the field names names flowing from the stream source step into the template ktr's streaming target
-      // step directly
-      final Set<String> streamSourceInputStepNames = getInputs().getFieldNames( meta.getStreamSourceStepname() );
       int index = 0;
-      for ( final String streamSourceInputStepName : streamSourceInputStepNames ) {
-        final IMetaverseNode streamSourceFieldNode = getInputs().findNode( meta.getStreamSourceStepname(),
-          streamSourceInputStepName );
+      for ( final String sourceFieldName : sourceFieldNames ) {
 
-        final String targetFieldName = "field_" + StringUtils.leftPad( "" + index, 3 );
-        final IMetaverseNode streamTargetFieldNode = getVirtualNode( targetFieldName, DictionaryConst.NODE_TYPE_TRANS_FIELD,
-          (String) streamTargetStepNode.getProperty( DictionaryConst.PROPERTY_LOGICAL_ID ),
-          meta.getStreamTargetStepname() + ":" + targetFieldName, subTransFields );
-        metaverseBuilder.addLink( streamSourceFieldNode, DictionaryConst.LINK_DERIVES, streamTargetFieldNode );
-        metaverseBuilder.addLink( streamTargetStepNode, DictionaryConst.LINK_OUTPUTS, streamTargetFieldNode );
-        index++;
+        final Vertex streamSourceStepOutputField = findFieldVertex( parentTransMeta, meta.getStreamSourceStepname(),
+          sourceFieldName );
+        // get the target field at the same index, if it exists
+        if ( index < targetFieldNames.size() ) {
+          final Vertex streamTargetStepOutputField = findFieldVertex( subTransMeta, meta.getStreamTargetStepname(),
+            targetFieldNames.get( index++ ) );
+          getMetaverseBuilder().addLink( streamSourceStepOutputField, DictionaryConst.LINK_DERIVES,
+            streamTargetStepOutputField );
+        } else {
+          // we have mapped all the source fields we can, there are no more target steps to map to
+          break;
+        }
       }
     }
 
-    final List<String> verboseProperties = new ArrayList();
+    final String sourceStepName = parentTransMeta.environmentSubstitute( meta.getSourceStepName() );
+    final Iterator<Map.Entry<TargetStepAttribute, SourceStepField>> fieldMappingsIter
+      = meta.getTargetSourceMapping().entrySet().iterator();
 
+    final List<String> verboseProperties = new ArrayList();
+    int mappingCount = 1;
+    int ignoredMappingCount = 1;
     // process the injection mappings
     while ( fieldMappingsIter.hasNext() ) {
       final Map.Entry<TargetStepAttribute, SourceStepField> entry = fieldMappingsIter.next();
       final TargetStepAttribute targetTemplateStepAttr = entry.getKey();
       final SourceStepField sourceInjectorStepField = entry.getValue();
-
-      final IMetaverseNode templateStepNode = getVirtualNode( targetTemplateStepAttr.getStepname(),
-        DictionaryConst.NODE_TYPE_TRANS_STEP, descriptor.getNamespace(), targetTemplateStepAttr.getStepname(),
-        subTransSteps );
-      // it does not matter what the step type, we just need this property to exist
-      templateStepNode.setProperty( DictionaryConst.PROPERTY_STEP_TYPE, "N/A" );
-      metaverseBuilder.addLink( subTransNode, DictionaryConst.LINK_CONTAINS, templateStepNode );
+      final String targetTemplateStepName = targetTemplateStepAttr.getStepname();
 
       // if the source step is set to stream data directly to a step in the template (target) transformation, the
       // mappings are ignored, and instead, data is sent directly
       final boolean ignoreMapping = sourceInjectorStepField.getStepname().equalsIgnoreCase(
         meta.getStreamSourceStepname() );
-      final String mappingKey =  "mapping [" + ( verboseProperties.size() + 1 ) + "]";
-      verboseProperties.add( mappingKey );
-      final StringBuilder mapping = new StringBuilder();
-      mapping.append( sourceInjectorStepField.getStepname() ).append( ": " )
-        .append( sourceInjectorStepField.getField() )
-        .append( " > [" ).append( subTransNode.getName() ).append( "] " )
-        .append( targetTemplateStepAttr.getStepname()  ).append( ": " )
-        .append( targetTemplateStepAttr.getAttributeKey() );
-      rootNode.setProperty( mappingKey, mapping.toString() );
-
+      String mappingKey = "mapping [" + mappingCount++ + "]";
       if ( !ignoreMapping ) {
-        // if the target template step name is the same as the step we read from, we want to get the fields from the
-        // target template step and pass them back to the parant injector step
-        if ( targetTemplateStepAttr.getStepname().equalsIgnoreCase( sourceStepName ) ) {
-          final IMetaverseNode sourceStepNode = subTransSteps.get( sourceStepName );
-          final Set<String> inputStepNames = getInputs().getStepNames();
-          for ( final String inputStepName : inputStepNames ) {
-            if ( inputStepName.equalsIgnoreCase( sourceStepName ) ) {
-              final Set<String> inputFieldNames = getInputs().getFieldNames( inputStepName );
-              for ( final String inputFieldName : inputFieldNames ) {
-                // create node for each field for the source template Node and link "input" from the inputStep's
-                // equivalent field node
-                final IMetaverseNode subTransFieldNode = getVirtualNode( sourceInjectorStepField.getField(),
-                  DictionaryConst.NODE_TYPE_TRANS_FIELD, (String) sourceStepNode.getProperty(
-                    DictionaryConst.PROPERTY_LOGICAL_ID ), sourceInjectorStepField.getStepname() + ":"
-                    + sourceInjectorStepField.getField(), subTransFields );
-                subTransFieldNode.setProperty( DictionaryConst.PROPERTY_CATEGORY, DictionaryConst.CATEGORY_FIELD );
-                // get the field node from the template and link it to this subTransFieldNode
-                IMetaverseNode sourceStepFieldNode = getOutputs().findNode( inputStepName, inputFieldName );
-                metaverseBuilder.addLink( sourceStepFieldNode, DictionaryConst.LINK_INPUTS, subTransFieldNode );
-              }
-            }
+        // if the target template step name is the same as the step we read from (sourceStepName), we want to get the
+        // output fields from the target template step and pass them back (input) into the parent injector step
+        if ( targetTemplateStepName.equalsIgnoreCase( sourceStepName ) ) {
+
+          final List<Vertex> targetTemplateFields = findFieldVertices( subTransMeta, targetTemplateStepName );
+          for ( final Vertex targetTemplateField : targetTemplateFields ) {
+            getMetaverseBuilder().addLink( targetTemplateField, DictionaryConst.LINK_INPUTS, stepVertex );
           }
         }
-
         // create "pseudo" step property nodes - these are ANNOTATIONS assigned to step properties
-        final IMetaverseNode subTransStepNode = getVirtualNode( targetTemplateStepAttr.getStepname(),
-          DictionaryConst.NODE_TYPE_TRANS_STEP, descriptor.getNamespace(),
-          targetTemplateStepAttr.getStepname(), subTransSteps );
+        // Note, since the sub-transformation has already been analysed, this node will already exist, and therefore
+        // we need to fetch the Vertex directly, as we currenlty have no way ot finding nodes in the graph
+        final Vertex targetTemplateStepVertex = findStepVertex( subTransMeta, targetTemplateStepName );
 
-        final IMetaverseNode subTransPropertyNode = getVirtualNode( targetTemplateStepAttr.getAttributeKey(),
-          DictionaryConst.NODE_TYPE_STEP_PROPERTY, (String) subTransStepNode.getProperty(
-            DictionaryConst.PROPERTY_LOGICAL_ID ), targetTemplateStepAttr.getStepname() + ":"
-            + targetTemplateStepAttr.getAttributeKey(), subTransSteps );
+        final IMetaverseNode subTransPropertyNode = getNode( targetTemplateStepAttr.getAttributeKey(),
+          DictionaryConst.NODE_TYPE_STEP_PROPERTY, (String) targetTemplateStepVertex.getProperty(
+            DictionaryConst.PROPERTY_LOGICAL_ID ), targetTemplateStepName + ":"
+            + targetTemplateStepAttr.getAttributeKey(), null );
+        getMetaverseBuilder().addNode( subTransPropertyNode );
 
-        metaverseBuilder.addLink( templateStepNode, DictionaryConst.LINK_CONTAINS, subTransPropertyNode );
+        // now that the property node has been added, find the corresponding vertex to add the "contains" link from
+        // the target template step
+        final Vertex subTransPropertyVertex = findVertexById( subTransPropertyNode.getStringID() );
+        if ( subTransPropertyVertex != null ) {
+          getMetaverseBuilder().addLink( targetTemplateStepVertex, DictionaryConst.LINK_CONTAINS, subTransPropertyVertex );
+        }
 
         final String injectorStepName = sourceInjectorStepField.getStepname();
         final String injectotFieldName = sourceInjectorStepField.getField();
         final IMetaverseNode matchingInjectorFieldNode = getInputs().findNode( injectorStepName, injectotFieldName );
         if ( matchingInjectorFieldNode != null ) {
           // add 'populates' links back to the real ETL meta output fields
-          metaverseBuilder.addLink( matchingInjectorFieldNode, DictionaryConst.LINK_POPULATES, subTransPropertyNode );
+          getMetaverseBuilder().addLink( matchingInjectorFieldNode, DictionaryConst.LINK_POPULATES, subTransPropertyNode );
         }
+      } else {
+        mappingKey = "ignored mapping [" + ignoredMappingCount++ + "]";
       }
+      final StringBuilder mapping = new StringBuilder();
+      mapping.append( sourceInjectorStepField.getStepname() ).append( ": " )
+        .append( sourceInjectorStepField.getField() ).append( " > [" ).append( subTransMeta.getName() ).append( "] " )
+        .append( targetTemplateStepName ).append( ": " ).append( targetTemplateStepAttr.getAttributeKey() );
+      verboseProperties.add( mappingKey );
+      stepVertex.setProperty( mappingKey, mapping.toString() );
     }
 
-    // if reading from a sub-transformation step directly, create virtual output fields from that virtual step, add
-    // "input" links from those fields to the root node and "derives" links from those fields to the corresponding
-    // output fields of the root node
+    // if reading from a sub-transformation step directly, add "input" links from the source step fields to the root
+    // node and  "derives" links from those fields to the corresponding output fields of the root node
     if ( StringUtils.isNotBlank( sourceStepName ) ) {
       // we created this node earlier, so we know it exists
-      IMetaverseNode sourceStepNode = subTransSteps.get( sourceStepName );
-
-      final Set<StepField> outputFields = getOutputs().getFieldNames();
-      for ( final StepField outputField : outputFields ) {
-
-        final IMetaverseNode subTransFieldNode = getVirtualNode( outputField.getFieldName(),
-          DictionaryConst.NODE_TYPE_TRANS_FIELD, (String) sourceStepNode.getProperty(
-            DictionaryConst.PROPERTY_LOGICAL_ID ), outputField.getStepName() + ":" + outputField.getFieldName(),
-          subTransFields );
-        metaverseBuilder.addLink( sourceStepNode, DictionaryConst.LINK_OUTPUTS, subTransFieldNode );
-        metaverseBuilder.addLink( subTransFieldNode, DictionaryConst.LINK_INPUTS, rootNode );
-        subTransFieldNode.setProperty( DictionaryConst.PROPERTY_CATEGORY, DictionaryConst.CATEGORY_FIELD );
-
-        // get the field node from the template and link it to this subTransFieldNode
-        final List<IMetaverseNode> outputFieldNodes = getOutputs().findNodes( outputField.getFieldName() );
-        if ( outputFieldNodes.size() > 0 ) {
-          final IMetaverseNode outputFieldNode = outputFieldNodes.get( 0 );
-          metaverseBuilder.addLink( subTransFieldNode, DictionaryConst.LINK_DERIVES, outputFieldNode );
+      final List<Vertex> sourceStepFields = findFieldVertices( subTransMeta, sourceStepName );
+      for ( final Vertex sourceStepField : sourceStepFields ) {
+        getMetaverseBuilder().addLink( sourceStepField, DictionaryConst.LINK_INPUTS, stepVertex );
+        // find a field in this step with the same name as the source step field
+        final Vertex derivedField = findFieldVertex( parentTransMeta, stepVertex.getProperty(
+          DictionaryConst.PROPERTY_NAME ).toString(),
+          sourceStepField.getProperty( DictionaryConst.PROPERTY_NAME ).toString() );
+        if ( derivedField != null ) {
+          getMetaverseBuilder().addLink( sourceStepField, DictionaryConst.LINK_DERIVES, derivedField );
         }
       }
     }
-    // mappings are considered "verbose" details
-    rootNode.setProperty( DictionaryConst.PROPERTY_VERBOSE_DETAILS, StringUtils.join( verboseProperties, "," ) );
+    stepVertex.setProperty( DictionaryConst.PROPERTY_VERBOSE_DETAILS, StringUtils.join( verboseProperties, "," ) );
   }
 
   @Override protected IClonableStepAnalyzer newInstance() {


### PR DESCRIPTION
Integration test related to this functionality is located within the pentaho-metaverse project. These tests are currently disabled due to an unfavorable dependency chain, but can be enabled and run locally.

Related PR: https://github.com/pentaho/pentaho-metaverse/pull/533