### PR TITLE
[PDI-17588] null if step is not working consistently

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -119,9 +119,6 @@ public class ValueMetaBase implements ValueMetaInterface {
 
   public static final String COMPATIBLE_DATE_FORMAT_PATTERN = "yyyy/MM/dd HH:mm:ss.SSS";
 
-  public static final Boolean EMPTY_STRING_AND_NULL_ARE_DIFFERENT = convertStringToBoolean(
-          Const.NVL( System.getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
-
   protected String name;
   protected int length;
   protected int precision;
@@ -150,6 +147,7 @@ public class ValueMetaBase implements ValueMetaInterface {
   protected boolean dateFormatLenient;
   protected boolean lenientStringToNumber;
   protected boolean ignoreTimezone;
+  protected boolean emptyStringAndNullAreDifferent;
 
   protected SimpleDateFormat dateFormat;
   protected boolean dateFormatChanged;
@@ -244,9 +242,10 @@ public class ValueMetaBase implements ValueMetaInterface {
     this.ignoreTimezone =
       convertStringToBoolean( Const.NVL( System.getProperty( Const.KETTLE_COMPATIBILITY_DB_IGNORE_TIMEZONE, "N" ),
         "N" ) );
+    this.emptyStringAndNullAreDifferent = convertStringToBoolean(
+      Const.NVL( System.getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
 
     this.comparator = comparator;
-
     determineSingleByteEncoding();
     setDefaultConversionMask();
   }
@@ -1490,7 +1489,7 @@ public class ValueMetaBase implements ValueMetaInterface {
    */
   protected String convertBinaryStringToString( byte[] binary ) throws KettleValueException {
     //noinspection deprecation
-    return convertBinaryStringToString( binary, EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
+    return convertBinaryStringToString( binary, emptyStringAndNullAreDifferent );
   }
 
   /*
@@ -3564,7 +3563,7 @@ public class ValueMetaBase implements ValueMetaInterface {
   @Override
   public boolean isNull( Object data ) throws KettleValueException {
     //noinspection deprecation
-    return isNull( data, EMPTY_STRING_AND_NULL_ARE_DIFFERENT );
+    return isNull( data, emptyStringAndNullAreDifferent );
   }
 
   /*

--- a/engine/src/main/java/org/pentaho/di/trans/steps/nullif/NullIfMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/nullif/NullIfMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -35,6 +35,7 @@ import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -93,7 +94,10 @@ public class NullIfMeta extends BaseStepMeta implements StepMetaInterface {
      *          The fieldValue to set.
      */
     public void setFieldValue( String fieldValue ) {
-      this.fieldValue = fieldValue;
+      Boolean isEmptyAndNullDiffer = ValueMetaBase.convertStringToBoolean(
+        Const.NVL( System.getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
+
+      this.fieldValue = fieldValue == null && isEmptyAndNullDiffer ? Const.EMPTY_STRING : fieldValue;
     }
 
     public Field clone() {

--- a/engine/src/test/java/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.row.value.ValueMetaFactory;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.TransTestingUtil;
@@ -39,7 +38,6 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.steps.StepMockUtil;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import java.util.List;
 
@@ -73,7 +71,6 @@ public class DataGrid_EmptyStringVsNull_Test {
   @Test
   public void emptyAndNullsAreNotDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", false );
     List<Object[]> expected = Arrays.asList(
       new Object[] { "", "", null },
       new Object[] { null, "", null },
@@ -86,7 +83,6 @@ public class DataGrid_EmptyStringVsNull_Test {
   @Test
   public void emptyAndNullsAreDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", true );
     List<Object[]> expected = Arrays.asList(
       new Object[] { "", "", null },
       new Object[] { "", "", null },

--- a/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter_EmptyStringVsNull_Test.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter_EmptyStringVsNull_Test.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,7 +32,6 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.TransTestingUtil;
@@ -40,7 +39,6 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.steps.StepMockUtil;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import java.util.List;
 
@@ -75,7 +73,6 @@ public class FieldSplitter_EmptyStringVsNull_Test {
   @Test
   public void emptyAndNullsAreNotDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", false );
     List<Object[]> expected = Arrays.asList(
       new Object[] { "a", "", "a" },
       new Object[] { "b", null, "b" },
@@ -88,7 +85,6 @@ public class FieldSplitter_EmptyStringVsNull_Test {
   @Test
   public void emptyAndNullsAreDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", true );
     List<Object[]> expected = Arrays.asList(
       new Object[] { "a", "", "a" },
       new Object[] { "b", "", "b" },

--- a/engine/src/test/java/org/pentaho/di/trans/steps/ifnull/IfNullTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/ifnull/IfNullTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -44,7 +44,6 @@ import org.pentaho.di.core.logging.LoggingObjectInterface;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
@@ -56,7 +55,6 @@ import org.pentaho.metastore.api.IMetaStore;
 
 import junit.framework.Assert;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 /**
  * Tests for IfNull step
@@ -122,9 +120,7 @@ public class IfNullTest {
 
   @Test
   public void testString_emptyIsNull() throws KettleException {
-
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", false );
-
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
     IfNull step = new IfNull( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
     step.init( smh.initStepMetaInterface, smh.stepDataInterface );
     final RowMeta inputRowMeta = buildInputRowMeta( //
@@ -155,10 +151,7 @@ public class IfNullTest {
 
   @Test
   public void testString_emptyIsNotNull() throws KettleException {
-
-//    FieldAccessor.ensureEmptyStringIsNotNull( true );
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", true );
-
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
     IfNull step = new IfNull( smh.stepMeta, smh.stepDataInterface, 0, smh.transMeta, smh.trans );
     step.init( smh.initStepMetaInterface, smh.stepDataInterface );
     final RowMeta inputRowMeta = buildInputRowMeta( //

--- a/engine/src/test/java/org/pentaho/di/trans/steps/nullif/NullIfMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/nullif/NullIfMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,12 +31,14 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
 import org.pentaho.di.trans.steps.loadsave.validator.ArrayLoadSaveValidator;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
 import org.pentaho.di.trans.steps.nullif.NullIfMeta.Field;
+import static org.junit.Assert.assertEquals;
 
 public class NullIfMetaTest {
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
@@ -76,6 +78,30 @@ public class NullIfMetaTest {
   @Test
   public void testSerialization() throws KettleException {
     loadSaveTester.testSerialization();
+  }
+
+  @Test
+  public void setFieldValueTest() {
+    Field field = new Field();
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
+    field.setFieldValue( "theValue" );
+    assertEquals( "theValue", field.getFieldValue() );
+  }
+
+  @Test
+  public void setFieldValueNullTest() {
+    Field field = new Field();
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
+    field.setFieldValue( null );
+    assertEquals( null, field.getFieldValue() );
+  }
+
+  @Test
+  public void setFieldValueNullWithEmptyStringsDiffersFromNullTest() {
+    Field field = new Field();
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
+    field.setFieldValue( null );
+    assertEquals( "", field.getFieldValue() );
   }
 
   public static class NullIfFieldLoadSaveValidator implements FieldLoadSaveValidator<Field> {

--- a/engine/src/test/java/org/pentaho/di/trans/steps/regexeval/RegexEval_EmptyStringVsNull_Test.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/regexeval/RegexEval_EmptyStringVsNull_Test.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,7 +32,6 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaBase;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.TransTestingUtil;
@@ -40,7 +39,6 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.steps.StepMockUtil;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -76,7 +74,6 @@ public class RegexEval_EmptyStringVsNull_Test {
   @Test
   public void emptyAndNullsAreNotDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", false );
     List<Object[]> expected = Arrays.asList(
       new Object[] { false, "" },
       new Object[] { false, "" },
@@ -89,7 +86,6 @@ public class RegexEval_EmptyStringVsNull_Test {
   @Test
   public void emptyAndNullsAreDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", true );
     List<Object[]> expected = Arrays.asList(
       new Object[] { false, "" },
       new Object[] { false, "" },

--- a/ui/src/test/java/org/pentaho/di/ui/core/dialog/EditRowsDialog_EmptyStringVsNull_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/core/dialog/EditRowsDialog_EmptyStringVsNull_Test.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -35,7 +36,6 @@ import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.TransTestingUtil;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.when;
  */
 @RunWith( PowerMockRunner.class )
 public class EditRowsDialog_EmptyStringVsNull_Test {
+
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
 
   @BeforeClass
@@ -55,18 +56,17 @@ public class EditRowsDialog_EmptyStringVsNull_Test {
     KettleEnvironment.init();
   }
 
-
   @Test
   public void emptyAndNullsAreNotDifferent() throws Exception {
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", false );
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
     executeAndAssertResults( new String[]{ "", null, null } );
   }
 
 
   @Test
   public void emptyAndNullsAreDifferent() throws Exception {
-    Whitebox.setInternalState( ValueMetaBase.class, "EMPTY_STRING_AND_NULL_ARE_DIFFERENT", true );
-    executeAndAssertResults( new String[]{ "", "", null } );
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
+    executeAndAssertResults( new String[]{ "", "", "" } );
   }
 
   private void executeAndAssertResults( String[] expected ) throws Exception {


### PR DESCRIPTION
@pentaho-lmartins @pentaho/tatooine 

Two problems in the inconsistency of "Null If" step:
1 - The Kettle property KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL was saved in a static variable, causing that as soon as it was set, no further changes in the property were "seen", unless PDI was restarted.
2 - The value to turn to null in the "Null if" step if it was set to "" (empty string) was always interpreted as null, although the KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL was set to "Y". 