### PR TITLE
[PDI-17725] Expand Remote Job is not expanding job running on the Pen…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobExecutionConfigurationDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobExecutionConfigurationDialog.java
@@ -284,12 +284,12 @@ public class JobExecutionConfigurationDialog extends ConfigurationDialog {
 
   public void addRunConfigurationListenerForExpandRemoteOption() {
     wRunConfiguration.addModifyListener( modifyEvent -> {
-      List<Object> items = Arrays.asList( wRunConfiguration.getText(), false );
+      List<Object> items = Arrays.asList( wRunConfiguration.getText(), true );
       try {
         ExtensionPointHandler.callExtensionPoint( Spoon.getInstance().getLog(), KettleExtensionPoint
           .RunConfigurationIsRemote.id, items );
       } catch ( KettleException ignored ) {
-        // Ignore errors
+        // Ignore errors - keep old behavior - expand remote job always enabled
       }
       Boolean isRemote = (Boolean) items.get( 1 );
       getConfiguration().setRunConfiguration( wRunConfiguration.getText() );


### PR DESCRIPTION
…taho Server

Changed the initial value of IsRemote flag to ensure we keep the old behavior of this select box in case of error/plugin missing. 
With this change we have the same code in Master and Backported versions.
Backport versions clients still need to add the runConfigurationIsRemoteExtensionPoint bean in beans.xml file to see the initial fix working: https://github.com/pentaho/pentaho-kettle/pull/6131

@pentaho-lmartins 