### PR TITLE
[PDI-17903] google bigquery dependency left over in the 8.2 assembly for CE

### DIFF
--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -11,16 +11,16 @@
   <parent>
     <artifactId>pdi-assemblies</artifactId>
     <groupId>org.pentaho.di</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>
     <pdi-dataservice-driver-bundle.version>${project.version}</pdi-dataservice-driver-bundle.version>
-    <ael.version>8.2.0.0-SNAPSHOT</ael.version>
+    <ael.version>8.2.0.3-515</ael.version>
 
-    <pentaho-karaf.version>8.2.0.0-SNAPSHOT</pentaho-karaf.version>
-    <pentaho-launcher.version>8.2.0.0-SNAPSHOT</pentaho-launcher.version>
-    <oss-licenses.version>8.2.0.0-SNAPSHOT</oss-licenses.version>
+    <pentaho-karaf.version>8.2.0.3-515</pentaho-karaf.version>
+    <pentaho-launcher.version>8.2.0.3-515</pentaho-launcher.version>
+    <oss-licenses.version>8.2.0.3-515</oss-licenses.version>
 
     <!-- swt -->
     <org.eclipse.swt.gtk.linux.x86.version>4.3.2</org.eclipse.swt.gtk.linux.x86.version>

--- a/assemblies/core/client/pom.xml
+++ b/assemblies/core/client/pom.xml
@@ -12,16 +12,16 @@
     <parent>
         <groupId>org.pentaho.di</groupId>
         <artifactId>pdi-core</artifactId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 
     <properties>
         <pdi-dataservice-driver-bundle.version>${project.version}</pdi-dataservice-driver-bundle.version>
-        <ael.version>8.2.0.0-SNAPSHOT</ael.version>
+        <ael.version>8.2.0.3-515</ael.version>
 
-        <pentaho-karaf.version>8.2.0.0-SNAPSHOT</pentaho-karaf.version>
-        <pentaho-launcher.version>8.2.0.0-SNAPSHOT</pentaho-launcher.version>
-        <oss-licenses.version>8.2.0.0-SNAPSHOT</oss-licenses.version>
+        <pentaho-karaf.version>8.2.0.3-515</pentaho-karaf.version>
+        <pentaho-launcher.version>8.2.0.3-515</pentaho-launcher.version>
+        <oss-licenses.version>8.2.0.3-515</oss-licenses.version>
 
         <!-- swt -->
         <org.eclipse.swt.gtk.linux.x86.version>4.3.2</org.eclipse.swt.gtk.linux.x86.version>

--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -12,22 +12,22 @@
     <parent>
         <groupId>org.pentaho.di</groupId>
         <artifactId>pdi-core</artifactId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 
     <properties>
         <pdi-engine-spark.version>${project.version}</pdi-engine-spark.version>
         <rxjava.version>2.0.4</rxjava.version>
 
-        <pentaho-json.version>8.2.0.0-SNAPSHOT</pentaho-json.version>
+        <pentaho-json.version>8.2.0.3-515</pentaho-json.version>
         <pdi-spark-driver.version>${project.version}</pdi-spark-driver.version>
-        <pdi-osgi-bridge.version>8.2.0.0-SNAPSHOT</pdi-osgi-bridge.version>
-        <commons-database.version>8.2.0.0-SNAPSHOT</commons-database.version>
-        <pentaho-registry.version>8.2.0.0-SNAPSHOT</pentaho-registry.version>
-        <pentaho-metaverse.version>8.2.0.0-SNAPSHOT</pentaho-metaverse.version>
-        <platform.version>8.2.0.0-SNAPSHOT</platform.version>
-        <pentaho-reporting.version>8.2.0.0-SNAPSHOT</pentaho-reporting.version>
-        <pentaho-hadoop-shims-api.version>8.2.0.0-SNAPSHOT</pentaho-hadoop-shims-api.version>
+        <pdi-osgi-bridge.version>8.2.0.3-515</pdi-osgi-bridge.version>
+        <commons-database.version>8.2.0.3-515</commons-database.version>
+        <pentaho-registry.version>8.2.0.3-515</pentaho-registry.version>
+        <pentaho-metaverse.version>8.2.0.3-515</pentaho-metaverse.version>
+        <platform.version>8.2.0.3-515</platform.version>
+        <pentaho-reporting.version>8.2.0.3-515</pentaho-reporting.version>
+        <pentaho-hadoop-shims-api.version>8.2.2018.11.00-342</pentaho-hadoop-shims-api.version>
 
         <!-- third party -->
         <org.apache.karaf.main.version>3.0.3</org.apache.karaf.main.version>

--- a/assemblies/core/pom.xml
+++ b/assemblies/core/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.pentaho.di</groupId>
         <artifactId>pdi-assemblies</artifactId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 
     <modules>

--- a/assemblies/core/static/pom.xml
+++ b/assemblies/core/static/pom.xml
@@ -12,6 +12,6 @@
     <parent>
         <groupId>org.pentaho.di</groupId>
         <artifactId>pdi-core</artifactId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 </project>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -11,22 +11,22 @@
   <parent>
     <artifactId>pdi-assemblies</artifactId>
     <groupId>org.pentaho.di</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>
     <pdi-engine-spark.version>${project.version}</pdi-engine-spark.version>
     <rxjava.version>2.0.4</rxjava.version>
 
-    <pentaho-json.version>8.2.0.0-SNAPSHOT</pentaho-json.version>
+    <pentaho-json.version>8.2.0.3-515</pentaho-json.version>
     <pdi-spark-driver.version>${project.version}</pdi-spark-driver.version>
-    <pdi-osgi-bridge.version>8.2.0.0-SNAPSHOT</pdi-osgi-bridge.version>
-    <commons-database.version>8.2.0.0-SNAPSHOT</commons-database.version>
-    <pentaho-registry.version>8.2.0.0-SNAPSHOT</pentaho-registry.version>
-    <pentaho-metaverse.version>8.2.0.0-SNAPSHOT</pentaho-metaverse.version>
-    <platform.version>8.2.0.0-SNAPSHOT</platform.version>
-    <pentaho-reporting.version>8.2.0.0-SNAPSHOT</pentaho-reporting.version>
-    <pentaho-hadoop-shims-api.version>8.2.0.0-SNAPSHOT</pentaho-hadoop-shims-api.version>
+    <pdi-osgi-bridge.version>8.2.0.3-515</pdi-osgi-bridge.version>
+    <commons-database.version>8.2.0.3-515</commons-database.version>
+    <pentaho-registry.version>8.2.0.3-515</pentaho-registry.version>
+    <pentaho-metaverse.version>8.2.0.3-515</pentaho-metaverse.version>
+    <platform.version>8.2.0.3-515</platform.version>
+    <pentaho-reporting.version>8.2.0.3-515</pentaho-reporting.version>
+    <pentaho-hadoop-shims-api.version>8.2.2018.11.00-342</pentaho-hadoop-shims-api.version>
 
     <!-- third party -->
     <org.apache.karaf.main.version>3.0.3</org.apache.karaf.main.version>

--- a/assemblies/plugins/pom.xml
+++ b/assemblies/plugins/pom.xml
@@ -33,7 +33,6 @@
     <lucid-db-streaming-loader-plugin.version>${project.version}</lucid-db-streaming-loader-plugin.version>
     <gp-bulk-loader-plugin.version>${project.version}</gp-bulk-loader-plugin.version>
     <pentaho-googledrive-vfs-plugin.version>${project.version}</pentaho-googledrive-vfs-plugin.version>
