### PR TITLE
PDI-17902

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -445,7 +445,8 @@ public class TextFileOutput extends BaseStep implements StepInterface {
     Object[] row = getRow(); // This also waits for a row to be finished.
 
     if ( row != null  && first ) {
-      data.outputRowMeta = getInputRowMeta().clone();
+      data.inputRowMeta = getInputRowMeta();
+      data.outputRowMeta = data.inputRowMeta.clone();
     }
 
     if ( first ) {
@@ -742,6 +743,10 @@ public class TextFileOutput extends BaseStep implements StepInterface {
         }
         data.writer.write( data.binaryNewline );
       } else if ( r != null ) {
+        //PDI-17902 - Concat Fields changes the output row meta, only input rows are desired
+        if ( data.inputRowMeta != null ) {
+          r = data.inputRowMeta;
+        }
         // Just put all field names in the header/footer
         for ( int i = 0; i < r.size(); i++ ) {
           if ( i > 0 && data.binarySeparator.length > 0 ) {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputData.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputData.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -409,6 +409,7 @@ public class TextFileOutputData extends BaseStepData implements StepDataInterfac
   public OutputStream fos;
 
   public RowMetaInterface outputRowMeta;
+  public RowMetaInterface inputRowMeta;
 
   public byte[] binarySeparator;
   public byte[] binaryEnclosure;

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/concatfields/ConcatFields.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/concatfields/ConcatFields.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -68,7 +68,8 @@ public class ConcatFields extends TextFileOutput implements StepInterface {
     if ( r != null && first ) {
       first = false;
 
-      data.outputRowMeta = getInputRowMeta().clone();
+      data.inputRowMeta = getInputRowMeta();
+      data.outputRowMeta = data.inputRowMeta.clone();
       meta.getFields( data.outputRowMeta, getStepname(), null, null, this, repository, metaStore );
 
       // the field precisions and lengths are altered! see TextFileOutputMeta.getFields().


### PR DESCRIPTION
For the record, I didn't really like adding "data.inputRowMeta" to the data object of TextFileOutput. However, it was the only way to avoid AssertNotInvokedTwice for the call to getInputRowMeta() on the unit tests of TFO. I needed the TFO writeHeader() method to use the inputRowMeta instead of the outputRowMeta for the Concat Fields step, since Concat Fields updates data.outputRowMeta...