### PR TITLE
[BACKLOG-27577] Centralize karaf dependencies management

### DIFF
--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -30,9 +30,6 @@
         <pentaho-hadoop-shims-api.version>8.3.0.0-SNAPSHOT</pentaho-hadoop-shims-api.version>
 
         <!-- third party -->
-        <org.apache.karaf.main.version>3.0.3</org.apache.karaf.main.version>
-        <org.apache.karaf.util.version>3.0.3</org.apache.karaf.util.version>
-        <org.apache.karaf.jaas.boot.version>2.4.2</org.apache.karaf.jaas.boot.version>
         <derby.version>10.2.1.6</derby.version>
         <derbyclient.version>10.2.1.6</derbyclient.version>
         <hsqldb.version>2.3.2</hsqldb.version>
@@ -340,7 +337,6 @@
         <dependency>
             <groupId>org.apache.karaf</groupId>
             <artifactId>org.apache.karaf.util</artifactId>
-            <version>${org.apache.karaf.util.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -351,7 +347,6 @@
         <dependency>
             <groupId>org.apache.karaf.jaas</groupId>
             <artifactId>org.apache.karaf.jaas.boot</artifactId>
-            <version>${org.apache.karaf.jaas.boot.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -29,9 +29,6 @@
     <pentaho-hadoop-shims-api.version>8.3.0.0-SNAPSHOT</pentaho-hadoop-shims-api.version>
 
     <!-- third party -->
-    <org.apache.karaf.main.version>3.0.3</org.apache.karaf.main.version>
-    <org.apache.karaf.util.version>3.0.3</org.apache.karaf.util.version>
-    <org.apache.karaf.jaas.boot.version>2.4.2</org.apache.karaf.jaas.boot.version>
     <derby.version>10.2.1.6</derby.version>
     <derbyclient.version>10.2.1.6</derbyclient.version>
     <hsqldb.version>2.3.2</hsqldb.version>
@@ -348,7 +345,6 @@
     <dependency>
       <groupId>org.apache.karaf</groupId>
       <artifactId>org.apache.karaf.util</artifactId>
-      <version>${org.apache.karaf.util.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -359,7 +355,6 @@
     <dependency>
       <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.boot</artifactId>
-      <version>${org.apache.karaf.jaas.boot.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,7 +42,6 @@
     <com.wcohen.secondstring.version>0.1</com.wcohen.secondstring.version>
     <javassist.version>3.20.0-GA</javassist.version>
     <jcifs.version>1.3.3</jcifs.version>
-    <org.apache.karaf.main.version>3.0.3</org.apache.karaf.main.version>
     <simple-jndi.version>1.0.2</simple-jndi.version>
     <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>
     <httpclient.version>4.5.3</httpclient.version>
@@ -454,17 +453,6 @@
       <groupId>org.samba.jcifs</groupId>
       <artifactId>jcifs</artifactId>
       <version>${jcifs.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.karaf</groupId>
-      <artifactId>org.apache.karaf.main</artifactId>
-      <version>${org.apache.karaf.main.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/plugins/engine-configuration/impl/pom.xml
+++ b/plugins/engine-configuration/impl/pom.xml
@@ -17,7 +17,6 @@
 
   <properties>
     <dependency.mockito.version>1.9.5</dependency.mockito.version>
-    <dependecy.karaf.version>3.0.3</dependecy.karaf.version>
   </properties>
 
   <dependencies>

--- a/plugins/file-open-save/pom.xml
+++ b/plugins/file-open-save/pom.xml
@@ -22,7 +22,6 @@
 
   <properties>
     <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>
-    <dependency.karaf.version>3.0.3</dependency.karaf.version>
     <version.for.license>${project.version}</version.for.license>
     <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
     <angular.version>1.5.8</angular.version>

--- a/plugins/get-fields/pom.xml
+++ b/plugins/get-fields/pom.xml
@@ -22,7 +22,6 @@
 
   <properties>
     <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>
-    <dependency.karaf.version>3.0.3</dependency.karaf.version>
     <version.for.license>${project.version}</version.for.license>
     <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
     <angular.version>1.5.8</angular.version>

--- a/plugins/repositories/core/pom.xml
+++ b/plugins/repositories/core/pom.xml
@@ -19,7 +19,6 @@
     <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
     <mockito-all.version>1.9.5</mockito-all.version>
-    <karaf.version>3.0.3</karaf.version>
     <json-simple.version>1.1</json-simple.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <commons-vfs2.version>2.2</commons-vfs2.version>
@@ -118,12 +117,6 @@
     <dependency>
       <groupId>org.ops4j.pax.web</groupId>
       <artifactId>pax-web-spi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.karaf.kar</groupId>
-      <artifactId>org.apache.karaf.kar.core</artifactId>
-      <version>${karaf.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
@graimundo and @Pancho7 please review.

Note that this targets pentaho:karaf_update, so wingman will not run. Our build pipeline will, when all related PRs are merged.

Needs [pentaho/maven-parent-poms#107](https://github.com/pentaho/maven-parent-poms/pull/107).