-    <google-bigquery-plugin.version>${project.version}</google-bigquery-plugin.version>
     <elasticsearch-bulk-insert-plugin.version>${project.version}</elasticsearch-bulk-insert-plugin.version>
     <pdi-xml-plugin.version>8.2.0.3-515</pdi-xml-plugin.version>
     <pdi-json-plugin.version>8.2.0.3-515</pdi-json-plugin.version>
@@ -243,18 +242,6 @@
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>pentaho-googledrive-vfs-plugin</artifactId>
       <version>${pentaho-googledrive-vfs-plugin.version}</version>
-      <type>zip</type>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho.di.plugins</groupId>
-      <artifactId>google-bigquery-plugin</artifactId>
-      <version>${google-bigquery-plugin.version}</version>
       <type>zip</type>
       <exclusions>
         <exclusion>

--- a/assemblies/plugins/pom.xml
+++ b/assemblies/plugins/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>pdi-assemblies</artifactId>
     <groupId>org.pentaho.di</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>
@@ -27,23 +27,23 @@
     <kettle-openerp-plugin.version>${project.version}</kettle-openerp-plugin.version>
     <kettle-palo-plugin.version>${project.version}</kettle-palo-plugin.version>
     <kettle5-log4j-plugin.version>${project.version}</kettle5-log4j-plugin.version>
-    <pdi-google-analytics-plugin.version>8.2.0.0-SNAPSHOT</pdi-google-analytics-plugin.version>
-    <pdi-salesforce-plugin.version>8.2.0.0-SNAPSHOT</pdi-salesforce-plugin.version>
+    <pdi-google-analytics-plugin.version>8.2.0.3-515</pdi-google-analytics-plugin.version>
+    <pdi-salesforce-plugin.version>8.2.0.3-515</pdi-salesforce-plugin.version>
     <ms-access-plugin.version>${project.version}</ms-access-plugin.version>
     <lucid-db-streaming-loader-plugin.version>${project.version}</lucid-db-streaming-loader-plugin.version>
     <gp-bulk-loader-plugin.version>${project.version}</gp-bulk-loader-plugin.version>
     <pentaho-googledrive-vfs-plugin.version>${project.version}</pentaho-googledrive-vfs-plugin.version>
     <google-bigquery-plugin.version>${project.version}</google-bigquery-plugin.version>
     <elasticsearch-bulk-insert-plugin.version>${project.version}</elasticsearch-bulk-insert-plugin.version>
-    <pdi-xml-plugin.version>8.2.0.0-SNAPSHOT</pdi-xml-plugin.version>
-    <pdi-json-plugin.version>8.2.0.0-SNAPSHOT</pdi-json-plugin.version>
-    <pdi-sap-plugin.version>8.2.0.0-SNAPSHOT</pdi-sap-plugin.version>
-    <big-data-plugin.version>8.2.0.0-SNAPSHOT</big-data-plugin.version>
-    <pentaho-cassandra-plugin.version>8.2.0.0-SNAPSHOT</pentaho-cassandra-plugin.version>
+    <pdi-xml-plugin.version>8.2.0.3-515</pdi-xml-plugin.version>
+    <pdi-json-plugin.version>8.2.0.3-515</pdi-json-plugin.version>
+    <pdi-sap-plugin.version>8.2.0.3-515</pdi-sap-plugin.version>
+    <big-data-plugin.version>8.2.0.3-515</big-data-plugin.version>
+    <pentaho-cassandra-plugin.version>8.2.0.3-515</pentaho-cassandra-plugin.version>
     <pdi-teradata-tpt-plugin-package.version>${project.version}</pdi-teradata-tpt-plugin-package.version>
-    <pdi-platform-utils-plugin.version>8.2.0.0-SNAPSHOT</pdi-platform-utils-plugin.version>
-    <vertica-bulkloader-plugin.version>8.2.0.0-SNAPSHOT</vertica-bulkloader-plugin.version>
-    <pdi-pur-plugin.version>8.2.0.0-SNAPSHOT</pdi-pur-plugin.version>
+    <pdi-platform-utils-plugin.version>8.2.0.3-515</pdi-platform-utils-plugin.version>
+    <vertica-bulkloader-plugin.version>8.2.0.3-515</vertica-bulkloader-plugin.version>
+    <pdi-pur-plugin.version>8.2.0.3-515</pdi-pur-plugin.version>
   </properties>
 
   <dependencies>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.pentaho.di</groupId>
   <artifactId>pdi-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Assemblies</name>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.pentaho.di</groupId>
     <artifactId>pdi</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>

--- a/assemblies/samples/pom.xml
+++ b/assemblies/samples/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>pdi-assemblies</artifactId>
     <groupId>org.pentaho.di</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>

--- a/assemblies/static/pom.xml
+++ b/assemblies/static/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>pdi-assemblies</artifactId>
     <groupId>org.pentaho.di</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>pentaho-kettle</groupId>
   <artifactId>kettle-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Core</name>
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.pentaho.di</groupId>
     <artifactId>pdi</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>

--- a/dbdialog/pom.xml
+++ b/dbdialog/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>pentaho-kettle</groupId>
   <artifactId>kettle-dbdialog</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI DB Dialog</name>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.pentaho.di</groupId>
     <artifactId>pdi</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>

--- a/engine-ext/api/pom.xml
+++ b/engine-ext/api/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.pentaho</groupId>
   <artifactId>pdi-engine-api</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <name>PDI Engine API</name>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.pentaho.di</groupId>
     <artifactId>pdi-engine-ext</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>

--- a/engine-ext/pom.xml
+++ b/engine-ext/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.pentaho.di</groupId>
   <artifactId>pdi-engine-ext</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Engine Extensions</name>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.pentaho.di</groupId>
     <artifactId>pdi</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <modules>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>pentaho-kettle</groupId>
   <artifactId>kettle-engine</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Engine</name>
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.pentaho.di</groupId>
     <artifactId>pdi</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>
@@ -23,10 +23,10 @@
     <maven-failsafe-plugin.reuseForks>false</maven-failsafe-plugin.reuseForks>
 
     <!-- Pentaho dependencies -->
-    <pentaho-reporting.version>8.2.0.0-SNAPSHOT</pentaho-reporting.version>
-    <pentaho-registry.version>8.2.0.0-SNAPSHOT</pentaho-registry.version>
-    <pentaho-connections.version>8.2.0.0-SNAPSHOT</pentaho-connections.version>
-    <mondrian.version>8.2.0.0-SNAPSHOT</mondrian.version>
+    <pentaho-reporting.version>8.2.0.3-515</pentaho-reporting.version>
+    <pentaho-registry.version>8.2.0.3-515</pentaho-registry.version>
+    <pentaho-connections.version>8.2.0.3-515</pentaho-connections.version>
+    <mondrian.version>8.2.0.3-515</mondrian.version>
 
     <!-- Third-party dependencies -->
     <antlr-complete.version>3.5.2</antlr-complete.version>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -6,14 +6,14 @@
 
   <groupId>org.pentaho</groupId>
   <artifactId>pdi-integration-tests</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>Pentaho Data Integration Integration Tests</name>
 
   <parent>
     <groupId>org.pentaho.di</groupId>
     <artifactId>pdi</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>
