### PR TITLE
[PDI-17585] Variable Replacement Is Not Working in Connection Pool Co…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/BaseDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/BaseDatabaseMeta.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1288,12 +1288,29 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterfaceEx
   }
 
   /**
+   * @return the maximum pool size variable name
+   */
+  @Override
+  public String getMaximumPoolSizeString() {
+    return attributes.getProperty( ATTRIBUTE_MAXIMUM_POOL_SIZE );
+  }
+
+  /**
    * @param maximumPoolSize
    *          the maximum pool size
    */
   @Override
   public void setMaximumPoolSize( int maximumPoolSize ) {
     attributes.setProperty( ATTRIBUTE_MAXIMUM_POOL_SIZE, Integer.toString( maximumPoolSize ) );
+  }
+
+  /**
+   * @param maximumPoolSize
+   *          the maximum pool size variable name
+   */
+  @Override
+  public void setMaximumPoolSizeString( String maximumPoolSize ) {
+    attributes.setProperty( ATTRIBUTE_MAXIMUM_POOL_SIZE, maximumPoolSize );
   }
 
   /**
@@ -1306,12 +1323,29 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterfaceEx
   }
 
   /**
+   * @return the initial pool size variable name
+   */
+  @Override
+  public String getInitialPoolSizeString() {
+    return attributes.getProperty( ATTRIBUTE_INITIAL_POOL_SIZE );
+  }
+
+  /**
    * @param initialPoolSize
    *          the initial pool size
    */
   @Override
   public void setInitialPoolSize( int initialPoolSize ) {
     attributes.setProperty( ATTRIBUTE_INITIAL_POOL_SIZE, Integer.toString( initialPoolSize ) );
+  }
+
+  /**
+   * @param initialPoolSize
+   *          the initial pool size variable name
+   */
+  @Override
+  public void setInitialPoolSizeString( String initialPoolSize ) {
+    attributes.setProperty( ATTRIBUTE_INITIAL_POOL_SIZE, initialPoolSize );
   }
 
   /**

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -738,10 +738,21 @@ public interface DatabaseInterface extends Cloneable {
   public int getMaximumPoolSize();
 
   /**
+    * @return the maximum pool size variable name
+   */
+  public String getMaximumPoolSizeString();
+
+  /**
    * @param maximumPoolSize
    *          the maximum pool size
    */
   public void setMaximumPoolSize( int maximumPoolSize );
+
+  /**
+   * @param maximumPoolSize
+   *          the maximum pool size variable name
+   */
+  public void setMaximumPoolSizeString( String maximumPoolSize );
 
   /**
    * @return the initial pool size
@@ -749,10 +760,21 @@ public interface DatabaseInterface extends Cloneable {
   public int getInitialPoolSize();
 
   /**
+   * @return the initial pool size variable name
+   */
+  public String getInitialPoolSizeString();
+
+  /**
    * @param initalPoolSize
    *          the initial pool size
    */
   public void setInitialPoolSize( int initalPoolSize );
