### PR TITLE
[PDI-17752] Running a transformation with an invalid Path returns a N…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1310,7 +1310,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
           } catch ( KettleException e ) {
             // try to load from repository, this trans may have been developed locally and later uploaded to the
             // repository
-            transMeta = getTransMetaFromRepository( rep, r, realFilename );
+            transMeta = rep == null ? new TransMeta( realFilename, metaStore, null, true, this, null ) : getTransMetaFromRepository( rep, r, realFilename );
           }
           break;
         case REPOSITORY_BY_NAME:


### PR DESCRIPTION
…ullPointerException and not the corresponding message defined by BACKLOG-21756

Ensure FILENAME code path has the same error message behavior as defined in the REPOSITORY_BY_NAME case.

@mbatchelor @pamval 