@@ -22,7 +22,7 @@
     <sshd-sftp.version>0.11.0</sshd-sftp.version>
     <ftpserver-core.version>1.0.6</ftpserver-core.version>
     <bcprov-jdk14.version>1.51</bcprov-jdk14.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <dependencies>

--- a/plugins/aggregate-rows/assemblies/plugin/pom.xml
+++ b/plugins/aggregate-rows/assemblies/plugin/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>aggregate-rows-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>aggregate-rows-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Aggregate Rows Plugin Distribution</name>
 
   <properties>
-    <project.revision>8.2.0.0-SNAPSHOT</project.revision>
+    <project.revision>8.2.0.3-515</project.revision>
   </properties>
 
   <dependencies>

--- a/plugins/aggregate-rows/assemblies/pom.xml
+++ b/plugins/aggregate-rows/assemblies/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>aggregate-rows</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>aggregate-rows-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Aggregate Rows Plugin Assemblies</name>

--- a/plugins/aggregate-rows/core/pom.xml
+++ b/plugins/aggregate-rows/core/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>aggregate-rows</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>aggregate-rows-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>PDI Aggregate Rows Plugin Core</name>
 
   <properties>
     <dependency.javax.servlet-api.version>3.0.1</dependency.javax.servlet-api.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <build.revision>${project.version}</build.revision>
     <timestamp>${maven.build.timestamp}</timestamp>
     <build.description>${project.description}</build.description>

--- a/plugins/aggregate-rows/pom.xml
+++ b/plugins/aggregate-rows/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>aggregate-rows</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Aggregate Rows Plugin</name>

--- a/plugins/core-ui/pom.xml
+++ b/plugins/core-ui/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>core-ui</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <name>Core UI Plugin</name>

--- a/plugins/core/assemblies/plugin/pom.xml
+++ b/plugins/core/assemblies/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pdi-core-plugins-assemblies</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/plugins/core/assemblies/pom.xml
+++ b/plugins/core/assemblies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pdi-core</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/plugins/core/impl/pom.xml
+++ b/plugins/core/impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pdi-core</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/plugins/core/pom.xml
+++ b/plugins/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pdi-plugins</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
   <name>PDI Core Plugins</name>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <dependencyManagement>

--- a/plugins/core/ui/pom.xml
+++ b/plugins/core/ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pdi-core</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/plugins/drools/assemblies/plugin/pom.xml
+++ b/plugins/drools/assemblies/plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>drools-assemblies</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-drools5-plugin</artifactId>

--- a/plugins/drools/assemblies/pom.xml
+++ b/plugins/drools/assemblies/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/plugins/drools/core/pom.xml
+++ b/plugins/drools/core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-drools5-core</artifactId>
@@ -18,7 +18,7 @@
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy/MM/dd hh\:mm</maven.build.timestamp.format>
 
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <drools.version>6.4.0.Final</drools.version>
     <xstream.version>1.4.10</xstream.version>
     <mvel2.version>2.2.8.Final</mvel2.version>

--- a/plugins/drools/pom.xml
+++ b/plugins/drools/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>drools</artifactId>

--- a/plugins/dummy/assemblies/plugin/pom.xml
+++ b/plugins/dummy/assemblies/plugin/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>dummy-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-dummy-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Dummy Plugin Distribution</name>

--- a/plugins/dummy/assemblies/pom.xml
+++ b/plugins/dummy/assemblies/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>dummy</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>dummy-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Dummy Plugin Assemblies</name>

--- a/plugins/dummy/core/pom.xml
+++ b/plugins/dummy/core/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>dummy</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-dummy-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Dummy Plugin Core</name>

--- a/plugins/dummy/pom.xml
+++ b/plugins/dummy/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>dummy</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Dummy Plugin</name>
@@ -33,7 +33,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
   <build>
     <resources>

--- a/plugins/elasticsearch-bulk-insert/assemblies/plugin/pom.xml
+++ b/plugins/elasticsearch-bulk-insert/assemblies/plugin/pom.xml
@@ -6,18 +6,18 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>elasticsearch-bulk-insert-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>elasticsearch-bulk-insert-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Elasticsearch Bulk Insert Plugin Distribution</name>
   <description>Elasticsearch Bulk Insert</description>
 
   <properties>
-    <project.revision>8.2.0.0-SNAPSHOT</project.revision>
+    <project.revision>8.2.0.3-515</project.revision>
   </properties>
 
   <dependencies>

--- a/plugins/elasticsearch-bulk-insert/assemblies/pom.xml
+++ b/plugins/elasticsearch-bulk-insert/assemblies/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>elasticsearch-bulk-insert</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>elasticsearch-bulk-insert-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Elasticsearch Bulk Insert Plugin Assemblies</name>

--- a/plugins/elasticsearch-bulk-insert/core/pom.xml
+++ b/plugins/elasticsearch-bulk-insert/core/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>elasticsearch-bulk-insert</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>elasticsearch-bulk-insert-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>PDI Elasticsearch Bulk Insert Plugin Core</name>
   <description>Elasticsearch Bulk Insert Plugin</description>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <build.revision>${project.version}</build.revision>
     <timestamp>${maven.build.timestamp}</timestamp>
     <build.description>${project.description}</build.description>

--- a/plugins/elasticsearch-bulk-insert/pom.xml
+++ b/plugins/elasticsearch-bulk-insert/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>elasticsearch-bulk-insert</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Elasticsearch Bulk Insert Plugin</name>

--- a/plugins/engine-configuration/api/pom.xml
+++ b/plugins/engine-configuration/api/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>pdi-engine-configuration-api</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>engine-configuration</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <name>PDI Engine Configuration Plugin API</name>

--- a/plugins/engine-configuration/assemblies/feature/pom.xml
+++ b/plugins/engine-configuration/assemblies/feature/pom.xml
@@ -5,13 +5,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>pdi-engine-configuration</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>feature</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>engine-configuration-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <name>PDI Engine Configuration Plugin Feature</name>

--- a/plugins/engine-configuration/assemblies/pom.xml
+++ b/plugins/engine-configuration/assemblies/pom.xml
@@ -5,13 +5,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>engine-configuration-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>engine-configuration</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <name>PDI Engine Configuration Plugin Assemblies</name>

--- a/plugins/engine-configuration/impl/pom.xml
+++ b/plugins/engine-configuration/impl/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>pdi-engine-configuration-impl</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>engine-configuration</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <name>PDI Engine Configuration Plugin Implementation</name>

--- a/plugins/engine-configuration/pom.xml
+++ b/plugins/engine-configuration/pom.xml
@@ -4,19 +4,19 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>engine-configuration</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <name>PDI Engine Configuration Plugin</name>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <modules>

--- a/plugins/engine-configuration/ui/pom.xml
+++ b/plugins/engine-configuration/ui/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>pdi-engine-configuration-ui</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>engine-configuration</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <name>PDI Engine Configuration Plugin UI</name>

--- a/plugins/file-open-save/assemblies/feature/pom.xml
+++ b/plugins/file-open-save/assemblies/feature/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>file-open-save-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>file-open-save-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>kar</packaging>
 
   <name>PDI File Open and Save Plugin Distribution</name>

--- a/plugins/file-open-save/assemblies/pom.xml
+++ b/plugins/file-open-save/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>file-open-save</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>file-open-save-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI File Open and Save Plugin Assemblies</name>

