### PR TITLE
[PDI-17892] The run configuration description is not according the se…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobExecutionConfigurationDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobExecutionConfigurationDialog.java
@@ -291,8 +291,11 @@ public class JobExecutionConfigurationDialog extends ConfigurationDialog {
       } catch ( KettleException ignored ) {
         // Ignore errors
       }
+      Boolean isRemote = (Boolean) items.get( 1 );
       getConfiguration().setRunConfiguration( wRunConfiguration.getText() );
-      wExpandRemote.setEnabled( (Boolean) items.get( 1 ) );
+      getConfiguration().setExecutingRemotely( isRemote );
+      getConfiguration().setExecutingLocally( !isRemote );
+      wExpandRemote.setEnabled( isRemote );
       wExpandRemote.setSelection( wExpandRemote.isEnabled() && wExpandRemote.getSelection() );
     } );
   }


### PR DESCRIPTION
…lected run option after closing the Run configuration Dialog

After discussing this case with Jens, it was decided that we will not refactoring the executeRemote/executeLocally logic. We need to have both flags due to legacy/compatibility issues.
So in this PR we set both of them accordingly.

@pentaho-lmartins 