+
+  /**
+   * @param initalPoolSize
+   *          the initial pool size variable name
+   */
+  public void setInitialPoolSizeString( String initalPoolSize );
 
   /**
    * @return true if the connection contains partitioning information

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
@@ -2438,7 +2438,15 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
    * @return the maximum pool size
    */
   public int getMaximumPoolSize() {
-    return databaseInterface.getMaximumPoolSize();
+    return Const.toInt(
+      environmentSubstitute( getMaximumPoolSizeString() ), ConnectionPoolUtil.defaultMaximumNrOfConnections );
+  }
+
+  /**
+   * @return the maximum pool size variable name
+   */
+  public String getMaximumPoolSizeString() {
+    return databaseInterface.getMaximumPoolSizeString();
   }
 
   /**
@@ -2450,10 +2458,26 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   }
 
   /**
+   * @param maximumPoolSize
+   *          the maximum pool size variable name
+   */
+  public void setMaximumPoolSizeString( String maximumPoolSize ) {
+    databaseInterface.setMaximumPoolSizeString( maximumPoolSize );
+  }
+
+  /**
    * @return the initial pool size
    */
   public int getInitialPoolSize() {
-    return databaseInterface.getInitialPoolSize();
+    return Const.toInt(
+      environmentSubstitute( getInitialPoolSizeString() ), ConnectionPoolUtil.defaultInitialNrOfConnections );
+  }
+
+  /**
+   * @return the initial pool size variable name
+   */
+  public String getInitialPoolSizeString() {
+    return databaseInterface.getInitialPoolSizeString();
   }
 
   /**
@@ -2462,6 +2486,14 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
    */
   public void setInitialPoolSize( int initalPoolSize ) {
     databaseInterface.setInitialPoolSize( initalPoolSize );
+  }
+
+  /**
+    * @param initalPoolSize
+   *          the initial pool size variable name
+   */
+  public void setInitialPoolSizeString( String initalPoolSize ) {
+    databaseInterface.setInitialPoolSizeString( initalPoolSize );
   }
 
   /**

--- a/core/src/test/java/org/pentaho/di/core/database/ConnectionPoolUtilTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/ConnectionPoolUtilTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -47,8 +47,13 @@ import java.util.logging.Logger;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
 
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 /**
  * User: Dzmitry Stsiapanau Date: 12/11/13 Time: 1:59 PM
@@ -103,6 +108,20 @@ public class ConnectionPoolUtilTest implements Driver {
     when( dbMeta.getName() ).thenReturn( "CP2" );
     when( dbMeta.getPassword() ).thenReturn( ENCR_PASSWORD );
     Connection conn = ConnectionPoolUtil.getConnection( logChannelInterface, dbMeta, "", 1, 2 );
+    assertTrue( conn != null );
+  }
+
+  @Test
+  public void testGetConnectionWithVariables() throws Exception {
+    when( dbMeta.getName() ).thenReturn( "CP3" );
+    when( dbMeta.getPassword() ).thenReturn( ENCR_PASSWORD );
+    when( dbMeta.getInitialPoolSizeString() ).thenReturn( "INITIAL_POOL_SIZE" );
+    when( dbMeta.environmentSubstitute( "INITIAL_POOL_SIZE" ) ).thenReturn( "5" );
+    when( dbMeta.getInitialPoolSize() ).thenCallRealMethod();
+    when( dbMeta.getMaximumPoolSizeString() ).thenReturn( "MAXIMUM_POOL_SIZE" );
+    when( dbMeta.environmentSubstitute( "MAXIMUM_POOL_SIZE" ) ).thenReturn( "10" );
+    when( dbMeta.getMaximumPoolSize() ).thenCallRealMethod();
+    Connection conn = ConnectionPoolUtil.getConnection( logChannelInterface, dbMeta, "" );
     assertTrue( conn != null );
   }
 

--- a/dbdialog/src/main/java/org/pentaho/ui/database/event/DataHandler.java
+++ b/dbdialog/src/main/java/org/pentaho/ui/database/event/DataHandler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -764,8 +764,7 @@ public class DataHandler extends AbstractXulEventHandler {
     if ( meta.isUsingConnectionPool() ) {
       if ( poolSizeBox != null ) {
         try {
-          int initialPoolSize = Integer.parseInt( this.databaseMeta.environmentSubstitute( poolSizeBox.getValue() ) );
-          meta.setInitialPoolSize( initialPoolSize );
+          meta.setInitialPoolSizeString( poolSizeBox.getValue() );
         } catch ( NumberFormatException e ) {
           // TODO log exception and move on ...
         }
@@ -773,8 +772,7 @@ public class DataHandler extends AbstractXulEventHandler {
 
       if ( maxPoolSizeBox != null ) {
         try {
-          int maxPoolSize = Integer.parseInt( this.databaseMeta.environmentSubstitute( maxPoolSizeBox.getValue() ) );
-          meta.setMaximumPoolSize( maxPoolSize );
+          meta.setMaximumPoolSizeString( maxPoolSizeBox.getValue() );
         } catch ( NumberFormatException e ) {
           // TODO log exception and move on ...
         }
@@ -919,11 +917,11 @@ public class DataHandler extends AbstractXulEventHandler {
 
     if ( meta.isUsingConnectionPool() ) {
       if ( poolSizeBox != null ) {
-        poolSizeBox.setValue( Integer.toString( meta.getInitialPoolSize() ) );
+        poolSizeBox.setValue( meta.getInitialPoolSizeString() );
       }
 
       if ( maxPoolSizeBox != null ) {
-        maxPoolSizeBox.setValue( Integer.toString( meta.getMaximumPoolSize() ) );
+        maxPoolSizeBox.setValue( meta.getMaximumPoolSizeString() );
       }
 
       setPoolProperties( meta.getConnectionPoolingProperties() );


### PR DESCRIPTION
…nfiguration

@pentaho/tatooine 
@pentaho-lmartins @mbatchelor 

Following @pentaho-lmartins suggestion, now the initialPoolSize and maximumPoolSize variable names are stored and evaluated at runtime.  