### PR TITLE
[SP-4909] - Backport of PDI-17781- Logging Registry is not cleaning u…

### DIFF
--- a/core/src/org/pentaho/di/core/logging/LogChannel.java
+++ b/core/src/org/pentaho/di/core/logging/LogChannel.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -53,6 +53,8 @@ public class LogChannel implements LogChannelInterface {
   private static MetricsRegistry metricsRegistry = MetricsRegistry.getInstance();
 
   private String filter;
+
+  private LogChannelFileWriterBuffer fileWriter;
 
   public LogChannel( Object subject ) {
     logLevel = DefaultLogLevel.getLogLevel();
@@ -122,10 +124,13 @@ public class LogChannel implements LogChannelInterface {
       KettleLoggingEvent loggingEvent = new KettleLoggingEvent( logMessage, System.currentTimeMillis(), logLevel );
       KettleLogStore.getAppender().addLogggingEvent( loggingEvent );
 
+      if ( this.fileWriter == null ) {
+        this.fileWriter = LoggingRegistry.getInstance().getLogChannelFileWriterBuffer( logChannelId );
+      }
+
       // add to buffer
-      LogChannelFileWriterBuffer fileWriter = LoggingRegistry.getInstance().getLogChannelFileWriterBuffer( logChannelId );
-      if ( fileWriter != null ) {
-        fileWriter.addEvent( loggingEvent );
+      if ( this.fileWriter != null ) {
+        this.fileWriter.addEvent( loggingEvent );
       }
     }
   }

--- a/core/test-src/org/pentaho/di/core/logging/LogChannelTest.java
+++ b/core/test-src/org/pentaho/di/core/logging/LogChannelTest.java
@@ -1,0 +1,121 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.logging;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.pentaho.di.core.util.Utils;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.times;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( {DefaultLogLevel.class, LoggingRegistry.class, LogLevel.class, KettleLogStore.class, Utils.class} )
+public class LogChannelTest {
+
+  private LogChannel logChannel;
+  private String logChannelSubject = "pdi";
+  private String channelId = "1234-5678-abcd-efgh";
+
+  private LogLevel logLevel;
+  private LogMessageInterface logMsgInterface;
+  private LogChannelFileWriterBuffer logChFileWriterBuffer;
+
+  @Before
+  public void setUp() throws Exception {
+    LogLevel logLevelStatic = PowerMockito.mock( LogLevel.class );
+    Whitebox.setInternalState( logLevelStatic, "name", "Basic" );
+    Whitebox.setInternalState( logLevelStatic, "ordinal", 3 );
+
+    PowerMockito.mockStatic( DefaultLogLevel.class );
+    when( DefaultLogLevel.getLogLevel() ).thenReturn( LogLevel.BASIC );
+
+    logChFileWriterBuffer = mock( LogChannelFileWriterBuffer.class );
+
+    LoggingRegistry regInstance = mock( LoggingRegistry.class );
+    Mockito.when( regInstance.registerLoggingSource( logChannelSubject ) ).thenReturn( channelId );
+    Mockito.when( regInstance.getLogChannelFileWriterBuffer( channelId ) ).thenReturn( logChFileWriterBuffer );
+
+    PowerMockito.mockStatic( LoggingRegistry.class );
+    when( LoggingRegistry.getInstance() ).thenReturn( regInstance );
+
+    logLevel = PowerMockito.mock( LogLevel.class );
+    Whitebox.setInternalState( logLevel, "name", "Basic" );
+    Whitebox.setInternalState( logLevel, "ordinal", 3 );
+
+    logMsgInterface = mock( LogMessageInterface.class );
+    Mockito.when( logMsgInterface.getLevel() ).thenReturn( logLevel );
+
+    logChannel = new LogChannel( logChannelSubject );
+  }
+
+  @Test
+  public void testPrintlnWithNullLogChannelFileWriterBuffer() {
+    when( logLevel.isVisible( any( LogLevel.class ) ) ).thenReturn( true );
+
+    LoggingBuffer loggingBuffer = mock( LoggingBuffer.class );
+    PowerMockito.mockStatic( KettleLogStore.class );
+    when( KettleLogStore.getAppender() ).thenReturn( loggingBuffer );
+
+    logChannel.println( logMsgInterface, LogLevel.BASIC );
+    verify( logChFileWriterBuffer, times( 1 ) ).addEvent( any( KettleLoggingEvent.class ) );
+    verify( loggingBuffer, times( 1 ) ).addLogggingEvent( any( KettleLoggingEvent.class ) );
+  }
+
+  @Test
+  public void testPrintlnLogNotVisible() {
+    when( logLevel.isVisible( any( LogLevel.class ) ) ).thenReturn( false );
+    logChannel.println( logMsgInterface, LogLevel.BASIC );
+    verify( logChFileWriterBuffer, times( 0 ) ).addEvent( any( KettleLoggingEvent.class ) );
+  }
+
+  @Test
+  public void testPrintMessageFiltered() {
+    LogLevel logLevelFil = PowerMockito.mock( LogLevel.class );
+    Whitebox.setInternalState( logLevelFil, "name", "Error" );
+    Whitebox.setInternalState( logLevelFil, "ordinal", 1 );
+    when( logLevelFil.isError() ).thenReturn( false );
+
+    LogMessageInterface logMsgInterfaceFil = mock( LogMessageInterface.class );
+    Mockito.when( logMsgInterfaceFil.getLevel() ).thenReturn( logLevelFil );
+    Mockito.when( logMsgInterfaceFil.toString() ).thenReturn( "a" );
+
+    PowerMockito.mockStatic( Utils.class );
+    when( Utils.isEmpty( anyString() ) ).thenReturn( false );
+
+    when( logLevelFil.isVisible( any( LogLevel.class ) ) ).thenReturn( true );
+    logChannel.setFilter( "b" );
+    logChannel.println( logMsgInterfaceFil, LogLevel.BASIC );
+    verify( logChFileWriterBuffer, times( 0 ) ).addEvent( any( KettleLoggingEvent.class ) );
+  }
+}

--- a/engine/src/org/pentaho/di/core/logging/LogChannelFileWriter.java
+++ b/engine/src/org/pentaho/di/core/logging/LogChannelFileWriter.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -129,6 +129,10 @@ public class LogChannelFileWriter {
               logFileOutputStream.close();
               logFileOutputStream = null;
             }
+
+            if ( buffer != null ) {
+              LoggingRegistry.getInstance().removeLogChannelFileWriterBuffer( buffer.getLogChannelId() );
+            }
           } catch ( Exception e ) {
             exception = new KettleException( "There was an error closing log file file '" + logFile + "'", e );
           } finally {
@@ -145,6 +149,7 @@ public class LogChannelFileWriter {
       StringBuffer buffer = this.buffer.getBuffer();
       logFileOutputStream.write( buffer.toString().getBytes() );
       logFileOutputStream.flush();
+
     } catch ( Exception e ) {
       exception = new KettleException( "There was an error logging to file '" + logFile + "'", e );
     }
@@ -155,6 +160,10 @@ public class LogChannelFileWriter {
     active.set( false );
     while ( !finished.get() ) {
       Thread.yield();
+    }
+
+    if ( this.buffer != null ) {
+      LoggingRegistry.getInstance().removeLogChannelFileWriterBuffer( this.buffer.getLogChannelId() );
     }
   }
 


### PR DESCRIPTION
…p child loggers, resulting in decreased performance over time (7.1 Suite)

@pentaho-lmartins @bantonio82 
"Indirect" cherry pick https://github.com/pentaho/pentaho-kettle/commit/5a721f3a794863e76221e35d87a3c6e7b829f185, code is the same, different packages names