--- a/plugins/file-open-save/core/pom.xml
+++ b/plugins/file-open-save/core/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>file-open-save</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
   
   <artifactId>file-open-save-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <name>PDI File Open and Save Plugin Core</name>

--- a/plugins/file-open-save/pom.xml
+++ b/plugins/file-open-save/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>file-open-save</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI File Open and Save Plugin</name>
@@ -21,16 +21,16 @@
   </modules>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <dependency.karaf.version>3.0.3</dependency.karaf.version>
     <dependency.osgi.version>4.3.1</dependency.osgi.version>
     <version.for.license>${project.version}</version.for.license>
     <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
     <angular.version>1.5.8</angular.version>
-    <pentaho-osgi-bundles.version>8.2.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
+    <pentaho-osgi-bundles.version>8.2.0.3-515</pentaho-osgi-bundles.version>
     <angular-ui-router.version>0.4.2</angular-ui-router.version>
     <karaf-maven-plugin.version>3.0.3</karaf-maven-plugin.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <cxf.karaf.version>3.0.13</cxf.karaf.version>
     <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>

--- a/plugins/file-stream/pom.xml
+++ b/plugins/file-stream/pom.xml
@@ -25,11 +25,11 @@
   <parent>
     <groupId>org.pentaho</groupId>
     <artifactId>pentaho-ce-bundle-parent-pom</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>file-stream</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <name>file-stream Bundle</name>
@@ -53,7 +53,7 @@
   </repositories>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <target.jdk.version>1.8</target.jdk.version>
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
     <junit.version>4.12</junit.version>

--- a/plugins/get-fields/assemblies/feature/pom.xml
+++ b/plugins/get-fields/assemblies/feature/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>get-fields-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>get-fields-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>kar</packaging>
 
   <name>PDI Get Fields Plugin Distribution</name>

--- a/plugins/get-fields/assemblies/pom.xml
+++ b/plugins/get-fields/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>get-fields</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>get-fields-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Get Fields Plugin Assemblies</name>

--- a/plugins/get-fields/core/pom.xml
+++ b/plugins/get-fields/core/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>get-fields</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
   
   <artifactId>get-fields-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <name>PDI Get Fields Plugin Core</name>

--- a/plugins/get-fields/pom.xml
+++ b/plugins/get-fields/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>get-fields</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>Get Fields Plugin</name>
@@ -21,16 +21,16 @@
   </modules>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <dependency.karaf.version>3.0.3</dependency.karaf.version>
     <dependency.osgi.version>4.3.1</dependency.osgi.version>
     <version.for.license>${project.version}</version.for.license>
     <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
     <angular.version>1.5.8</angular.version>
-    <pentaho-osgi-bundles.version>8.2.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
+    <pentaho-osgi-bundles.version>8.2.0.3-515</pentaho-osgi-bundles.version>
     <angular-ui-router.version>0.4.2</angular-ui-router.version>
     <karaf-maven-plugin.version>3.0.3</karaf-maven-plugin.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <cxf.karaf.version>3.0.13</cxf.karaf.version>
     <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>

--- a/plugins/get-previous-row-field/assemblies/plugin/pom.xml
+++ b/plugins/get-previous-row-field/assemblies/plugin/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>get-previous-row-field-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>get-previous-row-field-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Get Previous Row Field Plugin</name>

--- a/plugins/get-previous-row-field/assemblies/pom.xml
+++ b/plugins/get-previous-row-field/assemblies/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>get-previous-row-field</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>get-previous-row-field-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Get Previous Row Field Assemblies</name>

--- a/plugins/get-previous-row-field/core/pom.xml
+++ b/plugins/get-previous-row-field/core/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>get-previous-row-field</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>get-previous-row-field-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Get Previous Row Field Plugin Core</name>

--- a/plugins/get-previous-row-field/pom.xml
+++ b/plugins/get-previous-row-field/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>get-previous-row-field</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Get Previous Row Field Plugin</name>
@@ -34,7 +34,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.4</junit.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <dependencyManagement>

--- a/plugins/google-analytics/assemblies/plugin/pom.xml
+++ b/plugins/google-analytics/assemblies/plugin/pom.xml
@@ -7,17 +7,17 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>google-analytics-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>pdi-google-analytics-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Google Analytics Plugin Distribution</name>
 
   <properties>
-    <project.revision>8.2.0.0-SNAPSHOT</project.revision>
+    <project.revision>8.2.0.3-515</project.revision>
   </properties>
 
   <dependencies>

--- a/plugins/google-analytics/assemblies/pom.xml
+++ b/plugins/google-analytics/assemblies/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>google-analytics</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>google-analytics-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Google Analytics Plugin Assemblies</name>

--- a/plugins/google-analytics/core/pom.xml
+++ b/plugins/google-analytics/core/pom.xml
@@ -7,17 +7,17 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>google-analytics</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>pdi-google-analytics-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Google Analytics Plugin Core</name>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <commons-vfs2.version>2.2</commons-vfs2.version>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>

--- a/plugins/google-analytics/pom.xml
+++ b/plugins/google-analytics/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>google-analytics</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Google Analytics Plugin</name>

--- a/plugins/gp-bulk-loader/assemblies/plugin/pom.xml
+++ b/plugins/gp-bulk-loader/assemblies/plugin/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>gp-bulk-loader-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>gp-bulk-loader-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI GP Bulk Loader Plugin Distribution</name>
 
   <properties>
-    <project.revision>8.2.0.0-SNAPSHOT</project.revision>
+    <project.revision>8.2.0.3-515</project.revision>
   </properties>
 
   <dependencies>

--- a/plugins/gp-bulk-loader/assemblies/pom.xml
+++ b/plugins/gp-bulk-loader/assemblies/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>gp-bulk-loader</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>gp-bulk-loader-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI GP Bulk Loader Plugin Assemblies</name>

--- a/plugins/gp-bulk-loader/core/pom.xml
+++ b/plugins/gp-bulk-loader/core/pom.xml
@@ -6,17 +6,17 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>gp-bulk-loader</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>gp-bulk-loader-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>PDI GP Bulk Loader Plugin Core</name>
 
   <properties>
     <dependency.javax.servlet-api.version>3.0.1</dependency.javax.servlet-api.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <build.revision>${project.version}</build.revision>
     <timestamp>${maven.build.timestamp}</timestamp>
     <build.description>${project.description}</build.description>

--- a/plugins/gp-bulk-loader/pom.xml
+++ b/plugins/gp-bulk-loader/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>gp-bulk-loader</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI GP Bulk Loader Plugin</name>

--- a/plugins/gpload/assemblies/plugin/pom.xml
+++ b/plugins/gpload/assemblies/plugin/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>gpload-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-gpload-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI GPLoad Plugin Distribution</name>

--- a/plugins/gpload/assemblies/pom.xml
+++ b/plugins/gpload/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>gpload</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>gpload-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI GPLoad Plugin Assemblies</name>

--- a/plugins/gpload/core/pom.xml
+++ b/plugins/gpload/core/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>gpload</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-gpload-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI GPLoad Plugin Core</name>

--- a/plugins/gpload/pom.xml
+++ b/plugins/gpload/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>gpload</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI GPLoad Plugin</name>
@@ -38,7 +38,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <commons-vfs2.version>2.2</commons-vfs2.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <mockito.version>1.9.5</mockito.version>
   </properties>
 

