### PR TITLE
[SP-4801] Backport of PDI-17752 - Running a transformation with an in…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1310,7 +1310,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
           } catch ( KettleException e ) {
             // try to load from repository, this trans may have been developed locally and later uploaded to the
             // repository
-            transMeta = getTransMetaFromRepository( rep, r, realFilename );
+            transMeta = rep == null ? new TransMeta( realFilename, metaStore, null, true, this, null ) : getTransMetaFromRepository( rep, r, realFilename );
           }
           break;
         case REPOSITORY_BY_NAME:


### PR DESCRIPTION
…valid Path returns a NullPointerException and not the corresponding message defined by BACKLOG-21756 (8.2 Suite)

Cherry pick of https://github.com/pentaho/pentaho-kettle/pull/6026
@RPAraujo 