### PR TITLE
[SP-4932] Backport of PDI-17845 - Sample transformation: 'GetXMLData …

### DIFF
--- a/plugins/xml/core/src/main/java/org/pentaho/di/trans/steps/getxmldata/GetXMLData.java
+++ b/plugins/xml/core/src/main/java/org/pentaho/di/trans/steps/getxmldata/GetXMLData.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -122,7 +122,8 @@ public class GetXMLData extends BaseStep implements StepInterface {
           }
 
           public void onEnd( ElementPath path ) {
-            if ( isStopped() ) {
+            long rowLimit = meta.getRowLimit();
+            if ( isStopped() || ( rowLimit > 0 && data.rownr > rowLimit ) ) {
               // when a large file is processed and it should be stopped it is still reading the hole thing
               // the only solution I see is to prune / detach the document and this will lead into a
               // NPE or other errors depending on the parsing location - this will be treated in the catch part below


### PR DESCRIPTION
…- large files.ktr' - 'Limit' option is being ignored (8.2 Suite)

Cherry-pick of https://github.com/Pentaho/pentaho-kettle/commit/b5f155fced46c3c01aaf13a3473415161017f2f1

@pentaho-lmartins @bantonio82 