--- a/plugins/hl7/assemblies/plugin/pom.xml
+++ b/plugins/hl7/assemblies/plugin/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>hl7-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-hl7-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI HL7 Plugin Distribution</name>
 
   <properties>
-    <project.revision>8.2.0.0-SNAPSHOT</project.revision>
+    <project.revision>8.2.0.3-515</project.revision>
   </properties>
 
   <dependencies>

--- a/plugins/hl7/assemblies/pom.xml
+++ b/plugins/hl7/assemblies/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>hl7</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>hl7-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI HL7 Plugin Assemblies</name>

--- a/plugins/hl7/core/pom.xml
+++ b/plugins/hl7/core/pom.xml
@@ -6,16 +6,16 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>hl7</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-hl7-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>PDI HL7 Plugin Core</name>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <build.revision>${project.version}</build.revision>
     <timestamp>${maven.build.timestamp}</timestamp>
     <build.description>${project.description}</build.description>

--- a/plugins/hl7/pom.xml
+++ b/plugins/hl7/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>hl7</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI HL7 Plugin</name>

--- a/plugins/json/assemblies/plugin/pom.xml
+++ b/plugins/json/assemblies/plugin/pom.xml
@@ -5,17 +5,17 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>json-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-json-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Json Plugin Distribution</name>
 
   <properties>
-    <project.revision>8.2.0.0-SNAPSHOT</project.revision>
+    <project.revision>8.2.0.3-515</project.revision>
   </properties>
 
   <dependencies>

--- a/plugins/json/assemblies/pom.xml
+++ b/plugins/json/assemblies/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>json</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>json-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Json Plugin Assemblies</name>

--- a/plugins/json/core/pom.xml
+++ b/plugins/json/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>json</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-json-plugin-core</artifactId>
@@ -15,9 +15,9 @@
   <name>PDI Json Plugin Core</name>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
-    <pentaho-metaverse.version>8.2.0.0-SNAPSHOT</pentaho-metaverse.version>
-    <platform.version>8.2.0.0-SNAPSHOT</platform.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
+    <pentaho-metaverse.version>8.2.0.3-515</pentaho-metaverse.version>
+    <platform.version>8.2.0.3-515</platform.version>
     <commons.io.version>1.4</commons.io.version>
     <commons-vfs2.version>2.2</commons-vfs2.version>
     <commons-codec.version>1.9</commons-codec.version>

--- a/plugins/json/pom.xml
+++ b/plugins/json/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>json</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Json Plugin</name>

--- a/plugins/log4j/assemblies/plugin/pom.xml
+++ b/plugins/log4j/assemblies/plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>log4j-assemblies</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle5-log4j-plugin</artifactId>

--- a/plugins/log4j/assemblies/pom.xml
+++ b/plugins/log4j/assemblies/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>log4j</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>log4j-assemblies</artifactId>

--- a/plugins/log4j/core/pom.xml
+++ b/plugins/log4j/core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>log4j</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-log4j-core</artifactId>
@@ -18,7 +18,7 @@
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy/MM/dd hh\:mm</maven.build.timestamp.format>
 
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <log4j.version>1.2.17</log4j.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.9.5</mockito.version>

--- a/plugins/log4j/pom.xml
+++ b/plugins/log4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>pdi-plugins</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>log4j</artifactId>

--- a/plugins/lucid-db-bulk-loader/build.properties
+++ b/plugins/lucid-db-bulk-loader/build.properties
@@ -1,4 +1,4 @@
-project.revision=8.2.0.0-SNAPSHOT
+project.revision=8.2.0.3-515
 ivy.artifact.group=pentaho-kettle
 ivy.artifact.id=lucid-db-bulk-loader-plugin
 impl.vendor=Hitachi Vantara
@@ -6,5 +6,5 @@ impl.title=Lucid DB Bulk Loader Plugin
 impl.productID=${ivy.artifact.id}
 dev-lib.dir=dev-lib
 
-pdi.version=8.2.0.0-SNAPSHOT
-commons-xul.version=8.2.0.0-SNAPSHOT
+pdi.version=8.2.0.3-515
+commons-xul.version=8.2.0.3-515

--- a/plugins/lucid-db-streaming-loader/assemblies/plugin/pom.xml
+++ b/plugins/lucid-db-streaming-loader/assemblies/plugin/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>lucid-db-streaming-loader-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>lucid-db-streaming-loader-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Lucid DB Streaming Loader Plugin Distribution</name>

--- a/plugins/lucid-db-streaming-loader/assemblies/pom.xml
+++ b/plugins/lucid-db-streaming-loader/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>lucid-db-streaming-loader</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>lucid-db-streaming-loader-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Lucid DB Streaming Loader Plugin Assemblies</name>

--- a/plugins/lucid-db-streaming-loader/core/pom.xml
+++ b/plugins/lucid-db-streaming-loader/core/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>lucid-db-streaming-loader</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>lucid-db-streaming-loader-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Lucid DB Streaming Loader Plugin Core</name>

--- a/plugins/lucid-db-streaming-loader/pom.xml
+++ b/plugins/lucid-db-streaming-loader/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>lucid-db-streaming-loader</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Lucid DB Streaming Loader Plugin</name>
@@ -35,7 +35,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <dependencyManagement>

--- a/plugins/meta-inject/pom.xml
+++ b/plugins/meta-inject/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>meta-inject-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <name>PDI Metadata Injection Plugin</name>
@@ -18,9 +18,9 @@
   <url>http://www.pentaho.com</url>
 
   <properties>
-    <pdi.version>${project.version}</pdi.version>
-    <pentaho-metaverse.version>${project.version}</pentaho-metaverse.version>
-    <platform.version>${project.version}</platform.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
+    <pentaho-metaverse.version>8.2.0.3-515</pentaho-metaverse.version>
+    <platform.version>8.2.0.3-515</platform.version>
     <servlet-api.version>2.3</servlet-api.version>
     <mockito.version>1.10.19</mockito.version>
     <guava.version>17.0</guava.version>
@@ -35,7 +35,7 @@
     <maven-bundle-plugin.version>2.3.7</maven-bundle-plugin.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.3</powermock.version>
-    <pentaho-hadoop-shims-api.version>${project.version}</pentaho-hadoop-shims-api.version>
+    <pentaho-hadoop-shims-api.version>8.2.2018.11.00-342</pentaho-hadoop-shims-api.version>
     <commons-configuration.revision>1.9</commons-configuration.revision>
   </properties>
 

--- a/plugins/ms-access/assemblies/plugin/pom.xml
+++ b/plugins/ms-access/assemblies/plugin/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>ms-access-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>ms-access-plugins</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Ms Access Plugins Distribution</name>

--- a/plugins/ms-access/assemblies/pom.xml
+++ b/plugins/ms-access/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>ms-access</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>ms-access-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Ms Access Plugins Assemblies</name>

--- a/plugins/ms-access/impl/pom.xml
+++ b/plugins/ms-access/impl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>ms-access</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>ms-access-plugins-impl</artifactId>

--- a/plugins/ms-access/pom.xml
+++ b/plugins/ms-access/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>ms-access</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Ms Access Plugins</name>
@@ -36,7 +36,7 @@
   <properties>
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <dependencyManagement>

--- a/plugins/ms-access/ui/pom.xml
+++ b/plugins/ms-access/ui/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>ms-access</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>ms-access-plugins-ui</artifactId>

