### PR TITLE
[PDI-17775] Process Files step no longer supports HTTP scheme

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,7 +29,6 @@
     <spring.framework.version>4.3.2.RELEASE</spring.framework.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <commons-io.version>2.2</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-pool.version>1.5.7</commons-pool.version>
@@ -45,7 +44,6 @@
     <org.apache.karaf.main.version>3.0.3</org.apache.karaf.main.version>
     <simple-jndi.version>1.0.2</simple-jndi.version>
     <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>
-    <httpclient.version>4.5.3</httpclient.version>
     <httpccore.version>4.4.6</httpccore.version>
     <xmlunit.version>1.5</xmlunit.version>
   </properties>

--- a/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,6 +28,7 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.cache.WeakRefFilesCache;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
@@ -70,6 +71,10 @@ public class KettleVFS {
 
   private KettleVFS() {
     fsm = new ConcurrentFileSystemManager();
+    // Forcibly overrides VFS's default StandardFileSystemManager with our Concurrent File System Manager, which will
+    // also allow us to point at our own providers.xml file, instead of the default file that comes with the
+    // commons-vfs2 library.
+    VFS.setManager( fsm );
     try {
       fsm.setFilesCache( new WeakRefFilesCache() );
       fsm.init();

--- a/core/src/main/resources/org/pentaho/di/core/vfs/providers.xml
+++ b/core/src/main/resources/org/pentaho/di/core/vfs/providers.xml
@@ -55,13 +55,11 @@
         <scheme name="ftps"/>
         <if-available class-name="org.apache.commons.net.ftp.FTPFile"/>
     </provider>
-    <provider class-name="org.apache.commons.vfs2.provider.http.HttpFileProvider">
+    <provider class-name="org.apache.commons.vfs2.provider.http4.Http4FileProvider">
         <scheme name="http"/>
-        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
     </provider>
-    <provider class-name="org.apache.commons.vfs2.provider.https.HttpsFileProvider">
+    <provider class-name="org.apache.commons.vfs2.provider.http4s.Http4sFileProvider">
         <scheme name="https"/>
-        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
     </provider>
 
     <!-- Custom Sftp provider -->

--- a/engine/src/test/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -387,7 +387,9 @@ public class TextFileInputTest {
   }
 
   private static void deleteVfsFile( String path ) throws Exception {
-    TestUtils.getFileObject( path ).delete();
+    FileObject fileObject = TestUtils.getFileObject( path );
+    fileObject.close();
+    fileObject.delete();
   }
 
   private static BaseFileField field( String name ) {

--- a/plugins/google-analytics/core/pom.xml
+++ b/plugins/google-analytics/core/pom.xml
@@ -18,7 +18,6 @@
 
   <properties>
     <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-logging.version>1.2</commons-logging.version>

--- a/plugins/gpload/pom.xml
+++ b/plugins/gpload/pom.xml
@@ -37,7 +37,6 @@
 
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>
     <mockito.version>1.9.5</mockito.version>
   </properties>

--- a/plugins/json/core/pom.xml
+++ b/plugins/json/core/pom.xml
@@ -19,7 +19,6 @@
     <pentaho-metaverse.version>8.3.0.0-SNAPSHOT</pentaho-metaverse.version>
     <platform.version>8.3.0.0-SNAPSHOT</platform.version>
     <commons.io.version>1.4</commons.io.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
     <encoder.version>1.2</encoder.version>

--- a/plugins/openerp/pom.xml
+++ b/plugins/openerp/pom.xml
@@ -38,7 +38,6 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <junit.version>4.7</junit.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>
     <mockito.version>1.9.5</mockito.version>
     <openerp-java-api.version>1.3.0</openerp-java-api.version>

--- a/plugins/pentaho-googledrive-vfs/core/pom.xml
+++ b/plugins/pentaho-googledrive-vfs/core/pom.xml
@@ -18,7 +18,6 @@
         <project.http.version>1.22.0</project.http.version>
         <project.oauth.version>1.22.0</project.oauth.version>
         <!--project.build.sourceEncoding>UTF-8</project.build.sourceEncoding-->
-        <project.commons-vfs2.version>2.2</project.commons-vfs2.version>
         <project.junit.version>4.4</project.junit.version>
         <project.mockito.version>1.8.4</project.mockito.version>
         <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>
@@ -61,7 +60,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-vfs2</artifactId>
-            <version>${project.commons-vfs2.version}</version>
+            <version>${commons-vfs2.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/plugins/repositories/core/pom.xml
+++ b/plugins/repositories/core/pom.xml
@@ -22,7 +22,6 @@
     <karaf.version>3.0.3</karaf.version>
     <json-simple.version>1.1</json-simple.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <eclipse.version>3.6.0</eclipse.version>
     <junit.version>4.11</junit.version>
     <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
@@ -183,12 +182,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-vfs2</artifactId>
-      <version>${commons-vfs2.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,12 @@
     <!-- Third-party dependencies -->
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <js.version>1.7R3</js.version>
-    <httpclient.version>4.5.3</httpclient.version>
+    <httpclient.version>4.5.4</httpclient.version>
     <httpccore.version>4.4.6</httpccore.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
     <commons-logging.version>1.1.3</commons-logging.version>
+    <commons-vfs2.version>2.3</commons-vfs2.version>
     <guava.version>17.0</guava.version>
     <encoder.version>1.2</encoder.version>
     <h2.version>1.2.131</h2.version>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @ssamora @wseyler 

* [PDI-17775] Updated providers to point to new HTTP 4 scheme.
* [PDI-17775] Updated poms to use the new commons-vfs2 and httpclient dependencies.
* [PDI-17775] Updated KettleVFS to force set the VFS Manager, so we use our own instead of the default stored in the commons-vfs2 dependency.
* [PDI-17775] Fixing test issues with upgrade

This is a multi-pull request:
- #6316 
- pentaho/pentaho-osgi-bundles#315

