### PR TITLE
[PDI-17568] An iterating job entry with Execute every input row and a…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/www/GetTransStatusServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/GetTransStatusServlet.java
@@ -308,7 +308,7 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
             out.write( XML_HEADER );
             out.write( data );
             out.flush();
-            if ( finishedOrStopped && logId != null && !dontUseCache ) {
+            if ( finishedOrStopped && logId != null ) {
               cache.put( logId, xml, startLineNr );
             }
           }


### PR DESCRIPTION
… slave server run configuration hangs

Since in our scenario we were only saving the first transStatus response to Cache, if that first response returned a not yet Finished status (ex: <status_desc>Running</status_desc>) it will cause an infinite loop asking for a status update or error from Cache, that will never come - causing the hanging behavior described in this issue. 
This PR ensure that even if we use or not use cache, we will always have all the status updates saved there. 
 