--- a/plugins/openerp/assemblies/plugin/pom.xml
+++ b/plugins/openerp/assemblies/plugin/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>openerp-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-openerp-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Openerp Plugin Distribution</name>

--- a/plugins/openerp/assemblies/pom.xml
+++ b/plugins/openerp/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>openerp</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>openerp-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Openerp Plugin Assemblies</name>

--- a/plugins/openerp/core/pom.xml
+++ b/plugins/openerp/core/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>openerp</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-openerp-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Openerp Plugin Core</name>

--- a/plugins/openerp/pom.xml
+++ b/plugins/openerp/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>openerp</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Openerp Plugin</name>
@@ -39,7 +39,7 @@
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
     <commons-vfs2.version>2.2</commons-vfs2.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <mockito.version>1.9.5</mockito.version>
     <openerp-java-api.version>1.3.0</openerp-java-api.version>
     <ws-commons-util.version>1.0.2</ws-commons-util.version>

--- a/plugins/palo/assemblies/plugin/pom.xml
+++ b/plugins/palo/assemblies/plugin/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>palo-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-palo-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Palo Plugin Distribution</name>

--- a/plugins/palo/assemblies/pom.xml
+++ b/plugins/palo/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>palo</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>palo-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Palo Plugin Assemblies</name>

--- a/plugins/palo/core/pom.xml
+++ b/plugins/palo/core/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>palo</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-palo-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Palo Plugin Core</name>

--- a/plugins/palo/pom.xml
+++ b/plugins/palo/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>palo</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Palo Plugin</name>
@@ -40,7 +40,7 @@
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
     <ascsapjco3wrp.version>20100529</ascsapjco3wrp.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <dependencyManagement>

--- a/plugins/pentaho-googledrive-vfs/assemblies/plugin/pom.xml
+++ b/plugins/pentaho-googledrive-vfs/assemblies/plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>pentaho-googledrive-vfs-assemblies</artifactId>
         <groupId>org.pentaho.di.plugins</groupId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 
     <artifactId>pentaho-googledrive-vfs-plugin</artifactId>

--- a/plugins/pentaho-googledrive-vfs/assemblies/pom.xml
+++ b/plugins/pentaho-googledrive-vfs/assemblies/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>pentaho-googledrive-vfs</artifactId>
         <groupId>org.pentaho.di.plugins</groupId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 
     <artifactId>pentaho-googledrive-vfs-assemblies</artifactId>

--- a/plugins/pentaho-googledrive-vfs/core/pom.xml
+++ b/plugins/pentaho-googledrive-vfs/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>pentaho-googledrive-vfs</artifactId>
         <groupId>org.pentaho.di.plugins</groupId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 
     <artifactId>pentaho-googledrive-vfs-core</artifactId>
@@ -21,7 +21,7 @@
         <project.commons-vfs2.version>2.2</project.commons-vfs2.version>
         <project.junit.version>4.4</project.junit.version>
         <project.mockito.version>1.8.4</project.mockito.version>
-        <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+        <pdi.version>8.2.0.3-515</pdi.version>
     </properties>
 
     <build>

--- a/plugins/pentaho-googledrive-vfs/pom.xml
+++ b/plugins/pentaho-googledrive-vfs/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>pdi-plugins</artifactId>
         <groupId>org.pentaho.di.plugins</groupId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 
     <artifactId>pentaho-googledrive-vfs</artifactId>

--- a/plugins/pentaho-repository-vfs/assemblies/feature/pom.xml
+++ b/plugins/pentaho-repository-vfs/assemblies/feature/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>pentaho-repository-vfs-assemblies</artifactId>
         <groupId>org.pentaho.di.plugins</groupId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 
     <artifactId>pentaho-repository-vfs-feature</artifactId>

--- a/plugins/pentaho-repository-vfs/assemblies/pom.xml
+++ b/plugins/pentaho-repository-vfs/assemblies/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>pentaho-repository-vfs</artifactId>
         <groupId>org.pentaho.di.plugins</groupId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.3-515</version>
     </parent>
 
     <artifactId>pentaho-repository-vfs-assemblies</artifactId>

--- a/plugins/pentaho-repository-vfs/core/pom.xml
+++ b/plugins/pentaho-repository-vfs/core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>pentaho-repository-vfs</artifactId>
 		<groupId>org.pentaho.di.plugins</groupId>
-		<version>8.2.0.0-SNAPSHOT</version>
+		<version>8.2.0.3-515</version>
 	</parent>
 
 	<artifactId>pentaho-repository-vfs-core</artifactId>
@@ -15,7 +15,7 @@
 	<name>Pentaho Repository VFS Plugin Core</name>
 
 	<properties>
-		<pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+		<pdi.version>8.2.0.3-515</pdi.version>
 	</properties>
 
 	<dependencies>

--- a/plugins/pentaho-repository-vfs/pom.xml
+++ b/plugins/pentaho-repository-vfs/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>pdi-plugins</artifactId>
 		<groupId>org.pentaho.di.plugins</groupId>
-		<version>8.2.0.0-SNAPSHOT</version>
+		<version>8.2.0.3-515</version>
 	</parent>
 
 	<artifactId>pentaho-repository-vfs</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.pentaho.di.plugins</groupId>
   <artifactId>pdi-plugins</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Plugins</name>
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.pentaho.di</groupId>
     <artifactId>pdi</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>

--- a/plugins/pur/assemblies/plugin/pom.xml
+++ b/plugins/pur/assemblies/plugin/pom.xml
@@ -5,14 +5,14 @@
 
   <artifactId>pdi-pur-plugin</artifactId>
   <packaging>pom</packaging>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>PDI PUR Plugin Distribution</name>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pur-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <dependencies>

--- a/plugins/pur/assemblies/pom.xml
+++ b/plugins/pur/assemblies/pom.xml
@@ -5,14 +5,14 @@
 
   <artifactId>pur-assemblies</artifactId>
   <packaging>pom</packaging>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>PDI PUR Plugin Assemblies</name>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pur</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <modules>

--- a/plugins/pur/core/pom.xml
+++ b/plugins/pur/core/pom.xml
@@ -5,23 +5,23 @@
 
   <artifactId>pdi-pur-plugin-core</artifactId>
   <packaging>jar</packaging>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>PDI PUR Plugin Core</name>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pur</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>
     <!-- Kettle dependencies -->
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
 
     <!-- Pentaho dependenceis -->
-    <platform.version>8.2.0.0-SNAPSHOT</platform.version>
-    <pentaho-json.version>8.2.0.0-SNAPSHOT</pentaho-json.version>
+    <platform.version>8.2.0.3-515</platform.version>
+    <pentaho-json.version>8.2.0.3-515</pentaho-json.version>
 
     <!-- Third party dependencies -->
     <slf4j-api.version>1.7.7</slf4j-api.version>

--- a/plugins/pur/pom.xml
+++ b/plugins/pur/pom.xml
@@ -5,14 +5,14 @@
 
   <artifactId>pur</artifactId>
   <packaging>pom</packaging>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>PDI PUR Plugin</name>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <modules>

