### PR TITLE
[PDI-17652] Internal.Entry.Current.Directory not reporting correctly

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -437,10 +437,15 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
     }
     String[] variableNames = replaceBy.listVariables();
     for ( String variableName : variableNames ) {
-      if ( childTransMeta.getVariable( variableName ) != null ) {
+      if ( childTransMeta.getVariable( variableName ) != null && !isInternalVariable( variableName ) ) {
         childTransMeta.setVariable( variableName, replaceBy.getVariable( variableName ) );
       }
     }
+  }
+
+  private static boolean isInternalVariable( String variableName ) {
+    return ( Arrays.asList( Const.INTERNAL_JOB_VARIABLES ).contains( variableName )
+      || Arrays.asList( Const.INTERNAL_TRANS_VARIABLES ).contains( variableName ) );
   }
 
   /**

--- a/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
@@ -389,4 +389,60 @@ public class StepWithMappingMetaTest {
     Mockito.verify( rep, Mockito.times( 1 ) ).loadTransformation( Mockito.eq( transName ),
       Mockito.eq( directoryInterface ), Mockito.eq( null ), Mockito.eq( true ), Mockito.eq( null ) );
   }
+
+  @Test
+  @PrepareForTest( StepWithMappingMeta.class )
+  public void replaceVariablesWithJobInternalVariablesTest()  {
+    String variableOverwrite = "paramOverwrite";
+    String variableChildOnly = "childValueVariable";
+    String [] jobVariables = Const.INTERNAL_JOB_VARIABLES;
+    VariableSpace ChildVariables = new Variables();
+    VariableSpace replaceByParentVariables = new Variables();
+
+    for ( String internalVariable : jobVariables ) {
+      ChildVariables.setVariable( internalVariable, "childValue" );
+      replaceByParentVariables.setVariable( internalVariable, "parentValue" );
+    }
+
+    ChildVariables.setVariable( variableChildOnly, "childValueVariable" );
+    ChildVariables.setVariable( variableOverwrite, "childNotInternalValue" );
+    replaceByParentVariables.setVariable( variableOverwrite, "parentNotInternalValue" );
+
+    StepWithMappingMeta.replaceVariableValues( ChildVariables, replaceByParentVariables );
+    // do not replace internal variables
+    Assert.assertEquals( "childValue", ChildVariables.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
+    // replace non internal variables
+    Assert.assertEquals( "parentNotInternalValue", ChildVariables.getVariable( variableOverwrite ) );
+    // keep child only variables
+    Assert.assertEquals( variableChildOnly, ChildVariables.getVariable( variableChildOnly ) );
+
+  }
+
+  @Test
+  @PrepareForTest( StepWithMappingMeta.class )
+  public void replaceVariablesWithTransInternalVariablesTest()  {
+    String variableOverwrite = "paramOverwrite";
+    String variableChildOnly = "childValueVariable";
+    String [] jobVariables = Const.INTERNAL_TRANS_VARIABLES;
+    VariableSpace ChildVariables = new Variables();
+    VariableSpace replaceByParentVariables = new Variables();
+
+    for ( String internalVariable : jobVariables ) {
+      ChildVariables.setVariable( internalVariable, "childValue" );
+      replaceByParentVariables.setVariable( internalVariable, "parentValue" );
+    }
+
+    ChildVariables.setVariable( variableChildOnly, "childValueVariable" );
+    ChildVariables.setVariable( variableOverwrite, "childNotInternalValue" );
+    replaceByParentVariables.setVariable( variableOverwrite, "parentNotInternalValue" );
+
+    StepWithMappingMeta.replaceVariableValues( ChildVariables, replaceByParentVariables );
+    // do not replace internal variables
+    Assert.assertEquals( "childValue", ChildVariables.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
+    // replace non internal variables
+    Assert.assertEquals( "parentNotInternalValue", ChildVariables.getVariable( variableOverwrite ) );
+    // keep child only variables
+    Assert.assertEquals( variableChildOnly, ChildVariables.getVariable( variableChildOnly ) );
+
+  }
 }


### PR DESCRIPTION
The internal variables were always being replaced by parent meta. This PR excludes the JOB & TRANS internal variables from being replaced, keeping them correct in their own context.

@mbatchelor 
@mkambol  
@pentaho-lmartins  