### PR TITLE
PDI-17916 - CheckSum step cleanup and field separator

### DIFF
--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,10 +22,10 @@
 
 package org.pentaho.di.trans.steps.checksum;
 
-import java.io.ByteArrayOutputStream;
 import java.security.MessageDigest;
 import java.util.zip.Adler32;
 import java.util.zip.CRC32;
+import java.util.zip.Checksum;
 
 import org.apache.commons.codec.binary.Hex;
 import org.pentaho.di.core.exception.KettleException;
@@ -55,7 +55,7 @@ public class CheckSum extends BaseStep implements StepInterface {
   private CheckSumData data;
 
   public CheckSum( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
-    Trans trans ) {
+      Trans trans ) {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
   }
 
@@ -87,7 +87,7 @@ public class CheckSum extends BaseStep implements StepInterface {
           if ( data.fieldnrs[i] < 0 ) {
             logError( BaseMessages.getString( PKG, "CheckSum.Log.CanNotFindField", meta.getFieldName()[i] ) );
             throw new KettleException( BaseMessages.getString( PKG, "CheckSum.Log.CanNotFindField", meta
-              .getFieldName()[i] ) );
+                .getFieldName()[i] ) );
           }
         }
       } else {
@@ -99,10 +99,20 @@ public class CheckSum extends BaseStep implements StepInterface {
       data.fieldnr = data.fieldnrs.length;
 
       try {
-        if ( meta.getCheckSumType().equals( CheckSumMeta.TYPE_MD5 )
-          || meta.getCheckSumType().equals( CheckSumMeta.TYPE_SHA1 )
-          || meta.getCheckSumType().equals( CheckSumMeta.TYPE_SHA256 ) ) {
-          data.digest = MessageDigest.getInstance( meta.getCheckSumType() );
+
+        switch ( meta.getCheckSumType() ) {
+          case CheckSumMeta.TYPE_MD5:
+          case CheckSumMeta.TYPE_SHA1:
+          case CheckSumMeta.TYPE_SHA256:
+            data.checksumCalculator =
+                new DigestChecksumCalculator( MessageDigest.getInstance( meta.getCheckSumType() ) );
+            break;
+          case CheckSumMeta.TYPE_ADLER32:
+            data.checksumCalculator = new ChecksumChecksumCalculator( new Adler32() );
+            break;
+          case CheckSumMeta.TYPE_CRC32:
+            data.checksumCalculator = new ChecksumChecksumCalculator( new CRC32() );
+            break;
         }
       } catch ( Exception e ) {
         throw new KettleException( BaseMessages.getString( PKG, "CheckSum.Error.Digest" ), e );
@@ -113,23 +123,35 @@ public class CheckSum extends BaseStep implements StepInterface {
     Object[] outputRowData = null;
 
     try {
-      if ( meta.getCheckSumType().equals( CheckSumMeta.TYPE_ADLER32 )
-        || meta.getCheckSumType().equals( CheckSumMeta.TYPE_CRC32 ) ) {
-        // get checksum
-        Long checksum = calculCheckSum( r );
-        outputRowData = RowDataUtil.addValueData( r, data.nrInfields, checksum );
-      } else {
-        // get checksum
 
-        byte[] o = createCheckSum( r );
+      for ( int i = 0; i < data.fieldnr; i++ ) {
+        if ( meta.isOldChecksumBehaviour() ) {
+          data.checksumCalculator.update( String.valueOf( getInputRowMeta().getValueMeta( data.fieldnrs[i] )
+              .getNativeDataType( r[data.fieldnrs[i]] ) ).getBytes() );
+        } else {
+          //New Behavior (uses byte[]) instead of building through String
+          if ( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).isBinary() ) {
+            data.checksumCalculator.update( getInputRowMeta().getBinary( r, data.fieldnrs[i] ) );
+          } else {
+            data.checksumCalculator.update( getInputRowMeta().getValueMeta( data.fieldnrs[i] )
+                .getNativeDataType( r[data.fieldnrs[i]] ).toString().getBytes() );
+          }
 
+        }
+      }
+      Object checksumResult = data.checksumCalculator.getResult();
+
+      if ( checksumResult instanceof Long ) {
+        outputRowData = RowDataUtil.addValueData( r, data.nrInfields, (Long) checksumResult );
+      } else if ( checksumResult instanceof byte[] ) {
+        byte[] o = (byte[]) checksumResult;
         switch ( meta.getResultType() ) {
           case CheckSumMeta.result_TYPE_BINARY:
             outputRowData = RowDataUtil.addValueData( r, data.nrInfields, o );
             break;
           case CheckSumMeta.result_TYPE_HEXADECIMAL:
             String hex =
-              meta.isCompatibilityMode() ? byteToHexEncode_compatible( o ) : new String( Hex.encodeHex( o ) );
+                meta.isCompatibilityMode() ? byteToHexEncode_compatible( o ) : new String( Hex.encodeHex( o ) );
             outputRowData = RowDataUtil.addValueData( r, data.nrInfields, hex );
             break;
           default:
@@ -169,40 +191,6 @@ public class CheckSum extends BaseStep implements StepInterface {
     return true;
   }
 
-  private byte[] createCheckSum( Object[] r ) throws Exception {
-    if ( meta.isOldChecksumBehaviour() ) {
-      StringBuilder Buff = new StringBuilder();
-
-      // Loop through fields
-      for ( int i = 0; i < data.fieldnr; i++ ) {
-        Buff.append( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[data.fieldnrs[i]] ) );
-      }
-
-      // Updates the digest using the specified array of bytes
-      data.digest.update( Buff.toString().getBytes() );
-    } else {
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-      // Loop through fields
-      for ( int i = 0; i < data.fieldnr; i++ ) {
-        if ( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).isBinary() ) {
-          baos.write( getInputRowMeta().getBinary( r, data.fieldnrs[i] ) );
-        } else {
-          baos.write( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[data.fieldnrs[i]] )
-              .toString().getBytes() );
-        }
-      }
-
-      // Updates the digest using the specified array of bytes
-      data.digest.update( baos.toByteArray() );
-    }
-    // Completes the hash computation by performing final operations such as padding
-    byte[] hash = data.digest.digest();
-    // After digest has been called, the MessageDigest object is reset to its initialized state
-
-    return hash;
-  }
-
   private static String getStringFromBytes( byte[] bytes ) {
     StringBuilder sb = new StringBuilder();
     for ( int i = 0; i < bytes.length; i++ ) {
@@ -234,45 +222,6 @@ public class CheckSum extends BaseStep implements StepInterface {
     return hexString.toString();
   }
 
-  private Long calculCheckSum( Object[] r ) throws Exception {
-    Long retval;
-    byte[] byteArray;
-    if ( meta.isOldChecksumBehaviour() ) {
-      StringBuilder Buff = new StringBuilder();
-
-      // Loop through fields
-      for ( int i = 0; i < data.fieldnr; i++ ) {
-        Buff.append( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[data.fieldnrs[i]] ) );
-      }
-      byteArray = Buff.toString().getBytes();
-    } else {
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-      // Loop through fields
-      for ( int i = 0; i < data.fieldnr; i++ ) {
-        if ( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).isBinary() ) {
-          baos.write( getInputRowMeta().getBinary( r, data.fieldnrs[i] ) );
-        } else {
-          baos.write( getInputRowMeta().getValueMeta( data.fieldnrs[i] ).getNativeDataType( r[data.fieldnrs[i]] )
-              .toString().getBytes() );
-        }
-      }
-      byteArray = baos.toByteArray();
-    }
-
-    if ( meta.getCheckSumType().equals( CheckSumMeta.TYPE_CRC32 ) ) {
-      CRC32 crc32 = new CRC32();
-      crc32.update( byteArray );
-      retval = new Long( crc32.getValue() );
-    } else {
-      Adler32 adler32 = new Adler32();
-      adler32.update( byteArray );
-      retval = new Long( adler32.getValue() );
-    }
-
-    return retval;
-  }
-
   @SuppressWarnings( "deprecation" )
   @Override
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
@@ -291,6 +240,59 @@ public class CheckSum extends BaseStep implements StepInterface {
       return true;
     }
     return false;
+  }
+
+  public static interface GenericChecksumCalculator<R> {
+
+    void update( byte[] contentBytes );
+
+    R getResult();
+  }
+
+  public static class ChecksumChecksumCalculator implements GenericChecksumCalculator<Long> {
+
+    private final Checksum checksum;
+
+    public ChecksumChecksumCalculator( Checksum checksum ) {
+      this.checksum = checksum;
+    }
+
+    @Override
+    public void update( byte[] contentBytes ) {
+      if ( contentBytes != null ) {
+        checksum.update( contentBytes, 0, contentBytes.length );
+      }
+    }
+
+    @Override
+    public Long getResult() {
+      try {
+        return new Long( checksum.getValue() );
+      } finally {
+        checksum.reset();
+      }
+    }
+
+  }
+
+  public static class DigestChecksumCalculator implements GenericChecksumCalculator<byte[]> {
+
+    private final MessageDigest digest;
+
+    public DigestChecksumCalculator( MessageDigest digest ) {
+      this.digest = digest;
+    }
+
+    @Override
+    public void update( byte[] contentBytes ) {
+      digest.update( contentBytes );
+    }
+
+    @Override
+    public byte[] getResult() {
+      return digest.digest();
+    }
+
   }
 
 }

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.checksum;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.zip.Adler32;
 import java.util.zip.CRC32;
@@ -81,6 +82,10 @@ public class CheckSum extends BaseStep implements StepInterface {
       data.outputRowMeta = inputRowMeta.clone();
       data.nrInfields = data.outputRowMeta.size();
       meta.getFields( data.outputRowMeta, getStepname(), null, null, this, repository, metaStore );
+
+      if ( meta.getFieldSeparatorString() != null && !meta.getFieldSeparatorString().isEmpty() ) {
+        data.fieldSeparatorStringBytes = meta.getFieldSeparatorString().getBytes( StandardCharsets.UTF_8 );
+      }
 
       int[] fieldIndexMapping;
 
@@ -144,6 +149,9 @@ public class CheckSum extends BaseStep implements StepInterface {
 
       // Update the checksum with the field content
       for ( int i = 0; i < data.fieldConverters.length; i++ ) {
+        if ( i != 0 && data.fieldSeparatorStringBytes != null ) {
+          data.checksumCalculator.update( data.fieldSeparatorStringBytes );
+        }
         data.checksumCalculator.update( data.fieldConverters[i].getBytes( r ) );
       }
       Object checksumResult = data.checksumCalculator.getResult();

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumData.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumData.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,11 +22,10 @@
 
 package org.pentaho.di.trans.steps.checksum;
 
-import java.security.MessageDigest;
-
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.steps.checksum.CheckSum.GenericChecksumCalculator;
 
 /**
  * Data class for the Cheksum class
@@ -43,7 +42,7 @@ public class CheckSumData extends BaseStepData implements StepDataInterface {
   public RowMetaInterface outputRowMeta;
   public int nrInfields;
 
-  public MessageDigest digest;
+  public GenericChecksumCalculator<?> checksumCalculator;
 
   public CheckSumData() {
     super();

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumData.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumData.java
@@ -41,6 +41,8 @@ public class CheckSumData extends BaseStepData implements StepDataInterface {
   public RowMetaInterface outputRowMeta;
   public int nrInfields;
 
+  public byte[] fieldSeparatorStringBytes;
+
   public GenericChecksumCalculator<?> checksumCalculator;
 
   public CheckSumData() {

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumData.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumData.java
@@ -25,6 +25,7 @@ package org.pentaho.di.trans.steps.checksum;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.steps.checksum.CheckSum.FieldToBytesConverter;
 import org.pentaho.di.trans.steps.checksum.CheckSum.GenericChecksumCalculator;
 
 /**
@@ -35,9 +36,7 @@ import org.pentaho.di.trans.steps.checksum.CheckSum.GenericChecksumCalculator;
  */
 public class CheckSumData extends BaseStepData implements StepDataInterface {
 
-  public int[] fieldnrs;
-
-  public int fieldnr;
+  public FieldToBytesConverter[] fieldConverters;
 
   public RowMetaInterface outputRowMeta;
   public int nrInfields;

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumMeta.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSumMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -112,6 +112,9 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
 
   @Injection( name = "OLD_CHECKSUM_BEHAVIOR" )
   private boolean oldChecksumBehaviour;
+
+  @Injection( name = "FIELD_SEPARATOR_STRING" )
+  private String fieldSeparatorString;
 
   /** result type */
   @Injection( name = "RESULT_TYPE" )
@@ -241,6 +244,14 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
     this.fieldName = fieldName;
   }
 
+  public String getFieldSeparatorString() {
+    return fieldSeparatorString;
+  }
+
+  public void setFieldSeparatorString( String fieldSeparatorString ) {
+    this.fieldSeparatorString = fieldSeparatorString;
+  }
+
   private void readData( Node stepnode ) throws KettleXMLException {
     try {
       checksumtype = XMLHandler.getTagValue( stepnode, "checksumtype" );
@@ -248,6 +259,7 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
       resultType = getResultTypeByCode( Const.NVL( XMLHandler.getTagValue( stepnode, "resultType" ), "" ) );
       compatibilityMode = parseCompatibilityMode( XMLHandler.getTagValue( stepnode, "compatibilityMode" ) );
       oldChecksumBehaviour = parseOldChecksumBehaviour( XMLHandler.getTagValue( stepnode, "oldChecksumBehaviour" ) );
+      setFieldSeparatorString( XMLHandler.getTagValue( stepnode, "fieldSeparatorString" ) );
 
       Node fields = XMLHandler.getSubNode( stepnode, "fields" );
       int nrfields = XMLHandler.countNodes( fields, "field" );
@@ -294,6 +306,9 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
     retval.append( "      " ).append( XMLHandler.addTagValue( "resultType", getResultTypeCode( resultType ) ) );
     retval.append( "      " ).append( XMLHandler.addTagValue( "compatibilityMode", compatibilityMode ) );
     retval.append( "      " ).append( XMLHandler.addTagValue( "oldChecksumBehaviour", oldChecksumBehaviour ) );
+    if ( getFieldSeparatorString() != null ) {
+      retval.append( retval.append( "      " ).append( XMLHandler.addTagValue( "fieldSeparatorString", getFieldSeparatorString() ) ) );
+    }
 
     retval.append( "    <fields>" ).append( Const.CR );
     for ( int i = 0; i < fieldName.length; i++ ) {
@@ -311,6 +326,7 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
     resultfieldName = null;
     checksumtype = checksumtypeCodes[0];
     resultType = result_TYPE_HEXADECIMAL;
+    fieldSeparatorString = null;
     int nrfields = 0;
 
     allocate( nrfields );
@@ -329,6 +345,7 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
       resultType = getResultTypeByCode( Const.NVL( rep.getStepAttributeString( id_step, "resultType" ), "" ) );
       compatibilityMode = parseCompatibilityMode( rep.getStepAttributeString( id_step, "compatibilityMode" ) );
       oldChecksumBehaviour = parseOldChecksumBehaviour( rep.getStepAttributeString( id_step, "oldChecksumBehaviour" ) );
+      setFieldSeparatorString( rep.getStepAttributeString( id_step, "fieldSeparatorString" ) );
 
       int nrfields = rep.countNrStepAttributes( id_step, "field_name" );
 
@@ -351,6 +368,10 @@ public class CheckSumMeta extends BaseStepMeta implements StepMetaInterface {
       rep.saveStepAttribute( id_transformation, id_step, "resultType", getResultTypeCode( resultType ) );
       rep.saveStepAttribute( id_transformation, id_step, "compatibilityMode", compatibilityMode );
       rep.saveStepAttribute( id_transformation, id_step, "oldChecksumBehaviour", oldChecksumBehaviour );
+
+      if ( getFieldSeparatorString() != null ) {
+        rep.saveStepAttribute( id_transformation, id_step, "fieldSeparatorString", getFieldSeparatorString() );
+      }
 
       for ( int i = 0; i < fieldName.length; i++ ) {
         rep.saveStepAttribute( id_transformation, id_step, i, "field_name", fieldName[i] );

--- a/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/checksum/messages/messages_en_US.properties
+++ b/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/checksum/messages/messages_en_US.properties
@@ -49,4 +49,4 @@ CheckSum.Injection.RESULT_FIELD=The name of the result field containing the chec
 CheckSum.Injection.COMPATIBILITY_MODE=Select for compatibility with transformations created with a PDI version before 4\
   .2.0.
 CheckSum.Injection.OLD_CHECKSUM_BEHAVIOR=Select to enable old checksum behavior.
-
+CheckSum.Injection.FIELD_SEPARATOR_STRING=Enter a salting string to use a separator between fields.

--- a/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumMetaInjectionTest.java
+++ b/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumMetaInjectionTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -67,6 +67,11 @@ public class CheckSumMetaInjectionTest extends BaseMetadataInjectionTest<CheckSu
     check( "FIELD_NAME", new StringGetter() {
       public String get() {
         return meta.getFieldName()[ 0 ];
+      }
+    } );
+    check( "FIELD_SEPARATOR_STRING", new StringGetter() {
+      public String get() {
+        return meta.getFieldSeparatorString();
       }
     } );
   }

--- a/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumMetaTest.java
+++ b/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -67,7 +67,7 @@ public class CheckSumMetaTest implements InitializerInterface<CheckSumMeta> {
   @Test
   public void testSerialization() throws KettleException {
     List<String> attributes =
-      Arrays.asList( "FieldName", "ResultFieldName", "CheckSumType", "CompatibilityMode", "ResultType", "oldChecksumBehaviour" );
+      Arrays.asList( "FieldName", "ResultFieldName", "CheckSumType", "CompatibilityMode", "ResultType", "oldChecksumBehaviour", "fieldSeparatorString" );
 
     Map<String, String> getterMap = new HashMap<String, String>();
     Map<String, String> setterMap = new HashMap<String, String>();

--- a/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumTest.java
+++ b/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumTest.java
+++ b/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumTest.java
@@ -61,7 +61,8 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.dummytrans.DummyTransMeta;
 
 public class CheckSumTest {
-  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
+  @ClassRule
+  public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
 
   private static Object previousKettleDefaultNumberFormat;
 
@@ -84,7 +85,8 @@ public class CheckSumTest {
     }
   }
 
-  private Trans buildHexadecimalChecksumTrans( int checkSumType, boolean compatibilityMode, boolean oldChecksumBehaviour ) throws Exception {
+  private Trans buildHexadecimalChecksumTrans( int checkSumType, boolean compatibilityMode,
+      boolean oldChecksumBehaviour, String fieldSeparatorString, String[] fieldNames ) throws Exception {
     // Create a new transformation...
     TransMeta transMeta = new TransMeta();
     transMeta.setName( getClass().getName() );
@@ -98,8 +100,9 @@ public class CheckSumTest {
     meta.setResultFieldName( "hex" );
     meta.setCheckSumType( checkSumType );
     meta.setResultType( CheckSumMeta.result_TYPE_HEXADECIMAL );
-    meta.setFieldName( new String[] { "test" } );
+    meta.setFieldName( fieldNames );
     meta.setOldChecksumBehaviour( oldChecksumBehaviour );
+    meta.setFieldSeparatorString( fieldSeparatorString );
 
     String checkSumPluginPid = PluginRegistry.getInstance().getPluginId( StepPluginType.class, meta );
     StepMeta checkSumStep = new StepMeta( checkSumPluginPid, checkSumStepname, meta );
@@ -117,12 +120,6 @@ public class CheckSumTest {
     transMeta.addTransHop( hop );
 
     return new Trans( transMeta );
-  }
-
-  private RowMeta createStringRowMeta( ValueMetaInterface meta ) throws Exception {
-    RowMeta rowMeta = new RowMeta();
-    rowMeta.addValueMeta( meta );
-    return rowMeta;
   }
 
   private class MockRowListener extends RowAdapter {
@@ -171,8 +168,39 @@ public class CheckSumTest {
    *          meta to be used
    * @return RowListener with results.
    */
-  private MockRowListener executeHexTest( int checkSumType, boolean compatibilityMode, Object input, ValueMetaInterface meta, boolean oldChecksumBehaviour ) throws Exception {
-    Trans trans = buildHexadecimalChecksumTrans( checkSumType, compatibilityMode, oldChecksumBehaviour );
+  private MockRowListener executeHexTest( int checkSumType, boolean compatibilityMode, Object input,
+      ValueMetaInterface meta, boolean oldChecksumBehaviour ) throws Exception {
+    return executeHexTest( checkSumType, compatibilityMode, oldChecksumBehaviour, null, new Object[] { input }, meta );
+  }
+
+  /**
+   * Create, execute, and return the row listener attached to the output step with complete results from the execution.
+   *
+   * @param checkSumType
+   *          Type of checksum to use (the array index of {@link CheckSumMeta#checksumtypeCodes})
+   * @param compatibilityMode
+   *          Use compatibility mode for CheckSum
+   * @param fieldSeparatorString
+   *          The string separate multiple fields with
+   * @param inputs
+   *          Array of objects representing row data
+   * @param inputValueMetas
+   *          metas to be processed
+   * @return RowListener with results.
+   */
+  private MockRowListener executeHexTest( int checkSumType, boolean compatibilityMode, boolean oldChecksumBehaviour,
+      String fieldSeparatorString, Object[] inputs, ValueMetaInterface... inputValueMetas ) throws Exception {
+
+    String[] fieldNames = new String[inputValueMetas.length];
+    RowMeta inputRowMeta = new RowMeta();
+    for ( int i = 0; i < inputValueMetas.length; i++ ) {
+      inputRowMeta.addValueMeta( inputValueMetas[i] );
+      fieldNames[i] = inputValueMetas[i].getName();
+    }
+
+    Trans trans =
+        buildHexadecimalChecksumTrans( checkSumType, compatibilityMode, oldChecksumBehaviour, fieldSeparatorString,
+            fieldNames );
 
     trans.prepareExecution( null );
 
@@ -181,12 +209,12 @@ public class CheckSumTest {
     output.addRowListener( listener );
 
     RowProducer rp = trans.addRowProducer( "CheckSum", 0 );
-    RowMeta inputRowMeta = createStringRowMeta( meta );
+
     ( (BaseStep) trans.getRunThread( "CheckSum", 0 ) ).setInputRowMeta( inputRowMeta );
 
     trans.startThreads();
 
-    rp.putRow( inputRowMeta, new Object[] { input } );
+    rp.putRow( inputRowMeta, inputs );
     rp.finished();
 
     trans.waitUntilFinished();
@@ -209,7 +237,9 @@ public class CheckSumTest {
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "68b142f87143c917f29d178aa1715957", results.getWritten().get( 0 )[1] );
 
-    byte[] input = IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" ).getContent().getInputStream() );
+    byte[] input =
+        IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" )
+            .getContent().getInputStream() );
     results = executeHexTest( 2, false, input, new ValueMetaBinary( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "8d808ff9051fdbfd8050f762daddf813", results.getWritten().get( 0 )[1] );
@@ -244,7 +274,9 @@ public class CheckSumTest {
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "68FD42FD7143FD17FD17FDFD715957", results.getWritten().get( 0 )[1] );
 
-    byte[] input = IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" ).getContent().getInputStream() );
+    byte[] input =
+        IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" )
+            .getContent().getInputStream() );
     results = executeHexTest( 2, true, input, new ValueMetaBinary( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "FDFDFDFD051FFDFDFD50FD62FDFDFD13", results.getWritten().get( 0 )[1] );
@@ -279,7 +311,9 @@ public class CheckSumTest {
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "749f3d4c2db67c9f3186563a72ef5da9461f0496", results.getWritten().get( 0 )[1] );
 
-    byte[] input = IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" ).getContent().getInputStream() );
+    byte[] input =
+        IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" )
+            .getContent().getInputStream() );
     results = executeHexTest( 3, false, input, new ValueMetaBinary( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "e67d0b5b60663b8a5e0df1d23b44de673738315a", results.getWritten().get( 0 )[1] );
@@ -314,7 +348,9 @@ public class CheckSumTest {
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "74FD3D4C2DFD7CFD31FD563A72FD5DFD461F04FD", results.getWritten().get( 0 )[1] );
 
-    byte[] input = IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" ).getContent().getInputStream() );
+    byte[] input =
+        IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" )
+            .getContent().getInputStream() );
     results = executeHexTest( 3, true, input, new ValueMetaBinary( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "FD7D0B5B60663BFD5E0DFDFD3B44FD673738315A", results.getWritten().get( 0 )[1] );
@@ -340,22 +376,25 @@ public class CheckSumTest {
     MockRowListener results = executeHexTest( 4, false, "xyz", new ValueMetaString( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "3608bca1e44ea6c4d268eb6db02260269892c0b42b86bbf1e77a6fa16c3c9282",
-      results.getWritten().get( 0 )[1] );
+        results.getWritten().get( 0 )[1] );
 
     results = executeHexTest( 4, false, 10.8, new ValueMetaNumber( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "b52b603f9ec86c382a8483cad4f788f2f927535a76ad1388caedcef5e3c3c813",
-            results.getWritten().get( 0 )[1] );
+        results.getWritten().get( 0 )[1] );
 
     results = executeHexTest( 4, false, 10.82, new ValueMetaNumber( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "45cbb96ff9625490cd675a7a39fecad6c167c1ed9b8957f53224fcb3e4a1e4a1",
-            results.getWritten().get( 0 )[1] );
+        results.getWritten().get( 0 )[1] );
 
-    byte[] input = IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" ).getContent().getInputStream() );
+    byte[] input =
+        IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" )
+            .getContent().getInputStream() );
     results = executeHexTest( 4, false, input, new ValueMetaBinary( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
-    assertEquals( "6914d0cb9296d658569570c23924ea4822be73f0ee3bc46d11651fb4041a43e1", results.getWritten().get( 0 )[1] );
+    assertEquals( "6914d0cb9296d658569570c23924ea4822be73f0ee3bc46d11651fb4041a43e1", results.getWritten().get(
+        0 )[1] );
   }
 
   @Test
@@ -363,17 +402,17 @@ public class CheckSumTest {
     MockRowListener results = executeHexTest( 4, false, "xyz", new ValueMetaString( "test" ), true );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "3608bca1e44ea6c4d268eb6db02260269892c0b42b86bbf1e77a6fa16c3c9282",
-            results.getWritten().get( 0 )[1] );
+        results.getWritten().get( 0 )[1] );
 
     results = executeHexTest( 4, false, 10.8, new ValueMetaNumber( "test" ), true );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "b52b603f9ec86c382a8483cad4f788f2f927535a76ad1388caedcef5e3c3c813",
-            results.getWritten().get( 0 )[1] );
+        results.getWritten().get( 0 )[1] );
 
     results = executeHexTest( 4, false, 10.82, new ValueMetaNumber( "test" ), true );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "45cbb96ff9625490cd675a7a39fecad6c167c1ed9b8957f53224fcb3e4a1e4a1",
-            results.getWritten().get( 0 )[1] );
+        results.getWritten().get( 0 )[1] );
   }
 
   @Test
@@ -390,7 +429,9 @@ public class CheckSumTest {
     assertEquals( 1, results.getWritten().size() );
     assertEquals( Long.valueOf( "48627962" ), results.getWritten().get( 0 )[1] );
 
-    byte[] input = IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" ).getContent().getInputStream() );
+    byte[] input =
+        IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" )
+            .getContent().getInputStream() );
     results = executeHexTest( 1, false, input, new ValueMetaBinary( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( Long.valueOf( "1586189688" ), results.getWritten().get( 0 )[1] );
@@ -425,7 +466,9 @@ public class CheckSumTest {
     assertEquals( 1, results.getWritten().size() );
     assertEquals( Long.valueOf( "1205016603" ), results.getWritten().get( 0 )[1] );
 
-    byte[] input = IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" ).getContent().getInputStream() );
+    byte[] input =
+        IOUtils.toByteArray( getFile( "/org/pentaho/di/trans/steps/loadfileinput/files/pentaho_splash.png" )
+            .getContent().getInputStream() );
     results = executeHexTest( 0, false, input, new ValueMetaBinary( "test" ), false );
     assertEquals( 1, results.getWritten().size() );
     assertEquals( Long.valueOf( "1508231614" ), results.getWritten().get( 0 )[1] );
@@ -464,6 +507,35 @@ public class CheckSumTest {
     } catch ( KettleException e ) {
       // expected, SHA-256 is not supported for compatibility mode
     }
+  }
+
+  @Test
+  public void testHexOutput_sha256_fieldStringSeparators() throws Exception {
+    MockRowListener results =
+        executeHexTest( 4, false, false, "", new Object[] { "abc", "def" },
+            new ValueMetaString( "a" ), new ValueMetaString( "b" ) );
+    assertEquals( 1, results.getWritten().size() );
+    assertEquals( "bef57ec7f53a6d40beb640a780a639c83bc29ac8a9816f1fc6c5c6dcd93c4721",
+        results.getWritten().get( 0 )[2] );
+
+    results = executeHexTest( 4, false, false, "", new Object[] { "ab", "cdef" },
+            new ValueMetaString( "a" ), new ValueMetaString( "b" ) );
+    assertEquals( 1, results.getWritten().size() );
+    assertEquals( "bef57ec7f53a6d40beb640a780a639c83bc29ac8a9816f1fc6c5c6dcd93c4721",
+        results.getWritten().get( 0 )[2] );
+
+    results = executeHexTest( 4, false, false, "|", new Object[] { "abc", "def" },
+            new ValueMetaString( "a" ), new ValueMetaString( "b" ) );
+    assertEquals( 1, results.getWritten().size() );
+    assertEquals( "0def6826e591afbb7b4431daaa6f2a78c1e5af533cb94b6db1635efbf255cb16",
+        results.getWritten().get( 0 )[2] );
+
+    results = executeHexTest( 4, false, false, "|", new Object[] { "ab", "cdef" },
+            new ValueMetaString( "a" ), new ValueMetaString( "b" ) );
+    assertEquals( 1, results.getWritten().size() );
+    assertEquals( "a3aa77adf7a0bc55c91bc2e482db25bb520d5903fe7adcee9f6a09fd5ae200f6",
+        results.getWritten().get( 0 )[2] );
+
   }
 
   private FileObject getFile( final String filepath ) {

--- a/plugins/core/ui/src/main/java/org/pentaho/di/ui/trans/steps/checksum/CheckSumDialog.java
+++ b/plugins/core/ui/src/main/java/org/pentaho/di/ui/trans/steps/checksum/CheckSumDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -60,6 +60,7 @@ import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepDialogInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.checksum.CheckSumMeta;
+import org.pentaho.di.ui.core.FormDataBuilder;
 import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.core.widget.ColumnInfo;
 import org.pentaho.di.ui.core.widget.TableView;
@@ -92,6 +93,8 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
   private Label wlOldChecksumBehaviour;
   private Button wOldChecksumBehaviour;
   private FormData fdlOldChecksumBehaviour, fdOldChecksumBehaviour;
+
+  private Text wFieldSeparatorString;
 
   private ColumnInfo[] colinf;
 
@@ -226,6 +229,16 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
     fdResult.right = new FormAttachment( 100, 0 );
     wResult.setLayoutData( fdResult );
 
+    Label lFieldSeparator = new Label( shell, SWT.RIGHT );
+    lFieldSeparator.setText( BaseMessages.getString( PKG, "CheckSumDialog.FieldSeparatorString.Label" ) );
+    props.setLook( lFieldSeparator );
+    lFieldSeparator.setLayoutData( new FormDataBuilder().left( 0, 0 ).right( middle, -margin ).top( wResult, margin * 2 ).result() );
+    wFieldSeparatorString = new Text( shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    props.setLook( wFieldSeparatorString );
+    wFieldSeparatorString.addModifyListener( lsMod );
+    wFieldSeparatorString.setLayoutData( new FormDataBuilder().left( middle, 0 ).top( wResult, margin * 2 ).right( 100, 0 ).result() );
+
+
     wOK = new Button( shell, SWT.PUSH );
     wOK.setText( BaseMessages.getString( PKG, "System.Button.OK" ) );
     wGet = new Button( shell, SWT.PUSH );
@@ -241,7 +254,7 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
     props.setLook( wlCompatibility );
     fdlCompatibility = new FormData();
     fdlCompatibility.left = new FormAttachment( 0, 0 );
-    fdlCompatibility.top = new FormAttachment( wResult, margin );
+    fdlCompatibility.top = new FormAttachment( wFieldSeparatorString, margin );
     fdlCompatibility.right = new FormAttachment( middle, -margin );
     wlCompatibility.setLayoutData( fdlCompatibility );
     wCompatibility = new Button( shell, SWT.CHECK );
@@ -249,7 +262,7 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
     props.setLook( wCompatibility );
     fdCompatibility = new FormData();
     fdCompatibility.left = new FormAttachment( middle, 0 );
-    fdCompatibility.top = new FormAttachment( wResult, margin );
+    fdCompatibility.top = new FormAttachment( wFieldSeparatorString, margin );
     fdCompatibility.right = new FormAttachment( 100, 0 );
     wCompatibility.setLayoutData( fdCompatibility );
     SelectionAdapter lsSelR = new SelectionAdapter() {
@@ -447,6 +460,9 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
     if ( input.getResultFieldName() != null ) {
       wResult.setText( input.getResultFieldName() );
     }
+    if ( input.getFieldSeparatorString() != null ) {
+      wFieldSeparatorString.setText( input.getFieldSeparatorString() );
+    }
     wResultType.setText( input.getResultTypeDesc( input.getResultType() ) );
     wCompatibility.setSelection( input.isCompatibilityMode() );
     wOldChecksumBehaviour.setSelection( input.isOldChecksumBehaviour() );
@@ -487,6 +503,7 @@ public class CheckSumDialog extends BaseStepDialog implements StepDialogInterfac
     }
 
     input.setResultFieldName( wResult.getText() );
+    input.setFieldSeparatorString( wFieldSeparatorString.getText() );
     input.setResultType( input.getResultTypeByDesc( wResultType.getText() ) );
 
     input.setCompatibilityMode( wCompatibility.getSelection() );

--- a/plugins/core/ui/src/main/resources/org/pentaho/di/ui/trans/steps/checksum/messages/messages_en_US.properties
+++ b/plugins/core/ui/src/main/resources/org/pentaho/di/ui/trans/steps/checksum/messages/messages_en_US.properties
@@ -12,6 +12,7 @@ CheckSumDialog.FailedToGetFields.DialogMessage=Error getting fields from previou
 CheckSumDialog.Fields.Label=Fields used in checksum
 CheckSumDialog.Fieldname.Column=Field
 CheckSumDialog.Result.Label=Result field
+CheckSumDialog.FieldSeparatorString.Label=Field separator string
 
 CheckSumDialog.ResultType.Label=Result type
 CheckSumDialog.ResultType.String=String


### PR DESCRIPTION
- Cleans up step processRow into single codepath
- Allows nulls to be in fields of New Behavior (does not update the digest)
- Added field separator option to step impl
- Added field separator option to step ui