--- a/plugins/pur/repository-proxy/pom.xml
+++ b/plugins/pur/repository-proxy/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pur</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>repository-proxy</artifactId>
@@ -18,11 +18,11 @@
 
   <properties>
     <!-- Kettle dependencies -->
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
-    <metastore.version>8.2.0.0-SNAPSHOT</metastore.version>
-    <platform.version>8.2.0.0-SNAPSHOT</platform.version>
-    <pentaho-osgi-bundles.version>8.2.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <pdi-pur-plugin.version>8.2.0.0-SNAPSHOT</pdi-pur-plugin.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
+    <metastore.version>8.2.0.3-515</metastore.version>
+    <platform.version>8.2.0.3-515</platform.version>
+    <pentaho-osgi-bundles.version>8.2.0.3-515</pentaho-osgi-bundles.version>
+    <pdi-pur-plugin.version>8.2.0.3-515</pdi-pur-plugin.version>
     <slf4j-api.version>1.7.7</slf4j-api.version>
     <junit.version>4.11</junit.version>
     <mockito-core.version>1.9.5</mockito-core.version>

--- a/plugins/repositories/assemblies/feature/pom.xml
+++ b/plugins/repositories/assemblies/feature/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>repositories-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>kar</packaging>
 
   <name>PDI Repositories Plugin Feature</name>
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>repositories-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <dependencies>

--- a/plugins/repositories/assemblies/pom.xml
+++ b/plugins/repositories/assemblies/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>repositories-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Repositories Plugin Assemblies</name>
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>repositories</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <modules>

--- a/plugins/repositories/core/pom.xml
+++ b/plugins/repositories/core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>repositories-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <name>PDI Repositories Plugin Core</name>
@@ -12,11 +12,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>repositories</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
     <mockito-all.version>1.9.5</mockito-all.version>
     <karaf.version>3.0.3</karaf.version>

--- a/plugins/repositories/pom.xml
+++ b/plugins/repositories/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>repositories</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Repositories Plugin</name>
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>

--- a/plugins/s3csvinput/assemblies/plugin/pom.xml
+++ b/plugins/s3csvinput/assemblies/plugin/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>s3csvinput-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-s3csvinput-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI S3 CSV Input Plugin Distribution</name>

--- a/plugins/s3csvinput/assemblies/pom.xml
+++ b/plugins/s3csvinput/assemblies/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>s3csvinput</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>s3csvinput-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI S3 CSV Input Plugin Assemblies</name>

--- a/plugins/s3csvinput/core/pom.xml
+++ b/plugins/s3csvinput/core/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>s3csvinput</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-s3csvinput-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI S3 CSV Input Plugin Core</name>

--- a/plugins/s3csvinput/pom.xml
+++ b/plugins/s3csvinput/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>s3csvinput</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI S3 CSV Input Plugin</name>
@@ -34,7 +34,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <aws.version>1.11.275</aws.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <dependencyManagement>

--- a/plugins/salesforce/assemblies/plugin/pom.xml
+++ b/plugins/salesforce/assemblies/plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>salesforce-assemblies</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>pdi-salesforce-plugin</artifactId>

--- a/plugins/salesforce/assemblies/pom.xml
+++ b/plugins/salesforce/assemblies/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>salesforce</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>salesforce-assemblies</artifactId>

--- a/plugins/salesforce/core/pom.xml
+++ b/plugins/salesforce/core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>salesforce</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>pdi-salesforce-core</artifactId>
@@ -18,7 +18,7 @@
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy/MM/dd hh\:mm</maven.build.timestamp.format>
 
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <com.force.api.version>41.0.0</com.force.api.version>
   </properties>
 

--- a/plugins/salesforce/pom.xml
+++ b/plugins/salesforce/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>pdi-plugins</artifactId>
     <groupId>org.pentaho.di.plugins</groupId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>salesforce</artifactId>

--- a/plugins/sap/assemblies/plugin/pom.xml
+++ b/plugins/sap/assemblies/plugin/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>sap-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-sap-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI SAP Plugin Distribution</name>

--- a/plugins/sap/assemblies/pom.xml
+++ b/plugins/sap/assemblies/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>sap</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>sap-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI SAP Plugin Assemblies</name>

--- a/plugins/sap/core/pom.xml
+++ b/plugins/sap/core/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>sap</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-sap-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI SAP Plugin Core</name>

--- a/plugins/sap/pom.xml
+++ b/plugins/sap/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>sap</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI SAP Plugin</name>
@@ -35,7 +35,7 @@
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
     <ascsapjco3wrp.version>20100529</ascsapjco3wrp.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
 

--- a/plugins/shapefilereader/assemblies/plugin/pom.xml
+++ b/plugins/shapefilereader/assemblies/plugin/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>shapefilereader-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-shapefilereader-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Shape File Reader Plugin Distribution</name>

--- a/plugins/shapefilereader/assemblies/pom.xml
+++ b/plugins/shapefilereader/assemblies/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>shapefilereader</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>shapefilereader-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Shape File Reader Plugin Assemblies</name>

--- a/plugins/shapefilereader/core/pom.xml
+++ b/plugins/shapefilereader/core/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>shapefilereader</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-shapefilereader-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Shape File Reader Plugin Core</name>

--- a/plugins/shapefilereader/pom.xml
+++ b/plugins/shapefilereader/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>shapefilereader</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Shape File Reader Plugin</name>
@@ -36,7 +36,7 @@
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
     <ascsapjco3wrp.version>20100529</ascsapjco3wrp.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <dependencyManagement>

--- a/plugins/ssh2/build.properties
+++ b/plugins/ssh2/build.properties
@@ -1,4 +1,4 @@
-project.revision=8.2.0.0-SNAPSHOT
+project.revision=8.2.0.3-515
 ivy.artifact.group=pentaho-kettle
 ivy.artifact.id=ssh2-plugin
 impl.vendor=Hitachi Vantara
@@ -6,5 +6,5 @@ impl.title=SSH2 Get Plugin
 impl.productID=${ivy.artifact.id}
 dev-lib.dir=dev-lib
 
-pdi.version=8.2.0.0-SNAPSHOT
-commons-xul.version=8.2.0.0-SNAPSHOT
+pdi.version=8.2.0.3-515
+commons-xul.version=8.2.0.3-515

--- a/plugins/star-modeler/build.properties
+++ b/plugins/star-modeler/build.properties
@@ -1,4 +1,4 @@
-project.revision=8.2.0.0-SNAPSHOT
+project.revision=8.2.0.3-515
 ivy.artifact.group=pentaho-kettle
 ivy.artifact.id=star-modeler
 impl.vendor=Hitachi Vantara
@@ -6,6 +6,6 @@ impl.title=Star Schema Modeler
 impl.productID=${ivy.artifact.id}
 dev-lib.dir=dev-lib
 
-pdi.version=8.2.0.0-SNAPSHOT
-pentaho-metadata.version=8.2.0.0-SNAPSHOT
-commons-xul.version=8.2.0.0-SNAPSHOT
+pdi.version=8.2.0.3-515
+pentaho-metadata.version=8.2.0.3-515
+commons-xul.version=8.2.0.3-515

--- a/plugins/streaming/assemblies/feature/pom.xml
+++ b/plugins/streaming/assemblies/feature/pom.xml
@@ -5,13 +5,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>pentaho-streaming-feature</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>feature</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pentaho-streaming-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <name>Pentaho Streaming Plugin Feature</name>

--- a/plugins/streaming/assemblies/pom.xml
+++ b/plugins/streaming/assemblies/pom.xml
@@ -5,13 +5,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>pentaho-streaming-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pentaho-streaming</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <name>Pentaho Streaming Plugin Assembly</name>

