### PR TITLE
j[BACKLOG-26905] - jms consumer might lose messages on safe stopping

### DIFF
--- a/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsStreamSource.java
+++ b/plugins/streaming/impls/jms/src/main/java/org/pentaho/di/trans/step/jms/JmsStreamSource.java
@@ -23,22 +23,19 @@
 
 package org.pentaho.di.trans.step.jms;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableOnSubscribe;
 import org.pentaho.di.trans.streaming.common.BaseStreamStep;
 import org.pentaho.di.trans.streaming.common.BlockingQueueStreamSource;
 
 import javax.jms.JMSConsumer;
+import javax.jms.JMSException;
 import javax.jms.JMSRuntimeException;
 import javax.jms.Message;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static io.reactivex.schedulers.Schedulers.io;
 import static java.util.Collections.singletonList;
-import static java.util.Optional.ofNullable;
 import static org.pentaho.di.i18n.BaseMessages.getString;
 import static org.pentaho.di.trans.step.jms.JmsConstants.PKG;
 
@@ -58,43 +55,33 @@ public class JmsStreamSource extends BlockingQueueStreamSource<List<Object>> {
   @Override public void open() {
     consumer = jmsDelegate.getJmsContext()
       .createConsumer( jmsDelegate.getDestination() );
-    Observable
-      .create( receiveLoop() )  // jms loop
-      .subscribeOn( io() )   // subscribe and observe on new io threads
-      .observeOn( io() )
-      .doOnNext( message -> acceptRows( singletonList( Arrays.asList(
-        ( (Optional) message ).orElse( null ), // unwrap message - RX doesn't allow nulls
-         jmsDelegate.destinationName ) ) ) )
-      .doOnComplete( this::close )
-      .doOnError( this::error )
-      .publish() // publish/connect will "start" the receive loop
-      .connect();
+    Executors.newSingleThreadExecutor().submit( this::receiveLoop  );
   }
 
   /**
    * Will receive messages from consumer.  If timeout is hit, consumer.receive(timeout)
    * will return null, and the observable will be completed.
    */
-  private ObservableOnSubscribe<Object> receiveLoop() {
-    return emitter -> {
-      Message message;
-      try {
-        while ( ( message = consumer.receive( receiverTimeout ) ) != null ) {
-          streamStep.logDebug( message.toString() );
-          emitter.onNext( ofNullable( message.getBody( Object.class ) ) ); //wrap message - RX doesn't allow nulls
-        }
-      } catch ( JMSRuntimeException jmsException ) {
-        emitter.onError( jmsException );
+  private void receiveLoop() {
+    Message message;
+    try {
+      while ( !closed.get() && ( message = consumer.receive( receiverTimeout ) ) != null ) {
+        streamStep.logDebug( message.toString() );
+        acceptRows( singletonList( Arrays.asList( message.getBody( Object.class ), jmsDelegate.destinationName ) ) );
       }
+    } catch ( JMSRuntimeException | JMSException jmsException ) {
+      error( jmsException );
+    } finally {
+      super.close();
       if ( !closed.get() ) {
+        close();
         streamStep.logBasic( getString( PKG, "JmsStreamSource.HitReceiveTimeout" ) );
       }
-      emitter.onComplete();
-    };
+    }
   }
 
   @Override public void close() {
-    super.close();
+    //don't call super.close().  need to wait for the receiveLoop to be done
     if ( consumer != null && !closed.getAndSet( true ) ) {
       consumer.close();
       jmsDelegate.getJmsContext().close();

--- a/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/JmsStreamSourceTest.java
+++ b/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/JmsStreamSourceTest.java
@@ -71,6 +71,7 @@ public class JmsStreamSourceTest {
     AtomicBoolean first = new AtomicBoolean( true );
     when( consumer.receive( 0 ) ).thenAnswer( ans -> {
       if ( first.getAndSet( false ) ) {
+        source.close();
         return message;
       } else {
         return null;


### PR DESCRIPTION
need to wait for receive loop to finish before completing publishProcessor

rx Observable created multiple threads so that emitter.onNext was asyncronous before hitting the publisher.  that allowed time for the publisher to close before it got the last message sent.  removed in favor of a single thread for receive loop