### PR TITLE
[PDI-17761] - Job in 'Running' status when stopped from Spoon GUI or …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -518,7 +518,9 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
       log.logMinimal( BaseMessages.getString( PKG, "Job.Comment.JobFinished" ) );
 
       setActive( false );
-      setFinished( true );
+      if ( !isStopped() ) {
+        setFinished( true );
+      }
       return res;
     } finally {
       log.snap( Metrics.METRIC_JOB_STOP );


### PR DESCRIPTION
…from Kettle Status page, status for Job entry is shown as 'Finished (with errors)'

@pentaho/tatooine @mbatchelor @bmorrise 