### PR TITLE
[PDI-17789] Job execution fails to clean up EmbeddedMetastore objects…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -405,6 +405,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
 
         ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobFinish.id, this );
         jobMeta.disposeEmbeddedMetastoreProvider();
+        log.logDebug( BaseMessages.getString( PKG, "Job.Log.DisposeEmbeddedMetastore" ) );
 
         fireJobFinishListeners();
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJobRunner.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJobRunner.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -77,7 +77,8 @@ public class JobEntryJobRunner implements Runnable {
       job.setResult( result );
       try {
         ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobFinish.id, getJob() );
-
+        job.getJobMeta().disposeEmbeddedMetastoreProvider();
+        log.logDebug( BaseMessages.getString( PKG, "Job.Log.DisposeEmbeddedMetastore" ) );
         job.fireJobFinishListeners();
 
         //catch more general exception to prevent thread hanging

--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -247,6 +247,8 @@ public class JobExecutor extends BaseStep implements StepInterface {
     } finally {
       try {
         ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobFinish.id, data.executorJob );
+        getExecutorJob().getJobMeta().disposeEmbeddedMetastoreProvider();
+        log.logDebug( BaseMessages.getString( PKG, "JobExecutor.Log.DisposeEmbeddedMetastore" ) );
         data.executorJob.fireJobFinishListeners();
       } catch ( KettleException e ) {
         result.setNrErrors( 1 );

--- a/engine/src/main/resources/org/pentaho/di/job/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/job/messages/messages_en_US.properties
@@ -19,6 +19,7 @@ JobCategory.Category.Palo=Palo
 JobMeta.Exception.UnableToLoadJobFromXMLFile=Unable to load the job from XML file [
 Job.Log.UniqueJobName=The job needs a name to uniquely identify it by on the remote server.
 Job.Log.UnableToProcessLoggingStart=Unable to begin processing by logging start in logtable {0}
+Job.Log.DisposeEmbeddedMetastore = EmbeddedMetastore objects have been disposed.
 JobPlugin.Information.ClassName.Label=Class name
 EnterOptionsDialog.MaxNrHistLinesSize.Label=Maximum number of lines in the history views
 JobMeta.Monitor.ReadingNoteNr=Reading note \#

--- a/engine/src/main/resources/org/pentaho/di/trans/steps/jobexecutor/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/jobexecutor/messages/messages_en_US.properties
@@ -10,6 +10,7 @@ JobExecutorDialog.ResultFields.Label=Expected layout for result rows\:
 JobExecutorDialog.ExecutionFilesRetrievedField.Label=Number of files retrieved
 JobExecutorDialog.Parameters.Title=Parameters
 JobExecutor.Log.ErrorExecJob=There was an unexpected error during the execution of the job\:
+JobExecutor.Log.DisposeEmbeddedMetastore = EmbeddedMetastore objects have been disposed.
 JobExecutorDialog.ErrorSelectingObject.DialogTitle=Error
 JobExecutorDialog.Parameters.column.Input=Static input value
 JobExecutorDialog.ExecutionTimeField.Label=Execution time (ms)

--- a/engine/src/test/java/org/pentaho/di/job/entries/job/JobEntryJobRunnerTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/job/JobEntryJobRunnerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,6 +29,7 @@ import org.pentaho.di.core.Result;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobMeta;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -46,6 +47,7 @@ public class JobEntryJobRunnerTest {
 
   private JobEntryJobRunner jobRunner;
   private Job mockJob;
+  private JobMeta mockJobMeta;
   private Result mockResult;
   private LogChannelInterface mockLog;
   private Job parentJob;
@@ -53,6 +55,7 @@ public class JobEntryJobRunnerTest {
   @Before
   public void setUp() throws Exception {
     mockJob = mock( Job.class );
+    mockJobMeta = mock( JobMeta.class );
     mockResult = mock( Result.class );
     mockLog = mock( LogChannelInterface.class );
     jobRunner = new JobEntryJobRunner( mockJob, mockResult, 0, mockLog );
@@ -66,6 +69,7 @@ public class JobEntryJobRunnerTest {
     jobRunner.run();
     when( mockJob.isStopped() ).thenReturn( false );
     when( mockJob.getParentJob() ).thenReturn( null );
+    when( mockJob.getJobMeta() ).thenReturn( mockJobMeta );
     jobRunner.run();
     when( parentJob.isStopped() ).thenReturn( true );
     when( mockJob.getParentJob() ).thenReturn( parentJob );
@@ -131,6 +135,7 @@ public class JobEntryJobRunnerTest {
   public void testRunWithException() throws Exception {
     when( mockJob.isStopped() ).thenReturn( false );
     when( mockJob.getParentJob() ).thenReturn( parentJob );
+    when( mockJob.getJobMeta() ).thenReturn( mockJobMeta );
     when( parentJob.isStopped() ).thenReturn( false );
     doThrow( KettleException.class ).when( mockJob ).execute( anyInt(), any( Result.class ) );
     jobRunner.run();

--- a/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Mikhail_Chen-Len-Son
@@ -95,6 +96,9 @@ public class JobExecutorTest {
     data.groupField = "groupField";
     executor.init( meta, data );
 
+    when( executor.getExecutorJob() ).thenReturn( mock( Job.class ) );
+    when( executor.getExecutorJob().getJobMeta() ).thenReturn( mock( JobMeta.class ) );
+
     RowMetaInterface rowMeta = new RowMeta();
     rowMeta.addValueMeta( new ValueMetaString( "groupField" ) );
     executor.setInputRowMeta( rowMeta );
@@ -138,6 +142,9 @@ public class JobExecutorTest {
 
     data.groupSize = 5;
     executor.init( meta, data );
+
+    when( executor.getExecutorJob() ).thenReturn( mock( Job.class ) );
+    when( executor.getExecutorJob().getJobMeta() ).thenReturn( mock( JobMeta.class ) );
 
     // start processing
     executor.processRow( meta, data ); // 1st row


### PR DESCRIPTION
…, leading to eventual memory issues

@pentaho/tatooine @pentaho-lmartins 
@mbatchelor @kurtwalker  

I've included a log debug message, to be sure that the EmbeddedMetastore objects are been disposed.