### PR TITLE
[PDI-17675] job log table entries in the Spoon UI under Execution res…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransHistoryDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransHistoryDelegate.java
@@ -24,10 +24,14 @@ package org.pentaho.di.ui.spoon.trans;
 
 import java.sql.ResultSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
@@ -457,36 +461,74 @@ public class TransHistoryDelegate extends SpoonDelegate implements XulEventHandl
     return moreRows;
   }
 
+  /**
+   * Maps UI columns to DB columns
+   * @return {@link Map} with the mapping between UI column names and index of the corresponding DB column
+   */
+  @VisibleForTesting
+  Map<String, Integer> getColumnMappings( TransHistoryLogTab model ) {
+    Map<String, Integer> map = new HashMap();
+
+    for ( ColumnInfo ci : model.logDisplayTableView.getColumns() ) {
+      for ( int i = 0; i < model.logTableFields.size(); i++ ) {
+        if ( ci.getValueMeta().getName().equals( model.logTableFields.get( i ).getId() ) ) {
+          map.put( model.logTableFields.get( i ).getId(), i );
+          break;
+        }
+      }
+    }
+
+    return map;
+  }
+
+  /**
+   * Returns the {@link ValueMetaInterface} for a specified log table field
+   * @param columns The list of UI columns
+   * @param field The field to look for
+   * @return The {@link ValueMetaInterface} for the specified field
+   */
+  @VisibleForTesting
+  ValueMetaInterface getValueMetaForColumn( ColumnInfo[] columns, LogTableField field ) {
+    return Arrays.stream( columns )
+      .filter( x -> x.getValueMeta().getName().equals( field.getId() ) )
+      .findFirst()
+      .get()
+      .getValueMeta();
+  }
+
   private void displayHistoryData( final int index ) {
     TransHistoryLogTab model = models[index];
-    ColumnInfo[] colinf = model.logDisplayTableView.getColumns();
 
-    // Now, we're going to display the data in the table view
-    //
     if ( model.logDisplayTableView == null || model.logDisplayTableView.isDisposed() ) {
       return;
     }
 
-    int selectionIndex = model.logDisplayTableView.getSelectionIndex();
+    // display the data in the table view
+    ColumnInfo[] colinf = model.logDisplayTableView.getColumns();
 
+    int selectionIndex = model.logDisplayTableView.getSelectionIndex();
     model.logDisplayTableView.table.clearAll();
 
     List<Object[]> rows = model.rows;
 
+    LogTableField errorsField = model.logTable.getErrorsField();
+    LogTableField statusField = model.logTable.getStatusField();
+
     if ( rows != null && rows.size() > 0 ) {
-      // OK, now that we have a series of rows, we can add them to the table view...
-      //
+      // we need to map ui columns to db columns before rendering data
+      Map<String, Integer> map = getColumnMappings( model );
+
+      // add row data to the table view
       for ( Object[] rowData : rows ) {
         TableItem item = new TableItem( model.logDisplayTableView.table, SWT.NONE );
 
         for ( int c = 0; c < colinf.length; c++ ) {
-
           ColumnInfo column = colinf[c];
 
           ValueMetaInterface valueMeta = column.getValueMeta();
           String string = null;
           try {
-            string = valueMeta.getString( rowData[c] );
+            string = valueMeta.getString( rowData[ map.get( column.getValueMeta().getName() ) ] );
           } catch ( KettleValueException e ) {
             log.logError( "history data conversion issue", e );
           }
@@ -498,21 +540,19 @@ public class TransHistoryDelegate extends SpoonDelegate implements XulEventHandl
         Long errors = null;
         LogStatus status = null;
 
-        LogTableField errorsField = model.logTable.getErrorsField();
         if ( errorsField != null ) {
-          int index1 = model.logTableFields.indexOf( errorsField );
+          ValueMetaInterface  valueMeta = getValueMetaForColumn( colinf, errorsField );
           try {
-            errors = colinf[index1].getValueMeta().getInteger( rowData[index1] );
+            errors = valueMeta.getInteger( rowData[ map.get( valueMeta.getName() ) ] );
           } catch ( KettleValueException e ) {
             log.logError( "history data conversion issue", e );
           }
         }
-        LogTableField statusField = model.logTable.getStatusField();
         if ( statusField != null ) {
-          int index1 = model.logTableFields.indexOf( statusField );
+          ValueMetaInterface  valueMeta = getValueMetaForColumn( colinf, statusField );
           String statusString = null;
           try {
-            statusString = colinf[index1].getValueMeta().getString( rowData[index1] );
+            statusString = valueMeta.getString( rowData[ map.get( valueMeta.getName() ) ] );
           } catch ( KettleValueException e ) {
             log.logError( "history data conversion issue", e );
           }
@@ -533,8 +573,6 @@ public class TransHistoryDelegate extends SpoonDelegate implements XulEventHandl
       model.logDisplayTableView.optWidth( true );
     } else {
       model.logDisplayTableView.clearAll( false );
-      // new TableItem(wFields.get(tabIndex).table, SWT.NONE); // Give it an item to prevent errors on various
-      // platforms.
     }
 
     if ( selectionIndex >= 0 && selectionIndex < model.logDisplayTableView.getItemCount() ) {
@@ -670,7 +708,8 @@ public class TransHistoryDelegate extends SpoonDelegate implements XulEventHandl
     refreshHistory( tabIndex, Mode.ALL );
   }
 
-  private class TransHistoryLogTab extends CTabItem {
+  @VisibleForTesting
+  class TransHistoryLogTab extends CTabItem {
     private List<LogTableField> logTableFields = new ArrayList<LogTableField>();
     private List<Object[]> rows;
     private LogTableInterface logTable;

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/trans/TransHistoryDelegateTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/trans/TransHistoryDelegateTest.java
@@ -1,0 +1,110 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.spoon.trans;
+
+import org.junit.Test;
+import org.pentaho.di.core.logging.LogTableField;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.ui.core.widget.ColumnInfo;
+import org.pentaho.di.ui.core.widget.TableView;
+import org.pentaho.di.ui.spoon.Spoon;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.powermock.reflect.Whitebox.setInternalState;
+
+public class TransHistoryDelegateTest {
+
+  @Test
+  public void getColumnMappings() {
+    TableView view = mock( TableView.class );
+    doReturn( getColumnInfo() ).when( view ).getColumns();
+
+    TransHistoryDelegate.TransHistoryLogTab model = mock( TransHistoryDelegate.TransHistoryLogTab.class );
+    setInternalState( model, "logDisplayTableView", view );
+    setInternalState( model, "logTableFields", getLogTableFields() );
+
+    TransHistoryDelegate history = new TransHistoryDelegate( mock( Spoon.class ), mock( TransGraph.class ) );
+    Map<String, Integer> map = history.getColumnMappings( model );
+
+    assertEquals( 0, (int) map.get( "COLUMN_1" ) );
+    assertEquals( 1, (int) map.get( "COLUMN_2" ) );
+    assertEquals( 2, (int) map.get( "COLUMN_3" ) );
+    assertEquals( 4, (int) map.get( "COLUMN_5" ) );
+    assertEquals( 5, (int) map.get( "COLUMN_6" ) );
+  }
+
+  @Test
+  public void getValueMetaForStringColumn() {
+    TransHistoryDelegate history = new TransHistoryDelegate( mock( Spoon.class ), mock( TransGraph.class ) );
+    ValueMetaInterface valueMeta = history.getValueMetaForColumn( getColumnInfo(), new LogTableField( "COLUMN_2", "", null ) );
+
+    assertEquals( "COLUMN_2", valueMeta.getName() );
+    assertThat( valueMeta, instanceOf( ValueMetaString.class ) );
+  }
+
+  @Test
+  public void getValueMetaForIntegerColumn() {
+    TransHistoryDelegate history = new TransHistoryDelegate( mock( Spoon.class ), mock( TransGraph.class ) );
+    ValueMetaInterface valueMeta = history.getValueMetaForColumn( getColumnInfo(), new LogTableField( "COLUMN_5", "", null ) );
+
+    assertEquals( "COLUMN_5", valueMeta.getName() );
+    assertThat( valueMeta, instanceOf( ValueMetaInteger.class ) );
+  }
+
+  private ColumnInfo[] getColumnInfo() {
+    ColumnInfo[] colinf = new ColumnInfo[] {
+      new ColumnInfo( "COLUMN_1", ColumnInfo.COLUMN_TYPE_TEXT ),
+      new ColumnInfo( "COLUMN_2", ColumnInfo.COLUMN_TYPE_TEXT ),
+      new ColumnInfo( "COLUMN_3", ColumnInfo.COLUMN_TYPE_TEXT ),
+      new ColumnInfo( "COLUMN_5", ColumnInfo.COLUMN_TYPE_TEXT ),
+      new ColumnInfo( "COLUMN_6", ColumnInfo.COLUMN_TYPE_TEXT )
+    };
+
+    colinf[1].setValueMeta( new ValueMetaString( "COLUMN_2" ) );
+    colinf[3].setValueMeta( new ValueMetaInteger( "COLUMN_5" ) );
+
+    return colinf;
+  }
+
+  private List<LogTableField> getLogTableFields() {
+    return Arrays.asList(
+      new LogTableField( "COLUMN_1", "", null ),
+      new LogTableField( "COLUMN_2", "", null ),
+      new LogTableField( "COLUMN_3", "", null ),
+      new LogTableField( "COLUMN_4", "", null ),
+      new LogTableField( "COLUMN_5", "", null ),
+      new LogTableField( "COLUMN_6", "", null ),
+      new LogTableField( "COLUMN_7", "", null )
+    );
+  }
+}


### PR DESCRIPTION
…ults are incorrect

The problem lies in the fact that the two relevant lists (list of UI columns and list of DB columns) have different sizes. One can't expect the index of `COLUMN_X` in one list to be the same in the other.

Using the column name/id solves this problem.
Besides the bug described in the JIRA case there were two other potential issues that were fixed.

@pentaho/tatooine @mbatchelor @bmorrise @mkambol 