### PR TITLE
[PDI-17907] Parsing NULL values in Integer columns throws a conversio…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -234,10 +234,7 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
     if ( mappingVariables != null ) {
       for ( int i = 0; i < mappingVariables.length; i++ ) {
         parameters.put( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
-        //If inputField value is not empty then create it in variableSpace of step(Parent)
-        if ( !Utils.isEmpty( Const.trim( parent.environmentSubstitute( inputFields[ i ] ) ) ) ) {
-          parent.setVariable( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
-        }
+        parent.setVariable( mappingVariables[ i ], parent.environmentSubstitute( inputFields[ i ] ) );
       }
     }
 


### PR DESCRIPTION
…n error when passed as a parameter

@pentaho/tatooine @pentaho-lmartins 
@ppatricio @mbatchelor 

Variables were not being updated in parent step when the variable value was null.
Now when a variable is null, it is removed from the properties map. 