### PR TITLE
[PDI-17782] Fixed File Input gets stuck pressing "Get Fields" only on…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/trans/dialog/TransPreviewProgressDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/dialog/TransPreviewProgressDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -177,6 +177,20 @@ public class TransPreviewProgressDialog {
       transDebugMeta.getStepDebugMetaMap().put( stepMeta, stepDebugMeta );
     }
 
+    int previousPct = 0;
+    final List<String> previewComplete = new ArrayList<String>();
+    // We add a break-point that is called every time we have a step with a full preview row buffer
+    // That makes it easy and fast to see if we have all the rows we need
+    //
+    transDebugMeta.addBreakPointListers( new BreakPointListener() {
+      public void breakPointHit( TransDebugMeta transDebugMeta, StepDebugMeta stepDebugMeta,
+                                 RowMetaInterface rowBufferMeta, List<Object[]> rowBuffer ) {
+        String stepName = stepDebugMeta.getStepMeta().getName();
+        previewComplete.add( stepName );
+        progressMonitor.subTask( BaseMessages.getString(
+          PKG, "TransPreviewProgressDialog.SubTask.StepPreviewFinished", stepName ) );
+      }
+    } );
     // set the appropriate listeners on the transformation...
     //
     transDebugMeta.addRowListenersToTransformation( trans );
@@ -198,23 +212,8 @@ public class TransPreviewProgressDialog {
       return;
     }
 
-    int previousPct = 0;
-    final List<String> previewComplete = new ArrayList<String>();
-
     while ( previewComplete.size() < previewStepNames.length
       && !trans.isFinished() && !progressMonitor.isCanceled() ) {
-      // We add a break-point that is called every time we have a step with a full preview row buffer
-      // That makes it easy and fast to see if we have all the rows we need
-      //
-      transDebugMeta.addBreakPointListers( new BreakPointListener() {
-        public void breakPointHit( TransDebugMeta transDebugMeta, StepDebugMeta stepDebugMeta,
-          RowMetaInterface rowBufferMeta, List<Object[]> rowBuffer ) {
-          String stepName = stepDebugMeta.getStepMeta().getName();
-          previewComplete.add( stepName );
-          progressMonitor.subTask( BaseMessages.getString(
-            PKG, "TransPreviewProgressDialog.SubTask.StepPreviewFinished", stepName ) );
-        }
-      } );
 
       // How many rows are done?
       int nrDone = 0;


### PR DESCRIPTION
… first PDI start-up
@pentaho/tatooine @mbatchelor @pentaho-lmartins 

Issue happened because the row listener was added before the breakpoint listener. the breakpoint listener is triggered by the row listner. It may occur that that trigger is fired before the breakpoint listener is even added, causing a forever loop (until cancel). 
Also the breakpoint listener was added inside the while loop which could cause more than one addition of the listener to all steps. (the listener is always the same, no need to repeat, it can be added only once before the loop).