### PR TITLE
[BACKLOG-27573] - Temporarily managing scope of OSGi core to compile …

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -20,6 +20,17 @@
     <assembly.dir>${project.build.directory}/assembly</assembly.dir>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.core</artifactId>
+        <version>${osgi.core.version}</version>
+        <scope>compile</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <modules>
     <module>static</module>
     <module>samples</module>


### PR DESCRIPTION
…here to include it in all pdi lib assemblies.

*Note: Only merge after https://github.com/pentaho/pdi-osgi-bridge/pull/69 changes have been BUILT by Ciren so that the new pdi-osgi-bridge dependency tree is available.*