### PR TITLE
[BACKLOG-27641] - Letting maven-remote-resources-plugin version be ma…

### DIFF
--- a/plugins/file-open-save/core/pom.xml
+++ b/plugins/file-open-save/core/pom.xml
@@ -124,7 +124,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>1.5</version>
         <executions>
           <execution>
             <goals>

--- a/plugins/pentaho-repository-vfs/core/pom.xml
+++ b/plugins/pentaho-repository-vfs/core/pom.xml
@@ -84,7 +84,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-remote-resources-plugin</artifactId>
-				<version>1.5</version>
 				<executions>
 					<execution>
 						<goals>

--- a/plugins/repositories/core/pom.xml
+++ b/plugins/repositories/core/pom.xml
@@ -241,7 +241,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>1.5</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
…naged by the parent pom. Effectively upgrading it to 1.6 in order to be able to build with openJDK.

@nantunes please review