### PR TITLE
[PDI-16603] Refactor JDBC drivers out of data-integration/lib and into lib/jdbc

### DIFF
--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -45,6 +45,18 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho.di</groupId>
+      <artifactId>pdi-libs-jdbc</artifactId>
+      <version>${project.version}</version>
+      <type>zip</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.di</groupId>
       <artifactId>pdi-plugins</artifactId>
       <version>${project.version}</version>
       <type>zip</type>

--- a/assemblies/client/src/assembly/assembly.xml
+++ b/assemblies/client/src/assembly/assembly.xml
@@ -19,7 +19,8 @@
       <includes>
         <include>org.pentaho.di:pdi-static:zip</include>
         <include>org.pentaho.di:pdi-samples:zip</include>
-        <include>org.pentaho.di:pdi-libs:zip</include>
+	<include>org.pentaho.di:pdi-libs:zip</include>
+	<include>org.pentaho.di:pdi-libs-jdbc:zip</include>
         <include>org.pentaho.di:pdi-plugins:zip</include>
       </includes>
       <unpack>true</unpack>

--- a/assemblies/lib-jdbc/pom.xml
+++ b/assemblies/lib-jdbc/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>pdi-libs-jdbc</artifactId>
+  <packaging>pom</packaging>
+
+  <name>PDI JDBC Drivers</name>
+
+  <parent>
+    <artifactId>pdi-assemblies</artifactId>
+    <groupId>org.pentaho.di</groupId>
+    <version>8.3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <hsqldb.version>2.3.2</hsqldb.version>
+    <jaybird.version>2.1.6</jaybird.version>
+    <jt400.version>9.6</jt400.version>
+    <LucidDbClient-minimal.version>0.9.4</LucidDbClient-minimal.version>
+    <monetdb-jdbc.version>2.28</monetdb-jdbc.version>
+    <postgresql.version>42.1.1</postgresql.version>
+    <sapdbc.version>7.4.4</sapdbc.version>
+    <sqlite-jdbc.version>3.7.2</sqlite-jdbc.version>
+  </properties>
+
+  <dependencies>
+    <!-- Third-party JDBC drivers dependencies -->
+    <dependency>
+      <groupId>org.firebirdsql.jdbc</groupId>
+      <artifactId>jaybird</artifactId>
+      <version>${jaybird.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.jt400</groupId>
+      <artifactId>jt400</artifactId>
+      <version>${jt400.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>luciddb</groupId>
+      <artifactId>LucidDbClient-minimal</artifactId>
+      <version>${LucidDbClient-minimal.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/monetdb/monetdb-jdbc -->
+    <dependency>
+      <groupId>monetdb</groupId>
+      <artifactId>monetdb-jdbc</artifactId>
+      <version>${monetdb-jdbc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgresql.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.sap</groupId>
+      <artifactId>sapdbc</artifactId>
+      <version>${sapdbc.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>${sqlite-jdbc.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+      <artifactId>maven-dependency-plugin</artifactId>
+      <executions>
+      <execution>
+        <id>copy-libs</id>
+        <phase>generate-resources</phase>
+        <goals>
+          <goal>copy-dependencies</goal>
+        </goals>
+        <configuration>
+          <includeScope>compile</includeScope>
+          <outputDirectory>${assembly.dir}/jdbc</outputDirectory>
+        </configuration>
+      </execution>
+      </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+

--- a/assemblies/lib-jdbc/src/assembly/assembly.xml
+++ b/assemblies/lib-jdbc/src/assembly/assembly.xml
@@ -1,0 +1,15 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <id>libs</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>true</includeBaseDirectory>
+  <baseDirectory>lib</baseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${assembly.dir}</directory>
+      <outputDirectory>.</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -36,11 +36,6 @@
     <derby.version>10.2.1.6</derby.version>
     <derbyclient.version>10.2.1.6</derbyclient.version>
     <hsqldb.version>2.3.2</hsqldb.version>
-    <jaybird.version>2.1.6</jaybird.version>
-    <jt400.version>6.1</jt400.version>
-    <LucidDbClient-minimal.version>0.9.4</LucidDbClient-minimal.version>
-    <sapdbc.version>7.4.4</sapdbc.version>
-    <sqlite-jdbc.version>3.7.2</sqlite-jdbc.version>
     <geronimo-servlet_3.0_spec.version>1.0</geronimo-servlet_3.0_spec.version>
     <slf4j-api.version>1.7.7</slf4j-api.version>
     <slf4j-log4j12.version>1.7.7</slf4j-log4j12.version>
@@ -88,6 +83,14 @@
         <exclusion>
           <groupId>javax.servlet</groupId>
           <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.postgresql</groupId>
+          <artifactId>postgresql</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>monetdb</groupId>
+          <artifactId>monetdb-jdbc</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -406,61 +409,6 @@
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <version>${hsqldb.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.firebirdsql.jdbc</groupId>
-      <artifactId>jaybird</artifactId>
-      <version>${jaybird.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.jt400</groupId>
-      <artifactId>jt400</artifactId>
-      <version>${jt400.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>luciddb</groupId>
-      <artifactId>LucidDbClient-minimal</artifactId>
-      <version>${LucidDbClient-minimal.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.sap</groupId>
-      <artifactId>sapdbc</artifactId>
-      <version>${sapdbc.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.xerial</groupId>
-      <artifactId>sqlite-jdbc</artifactId>
-      <version>${sqlite-jdbc.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -24,6 +24,7 @@
     <module>static</module>
     <module>samples</module>
     <module>lib</module>
+    <module>lib-jdbc</module>
     <module>plugins</module>
     <module>client</module>
     <module>core</module>

--- a/assemblies/static/src/main/resources/launcher/launcher.properties
+++ b/assemblies/static/src/main/resources/launcher/launcher.properties
@@ -1,5 +1,5 @@
 main=org.pentaho.di.ui.spoon.Spoon
 libraries=../test:../lib:../libswt
-classpath=../classes:../:../ui:../ui/images:../lib
+classpath=../classes:../:../ui:../ui/images:../lib:../lib/jdbc
 
 system-property.pentaho.installed.licenses.file=${PENTAHO_INSTALLED_LICENSE_PATH}

--- a/core/src/main/java/org/pentaho/di/core/database/MonetDBDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/MonetDBDatabaseMeta.java
@@ -304,7 +304,7 @@ public class MonetDBDatabaseMeta extends BaseDatabaseMeta implements DatabaseInt
 
   @Override
   public String[] getUsedLibraries() {
-    return new String[] { "monetdb-jdbc-2.8.jar", };
+    return new String[] { "monetdb-jdbc-2.28.jar", };
   }
 
   /**

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -50,7 +50,7 @@
     <jersey-core.version>1.19.1</jersey-core.version>
     <jxl.version>2.6.12</jxl.version>
     <ldapjdk.version>20000524</ldapjdk.version>
-    <monetdb-jdbc.version>2.8</monetdb-jdbc.version>
+    <monetdb-jdbc.version>2.28</monetdb-jdbc.version>
     <odfdom-java.version>0.8.6</odfdom-java.version>
     <poi.version>3.17</poi.version>
     <commons-collections4.version>4.1</commons-collections4.version>


### PR DESCRIPTION
Hello.

Included here is a refactor of data-integration/lib which splits JDBC drivers into a new assembly project called libs-jdbc.  All of the existing compatibility is preserved with respect to class path.  All tests pass.

This updates launcher.properties to include the new libs/jdbc folder.
jar files previously dumped into the lib ocean now get cleanly placed into the jdbc folder.

This will make it much easier to keep tabs on which drivers are in play, and conforms also to the standard that exists in Pentaho Reporting where lib/jdbc also exists and has for a long time.  This will make it less likely for an administrator to overlook outdated drivers.  It also makes the drivers easily swapped out in containerized environments where a user can bind mount a folder with JDBC jars into lib/jdbc.'

I hope your team will see the value in this pull request and consider merging it into the main code line.

Best regards,

Brandon