### PR TITLE
[PDI-17449] S3 CSV Input does not work after upgrade from 7.1 to 8.1

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1279,6 +1279,12 @@ public class Const {
     String.valueOf( KETTLE_ZIP_MAX_TEXT_SIZE_DEFAULT );
 
   /**
+   * <p>A variable to configure if the S3 input / output steps should use the Amazon Default Credentials Provider Chain
+   * even if access credentials are specified within the transformation.</p>
+   */
+  public static final String KETTLE_USE_AWS_DEFAULT_CREDENTIALS = "KETTLE_USE_AWS_DEFAULT_CREDENTIALS";
+
+  /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer
    * overflow while rounding
    *

--- a/plugins/s3csvinput/core/src/main/java/org/pentaho/di/trans/steps/s3csvinput/S3CsvInputDialog.java
+++ b/plugins/s3csvinput/core/src/main/java/org/pentaho/di/trans/steps/s3csvinput/S3CsvInputDialog.java
@@ -70,6 +70,7 @@ import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.core.dialog.PreviewRowsDialog;
 import org.pentaho.di.ui.core.widget.ColumnInfo;
 import org.pentaho.di.ui.core.widget.ComboValuesSelectionListener;
+import org.pentaho.di.ui.core.widget.PasswordTextVar;
 import org.pentaho.di.ui.core.widget.TableView;
 import org.pentaho.di.ui.core.widget.TextVar;
 import org.pentaho.di.ui.trans.dialog.TransPreviewProgressDialog;
@@ -79,6 +80,8 @@ import org.pentaho.di.ui.trans.steps.textfileinput.TextFileCSVImportProgressDial
 public class S3CsvInputDialog extends BaseStepDialog implements StepDialogInterface {
   private S3CsvInputMeta inputMeta;
 
+  private TextVar      wAccessKey;
+  private TextVar      wSecretKey;
   private TextVar      wBucket;
   private Button       wbBucket; // browse for a bucket.
   private TextVar      wFilename;
@@ -149,6 +152,48 @@ public class S3CsvInputDialog extends BaseStepDialog implements StepDialogInterf
     fdStepname.right = new FormAttachment( 100, 0 );
     wStepname.setLayoutData( fdStepname );
     Control lastControl = wStepname;
+
+    // Access key
+    Label wlAccessKey = new Label( shell, SWT.RIGHT );
+    wlAccessKey.setText( Messages.getString( "S3CsvInputDialog.AccessKey.Label" ) ); //$NON-NLS-1$
+    props.setLook( wlAccessKey );
+    FormData fdlAccessKey = new FormData();
+    fdlAccessKey.top = new FormAttachment( lastControl, margin );
+    fdlAccessKey.left = new FormAttachment( 0, 0 );
+    fdlAccessKey.right = new FormAttachment( middle, -margin );
+    wlAccessKey.setLayoutData( fdlAccessKey );
+
+    wAccessKey = new PasswordTextVar( transMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+
+    props.setLook( wAccessKey );
+    wAccessKey.addModifyListener( lsMod );
+    FormData fdAccessKey = new FormData();
+    fdAccessKey.top = new FormAttachment( lastControl, margin );
+    fdAccessKey.left = new FormAttachment( middle, 0 );
+    fdAccessKey.right = new FormAttachment( 100, 0 );
+    wAccessKey.setLayoutData( fdAccessKey );
+    lastControl = wAccessKey;
+
+    // Secret key
+    Label wlSecretKey = new Label( shell, SWT.RIGHT );
+    wlSecretKey.setText( Messages.getString( "S3CsvInputDialog.SecretKey.Label" ) ); //$NON-NLS-1$
+    props.setLook( wlSecretKey );
+    FormData fdlSecretKey = new FormData();
+    fdlSecretKey.top = new FormAttachment( lastControl, margin );
+    fdlSecretKey.left = new FormAttachment( 0, 0 );
+    fdlSecretKey.right = new FormAttachment( middle, -margin );
+    wlSecretKey.setLayoutData( fdlSecretKey );
+
+    wSecretKey = new PasswordTextVar( transMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+
+    props.setLook( wSecretKey );
+    wSecretKey.addModifyListener( lsMod );
+    FormData fdSecretKey = new FormData();
+    fdSecretKey.top = new FormAttachment( lastControl, margin );
+    fdSecretKey.left = new FormAttachment( middle, 0 );
+    fdSecretKey.right = new FormAttachment( 100, 0 );
+    wSecretKey.setLayoutData( fdSecretKey );
+    lastControl = wSecretKey;
 
     // Bucket name
     Label wlBucket = new Label( shell, SWT.RIGHT );
@@ -623,6 +668,8 @@ public class S3CsvInputDialog extends BaseStepDialog implements StepDialogInterf
    */
   public void getData( S3CsvInputMeta inputMeta ) {
     wStepname.setText( stepname );
+    wAccessKey.setText( Const.NVL( inputMeta.getAwsAccessKey(), "" ) );
+    wSecretKey.setText( Const.NVL( inputMeta.getAwsSecretKey(), "" ) );
     wBucket.setText( Const.NVL( inputMeta.getBucket(), "" ) );
 
     if ( isReceivingInput ) {
@@ -668,7 +715,8 @@ public class S3CsvInputDialog extends BaseStepDialog implements StepDialogInterf
   }
 
   private void getInfo( S3CsvInputMeta inputMeta ) {
-
+    inputMeta.setAwsAccessKey( wAccessKey.getText() );
+    inputMeta.setAwsSecretKey( wSecretKey.getText() );
     inputMeta.setBucket( wBucket.getText() );
 
     if ( isReceivingInput ) {

--- a/plugins/s3csvinput/core/src/test/java/org/pentaho/di/trans/steps/s3csvinput/S3CsvInputMetaNewInjectionTest.java
+++ b/plugins/s3csvinput/core/src/test/java/org/pentaho/di/trans/steps/s3csvinput/S3CsvInputMetaNewInjectionTest.java
@@ -38,6 +38,16 @@ public class S3CsvInputMetaNewInjectionTest extends BaseMetadataInjectionTest<S3
 
   @Test
   public void test() throws Exception {
+    check( "AWS_ACCESS_KEY", new StringGetter() {
+      public String get() {
+        return meta.getAwsAccessKey();
+      }
+    } );
+    check( "AWS_SECRET_KEY", new StringGetter() {
+      public String get() {
+        return meta.getAwsSecretKey();
+      }
+    } );
     check( "BUCKET", new StringGetter() {
       public String get() {
         return meta.getBucket();

--- a/plugins/s3csvinput/core/src/test/java/org/pentaho/di/trans/steps/s3csvinput/S3CsvInputMetaTest.java
+++ b/plugins/s3csvinput/core/src/test/java/org/pentaho/di/trans/steps/s3csvinput/S3CsvInputMetaTest.java
@@ -19,16 +19,18 @@
  * limitations under the License.
  *
  ******************************************************************************/
-package org.pentaho.di.trans.steps.s3csvinput;
 
+package org.pentaho.di.trans.steps.s3csvinput;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.encryption.TwoWayPasswordEncoderPluginType;
@@ -40,12 +42,21 @@ import org.pentaho.di.trans.steps.loadsave.validator.ArrayLoadSaveValidator;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
 import org.pentaho.di.trans.steps.loadsave.validator.TextFileInputFieldValidator;
 import org.pentaho.di.trans.steps.textfileinput.TextFileInputField;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 /**
  * @author Tatsiana_Kasiankova
  *
  */
 @SuppressWarnings( "deprecation" )
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( EnvUtil.class )
 public class S3CsvInputMetaTest {
 
   private static final String TEST_AWS_SECRET_KEY = "TestAwsSecretKey";
@@ -54,7 +65,7 @@ public class S3CsvInputMetaTest {
   private static final String TEST_ACCESS_KEY_ENCRYPTED = "Encrypted 2be98af9c0fd486a5a81aab63cdb9aac3";
 
   @BeforeClass
-  public static void setUp() throws KettleException {
+  public static void once() throws KettleException {
     PluginRegistry.addPluginType( TwoWayPasswordEncoderPluginType.getInstance() );
     PluginRegistry.init( true );
     String passwordEncoderPluginID =
@@ -62,9 +73,14 @@ public class S3CsvInputMetaTest {
     Encr.init( passwordEncoderPluginID );
   }
 
+  @Before
+  public void setup() {
+    mockStatic( EnvUtil.class );
+  }
+
   @Test
   public void testSerialization() throws KettleException {
-    List<String> attributes = Arrays.asList( "Bucket", "Filename", "FilenameField",
+    List<String> attributes = Arrays.asList( "AwsAccessKey", "AwsSecretKey", "Bucket", "Filename", "FilenameField",
       "RowNumField", "IncludingFilename", "Delimiter", "Enclosure", "HeaderPresent", "MaxLineSize",
       "LazyConversionActive", "RunningInParallel", "InputFields" );
 
@@ -78,4 +94,28 @@ public class S3CsvInputMetaTest {
     tester.testSerialization();
   }
 
+  @Test
+  public void getUseAwsDefaultCredentialsWithoutCredentials() {
+    S3CsvInputMeta meta = new S3CsvInputMeta();
+    assertTrue( meta.getUseAwsDefaultCredentials() );
+  }
+
+  @Test
+  public void getUseAwsDefaultCredentialsWithCredentials() {
+    S3CsvInputMeta meta = new S3CsvInputMeta();
+    meta.setAwsAccessKey( TEST_ACCESS_KEY_ENCRYPTED );
+    meta.setAwsSecretKey( TEST_AWS_SECRET_KEY_ENCRYPTED );
+
+    assertFalse( meta.getUseAwsDefaultCredentials() );
+  }
+
+  @Test
+  public void getUseAwsDefaultCredentialsOverrideCredentials() {
+    S3CsvInputMeta meta = new S3CsvInputMeta();
+    meta.setAwsAccessKey( TEST_ACCESS_KEY_ENCRYPTED );
+    meta.setAwsSecretKey( TEST_AWS_SECRET_KEY_ENCRYPTED );
+
+    when( EnvUtil.getSystemProperty( Const.KETTLE_USE_AWS_DEFAULT_CREDENTIALS ) ).thenReturn( "Y" );
+    assertTrue( meta.getUseAwsDefaultCredentials() );
+  }
 }


### PR DESCRIPTION
Partial revert of 5bc0e4b85473fa7f5fe8c7f595ee7fda60ec5d41 to bring back lost functionality, i.e. ability to specify AWS credentials within the step as requested in JIRA case.

By default, if you don't specify AWS credentials, Spoon will get credentials from the Amazon Default Credentials Provider Chain. If credentials are specified in the step, Spoon will use those (legacy behavior).

For legacy transformations with embedded credentials you now have the option to override those credentials and use the provider chain by setting the Kettle property `KETTLE_USE_AWS_DEFAULT_CREDENTIALS` to `Y`.

@rmansoor @mbatchelor @pentaho/tatooine 

