### PR TITLE
[PDI-17843] Lookup Step Output Metadata not set correctly in 8.2

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -5013,7 +5013,6 @@ public class ValueMetaBase implements ValueMetaInterface {
       int originalColumnDisplaySize = originalPrecision;
       String originalColumnTypeName = rs.getString( "TYPE_NAME" );
       String originalColumnLabel = rs.getString( "REMARKS" );
-      boolean originalSigned = false; // TODO not sure this is possible to get through metadata
       int length = -1;
       int precision = -1;
       int valtype = ValueMetaInterface.TYPE_NONE;
@@ -5036,17 +5035,11 @@ public class ValueMetaBase implements ValueMetaInterface {
           break;
 
         case java.sql.Types.BIGINT:
-          // verify Unsigned BIGINT overflow!
-          //
-          if ( originalSigned ) {
-            valtype = ValueMetaInterface.TYPE_INTEGER;
-            precision = 0; // Max 9.223.372.036.854.775.807
-            length = 15;
-          } else {
-            valtype = ValueMetaInterface.TYPE_BIGNUMBER;
-            precision = 0; // Max 18.446.744.073.709.551.615
-            length = 16;
-          }
+          // SQL BigInt is equivalent to a Java Long
+          // And a Java Long is equivalent to a PDI Integer.
+          valtype = ValueMetaInterface.TYPE_INTEGER;
+          precision = 0; // Max 9.223.372.036.854.775.807
+          length = 15;
           break;
 
         case java.sql.Types.INTEGER:


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins 
@lucboudreau 

There was a condition to see if the BigInt is a Long (Type_Integer) or a BigDecimal (Type_BigNumber).
But a SQL BigInt is equivalent to a Java Long, and its max value is 9.223.372.036.854.775.807.