### PR TITLE
[PDI-15575] XML Output Step - should allow developers to save and edit when step configuraton is incomplete

### DIFF
--- a/plugins/xml/core/src/main/java/org/pentaho/di/trans/steps/xmloutput/XMLField.java
+++ b/plugins/xml/core/src/main/java/org/pentaho/di/trans/steps/xmloutput/XMLField.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.xmloutput;
 
+import com.google.common.base.Enums;
 import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.row.ValueMeta;
 
@@ -35,7 +36,18 @@ import org.pentaho.di.core.row.ValueMeta;
 public class XMLField implements Cloneable {
 
   public enum ContentType {
-    Element, Attribute,
+    Element, Attribute;
+
+    /**
+     * [PDI-15575] Ensuring that this enum can return with some default value. Necessary for when being used on the
+     * GUI side if a user leaves the field empty, it will enforce a default value. This allows the object to be saved,
+     * loaded, and cloned as necessary.
+     * @param contentType
+     * @return ContentType
+     */
+    public static ContentType getIfPresent( String contentType ) {
+      return Enums.getIfPresent( ContentType.class, contentType ).or( Element );
+    }
   }
 
   @Injection( name = "OUTPUT_FIELDNAME", group = "OUTPUT_FIELDS" )

--- a/plugins/xml/core/src/main/java/org/pentaho/di/ui/trans/steps/xmloutput/XMLOutputDialog.java
+++ b/plugins/xml/core/src/main/java/org/pentaho/di/ui/trans/steps/xmloutput/XMLOutputDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1118,7 +1118,7 @@ public class XMLOutputDialog extends BaseStepDialog implements StepDialogInterfa
       if ( field.getFieldName().equals( field.getElementName() ) ) {
         field.setElementName( "" );
       }
-      field.setContentType( ContentType.valueOf( item.getText( index++ ) ) );
+      field.setContentType( ContentType.getIfPresent( item.getText( index++ ) ) );
       field.setType( item.getText( index++ ) );
       field.setFormat( item.getText( index++ ) );
       field.setLength( Const.toInt( item.getText( index++ ), -1 ) );

--- a/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmloutput/XMLOutputTest.java
+++ b/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmloutput/XMLOutputTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -40,6 +40,7 @@ import org.pentaho.di.trans.steps.xmloutput.XMLField.ContentType;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -120,6 +121,22 @@ public class XMLOutputTest {
     xmlOutput.setVariable( Const.KETTLE_COMPATIBILITY_XML_OUTPUT_NULL_VALUES, "Y" );
 
     testNullValuesInAttribute( rowWithNullData.length  );
+  }
+
+  /**
+   * [PDI-15575] Testing to verify that getIfPresent defaults the XMLField ContentType value
+   */
+  @Test
+  public void testDefaultXmlFieldContentType() {
+    XMLField[] xmlFields = initOutputFields( 4, null );
+    xmlFields[0].setContentType( ContentType.getIfPresent( "Element" ) );
+    xmlFields[1].setContentType( ContentType.getIfPresent( "Attribute" ) );
+    xmlFields[2].setContentType( ContentType.getIfPresent( "" ) );
+    xmlFields[3].setContentType( ContentType.getIfPresent( "WrongValue" ) );
+    assertEquals( xmlFields[0].getContentType(), ContentType.Element );
+    assertEquals( xmlFields[1].getContentType(), ContentType.Attribute );
+    assertEquals( xmlFields[2].getContentType(), ContentType.Element );
+    assertEquals( xmlFields[3].getContentType(), ContentType.Element );
   }
 
   private void testNullValuesInAttribute( int writeNullInvocationExpected ) throws KettleException, XMLStreamException {


### PR DESCRIPTION
* [PDI-15575] Added in code to allow for default selection of the ContentType Enum if a user tries to add a ContentType that does not exist (or leaves it empty).
* [PDI-15575] Adding Test code to verify the getIfPresent default value is being set appropriately. Updating copyright years