### PR TITLE
Fixed missing ldconfig error when running as unprivileged user PDI-17771

### DIFF
--- a/assemblies/core/static/src/main/resources/spoon.sh
+++ b/assemblies/core/static/src/main/resources/spoon.sh
@@ -137,7 +137,12 @@ case `uname -s` in
 
 	Linux)
 
-            HASWEBKITGTK=`ldconfig -p | grep webkitgtk-1.0`
+            if [ -f /sbin/ldconfig ]; then
+              LDCONFIG=/sbin/ldconfig
+            else
+              LDCONFIG=ldconfig
+            fi
+            HASWEBKITGTK=`$LDCONFIG -p | grep webkitgtk-1.0`
             export LIBWEBKITGTK="$HASWEBKITGTK"
             export JavaScriptCoreUseJIT=0
             if [ -z "$HASWEBKITGTK" ] && [ "1" != "$SKIP_WEBKITGTK_CHECK" ]; then

--- a/assemblies/static/src/main/resources/spoon.sh
+++ b/assemblies/static/src/main/resources/spoon.sh
@@ -137,7 +137,12 @@ case `uname -s` in
 
 	Linux)
 
-            HASWEBKITGTK=`ldconfig -p | grep webkitgtk-1.0`
+            if [ -f /sbin/ldconfig ]; then
+              LDCONFIG=/sbin/ldconfig
+            else
+              LDCONFIG=ldconfig
+            fi
+            HASWEBKITGTK=`$LDCONFIG -p | grep webkitgtk-1.0`
             export LIBWEBKITGTK="$HASWEBKITGTK"
             export JavaScriptCoreUseJIT=0
             if [ -z "$HASWEBKITGTK" ] && [ "1" != "$SKIP_WEBKITGTK_CHECK" ]; then


### PR DESCRIPTION
This affects Debian-based systems like Ubuntu 16.04 LTS