### PR TITLE
[PDI-16411] HTTP Post step requires Encoding in PDI 7.1

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/httppost/HTTPPOST.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/httppost/HTTPPOST.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,6 +23,7 @@
 package org.pentaho.di.trans.steps.httppost;
 
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -50,6 +51,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowDataUtil;
 import org.pentaho.di.core.util.HttpClientManager;
+import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
@@ -70,6 +72,8 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.pentaho.di.trans.steps.httppost.HTTPPOSTMeta.DEFAULT_ENCODING;
 
 /**
  * Make a HTTP Post call
@@ -499,7 +503,8 @@ public class HTTPPOST extends BaseStep implements StepInterface {
     return true;
   }
 
-  private String getRequestBodyParamsAsStr( NameValuePair[] pairs, String charset ) throws KettleException {
+  @VisibleForTesting
+  String getRequestBodyParamsAsStr( NameValuePair[] pairs, String charset ) throws KettleException {
     StringBuffer buf = new StringBuffer();
     try {
       for ( int i = 0; i < pairs.length; ++i ) {
@@ -509,10 +514,10 @@ public class HTTPPOST extends BaseStep implements StepInterface {
             buf.append( "&" );
           }
 
-          buf.append( URLEncoder.encode( pair.getName(), charset ) );
+          buf.append( URLEncoder.encode( pair.getName(), !StringUtil.isEmpty( charset ) ? charset : DEFAULT_ENCODING ) );
           buf.append( "=" );
           if ( pair.getValue() != null ) {
-            buf.append( URLEncoder.encode( pair.getValue(), charset ) );
+            buf.append( URLEncoder.encode( pair.getValue(), !StringUtil.isEmpty( charset ) ? charset : DEFAULT_ENCODING ) );
           }
         }
       }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -69,6 +69,8 @@ public class HTTPPOSTMeta extends BaseStepMeta implements StepMetaInterface {
 
   // the time to wait till a connection is closed (milliseconds)? -1 is no not close.
   public static final int DEFAULT_CLOSE_CONNECTIONS_TIME = -1;
+
+  public static final String DEFAULT_ENCODING = "UTF-8";
 
   private String socketTimeout;
   private String connectionTimeout;
@@ -371,6 +373,7 @@ public class HTTPPOSTMeta extends BaseStepMeta implements StepMetaInterface {
     resultCodeFieldName = "";
     responseTimeFieldName = "";
     responseHeaderFieldName = "";
+    encoding = DEFAULT_ENCODING;
     postafile = false;
 
     socketTimeout = String.valueOf( DEFAULT_SOCKET_TIMEOUT );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -19,6 +19,7 @@
  * limitations under the License.
  *
  ******************************************************************************/
+
 package org.pentaho.di.trans.steps.httppost;
 
 import java.util.Arrays;
@@ -39,6 +40,9 @@ import org.pentaho.di.trans.steps.loadsave.validator.BooleanLoadSaveValidator;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
 import org.pentaho.di.trans.steps.loadsave.validator.PrimitiveBooleanArrayLoadSaveValidator;
 import org.pentaho.di.trans.steps.loadsave.validator.StringLoadSaveValidator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class HTTPPOSTMetaTest {
   LoadSaveTester loadSaveTester;
@@ -77,4 +81,12 @@ public class HTTPPOSTMetaTest {
     loadSaveTester.testSerialization();
   }
 
+  @Test
+  public void setDefault() {
+    HTTPPOSTMeta meta = new HTTPPOSTMeta();
+    assertNull( meta.getEncoding() );
+
+    meta.setDefault();
+    assertEquals( "UTF-8", meta.getEncoding() );
+  }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTTest.java
@@ -1,0 +1,51 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.httppost;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+
+public class HTTPPOSTTest {
+
+  @Test
+  public void getRequestBodyParametersAsStringWithNullEncoding() throws KettleException {
+    HTTPPOST http = mock( HTTPPOST.class );
+    doCallRealMethod().when( http ).getRequestBodyParamsAsStr( any( NameValuePair[].class ), anyString() );
+
+    NameValuePair[] pairs = new NameValuePair[] {
+      new BasicNameValuePair( "u", "usr" ),
+      new BasicNameValuePair( "p", "pass" )
+    };
+
+    assertEquals( "u=usr&p=pass", http.getRequestBodyParamsAsStr( pairs, null ) );
+  }
+
+}


### PR DESCRIPTION
An easy fix, inspired by the code already present in the `HTTP Client` step.

@pentaho/tatooine 