--- a/plugins/streaming/impls/jms/pom.xml
+++ b/plugins/streaming/impls/jms/pom.xml
@@ -23,14 +23,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>pentaho-streaming-jms-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pentaho-streaming-impls</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
 
@@ -41,7 +41,7 @@
   <properties>
     <ibmmq.version>9.0.4.0</ibmmq.version>
     <jms.version>2.0.1</jms.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <rxjava.version>2.0.4</rxjava.version>
     <artemis.version>2.5.0</artemis.version>
   </properties>

--- a/plugins/streaming/impls/mqtt/pom.xml
+++ b/plugins/streaming/impls/mqtt/pom.xml
@@ -24,12 +24,12 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pentaho-streaming-impls</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>pentaho-streaming-mqtt-plugin</artifactId>
 
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>bundle</packaging>
 
   <name>MQTT Streaming Step Plugin Bundle</name>
@@ -53,7 +53,7 @@
   </repositories>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <target.jdk.version>1.8</target.jdk.version>
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
     <junit.version>4.12</junit.version>

--- a/plugins/streaming/impls/pom.xml
+++ b/plugins/streaming/impls/pom.xml
@@ -6,13 +6,13 @@
 
   <groupId>org.pentaho.di.plugins</groupId>
   <artifactId>pentaho-streaming-impls</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pentaho-streaming</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
 

--- a/plugins/streaming/pom.xml
+++ b/plugins/streaming/pom.xml
@@ -4,19 +4,19 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>pentaho-streaming</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <name>Pentaho Streaming Plugins</name>
 
   <properties>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <guava.version>19.0</guava.version>
   </properties>
 

--- a/plugins/version-checker/assemblies/plugin/pom.xml
+++ b/plugins/version-checker/assemblies/plugin/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>version-checker-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-version-checker</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Version Checker Plugin Distribution</name>

--- a/plugins/version-checker/assemblies/pom.xml
+++ b/plugins/version-checker/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>version-checker</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>version-checker-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Version Checker Plugin Assemblies</name>

--- a/plugins/version-checker/core/pom.xml
+++ b/plugins/version-checker/core/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>version-checker</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>kettle-version-checker-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI Version Checker Plugin Core</name>

--- a/plugins/version-checker/pom.xml
+++ b/plugins/version-checker/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>version-checker</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI Version Checker Plugin</name>
@@ -36,7 +36,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/plugins/xml-input-stream/assemblies/plugin/pom.xml
+++ b/plugins/xml-input-stream/assemblies/plugin/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>xml-input-stream-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>pdi-xml-input-stream-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI XML Input Stream Plugin Distribution</name>

--- a/plugins/xml-input-stream/assemblies/pom.xml
+++ b/plugins/xml-input-stream/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>xml-input-stream</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>xml-input-stream-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI XML Input Stream Plugin Assemblies</name>

--- a/plugins/xml-input-stream/core/pom.xml
+++ b/plugins/xml-input-stream/core/pom.xml
@@ -7,12 +7,12 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>xml-input-stream</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
 
   <artifactId>pdi-xml-input-stream-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI XML Input Stream Plugin Core</name>

--- a/plugins/xml-input-stream/pom.xml
+++ b/plugins/xml-input-stream/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>xml-input-stream</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI XML Input Stream Plugin</name>
@@ -35,7 +35,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <mockito.version>1.9.5</mockito.version>
   </properties>
 

--- a/plugins/xml-input/assemblies/plugin/pom.xml
+++ b/plugins/xml-input/assemblies/plugin/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>xml-input-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>pdi-xml-input-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI XML Input Plugin Distribution</name>

--- a/plugins/xml-input/assemblies/pom.xml
+++ b/plugins/xml-input/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>xml-input</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>xml-input-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI XML Input Plugin Assemblies</name>

--- a/plugins/xml-input/core/pom.xml
+++ b/plugins/xml-input/core/pom.xml
@@ -7,12 +7,12 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>xml-input</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
 
   <artifactId>pdi-xml-input-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI XML Input Plugin Core</name>

--- a/plugins/xml-input/pom.xml
+++ b/plugins/xml-input/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>xml-input</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI XML Input Plugin</name>
@@ -34,7 +34,7 @@
   <properties>
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <junit.version>4.4</junit.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
   </properties>
 
   <dependencyManagement>

--- a/plugins/xml/assemblies/plugin/pom.xml
+++ b/plugins/xml/assemblies/plugin/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>xml-assemblies</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>pdi-xml-plugin</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI XML Plugin Distribution</name>

--- a/plugins/xml/assemblies/pom.xml
+++ b/plugins/xml/assemblies/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>xml</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>xml-assemblies</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI XML Plugin Assemblies</name>

--- a/plugins/xml/core/pom.xml
+++ b/plugins/xml/core/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>xml</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>pdi-xml-plugin-core</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>jar</packaging>
 
   <name>PDI XML Plugin Core</name>

--- a/plugins/xml/pom.xml
+++ b/plugins/xml/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.pentaho.di.plugins</groupId>
     <artifactId>pdi-plugins</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <artifactId>xml</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>PDI XML Plugin</name>
@@ -33,7 +33,7 @@
   <properties>
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
-    <pdi.version>8.2.0.0-SNAPSHOT</pdi.version>
+    <pdi.version>8.2.0.3-515</pdi.version>
     <mockito.version>1.9.5</mockito.version>
     <saxon.version>8.7</saxon.version>
     <poi.version>3.17</poi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.pentaho.di</groupId>
   <artifactId>pdi</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
   <packaging>pom</packaging>
 
   <name>Pentaho Data Integration</name>
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.pentaho</groupId>
     <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <scm>
@@ -55,8 +55,8 @@
     <license.licenseName>apache_v2</license.licenseName>
 
     <!-- Pentaho dependencies -->
-    <commons-xul.version>8.2.0.0-SNAPSHOT</commons-xul.version>
-    <pentaho-metastore.version>8.2.0.0-SNAPSHOT</pentaho-metastore.version>
+    <commons-xul.version>8.2.0.3-515</commons-xul.version>
+    <pentaho-metastore.version>8.2.0.3-515</pentaho-metastore.version>
 
     <!-- Third-party dependencies -->
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -6,14 +6,14 @@
   <groupId>pentaho-kettle</groupId>
   <artifactId>kettle-ui-swt</artifactId>
   <packaging>jar</packaging>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.3-515</version>
 
   <name>PDI User Interface</name>
 
   <parent>
     <groupId>org.pentaho.di</groupId>
     <artifactId>pdi</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.3-515</version>
   </parent>
 
   <properties>
@@ -21,7 +21,7 @@
     <maven-surefire-plugin.reuseForks>true</maven-surefire-plugin.reuseForks>
 
     <!-- Pentaho dependencies -->
-    <pentaho-vfs-browser.version>8.2.0.0-SNAPSHOT</pentaho-vfs-browser.version>
+    <pentaho-vfs-browser.version>8.2.0.3-515</pentaho-vfs-browser.version>
     <pentaho-capability-manager.version>${project.version}</pentaho-capability-manager.version>
 
     <!-- Third-party dependencies -->


### PR DESCRIPTION
Someone left Google Big Query dependency in the pom.xml in assembly/plugins after it was yanked to EE, which causes build failures for CE.  I simply removed it.