### PR TITLE
[PDI-17481] Some steps of Bulk loading return NPE if previous steps have no rows

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/infobrightoutput/InfobrightLoader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/infobrightoutput/InfobrightLoader.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -118,6 +118,13 @@ public class InfobrightLoader extends BaseStep implements StepInterface {
     return true;
   }
 
+  protected void verifyDatabaseConnection() throws KettleException {
+    // Confirming Database Connection is defined.
+    if ( meta.getDatabaseMeta() == null ) {
+      throw new KettleException( BaseMessages.getString( PKG, "InfobrightLoaderMeta.GetSQL.NoConnectionDefined" ) );
+    }
+  }
+
   /**
    * {@inheritDoc}
    *
@@ -131,6 +138,7 @@ public class InfobrightLoader extends BaseStep implements StepInterface {
 
     if ( super.init( smi, sdi ) ) {
       try {
+        verifyDatabaseConnection();
         data.databaseSetup( meta, this );
         res = true;
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseLoader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseLoader.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -617,11 +617,27 @@ public class IngresVectorwiseLoader extends BaseStep implements StepInterface {
     }
   }
 
+  protected void verifyDatabaseConnection() throws KettleException {
+    // Confirming Database Connection is defined.
+    if ( meta.getDatabaseMeta() == null ) {
+      throw new KettleException( BaseMessages.getString( PKG, "IngresVectorwiseLoaderMeta.GetSQL.NoConnectionDefined" ) );
+    }
+  }
+
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (IngresVectorwiseLoaderMeta) smi;
     data = (IngresVectorwiseLoaderData) sdi;
 
     if ( super.init( smi, sdi ) ) {
+
+      // Confirming Database Connection is defined.
+      try {
+        verifyDatabaseConnection();
+      } catch ( KettleException ex ) {
+        logError( ex.getMessage() );
+        return false;
+      }
+
       if ( Utils.isEmpty( meta.getDelimiter() ) ) {
         data.separator = data.getBytes( "|" );
       } else {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDBBulkLoader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDBBulkLoader.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -532,12 +532,27 @@ public class MonetDBBulkLoader extends BaseStep implements StepInterface {
     }
   }
 
+  protected void verifyDatabaseConnection() throws KettleException {
+    // Confirming Database Connection is defined.
+    if ( meta.getDatabaseMeta() == null ) {
+      throw new KettleException( BaseMessages.getString( PKG, "MonetDBBulkLoaderMeta.GetSQL.NoConnectionDefined" ) );
+    }
+  }
+
   @Override
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (MonetDBBulkLoaderMeta) smi;
     data = (MonetDBBulkLoaderData) sdi;
 
     if ( super.init( smi, sdi ) ) {
+
+      try {
+        verifyDatabaseConnection();
+      } catch ( KettleException ex ) {
+        logError( ex.getMessage() );
+        return false;
+      }
+
       data.quote = environmentSubstitute( meta.getFieldEnclosure() );
       data.separator = environmentSubstitute( meta.getFieldSeparator() );
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/mysqlbulkloader/MySQLBulkLoader.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -458,12 +458,28 @@ public class MySQLBulkLoader extends BaseStep implements StepInterface {
     }
   }
 
+  protected void verifyDatabaseConnection() throws KettleException {
+    // Confirming Database Connection is defined.
+    if ( meta.getDatabaseMeta() == null ) {
+      throw new KettleException( BaseMessages.getString( PKG, "MySQLBulkLoaderMeta.GetSQL.NoConnectionDefined" ) );
+    }
+  }
+
   @Override
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (MySQLBulkLoaderMeta) smi;
     data = (MySQLBulkLoaderData) sdi;
 
     if ( super.init( smi, sdi ) ) {
+
+      // Confirming Database Connection is defined.
+      try {
+        verifyDatabaseConnection();
+      } catch ( KettleException ex ) {
+        logError( ex.getMessage() );
+        return false;
+      }
+
       if ( Utils.isEmpty( meta.getEnclosure() ) ) {
         data.quote = new byte[] {};
       } else {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/pgbulkloader/PGBulkLoader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/pgbulkloader/PGBulkLoader.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -437,6 +437,13 @@ public class PGBulkLoader extends BaseStep implements StepInterface {
 
   }
 
+  protected void verifyDatabaseConnection() throws KettleException {
+    // Confirming Database Connection is defined.
+    if ( meta.getDatabaseMeta() == null ) {
+      throw new KettleException( BaseMessages.getString( PKG, "PGBulkLoaderMeta.GetSQL.NoConnectionDefined" ) );
+    }
+  }
+
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (PGBulkLoaderMeta) smi;
     data = (PGBulkLoaderData) sdi;
@@ -445,6 +452,15 @@ public class PGBulkLoader extends BaseStep implements StepInterface {
     String separator = environmentSubstitute( meta.getDelimiter() );
 
     if ( super.init( smi, sdi ) ) {
+
+      // Confirming Database Connection is defined.
+      try {
+        verifyDatabaseConnection();
+      } catch ( KettleException ex ) {
+        logError( ex.getMessage() );
+        return false;
+      }
+
       if ( enclosure != null ) {
         data.quote = enclosure.getBytes();
       } else {

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_en_US.properties
@@ -50,3 +50,4 @@ InfobrightLoaderMeta.CheckResult.UndefinedError = An error occurred: {0}
 InfobrightLoaderMeta.CheckResult.NoConnection = Please select or create a connection to use
 InfobrightLoaderMeta.CheckResult.ExcpectedInputOk=Step is receiving info from other steps.
 InfobrightLoaderMeta.CheckResult.MissingExpectedInput=No input received from other steps\!
+InfobrightLoaderMeta.GetSQL.NoConnectionDefined=There is no connection defined in this step.

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_es_AR.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_es_AR.properties
@@ -11,3 +11,4 @@ InfobrightLoader.Log.UnexpectedError=Error inesperado en ''
 InfobrightLoaderDialog.Dataformat.Label=Producto Infobright
 InfobrightLoaderDialog.Connection.Label=Conexi\u00F3n a BD
 InfobrightLoader.Log.FailedToKillQuery=Error al matar la consulta del cargador
+InfobrightLoaderMeta.GetSQL.NoConnectionDefined=No se ha definido una conexi\u00F3n en este paso.

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_fr_FR.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_fr_FR.properties
@@ -21,3 +21,4 @@ InfobrightLoaderDialog.Connection.Label=Connexion
 InfobrightLoaderDialog.Shell.Title=Chargement en bloc vers Infobright
 InfobrightLoader.Log.UnexpectedError=Erreur inattendue ''
 InfobrightLoaderDialog.Illegal.Dialog.Settings.Title=Valeur ill\u00E9gale
+InfobrightLoaderMeta.GetSQL.NoConnectionDefined=La connexion n''a pas \u00E9t\u00E9 renseign\u00E9e pour cette \u00E9tape.

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_it_IT.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_it_IT.properties
@@ -21,3 +21,4 @@ InfobrightLoaderDialog.Connection.Label=Connessione al database
 InfobrightLoaderDialog.Shell.Title=Infobright loader
 InfobrightLoader.Log.UnexpectedError=Errore inatteso in ''
 InfobrightLoaderDialog.Illegal.Dialog.Settings.Title=Valore illegale
+InfobrightLoaderMeta.GetSQL.NoConnectionDefined=Non \u00E8 stata definita alcuna connessione in questo passo.

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_ja_JP.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_ja_JP.properties
@@ -50,3 +50,4 @@ InfobrightLoaderMeta.CheckResult.UndefinedError = An error occurred: {0}
 InfobrightLoaderMeta.CheckResult.NoConnection = Please select or create a connection to use
 InfobrightLoaderMeta.CheckResult.ExcpectedInputOk=Step is receiving info from other steps.
 InfobrightLoaderMeta.CheckResult.MissingExpectedInput=No input received from other steps\!
+InfobrightLoaderMeta.GetSQL.NoConnectionDefined=There is no connection defined in this step.

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_ko_KR.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/infobrightoutput/messages/messages_ko_KR.properties
@@ -19,3 +19,4 @@ BrightHouseLoader.Log.StartingToRun=\uC2E4\uD589 \uC2DC\uC791...
 InfobrightLoaderDialog.AgentPort.Label=Agent \uD3EC\uD2B8
 InfobrightLoaderDialog.Charset.Label=\uBB38\uC790\uC14B
 InfobrightLoaderDialog.DebugFile.Label=\uB514\uBC84\uADF8 \uD30C\uC77C
+InfobrightLoaderMeta.GetSQL.NoConnectionDefined=Step\uC5D0 \uC815\uC758\uB41C \uC5F0\uACB0\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_en_US.properties
@@ -37,6 +37,7 @@ IngresVectorwiseLoader.Log.StartingToRun=Starting to run...
 IngresVectorWiseLoaderDialog.BuildSQLError.DialogTitle=Error
 IngresVectorWiseLoaderDialog.DoMapping.SomeSourceFieldsNotFound=Some fields were not found in source
 IngresVectorwiseLoaderMeta.CheckResult.NoConnection=Please select or create a connection to use
+IngresVectorwiseLoaderMeta.GetSQL.NoConnectionDefined=There is no connection defined in this step.
 IngresVectorwiseLoaderDialog.Illegal.Dialog.Settings.Title=Illegal value
 IngresVectorWiseLoaderDialog.FailedToGetFields.DialogTitle=Error
 IngresVectorWiseLoaderDialog.ColumnInfo.TableField=Table field

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_fr_FR.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_fr_FR.properties
@@ -25,6 +25,7 @@ IngresVectorWiseLoaderDialog.DoMapping.SomeTargetFieldsNotFound=Certains champs 
 IngresVectorWiseLoaderMeta.Error.NoInput=Cette \u00E9tape doit \u00EAtre connect\u00E9e aux autres \u00E9tapes\!
 IngresVectorWiseLoaderDialog.BuildSQLError.DialogTitle=Erreur
 IngresVectorWiseLoaderDialog.DoMapping.SomeSourceFieldsNotFound=Certains champs n''ont pas \u00E9t\u00E9 trouv\u00E9s dans le flux entrant
+IngresVectorwiseLoaderMeta.GetSQL.NoConnectionDefined=La connexion n''a pas \u00E9t\u00E9 renseign\u00E9e pour cette \u00E9tape.
 IngresVectorWiseLoaderDialog.FailedToGetFields.DialogTitle=Erreur
 IngresVectorwiseLoaderDialog.TruncateTable.Label=Tronquer la table avant chargement
 IngresVectorWiseLoaderDialog.ColumnInfo.TableField=Champ table

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_it_IT.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_it_IT.properties
@@ -25,6 +25,7 @@ IngresVectorWiseLoaderDialog.DoMapping.SomeTargetFieldsNotFound=Alcuni campi di 
 IngresVectorWiseLoaderMeta.Error.NoInput=Questo passo dovrebbe essere connesso ad altri passi\!
 IngresVectorWiseLoaderDialog.BuildSQLError.DialogTitle=Errore
 IngresVectorWiseLoaderDialog.DoMapping.SomeSourceFieldsNotFound=Alcuni campi non sono stati trovati nella sorgente
+IngresVectorwiseLoaderMeta.GetSQL.NoConnectionDefined=Non \u00E8 stata definita alcuna connessione in questo passo.
 IngresVectorWiseLoaderDialog.FailedToGetFields.DialogTitle=Errore
 IngresVectorwiseLoaderDialog.TruncateTable.Label=Tronca la tabella prima di caricare
 IngresVectorWiseLoaderDialog.ColumnInfo.TableField=Campo tabella

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_ja_JP.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_ja_JP.properties
@@ -48,6 +48,7 @@ IngresVectorWiseLoaderDialog.DoMapping.UnableToFindTargetFields.Message=\u30bf\u
 IngresVectorWiseLoaderDialog.NoSQL.DialogTitle=OK
 IngresVectorwiseLoaderDialog.Charset.Label=\u6587\u5b57\u30b3\u30fc\u30c9
 IngresVectorWiseLoaderDialog.DoMapping.SomeFieldsNotFoundContinue=\u898b\u3064\u304b\u3089\u306a\u3044\u30d5\u30a3\u30fc\u30eb\u30c9\u304c\u3042\u308a\u307e\u3059
+IngresVectorwiseLoaderMeta.GetSQL.NoConnectionDefined=There is no connection defined in this step.
 IngresVectorWiseLoaderDialog.DoMapping.UnableToFindSourceFields.Message=\u30bd\u30fc\u30b9\u30d5\u30a3\u30fc\u30eb\u30c9\u53d6\u5f97\u30a8\u30e9\u30fc
 IngresVectorwiseLoaderDialog.Delimiter.Label=\u5024\u306e\u533a\u5207\u308a\u6587\u5b57
 IngresVectorwiseLoader.Log.ErrorInStep=There was an unexpected error while running this step\:

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_ko_KR.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/ivwloader/messages/messages_ko_KR.properties
@@ -15,3 +15,4 @@ IngresVectorwiseLoaderDialog.Charset.Label=\uBB38\uC790\uC14B
 IngresVectorwiseLoaderDialog.SqlPath.Label='sql' \uBA85\uB839\uC5B4 \uACBD\uB85C
 IngresVectorWiseLoaderDialog.DoMapping.Button=\uB9E4\uD551 \uC124\uC815
 IngresVectorWiseLoaderDialog.DoMapping.UnableToFindTargetFields.Title=\uC624\uB958
+IngresVectorwiseLoaderMeta.GetSQL.NoConnectionDefined=Step\uC5D0 \uC815\uC758\uB41C \uC5F0\uACB0\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_en_US.properties
@@ -12,6 +12,7 @@ TeraFastDialog.DataFile.Label=Data file\:
 TeraFastDialog.StepName.Label=Step name\:
 TeraFastDialog.Sessions.Label=Sessions\:
 TeraFastDialog.DoMapping.SomeFieldsNotFoundContinue=Some fields were not found.
+TeraFastDialog.GetSQL.NoConnectionDefined=There is no connection defined in this step.
 TeraFastDialog.About.Shell.Title=About
 TeraFastDialog.ErrLimit.Label=Error limit\:
 TeraFastDialog.TruncateTable.Label=Truncate table\:

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_fr_FR.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_fr_FR.properties
@@ -12,6 +12,7 @@ TeraFastDialog.DataFile.Label=Fichier donn\u00E9es\:
 TeraFastDialog.StepName.Label=Nom \u00E9tape
 TeraFastDialog.Sessions.Label=Sessions\:
 TeraFastDialog.DoMapping.SomeFieldsNotFoundContinue=Les champs suivants sont introuvables
+TeraFastDialog.GetSQL.NoConnectionDefined=La connexion n''a pas \u00E9t\u00E9 renseign\u00E9e pour cette \u00E9tape.
 TeraFastDialog.About.Shell.Title=A propose
 TeraFastDialog.ErrLimit.Label=Nbr Erreur maximum\:
 TeraFastDialog.TruncateTable.Label=Vider la table

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_it_IT.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_it_IT.properties
@@ -12,6 +12,7 @@ TeraFastDialog.DataFile.Label=File di dati\:
 TeraFastDialog.StepName.Label=Nome passo\:
 TeraFastDialog.Sessions.Label=Sessioni\:
 TeraFastDialog.DoMapping.SomeFieldsNotFoundContinue=Alcuni campi non sono stati trovati.
+TeraFastDialog.GetSQL.NoConnectionDefined=Non \u00E8 stata definita alcuna connessione in questo passo.
 TeraFastDialog.About.Shell.Title=About
 TeraFastDialog.ErrLimit.Label=Limite errore\:
 TeraFastDialog.TruncateTable.Label=Troncare la tabella\:

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_ja_JP.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_ja_JP.properties
@@ -12,6 +12,7 @@ TeraFastDialog.DataFile.Label=\u30c7\u30fc\u30bf\u30d5\u30a1\u30a4\u30eb\:
 TeraFastDialog.StepName.Label=\u30b9\u30c6\u30c3\u30d7\u540d\:
 TeraFastDialog.Sessions.Label=\u30bb\u30c3\u30b7\u30e7\u30f3\:
 TeraFastDialog.DoMapping.SomeFieldsNotFoundContinue=\u3044\u304f\u3064\u304b\u306e\u30d5\u30a3\u30fc\u30eb\u30c9\u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093\u3002
+TeraFastDialog.GetSQL.NoConnectionDefined=There is no connection defined in this step.
 TeraFastDialog.About.Shell.Title=\u8aac\u660e
 TeraFastDialog.ErrLimit.Label=\u30a8\u30e9\u30fc\u5236\u9650\:
 TeraFastDialog.TruncateTable.Label=\u30c6\u30fc\u30d6\u30eb\u5207\u308a\u6368\u3066\:

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_ko_KR.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/terafast/messages/messages_ko_KR.properties
@@ -26,6 +26,7 @@ TeraFastDialog.FastloadPath.Label=fastload \uACBD\uB85C\:
 TeraFastDialog.About.Shell.Title=About
 TeraFastDialog.ErrLimit.Label=\uC624\uB958 \uC81C\uD55C\:
 TeraFastDialog.DoMapping.SomeFieldsNotFoundContinue=\uAC19\uC740 \uD544\uB4DC\uB97C \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
+TeraFastDialog.GetSQL.NoConnectionDefined=Step\uC5D0 \uC815\uC758\uB41C \uC5F0\uACB0\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.
 TeraFastDialog.Browse.Button=\uCC3E\uC544\uBCF4\uAE30...
 TeraFastDialog.ColumnInfo.StreamField=\uC2A4\uD2B8\uB9BC \uD544\uB4DC
 TeraFastDialog.ColumnInfo.TableField=\uD14C\uC774\uBE14 \uD544\uB4DC

--- a/engine/src/test/java/org/pentaho/di/trans/steps/infobrightoutput/InfobrightLoaderTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/infobrightoutput/InfobrightLoaderTest.java
@@ -1,0 +1,91 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2018-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.infobrightoutput;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+/**
+ * User: dgriffen Date: 12/10/2018
+ */
+public class InfobrightLoaderTest {
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
+  private StepMockHelper<InfobrightLoaderMeta, InfobrightLoaderData> stepMockHelper;
+  private InfobrightLoader infobrightLoader;
+
+  @BeforeClass
+  public static void initEnvironment() throws KettleException {
+    KettleEnvironment.init();
+  }
+
+  @Before
+  public void setUp() {
+    stepMockHelper = new StepMockHelper<>( "InfobrightLoader", InfobrightLoaderMeta.class,
+      InfobrightLoaderData.class );
+    when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) )
+      .thenReturn( stepMockHelper.logChannelInterface );
+    when( stepMockHelper.trans.isRunning() ).thenReturn( true );
+    infobrightLoader = new InfobrightLoader( stepMockHelper.stepMeta, stepMockHelper.stepDataInterface, 0,
+      stepMockHelper.transMeta, stepMockHelper.trans );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    stepMockHelper.cleanUp();
+  }
+
+  /**
+   * [PDI-17481] Testing the ability that if no connection is specified, we will mark it as a fail and log the
+   * appropriate reason to the user by throwing a KettleException.
+   */
+  @Test
+  public void testNoDatabaseConnection() {
+    try {
+      doReturn( null ).when( stepMockHelper.initStepMetaInterface ).getDatabaseMeta();
+      assertFalse( infobrightLoader.init( stepMockHelper.initStepMetaInterface, stepMockHelper.initStepDataInterface ) );
+      // Verify that the database connection being set to null throws a KettleException with the following message.
+      infobrightLoader.verifyDatabaseConnection();
+      // If the method does not throw a Kettle Exception, then the DB was set and not null for this test. Fail it.
+      fail( "Database Connection is not null, this fails the test." );
+    } catch ( KettleException aKettleException ) {
+      assertThat( aKettleException.getMessage(), containsString( "There is no connection defined in this step" ) );
+    }
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,7 +22,10 @@
 
 package org.pentaho.di.trans.steps.ivwloader;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -137,6 +140,13 @@ public class IngresVectorwiseTest {
     stepMockHelper.cleanUp();
   }
 
+  /**
+   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
+   * Systems:
+   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
+   * operating system besides Windows."
+   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
+   */
   @Test
   public void testGuiErrors() {
     try {
@@ -155,6 +165,13 @@ public class IngresVectorwiseTest {
     }
   }
 
+  /**
+   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
+   * Systems:
+   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
+   * operating system besides Windows."
+   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
+   */
   @Test
   public void testGuiErrorsWithErrorsAllowed() {
     try {
@@ -173,6 +190,13 @@ public class IngresVectorwiseTest {
     }
   }
 
+  /**
+   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
+   * Systems:
+   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
+   * operating system besides Windows."
+   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
+   */
   @Test
   public void testGuiSuccess() {
     try {
@@ -191,6 +215,13 @@ public class IngresVectorwiseTest {
     }
   }
 
+  /**
+   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
+   * Systems:
+   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
+   * operating system besides Windows."
+   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
+   */
   @Test
   public void testWaitForFinish() {
     try {
@@ -207,6 +238,13 @@ public class IngresVectorwiseTest {
     }
   }
 
+  /**
+   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
+   * Systems:
+   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
+   * operating system besides Windows."
+   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
+   */
   @Test
   @Ignore
   public void testVWLoadMocker() {
@@ -232,6 +270,29 @@ public class IngresVectorwiseTest {
     } catch ( InterruptedException e ) {
       e.printStackTrace();
       fail( e.toString() );
+    }
+  }
+
+  /**
+   * [PDI-17481] Testing the ability that if no connection is specified, we will mark it as a fail and log the
+   * appropriate reason to the user by throwing a KettleException.
+   */
+  @Test
+  public void testNoDatabaseConnection() {
+    IngresVectorwiseLoaderData ivwData = new IngresVectorwiseLoaderData();
+    IngresVectorwiseLoaderMeta ivwMeta = new IngresVectorwiseLoaderMeta();
+    IngresVectorwiseLoaderTest ivwLoader =
+            new IngresVectorwiseLoaderTest( stepMockHelper.stepMeta, ivwData, 0, stepMockHelper.transMeta,
+                    stepMockHelper.trans );
+    assertFalse( ivwLoader.init( ivwMeta, ivwData ) );
+
+    try {
+      // Verify that the database connection being set to null throws a KettleException with the following message.
+      ivwLoader.verifyDatabaseConnection();
+      // If the method does not throw a Kettle Exception, then the DB was set and not null for this test. Fail it.
+      fail( "Database Connection is not null, this fails the test." );
+    } catch ( KettleException aKettleException ) {
+      assertThat( aKettleException.getMessage(), containsString( "There is no connection defined in this step." ) );
     }
   }
 

--- a/engine/src/test/java/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDBBulkLoaderTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/monetdbbulkloader/MonetDBBulkLoaderTest.java
@@ -1,0 +1,91 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2018-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.monetdbbulkloader;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+/**
+ * User: dgriffen Date: 12/04/2018
+ */
+public class MonetDBBulkLoaderTest {
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
+  private StepMockHelper<MonetDBBulkLoaderMeta, MonetDBBulkLoaderData> stepMockHelper;
+  private MonetDBBulkLoader monetDbBulkLoader;
+
+  @BeforeClass
+  public static void initEnvironment() throws KettleException {
+    KettleEnvironment.init();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    stepMockHelper = new StepMockHelper<>( "MonetDB Bulk Loader", MonetDBBulkLoaderMeta.class,
+      MonetDBBulkLoaderData.class );
+    when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) )
+      .thenReturn( stepMockHelper.logChannelInterface );
+    when( stepMockHelper.trans.isRunning() ).thenReturn( true );
+    monetDbBulkLoader = new MonetDBBulkLoader( stepMockHelper.stepMeta, stepMockHelper.stepDataInterface,
+      0, stepMockHelper.transMeta, stepMockHelper.trans );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    stepMockHelper.cleanUp();
+  }
+
+  /**
+   * [PDI-17481] Testing the ability that if no connection is specified, we will mark it as a fail and log the
+   * appropriate reason to the user by throwing a KettleException.
+   */
+  @Test
+  public void testNoDatabaseConnection() {
+    try {
+      doReturn( null ).when( stepMockHelper.initStepMetaInterface ).getDatabaseMeta();
+      assertFalse( monetDbBulkLoader.init( stepMockHelper.initStepMetaInterface, stepMockHelper.initStepDataInterface ) );
+      // Verify that the database connection being set to null throws a KettleException with the following message.
+      monetDbBulkLoader.verifyDatabaseConnection();
+      // If the method does not throw a Kettle Exception, then the DB was set and not null for this test. Fail it.
+      fail( "Database Connection is not null, this fails the test." );
+    } catch ( KettleException aKettleException ) {
+      assertThat( aKettleException.getMessage(), containsString( "There is no connection defined in this step." ) );
+    }
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/trans/steps/terafast/TeraFastTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/terafast/TeraFastTest.java
@@ -1,0 +1,97 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2018-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *vg
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.terafast;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.util.GenericStepData;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * User: dgriffen Date: 12/04/2018
+ */
+public class TeraFastTest {
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
+  private StepMockHelper<TeraFastMeta, GenericStepData> stepMockHelper;
+  private TeraFast teraFast;
+
+  @BeforeClass
+  public static void initEnvironment() throws KettleException {
+    KettleEnvironment.init();
+  }
+
+  @Before
+  public void setUp() {
+    stepMockHelper = new StepMockHelper<>( "TeraFast", TeraFastMeta.class, GenericStepData.class );
+    when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn( stepMockHelper.logChannelInterface );
+    when( stepMockHelper.trans.isRunning() ).thenReturn( true );
+    teraFast = new TeraFast( stepMockHelper.stepMeta, stepMockHelper.stepDataInterface, 0, stepMockHelper.transMeta, stepMockHelper.trans );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    stepMockHelper.cleanUp();
+  }
+
+  @Test
+  public void testNullDataFilePrintStream() throws KettleException {
+    TeraFast teraFastDataFilePrintStreamIsNull = mock( TeraFast.class );
+    doReturn( null ).when( teraFastDataFilePrintStreamIsNull ).getRow();
+    TeraFastMeta meta = mock( TeraFastMeta.class );
+    GenericStepData data = mock( GenericStepData.class );
+    assertFalse( teraFastDataFilePrintStreamIsNull.processRow( meta, data ) );
+  }
+
+  /**
+   * [PDI-17481] Testing the ability that if no connection is specified, we will mark it as a fail and log the
+   * appropriate reason to the user by throwing a KettleException.
+   */
+  @Test
+  public void testNoDatabaseConnection() {
+    try {
+      doReturn( null ).when( stepMockHelper.initStepMetaInterface ).getDbMeta();
+      assertFalse( teraFast.init( stepMockHelper.initStepMetaInterface, stepMockHelper.initStepDataInterface ) );
+      // Verify that the database connection being set to null throws a KettleException with the following message.
+      teraFast.verifyDatabaseConnection();
+      // If the method does not throw a Kettle Exception, then the DB was set and not null for this test. Fail it.
+      fail( "Database Connection is not null, this fails the test." );
+    } catch ( KettleException aKettleException ) {
+      assertThat( aKettleException.getMessage(), containsString( "There is no connection defined in this step." ) );
+    }
+  }
+}


### PR DESCRIPTION
@pentaho/tatooine  @ssamora @pentaho-lmartins 
* [PDI-17481] Adding in tests for Infobright, MonetDB, TeraFast plugins. Adding in functions to check for Database Connections and ensuring they're not null, added messages for IngresVectorwise. Added messages from previously written message files (MySQLBulkLoader Messages)
* [PDI-17481] Code adjustments. Refactoring use of verification of data
* [PDI-17481] Updating imports
* [PDI-17481] Making PR Comment adjudication: Updated tests to force failure, import cleanup, fix postgres issue