### PR TITLE
[PDI-7538] S3 Input/Output Steps does not respect IAM security rules

### DIFF
--- a/plugins/s3csvinput/core/src/main/java/org/pentaho/di/trans/steps/s3csvinput/S3ObjectsProvider.java
+++ b/plugins/s3csvinput/core/src/main/java/org/pentaho/di/trans/steps/s3csvinput/S3ObjectsProvider.java
@@ -79,7 +79,7 @@ public class S3ObjectsProvider {
    * @throws SdkClientException
    */
   public Bucket getBucket( String bucketName ) throws SdkClientException {
-    return getBuckets().stream( ).filter( x -> bucketName.equals( x.getName() ) ).findFirst().orElse( null );
+    return s3Client.doesBucketExistV2( bucketName ) ? new Bucket( bucketName ) : null;
   }
 
   /**
@@ -182,5 +182,4 @@ public class S3ObjectsProvider {
   public long getS3ObjectContentLenght( Bucket bucket, String objectKey ) throws SdkClientException {
     return getS3ObjectDetails( bucket, objectKey ).getContentLength();
   }
-
 }

--- a/plugins/s3csvinput/core/src/test/java/org/pentaho/di/trans/steps/s3csvinput/S3ObjectsProviderTest.java
+++ b/plugins/s3csvinput/core/src/test/java/org/pentaho/di/trans/steps/s3csvinput/S3ObjectsProviderTest.java
@@ -43,8 +43,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,6 +58,7 @@ public class S3ObjectsProviderTest {
   private static final String BUCKET1_NAME = "Bucket1";
   private static final String BUCKET2_NAME = "Bucket2";
   private static final String BUCKET3_NAME = "Bucket3";
+  private static final String UNKNOWN_BUCKET = "UnknownBucket";
   private static final Bucket BUCKET2 = new Bucket( BUCKET2_NAME );
   private static final Bucket BUCKET3 = new Bucket( BUCKET3_NAME );
   private static final Bucket BUCKET1 = new Bucket( BUCKET1_NAME );
@@ -128,7 +135,7 @@ public class S3ObjectsProviderTest {
   }
 
   @Test public void testGetBucketNotFound_ReturnsNull() throws Exception {
-    Bucket actual = provider.getBucket( "UnknownBucket" );
+    Bucket actual = provider.getBucket( UNKNOWN_BUCKET );
     assertNull( actual );
   }
 
@@ -147,10 +154,10 @@ public class S3ObjectsProviderTest {
 
   @Test public void testGetObjectsNamesNoSuchBucket_ThrowsExeption() {
     try {
-      provider.getS3ObjectsNames( "UnknownBucket" );
-      fail( "The Exception: Unable to find bucket 'UnknownBucket' should be thrown but it was not." );
+      provider.getS3ObjectsNames( UNKNOWN_BUCKET );
+      fail( "The Exception: Unable to find bucket '" + UNKNOWN_BUCKET + "' should be thrown but it was not." );
     } catch ( Exception e ) {
-      assertTrue( e.getLocalizedMessage().contains( "Unable to find bucket 'UnknownBucket'" ) );
+      assertTrue( e.getLocalizedMessage().contains( "Unable to find bucket '" + UNKNOWN_BUCKET + "'" ) );
     }
   }
 
@@ -177,7 +184,10 @@ public class S3ObjectsProviderTest {
     ObjectMetadata mockMetaData = mock( ObjectMetadata.class );
     when( s3Client.getObjectMetadata( BUCKET1.getName(), "test3Object" ) ).thenReturn( mockMetaData );
 
+    doReturn( false ).when( s3Client ).doesBucketExistV2( UNKNOWN_BUCKET );
+    doReturn( true ).when( s3Client ).doesBucketExistV2( BUCKET2_NAME );
+    doReturn( true ).when( s3Client ).doesBucketExistV2( BUCKET3_NAME );
+
     return s3Client;
   }
-
 }


### PR DESCRIPTION
In the use case where a user only has permissions on a single bucket and lacks permissions to list all existing buckets the **S3 CSV input step** would fail to read the specified file.

While it isn't possible to browse and select the bucket that contains the file to read, the user must be able to type the bucket name and even the filename to process.

Because of this, we can't use the `listBuckets()` method and then filter the results and instead should use the `doesBucketExistV2( bucketName )` method.

@pentaho/tatooine and @rmansoor, please review and merge.