### PR TITLE
[BACKLOG-24264] PDI Service/Job supporting 'result-set' capability

### DIFF
--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -74,6 +74,7 @@ public class Pan {
     StringBuilder optionFilename, optionLoglevel, optionLogfile, optionLogfileOld, optionListdir;
     StringBuilder optionListtrans, optionListrep, optionExprep, optionNorep, optionSafemode;
     StringBuilder optionVersion, optionJarFilename, optionListParam, optionMetrics, initialDir;
+    StringBuilder optionResultSetStepName, optionResultSetCopyNumber;
 
     NamedParams optionParams = new NamedParamsDefault();
 
@@ -146,8 +147,15 @@ public class Pan {
           "initialDir", null, initialDir =
           new StringBuilder(), false, true ),
         new CommandLineOption(
+          "stepname", "ResultSetStepName", optionResultSetStepName =
+          new StringBuilder(), false, true ),
+        new CommandLineOption(
+          "copynum", "ResultSetCopyNumber", optionResultSetCopyNumber =
+          new StringBuilder(), false, true ),
+        new CommandLineOption(
           "metrics", BaseMessages.getString( PKG, "Pan.ComdLine.Metrics" ), optionMetrics =
           new StringBuilder(), true, false ), maxLogLinesOption, maxLogTimeoutOption };
+
 
     if ( args.size() == 2 ) { // 2 internal hidden argument (flag and value)
       CommandLineOption.printUsage( options );
@@ -232,7 +240,8 @@ public class Pan {
               optionTrustUser.toString(), optionPassword.toString(), optionDirname.toString(), optionFilename.toString(), optionJarFilename.toString(),
               optionTransname.toString(), optionListtrans.toString(), optionListdir.toString(), optionExprep.toString(),
               initialDir.toString(), optionListrep.toString(), optionSafemode.toString(), optionMetrics.toString(),
-              optionListParam.toString(), optionParams, args.toArray( new String[ args.size() ] ) );
+              optionListParam.toString(), optionResultSetStepName.toString(), optionResultSetCopyNumber.toString(),
+              optionParams, args.toArray( new String[ args.size() ] ) );
 
       exitJVM( result.getExitStatus() );
 

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *


### PR DESCRIPTION
Bringing in POC work from @pedrofvteixeira's branch to master.

Verified and tested locally, works as expected. PDI-Service's `/ktr` endpoint now takes two new parameters `resultSetStepName` and `resultSetCopyNumber`


@pentaho/rogueone