### PR TITLE
[PDI-17622] Build Model step works fine in Spoon but fails from Kitchen

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/plugins/PluginRegistry.java
+++ b/core/src/main/java/org/pentaho/di/core/plugins/PluginRegistry.java
@@ -94,6 +94,7 @@ public class PluginRegistry {
   private final Map<Class<? extends PluginTypeInterface>, Set<PluginTypeListener>> listeners = new HashMap<>();
 
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+  private static final int WAIT_FOR_PLUGIN_TO_BE_AVAILABLE_LIMIT = 3000;
 
 
   /**
@@ -1062,5 +1063,30 @@ public class PluginRegistry {
     } finally {
       lock.writeLock().unlock();
     }
+  }
+
+  public PluginInterface findPluginWithId( Class<? extends PluginTypeInterface> pluginType, String pluginId, boolean waitForPluginToBeAvailable ) {
+    PluginInterface pluginInterface = findPluginWithId(  pluginType,  pluginId );
+    return waitForPluginToBeAvailable && pluginInterface == null
+      ? waitForPluginToBeAvailable( pluginType,  pluginId, WAIT_FOR_PLUGIN_TO_BE_AVAILABLE_LIMIT )
+      : pluginInterface;
+  }
+
+  private PluginInterface waitForPluginToBeAvailable( Class<? extends PluginTypeInterface> pluginType, String pluginId, int waitLimit ) {
+    int timeToSleep = 50;
+    try {
+      Thread.sleep( timeToSleep );
+      waitLimit -= timeToSleep;
+    } catch ( InterruptedException e ) {
+      log.logError( e.getLocalizedMessage(), e );
+      Thread.currentThread().interrupt();
+      return null;
+    }
+    PluginInterface pluginInterface = findPluginWithId( pluginType, pluginId );
+    return  waitLimit <= 0 && pluginInterface == null
+      ? null
+      : pluginInterface != null
+        ? pluginInterface
+        : waitForPluginToBeAvailable( pluginType, pluginId, waitLimit );
   }
 }

--- a/engine/src/main/java/org/pentaho/di/job/entry/JobEntryCopy.java
+++ b/engine/src/main/java/org/pentaho/di/job/entry/JobEntryCopy.java
@@ -137,7 +137,7 @@ public class JobEntryCopy implements Cloneable, XMLInterface, GUIPositionInterfa
     try {
       String stype = XMLHandler.getTagValue( entrynode, "type" );
       PluginRegistry registry = PluginRegistry.getInstance();
-      PluginInterface jobPlugin = registry.findPluginWithId( JobEntryPluginType.class, stype );
+      PluginInterface jobPlugin = registry.findPluginWithId( JobEntryPluginType.class, stype, true );
       if ( jobPlugin == null ) {
         String name = XMLHandler.getTagValue( entrynode, "name" );
         entry = new MissingEntry( name, stype );


### PR DESCRIPTION
This is a race condition issue with 9 fails in 10 in my environment. The JobEntryType (of BuildModel for example) is not registered when we try to run it in Kitchen and the job ends unsuccessfully due to plugin missing. This PR complements that logic, providing a way of giving more time for that plugin registration process, instead of aborting the execution immediately.  A waitLimit flag is provided, preventing looping issues. Should this be a Const? Configured and visible to users?

This is a wait to get fix. Probably a more architectural approach is needed to ensure we have all plugins we need (or know at least they are already installed in Karaf and then wait for them to be active) before start running those objects in kitchen. But at the same time we should keep our code separated from how OSGI/Karaf bundle management works.
Spoon works fine.

This issue (PDI-17622) has another error solved in this PR,https://github.com/pentaho/pentaho-metadata/pull/199

For the overall fix, both should be considered.
@mkambol 
@mbatchelor 
@pedrofvteixeira
@pentaho-lmartins
@graimundo   
can you please review this?