### PR TITLE
[CLEANUP] Use POJO from Pan and Kitchen to call it's corresponding CommandExecutors

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/IParams.java
+++ b/engine/src/main/java/org/pentaho/di/base/IParams.java
@@ -29,190 +29,189 @@ import java.util.Map;
 
 public interface IParams extends Serializable {
 
-    /**
-     * @return uuid uniquely identifies an execution request
-     */
-    String getUuid();
+  /**
+   * @return uuid uniquely identifies an execution request
+   */
+  String getUuid();
 
-    /**
-     * @return repoName Enterprise or database repository name, if you are using one
-     */
-    String getRepoName();
+  /**
+   * @return repoName Enterprise or database repository name, if you are using one
+   */
+  String getRepoName();
 
-    /**
-     * @return blockRepoConns Prevents from logging into a repository. If you have set the KETTLE_REPOSITORY, KETTLE_USER,
-     * and KETTLE_PASSWORD environment variables, then this option will enable you to prevent from logging into the
-     * specified repository, assuming you would like to execute a local KTR file instead.
-     */
-    String getBlockRepoConns();
-
-
-    /**
-     * @return repoUsername Repository username
-     */
-    String getRepoUsername();
-
-    /**
-     * @return trustRepoUser Trust the repository username passed along ( i.e. no password required )
-     */
-    String getTrustRepoUser();
-
-    /**
-     * @return repoPassword Repository password
-     */
-    String getRepoPassword();
+  /**
+   * @return blockRepoConns Prevents from logging into a repository. If you have set the KETTLE_REPOSITORY, KETTLE_USER,
+   * and KETTLE_PASSWORD environment variables, then this option will enable you to prevent from logging into the
+   * specified repository, assuming you would like to execute a local KTR file instead.
+   */
+  String getBlockRepoConns();
 
 
-    /**
-     * @return inputDir The directory that contains the file, including the leading slash
-     */
-    String getInputDir();
+  /**
+   * @return repoUsername Repository username
+   */
+  String getRepoUsername();
+
+  /**
+   * @return trustRepoUser Trust the repository username passed along ( i.e. no password required )
+   */
+  String getTrustRepoUser();
+
+  /**
+   * @return repoPassword Repository password
+   */
+  String getRepoPassword();
 
 
-    /**
-     * @return localFile If you are calling a local file, this is the filename, including the path if it is not
-     * in the local directory
-     */
-    String getLocalFile();
+  /**
+   * @return inputDir The directory that contains the file, including the leading slash
+   */
+  String getInputDir();
 
 
-    /**
-     * @return localJarFile If you are calling a file within a local jar file, this is the filename, including the path if
-     * it is not in the local directory
-     */
-    String getLocalJarFile();
+  /**
+   * @return localFile If you are calling a local file, this is the filename, including the path if it is not
+   * in the local directory
+   */
+  String getLocalFile();
 
 
-    /**
-     * @return inputFile The name of the file to launch
-     */
-    String getInputFile();
+  /**
+   * @return localJarFile If you are calling a file within a local jar file, this is the filename, including the path if
+   * it is not in the local directory
+   */
+  String getLocalJarFile();
 
 
-    /**
-     * @return listRepoFiles Lists the transformations in the specified repository directory
-     */
-    String getListRepoFiles();
+  /**
+   * @return inputFile The name of the file to launch
+   */
+  String getInputFile();
 
 
-    /**
-     * @return listDirs Lists the directories in the specified repository
-     */
-    String getListRepoDirs();
+  /**
+   * @return listRepoFiles Lists the transformations in the specified repository directory
+   */
+  String getListRepoFiles();
 
 
-    /**
-     * @return exportRepo Exports all repository objects to one XML file
-     */
-    String getExportRepo();
+  /**
+   * @return listDirs Lists the directories in the specified repository
+   */
+  String getListRepoDirs();
 
 
-    /**
-     * @return localInitialDir if local filename starts with scheme like zip:, then you can pass along the initial dir to it
-     */
-    String getLocalInitialDir();
+  /**
+   * @return exportRepo Exports all repository objects to one XML file
+   */
+  String getExportRepo();
 
 
-    /**
-     * @return listRepos Lists the available repositories
-     */
-    String getListRepos();
+  /**
+   * @return localInitialDir if local filename starts with scheme like zip:, then you can pass along the initial dir to it
+   */
+  String getLocalInitialDir();
 
 
-    /**
-     * @return safeMode Runs in safe mode, which enables extra checking
-     */
-    String getSafeMode();
+  /**
+   * @return listRepos Lists the available repositories
+   */
+  String getListRepos();
 
 
-    /**
-     * @return metrics Enables kettle metric gathering
-     */
-    String getMetrics();
+  /**
+   * @return safeMode Runs in safe mode, which enables extra checking
+   */
+  String getSafeMode();
 
 
-    /**
-     * @return listFileParams List information about the defined named parameters in the specified file.
-     */
-    String getListFileParams();
+  /**
+   * @return metrics Enables kettle metric gathering
+   */
+  String getMetrics();
 
 
-    /**
-     * @return logLevel The logging level (Basic, Detailed, Debug, Rowlevel, Error, Nothing)
-     */
-    String getLogLevel();
+  /**
+   * @return listFileParams List information about the defined named parameters in the specified file.
+   */
+  String getListFileParams();
 
 
-    /**
-     * @return maxLogLines The maximum number of log lines that are kept internally by PDI.
-     * Set to 0 to keep all rows (default)
-     */
-    String getMaxLogLines();
+  /**
+   * @return logLevel The logging level (Basic, Detailed, Debug, Rowlevel, Error, Nothing)
+   */
+  String getLogLevel();
 
 
-    /**
-     * @return maxLogTimeout The maximum age (in minutes) of a log line while being kept internally by PDI.
-     * Set to 0 to keep all rows indefinitely (default)
-     */
-    String getMaxLogTimeout();
+  /**
+   * @return maxLogLines The maximum number of log lines that are kept internally by PDI.
+   * Set to 0 to keep all rows (default)
+   */
+  String getMaxLogLines();
 
 
-    /**
-     * @return logFile A local filename to write log output to
-     */
-    String getLogFile();
+  /**
+   * @return maxLogTimeout The maximum age (in minutes) of a log line while being kept internally by PDI.
+   * Set to 0 to keep all rows indefinitely (default)
+   */
+  String getMaxLogTimeout();
 
 
-    /**
-     * @return oldLogFile if the old style of logging name is filled in, and the new one is not, overwrite the new by the old
-     */
-    String getOldLogFile();
+  /**
+   * @return logFile A local filename to write log output to
+   */
+  String getLogFile();
 
 
-    /**
-     * @return version Shows the version, revision, and build date
-     */
-    String getVersion();
+  /**
+   * @return oldLogFile if the old style of logging name is filled in, and the new one is not, overwrite the new by the old
+   */
+  String getOldLogFile();
 
 
-    /**
-     * @return the step name from which we want the result set
-     */
-    String getResultSetStepName();
+  /**
+   * @return version Shows the version, revision, and build date
+   */
+  String getVersion();
 
 
-    /**
-     * @return the step copy number from which we want the result set
-     */
-    String getResultSetCopyNumber();
+  /**
+   * @return the step name from which we want the result set
+   */
+  String getResultSetStepName();
+
+  /**
+    * @return the step copy number from which we want the result set
+   */
+  String getResultSetCopyNumber();
 
 
-    /**
-     * @return params parameters to be passed into the executing file
-     */
-    Map<String, String> getParams();
+  /**
+   * @return params parameters to be passed into the executing file
+   */
+  Map<String, String> getParams();
 
 
-    /**
-     * @return namedParams parameters to be passed into the executing file
-     */
-    NamedParams getNamedParams();
+  /**
+   * @return namedParams parameters to be passed into the executing file
+   */
+  NamedParams getNamedParams();
 
 
-    /**
-     * @return customParams parameters to be passed into the executing file
-     */
-    Map<String, String> getCustomParams();
+  /**
+   * @return customParams parameters to be passed into the executing file
+   */
+  Map<String, String> getCustomParams();
 
 
-    /**
-     * @return namedParams custom parameters to be passed into the executing file
-     */
-    NamedParams getCustomNamedParams();
+  /**
+   * @return namedParams custom parameters to be passed into the executing file
+   */
+  NamedParams getCustomNamedParams();
 
-    /**
-     *
-     * @return a Map<String, String> with the param name and its value
-     */
-    Map<String, String> asMap();
+  /**
+   *
+   * @return a Map<String, String> with the param name and its value
+   */
+  Map<String, String> asMap();
 }

--- a/engine/src/main/java/org/pentaho/di/base/IParams.java
+++ b/engine/src/main/java/org/pentaho/di/base/IParams.java
@@ -1,0 +1,218 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.base;
+
+import org.pentaho.di.core.parameters.NamedParams;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public interface IParams extends Serializable {
+
+    /**
+     * @return uuid uniquely identifies an execution request
+     */
+    String getUuid();
+
+    /**
+     * @return repoName Enterprise or database repository name, if you are using one
+     */
+    String getRepoName();
+
+    /**
+     * @return blockRepoConns Prevents from logging into a repository. If you have set the KETTLE_REPOSITORY, KETTLE_USER,
+     * and KETTLE_PASSWORD environment variables, then this option will enable you to prevent from logging into the
+     * specified repository, assuming you would like to execute a local KTR file instead.
+     */
+    String getBlockRepoConns();
+
+
+    /**
+     * @return repoUsername Repository username
+     */
+    String getRepoUsername();
+
+    /**
+     * @return trustRepoUser Trust the repository username passed along ( i.e. no password required )
+     */
+    String getTrustRepoUser();
+
+    /**
+     * @return repoPassword Repository password
+     */
+    String getRepoPassword();
+
+
+    /**
+     * @return inputDir The directory that contains the file, including the leading slash
+     */
+    String getInputDir();
+
+
+    /**
+     * @return localFile If you are calling a local file, this is the filename, including the path if it is not
+     * in the local directory
+     */
+    String getLocalFile();
+
+
+    /**
+     * @return localJarFile If you are calling a file within a local jar file, this is the filename, including the path if
+     * it is not in the local directory
+     */
+    String getLocalJarFile();
+
+
+    /**
+     * @return inputFile The name of the file to launch
+     */
+    String getInputFile();
+
+
+    /**
+     * @return listRepoFiles Lists the transformations in the specified repository directory
+     */
+    String getListRepoFiles();
+
+
+    /**
+     * @return listDirs Lists the directories in the specified repository
+     */
+    String getListRepoDirs();
+
+
+    /**
+     * @return exportRepo Exports all repository objects to one XML file
+     */
+    String getExportRepo();
+
+
+    /**
+     * @return localInitialDir if local filename starts with scheme like zip:, then you can pass along the initial dir to it
+     */
+    String getLocalInitialDir();
+
+
+    /**
+     * @return listRepos Lists the available repositories
+     */
+    String getListRepos();
+
+
+    /**
+     * @return safeMode Runs in safe mode, which enables extra checking
+     */
+    String getSafeMode();
+
+
+    /**
+     * @return metrics Enables kettle metric gathering
+     */
+    String getMetrics();
+
+
+    /**
+     * @return listFileParams List information about the defined named parameters in the specified file.
+     */
+    String getListFileParams();
+
+
+    /**
+     * @return logLevel The logging level (Basic, Detailed, Debug, Rowlevel, Error, Nothing)
+     */
+    String getLogLevel();
+
+
+    /**
+     * @return maxLogLines The maximum number of log lines that are kept internally by PDI.
+     * Set to 0 to keep all rows (default)
+     */
+    String getMaxLogLines();
+
+
+    /**
+     * @return maxLogTimeout The maximum age (in minutes) of a log line while being kept internally by PDI.
+     * Set to 0 to keep all rows indefinitely (default)
+     */
+    String getMaxLogTimeout();
+
+
+    /**
+     * @return logFile A local filename to write log output to
+     */
+    String getLogFile();
+
+
+    /**
+     * @return oldLogFile if the old style of logging name is filled in, and the new one is not, overwrite the new by the old
+     */
+    String getOldLogFile();
+
+
+    /**
+     * @return version Shows the version, revision, and build date
+     */
+    String getVersion();
+
+
+    /**
+     * @return the step name from which we want the result set
+     */
+    String getResultSetStepName();
+
+
+    /**
+     * @return the step copy number from which we want the result set
+     */
+    String getResultSetCopyNumber();
+
+
+    /**
+     * @return params parameters to be passed into the executing file
+     */
+    Map<String, String> getParams();
+
+
+    /**
+     * @return namedParams parameters to be passed into the executing file
+     */
+    NamedParams getNamedParams();
+
+
+    /**
+     * @return customParams parameters to be passed into the executing file
+     */
+    Map<String, String> getCustomParams();
+
+
+    /**
+     * @return namedParams custom parameters to be passed into the executing file
+     */
+    NamedParams getCustomNamedParams();
+
+    /**
+     *
+     * @return a Map<String, String> with the param name and its value
+     */
+    Map<String, String> asMap();
+}

--- a/engine/src/main/java/org/pentaho/di/base/KettleConstants.java
+++ b/engine/src/main/java/org/pentaho/di/base/KettleConstants.java
@@ -24,41 +24,41 @@ package org.pentaho.di.base;
 
 public class KettleConstants {
 
-    /**
-     * See
-     * @link https://help.pentaho.com/Documentation/8.0/Products/Data_Integration/Command_Line_Tools#Pan_Options_and_Syntax
-     * @link https://help.pentaho.com/Documentation/8.0/Products/Data_Integration/Command_Line_Tools#Kitchen_Options_and_Syntax
-     */
+  /**
+   * See
+   * @link https://help.pentaho.com/Documentation/8.0/Products/Data_Integration/Command_Line_Tools#Pan_Options_and_Syntax
+   * @link https://help.pentaho.com/Documentation/8.0/Products/Data_Integration/Command_Line_Tools#Kitchen_Options_and_Syntax
+   */
 
-    public static final String LOG = "log";
-    public static final String DIR = "dir";
-    public static final String JOB = "job";
-    public static final String REPO = "rep";
-    public static final String FILE = "file";
-    public static final String USER = "user";
-    public static final String PASS = "pass";
-    public static final String LEVEL = "level";
-    public static final String TRANS = "trans";
-    public static final String PARAM = "param";
-    public static final String NO_REPO = "norep";
-    public static final String CUSTOM = "custom";
-    public static final String VERSION = "version";
-    public static final String JARFILE = "jarFile";
-    public static final String METRICS = "metrics";
-    public static final String LOGFILE = "logfile";
-    public static final String SAFEMODE = "safemode";
-    public static final String LIST_JOBS = "listjob";
-    public static final String LIST_DIRS = "listdir";
-    public static final String LIST_REPOS = "listrep";
-    public static final String TRUST_USER = "trustuser";
-    public static final String LIST_TRANS = "listtrans";
-    public static final String LIST_PARAMS = "listparam";
-    public static final String EXPORT_REPO_JOB = "export";
-    public static final String INITIAL_DIR = "initialDir";
-    public static final String EXPORT_REPO_TRANS = "exprep";
-    public static final String MAX_LOG_LINES = "maxloglines";
-    public static final String MAX_LOG_TIMEOUT = "maxlogtimeout";
-    public static final String RESULT_SET_STEP_NAME = "stepname";
-    public static final String RESULT_SET_COPY_NUMBER = "copynum";
+  public static final String LOG = "log";
+  public static final String DIR = "dir";
+  public static final String JOB = "job";
+  public static final String REPO = "rep";
+  public static final String FILE = "file";
+  public static final String USER = "user";
+  public static final String PASS = "pass";
+  public static final String LEVEL = "level";
+  public static final String TRANS = "trans";
+  public static final String PARAM = "param";
+  public static final String NO_REPO = "norep";
+  public static final String CUSTOM = "custom";
+  public static final String VERSION = "version";
+  public static final String JARFILE = "jarFile";
+  public static final String METRICS = "metrics";
+  public static final String LOGFILE = "logfile";
+  public static final String SAFEMODE = "safemode";
+  public static final String LIST_JOBS = "listjob";
+  public static final String LIST_DIRS = "listdir";
+  public static final String LIST_REPOS = "listrep";
+  public static final String TRUST_USER = "trustuser";
+  public static final String LIST_TRANS = "listtrans";
+  public static final String LIST_PARAMS = "listparam";
+  public static final String EXPORT_REPO_JOB = "export";
+  public static final String INITIAL_DIR = "initialDir";
+  public static final String EXPORT_REPO_TRANS = "exprep";
+  public static final String MAX_LOG_LINES = "maxloglines";
+  public static final String MAX_LOG_TIMEOUT = "maxlogtimeout";
+  public static final String RESULT_SET_STEP_NAME = "stepname";
+  public static final String RESULT_SET_COPY_NUMBER = "copynum";
 
 }

--- a/engine/src/main/java/org/pentaho/di/base/KettleConstants.java
+++ b/engine/src/main/java/org/pentaho/di/base/KettleConstants.java
@@ -1,0 +1,64 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.base;
+
+public class KettleConstants {
+
+    /**
+     * See
+     * @link https://help.pentaho.com/Documentation/8.0/Products/Data_Integration/Command_Line_Tools#Pan_Options_and_Syntax
+     * @link https://help.pentaho.com/Documentation/8.0/Products/Data_Integration/Command_Line_Tools#Kitchen_Options_and_Syntax
+     */
+
+    public static final String LOG = "log";
+    public static final String DIR = "dir";
+    public static final String JOB = "job";
+    public static final String REPO = "rep";
+    public static final String FILE = "file";
+    public static final String USER = "user";
+    public static final String PASS = "pass";
+    public static final String LEVEL = "level";
+    public static final String TRANS = "trans";
+    public static final String PARAM = "param";
+    public static final String NO_REPO = "norep";
+    public static final String CUSTOM = "custom";
+    public static final String VERSION = "version";
+    public static final String JARFILE = "jarFile";
+    public static final String METRICS = "metrics";
+    public static final String LOGFILE = "logfile";
+    public static final String SAFEMODE = "safemode";
+    public static final String LIST_JOBS = "listjob";
+    public static final String LIST_DIRS = "listdir";
+    public static final String LIST_REPOS = "listrep";
+    public static final String TRUST_USER = "trustuser";
+    public static final String LIST_TRANS = "listtrans";
+    public static final String LIST_PARAMS = "listparam";
+    public static final String EXPORT_REPO_JOB = "export";
+    public static final String INITIAL_DIR = "initialDir";
+    public static final String EXPORT_REPO_TRANS = "exprep";
+    public static final String MAX_LOG_LINES = "maxloglines";
+    public static final String MAX_LOG_TIMEOUT = "maxlogtimeout";
+    public static final String RESULT_SET_STEP_NAME = "stepname";
+    public static final String RESULT_SET_COPY_NUMBER = "copynum";
+
+}

--- a/engine/src/main/java/org/pentaho/di/base/Params.java
+++ b/engine/src/main/java/org/pentaho/di/base/Params.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.di.base;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.pentaho.di.core.parameters.NamedParams;
 import org.pentaho.di.core.parameters.UnknownParamException;
@@ -33,361 +32,361 @@ import java.util.HashMap;
 
 public abstract class Params implements IParams {
 
-    private String uuid;
-    private String repoName;
-    private String blockRepoConns;
-    private String repoUsername;
-    private String trustRepoUser;
-    private String repoPassword;
-    private String inputDir;
-    private String inputFile;
-    private String listRepoFiles;
-    private String listRepoDirs;
-    private String exportRepo;
-    private String localFile;
-    private String localJarFile;
-    private String localInitialDir;
-    private String listRepos;
-    private String safeMode;
-    private String metrics;
-    private String listFileParams;
-    private String logLevel;
-    private String maxLogLines;
-    private String maxLogTimeout;
-    private String logFile;
-    private String oldLogFile;
-    private String version;
-    private String resultSetStepName;
-    private String resultSetCopyNumber;
-    private NamedParams namedParams;
-    private NamedParams customNamedParams;
+  private String uuid;
+  private String repoName;
+  private String blockRepoConns;
+  private String repoUsername;
+  private String trustRepoUser;
+  private String repoPassword;
+  private String inputDir;
+  private String inputFile;
+  private String listRepoFiles;
+  private String listRepoDirs;
+  private String exportRepo;
+  private String localFile;
+  private String localJarFile;
+  private String localInitialDir;
+  private String listRepos;
+  private String safeMode;
+  private String metrics;
+  private String listFileParams;
+  private String logLevel;
+  private String maxLogLines;
+  private String maxLogTimeout;
+  private String logFile;
+  private String oldLogFile;
+  private String version;
+  private String resultSetStepName;
+  private String resultSetCopyNumber;
+  private NamedParams namedParams;
+  private NamedParams customNamedParams;
 
-    public Params( String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
+  public Params( String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
                    String inputFile, String listRepoFiles, String listRepoDirs, String exportRepo, String localFile,
                    String localJarFile, String localInitialDir, String listRepos, String safeMode, String metrics,
                    String listFileParams, String logLevel, String maxLogLines, String maxLogTimeout, String logFile,
                    String oldLogFile, String version, String resultSetStepName, String resultSetCopyNumber, NamedParams params,
                    NamedParams customNamedParams ) {
 
-        setUuid( java.util.UUID.randomUUID().toString() );
+    setUuid( java.util.UUID.randomUUID().toString() );
 
-        setBlockRepoConns( blockRepoConns );
-        setRepoName( repoName );
-        setRepoUsername( repoUsername );
-        setTrustRepoUser( trustRepoUser );
-        setRepoPassword( repoPassword );
-        setInputDir( inputDir );
-        setInputFile( inputFile );
-        setListRepoFiles( listRepoFiles );
-        setListRepoDirs( listRepoDirs );
-        setExportRepo( exportRepo );
-        setLocalFile( localFile );
-        setLocalJarFile( localJarFile );
-        setLocalInitialDir( localInitialDir );
-        setListRepos( listRepos );
-        setSafeMode( safeMode );
-        setMetrics( metrics );
-        setListFileParams( listFileParams );
-        setLogLevel( logLevel );
-        setMaxLogLines( maxLogLines );
-        setMaxLogTimeout( maxLogTimeout );
-        setLogFile( logFile );
-        setOldLogFile( oldLogFile );
-        setVersion( version );
-        setResultSetStepName( resultSetStepName );
-        setResultSetCopyNumber( NumberUtils.isNumber( resultSetCopyNumber ) ? resultSetCopyNumber : "0" /* default */ );
-        setNamedParams( params );
-        setNamedCustomParams( customNamedParams );
+    setBlockRepoConns( blockRepoConns );
+    setRepoName( repoName );
+    setRepoUsername( repoUsername );
+    setTrustRepoUser( trustRepoUser );
+    setRepoPassword( repoPassword );
+    setInputDir( inputDir );
+    setInputFile( inputFile );
+    setListRepoFiles( listRepoFiles );
+    setListRepoDirs( listRepoDirs );
+    setExportRepo( exportRepo );
+    setLocalFile( localFile );
+    setLocalJarFile( localJarFile );
+    setLocalInitialDir( localInitialDir );
+    setListRepos( listRepos );
+    setSafeMode( safeMode );
+    setMetrics( metrics );
+    setListFileParams( listFileParams );
+    setLogLevel( logLevel );
+    setMaxLogLines( maxLogLines );
+    setMaxLogTimeout( maxLogTimeout );
+    setLogFile( logFile );
+    setOldLogFile( oldLogFile );
+    setVersion( version );
+    setResultSetStepName( resultSetStepName );
+    setResultSetCopyNumber( NumberUtils.isNumber( resultSetCopyNumber ) ? resultSetCopyNumber : "0" /* default */ );
+    setNamedParams( params );
+    setNamedCustomParams( customNamedParams );
+  }
+
+  @Override
+  public abstract Map<String, String> asMap();
+
+  @Override
+  public String getUuid() {
+    return uuid;
+  }
+
+  public void setUuid( String uuid ) {
+    this.uuid = uuid;
+  }
+
+  @Override
+  public String getRepoName() {
+    return repoName;
+  }
+
+  public void setRepoName( String repoName ) {
+    this.repoName = repoName;
+  }
+
+  @Override
+  public String getBlockRepoConns() {
+    return blockRepoConns;
+  }
+
+  public void setBlockRepoConns( String blockRepoConns ) {
+    this.blockRepoConns = blockRepoConns;
+  }
+
+  @Override
+  public String getRepoUsername() {
+    return repoUsername;
+  }
+
+  public void setRepoUsername( String repoUsername ) {
+    this.repoUsername = repoUsername;
+  }
+
+  @Override
+  public String getTrustRepoUser() {
+    return trustRepoUser;
+  }
+
+  public void setTrustRepoUser( String trustRepoUser ) {
+    this.trustRepoUser = trustRepoUser;
+  }
+
+  @Override
+  public String getRepoPassword() {
+    return repoPassword;
+  }
+
+  public void setRepoPassword( String repoPassword ) {
+    this.repoPassword = repoPassword;
+  }
+
+  @Override
+  public String getInputDir() {
+    return inputDir;
+  }
+
+  public void setInputDir( String inputDir ) {
+    this.inputDir = inputDir;
+  }
+
+  public String getLocalFile() {
+    return localFile;
+  }
+
+  public void setLocalFile( String localFile ) {
+    this.localFile = localFile;
+  }
+
+  @Override
+  public String getLocalJarFile() {
+    return localJarFile;
+  }
+
+  public void setLocalJarFile( String localJarFile ) {
+    this.localJarFile = localJarFile;
+  }
+
+  @Override
+  public String getInputFile() {
+    return inputFile;
+  }
+
+  public void setInputFile( String inputFile ) {
+    this.inputFile = inputFile;
+  }
+
+  @Override
+  public String getListRepoFiles() {
+    return listRepoFiles;
+  }
+
+  public void setListRepoFiles( String listRepoFiles ) {
+    this.listRepoFiles = listRepoFiles;
+  }
+
+  @Override
+  public String getListRepoDirs() {
+    return listRepoDirs;
+  }
+
+  public void setListRepoDirs( String listRepoDirs ) {
+    this.listRepoDirs = listRepoDirs;
+  }
+
+  @Override
+  public String getExportRepo() {
+    return exportRepo;
+  }
+
+  public void setExportRepo( String exportRepo ) {
+    this.exportRepo = exportRepo;
+  }
+
+  @Override
+  public String getLocalInitialDir() {
+    return localInitialDir;
+  }
+
+  public void setLocalInitialDir( String localInitialDir ) {
+    this.localInitialDir = localInitialDir;
+  }
+
+  @Override
+  public String getListRepos() {
+    return listRepos;
+  }
+
+  public void setListRepos( String listRepos ) {
+    this.listRepos = listRepos;
+  }
+
+  @Override
+  public String getSafeMode() {
+    return safeMode;
+  }
+
+  public void setSafeMode( String safeMode ) {
+    this.safeMode = safeMode;
+  }
+
+  @Override
+  public String getMetrics() {
+    return metrics;
+  }
+
+  public void setMetrics( String metrics ) {
+    this.metrics = metrics;
+  }
+
+  public String getListFileParams() {
+    return listFileParams;
+  }
+
+  public void setListFileParams( String listFileParams ) {
+    this.listFileParams = listFileParams;
+  }
+
+  @Override
+  public String getLogLevel() {
+    return logLevel;
+  }
+
+  public void setLogLevel( String logLevel ) {
+    this.logLevel = logLevel;
+  }
+
+  @Override
+  public String getMaxLogLines() {
+    return maxLogLines;
+  }
+
+  public void setMaxLogLines( String maxLogLines ) {
+    this.maxLogLines = maxLogLines;
+  }
+
+  @Override
+  public String getMaxLogTimeout() {
+    return maxLogTimeout;
+  }
+
+  public void setMaxLogTimeout( String maxLogTimeout ) {
+    this.maxLogTimeout = maxLogTimeout;
+  }
+
+  @Override
+  public String getLogFile() {
+    return logFile;
+  }
+
+  public void setLogFile( String logFile ) {
+    this.logFile = logFile;
+  }
+
+  @Override
+  public String getOldLogFile() {
+    return oldLogFile;
+  }
+
+  public void setOldLogFile( String oldLogFile ) {
+    this.oldLogFile = oldLogFile;
+  }
+
+  @Override
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion( String version ) {
+    this.version = version;
+  }
+
+  @Override
+  public String getResultSetStepName() {
+    return resultSetStepName;
+  }
+
+  public void setResultSetStepName( String resultSetStepName ) {
+    this.resultSetStepName = resultSetStepName;
+  }
+
+  @Override
+  public String getResultSetCopyNumber() {
+    return resultSetCopyNumber;
+  }
+
+  public void setResultSetCopyNumber( String resultSetCopyNumber ) {
+    this.resultSetCopyNumber = resultSetCopyNumber;
+  }
+
+  @Override
+  public NamedParams getNamedParams() {
+    return namedParams;
+  }
+
+  public void setNamedParams( NamedParams params ) {
+    this.namedParams = params;
+  }
+
+  @Override
+  public Map<String, String> getParams() {
+    if ( this.namedParams == null ) {
+      return Collections.EMPTY_MAP;
     }
 
-    @Override
-    public abstract Map<String, String> asMap();
+    Map<String, String> params = new HashMap<String, String>();
 
-    @Override
-    public String getUuid() {
-        return uuid;
+    for ( String key : this.namedParams.listParameters() ) {
+      try {
+        params.put( key, this.namedParams.getParameterValue( key ) );
+      } catch ( UnknownParamException e ) {
+        /* no-op */
+      }
     }
 
-    public void setUuid( String uuid ) {
-        this.uuid = uuid;
+    return params;
+  }
+
+  @Override
+  public NamedParams getCustomNamedParams() {
+    return customNamedParams;
+  }
+
+  public void setNamedCustomParams( NamedParams customParams ) {
+    this.customNamedParams = customParams;
+  }
+
+  @Override
+  public Map<String, String> getCustomParams() {
+    if ( this.customNamedParams == null ) {
+      return Collections.EMPTY_MAP;
     }
 
-    @Override
-    public String getRepoName() {
-        return repoName;
+    Map<String, String> customParams = new HashMap<String, String>();
+
+    for ( String key : this.customNamedParams.listParameters() ) {
+      try {
+        customParams.put( key, this.customNamedParams.getParameterValue( key ) );
+      } catch ( UnknownParamException e ) {
+        /* no-op */
+      }
     }
 
-    public void setRepoName( String repoName ) {
-        this.repoName = repoName;
-    }
-
-    @Override
-    public String getBlockRepoConns() {
-        return blockRepoConns;
-    }
-
-    public void setBlockRepoConns( String blockRepoConns ) {
-        this.blockRepoConns = blockRepoConns;
-    }
-
-    @Override
-    public String getRepoUsername() {
-        return repoUsername;
-    }
-
-    public void setRepoUsername( String repoUsername ) {
-        this.repoUsername = repoUsername;
-    }
-
-    @Override
-    public String getTrustRepoUser() {
-        return trustRepoUser;
-    }
-
-    public void setTrustRepoUser( String trustRepoUser ) {
-        this.trustRepoUser = trustRepoUser;
-    }
-
-    @Override
-    public String getRepoPassword() {
-        return repoPassword;
-    }
-
-    public void setRepoPassword( String repoPassword ) {
-        this.repoPassword = repoPassword;
-    }
-
-    @Override
-    public String getInputDir() {
-        return inputDir;
-    }
-
-    public void setInputDir( String inputDir ) {
-        this.inputDir = inputDir;
-    }
-
-    public String getLocalFile() {
-        return localFile;
-    }
-
-    public void setLocalFile( String localFile ) {
-        this.localFile = localFile;
-    }
-
-    @Override
-    public String getLocalJarFile() {
-        return localJarFile;
-    }
-
-    public void setLocalJarFile( String localJarFile ) {
-        this.localJarFile = localJarFile;
-    }
-
-    @Override
-    public String getInputFile() {
-        return inputFile;
-    }
-
-    public void setInputFile( String inputFile ) {
-        this.inputFile = inputFile;
-    }
-
-    @Override
-    public String getListRepoFiles() {
-        return listRepoFiles;
-    }
-
-    public void setListRepoFiles( String listRepoFiles ) {
-        this.listRepoFiles = listRepoFiles;
-    }
-
-    @Override
-    public String getListRepoDirs() {
-        return listRepoDirs;
-    }
-
-    public void setListRepoDirs( String listRepoDirs ) {
-        this.listRepoDirs = listRepoDirs;
-    }
-
-    @Override
-    public String getExportRepo() {
-        return exportRepo;
-    }
-
-    public void setExportRepo( String exportRepo ) {
-        this.exportRepo = exportRepo;
-    }
-
-    @Override
-    public String getLocalInitialDir() {
-        return localInitialDir;
-    }
-
-    public void setLocalInitialDir( String localInitialDir ) {
-        this.localInitialDir = localInitialDir;
-    }
-
-    @Override
-    public String getListRepos() {
-        return listRepos;
-    }
-
-    public void setListRepos( String listRepos ) {
-        this.listRepos = listRepos;
-    }
-
-    @Override
-    public String getSafeMode() {
-        return safeMode;
-    }
-
-    public void setSafeMode( String safeMode ) {
-        this.safeMode = safeMode;
-    }
-
-    @Override
-    public String getMetrics() {
-        return metrics;
-    }
-
-    public void setMetrics( String metrics ) {
-        this.metrics = metrics;
-    }
-
-    public String getListFileParams() {
-        return listFileParams;
-    }
-
-    public void setListFileParams( String listFileParams ) {
-        this.listFileParams = listFileParams;
-    }
-
-    @Override
-    public String getLogLevel() {
-        return logLevel;
-    }
-
-    public void setLogLevel( String logLevel ) {
-        this.logLevel = logLevel;
-    }
-
-    @Override
-    public String getMaxLogLines() {
-        return maxLogLines;
-    }
-
-    public void setMaxLogLines( String maxLogLines ) {
-        this.maxLogLines = maxLogLines;
-    }
-
-    @Override
-    public String getMaxLogTimeout() {
-        return maxLogTimeout;
-    }
-
-    public void setMaxLogTimeout( String maxLogTimeout ) {
-        this.maxLogTimeout = maxLogTimeout;
-    }
-
-    @Override
-    public String getLogFile() {
-        return logFile;
-    }
-
-    public void setLogFile( String logFile ) {
-        this.logFile = logFile;
-    }
-
-    @Override
-    public String getOldLogFile() {
-        return oldLogFile;
-    }
-
-    public void setOldLogFile( String oldLogFile ) {
-        this.oldLogFile = oldLogFile;
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion( String version ) {
-        this.version = version;
-    }
-
-    @Override
-    public String getResultSetStepName() {
-        return resultSetStepName;
-    }
-
-    public void setResultSetStepName( String resultSetStepName ) {
-        this.resultSetStepName = resultSetStepName;
-    }
-
-    @Override
-    public String getResultSetCopyNumber() {
-        return resultSetCopyNumber;
-    }
-
-    public void setResultSetCopyNumber( String resultSetCopyNumber ) {
-        this.resultSetCopyNumber = resultSetCopyNumber;
-    }
-
-    @Override
-    public NamedParams getNamedParams() {
-        return namedParams;
-    }
-
-    public void setNamedParams( NamedParams params ) {
-        this.namedParams = params;
-    }
-
-    @Override
-    public Map<String, String> getParams() {
-        if ( this.namedParams == null ) {
-            return Collections.EMPTY_MAP;
-        }
-
-        Map <String, String> params = new HashMap<String, String> ();
-
-        for ( String key : this.namedParams.listParameters() ) {
-            try {
-                params.put(key, this.namedParams.getParameterValue( key ) );
-            } catch ( UnknownParamException e ) {
-                /* no-op */
-            }
-        }
-
-        return params;
-    }
-
-    @Override
-    public NamedParams getCustomNamedParams() {
-        return customNamedParams;
-    }
-
-    public void setNamedCustomParams( NamedParams customParams ) {
-        this.customNamedParams = customParams;
-    }
-
-    @Override
-    public Map<String, String> getCustomParams() {
-        if ( this.customNamedParams == null ) {
-            return Collections.EMPTY_MAP;
-        }
-
-        Map <String, String> customParams = new HashMap<String, String> ();
-
-        for ( String key : this.customNamedParams.listParameters() ) {
-            try {
-                customParams.put(key, this.customNamedParams.getParameterValue( key ) );
-            } catch ( UnknownParamException e ) {
-                /* no-op */
-            }
-        }
-
-        return customParams;
-    }
+    return customParams;
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/base/Params.java
+++ b/engine/src/main/java/org/pentaho/di/base/Params.java
@@ -1,0 +1,393 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.base;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.pentaho.di.core.parameters.NamedParams;
+import org.pentaho.di.core.parameters.UnknownParamException;
+
+import java.util.Map;
+import java.util.Collections;
+import java.util.HashMap;
+
+public abstract class Params implements IParams {
+
+    private String uuid;
+    private String repoName;
+    private String blockRepoConns;
+    private String repoUsername;
+    private String trustRepoUser;
+    private String repoPassword;
+    private String inputDir;
+    private String inputFile;
+    private String listRepoFiles;
+    private String listRepoDirs;
+    private String exportRepo;
+    private String localFile;
+    private String localJarFile;
+    private String localInitialDir;
+    private String listRepos;
+    private String safeMode;
+    private String metrics;
+    private String listFileParams;
+    private String logLevel;
+    private String maxLogLines;
+    private String maxLogTimeout;
+    private String logFile;
+    private String oldLogFile;
+    private String version;
+    private String resultSetStepName;
+    private String resultSetCopyNumber;
+    private NamedParams namedParams;
+    private NamedParams customNamedParams;
+
+    public Params( String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
+                   String inputFile, String listRepoFiles, String listRepoDirs, String exportRepo, String localFile,
+                   String localJarFile, String localInitialDir, String listRepos, String safeMode, String metrics,
+                   String listFileParams, String logLevel, String maxLogLines, String maxLogTimeout, String logFile,
+                   String oldLogFile, String version, String resultSetStepName, String resultSetCopyNumber, NamedParams params,
+                   NamedParams customNamedParams ) {
+
+        setUuid( java.util.UUID.randomUUID().toString() );
+
+        setBlockRepoConns( blockRepoConns );
+        setRepoName( repoName );
+        setRepoUsername( repoUsername );
+        setTrustRepoUser( trustRepoUser );
+        setRepoPassword( repoPassword );
+        setInputDir( inputDir );
+        setInputFile( inputFile );
+        setListRepoFiles( listRepoFiles );
+        setListRepoDirs( listRepoDirs );
+        setExportRepo( exportRepo );
+        setLocalFile( localFile );
+        setLocalJarFile( localJarFile );
+        setLocalInitialDir( localInitialDir );
+        setListRepos( listRepos );
+        setSafeMode( safeMode );
+        setMetrics( metrics );
+        setListFileParams( listFileParams );
+        setLogLevel( logLevel );
+        setMaxLogLines( maxLogLines );
+        setMaxLogTimeout( maxLogTimeout );
+        setLogFile( logFile );
+        setOldLogFile( oldLogFile );
+        setVersion( version );
+        setResultSetStepName( resultSetStepName );
+        setResultSetCopyNumber( NumberUtils.isNumber( resultSetCopyNumber ) ? resultSetCopyNumber : "0" /* default */ );
+        setNamedParams( params );
+        setNamedCustomParams( customNamedParams );
+    }
+
+    @Override
+    public abstract Map<String, String> asMap();
+
+    @Override
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid( String uuid ) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public String getRepoName() {
+        return repoName;
+    }
+
+    public void setRepoName( String repoName ) {
+        this.repoName = repoName;
+    }
+
+    @Override
+    public String getBlockRepoConns() {
+        return blockRepoConns;
+    }
+
+    public void setBlockRepoConns( String blockRepoConns ) {
+        this.blockRepoConns = blockRepoConns;
+    }
+
+    @Override
+    public String getRepoUsername() {
+        return repoUsername;
+    }
+
+    public void setRepoUsername( String repoUsername ) {
+        this.repoUsername = repoUsername;
+    }
+
+    @Override
+    public String getTrustRepoUser() {
+        return trustRepoUser;
+    }
+
+    public void setTrustRepoUser( String trustRepoUser ) {
+        this.trustRepoUser = trustRepoUser;
+    }
+
+    @Override
+    public String getRepoPassword() {
+        return repoPassword;
+    }
+
+    public void setRepoPassword( String repoPassword ) {
+        this.repoPassword = repoPassword;
+    }
+
+    @Override
+    public String getInputDir() {
+        return inputDir;
+    }
+
+    public void setInputDir( String inputDir ) {
+        this.inputDir = inputDir;
+    }
+
+    public String getLocalFile() {
+        return localFile;
+    }
+
+    public void setLocalFile( String localFile ) {
+        this.localFile = localFile;
+    }
+
+    @Override
+    public String getLocalJarFile() {
+        return localJarFile;
+    }
+
+    public void setLocalJarFile( String localJarFile ) {
+        this.localJarFile = localJarFile;
+    }
+
+    @Override
+    public String getInputFile() {
+        return inputFile;
+    }
+
+    public void setInputFile( String inputFile ) {
+        this.inputFile = inputFile;
+    }
+
+    @Override
+    public String getListRepoFiles() {
+        return listRepoFiles;
+    }
+
+    public void setListRepoFiles( String listRepoFiles ) {
+        this.listRepoFiles = listRepoFiles;
+    }
+
+    @Override
+    public String getListRepoDirs() {
+        return listRepoDirs;
+    }
+
+    public void setListRepoDirs( String listRepoDirs ) {
+        this.listRepoDirs = listRepoDirs;
+    }
+
+    @Override
+    public String getExportRepo() {
+        return exportRepo;
+    }
+
+    public void setExportRepo( String exportRepo ) {
+        this.exportRepo = exportRepo;
+    }
+
+    @Override
+    public String getLocalInitialDir() {
+        return localInitialDir;
+    }
+
+    public void setLocalInitialDir( String localInitialDir ) {
+        this.localInitialDir = localInitialDir;
+    }
+
+    @Override
+    public String getListRepos() {
+        return listRepos;
+    }
+
+    public void setListRepos( String listRepos ) {
+        this.listRepos = listRepos;
+    }
+
+    @Override
+    public String getSafeMode() {
+        return safeMode;
+    }
+
+    public void setSafeMode( String safeMode ) {
+        this.safeMode = safeMode;
+    }
+
+    @Override
+    public String getMetrics() {
+        return metrics;
+    }
+
+    public void setMetrics( String metrics ) {
+        this.metrics = metrics;
+    }
+
+    public String getListFileParams() {
+        return listFileParams;
+    }
+
+    public void setListFileParams( String listFileParams ) {
+        this.listFileParams = listFileParams;
+    }
+
+    @Override
+    public String getLogLevel() {
+        return logLevel;
+    }
+
+    public void setLogLevel( String logLevel ) {
+        this.logLevel = logLevel;
+    }
+
+    @Override
+    public String getMaxLogLines() {
+        return maxLogLines;
+    }
+
+    public void setMaxLogLines( String maxLogLines ) {
+        this.maxLogLines = maxLogLines;
+    }
+
+    @Override
+    public String getMaxLogTimeout() {
+        return maxLogTimeout;
+    }
+
+    public void setMaxLogTimeout( String maxLogTimeout ) {
+        this.maxLogTimeout = maxLogTimeout;
+    }
+
+    @Override
+    public String getLogFile() {
+        return logFile;
+    }
+
+    public void setLogFile( String logFile ) {
+        this.logFile = logFile;
+    }
+
+    @Override
+    public String getOldLogFile() {
+        return oldLogFile;
+    }
+
+    public void setOldLogFile( String oldLogFile ) {
+        this.oldLogFile = oldLogFile;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion( String version ) {
+        this.version = version;
+    }
+
+    @Override
+    public String getResultSetStepName() {
+        return resultSetStepName;
+    }
+
+    public void setResultSetStepName( String resultSetStepName ) {
+        this.resultSetStepName = resultSetStepName;
+    }
+
+    @Override
+    public String getResultSetCopyNumber() {
+        return resultSetCopyNumber;
+    }
+
+    public void setResultSetCopyNumber( String resultSetCopyNumber ) {
+        this.resultSetCopyNumber = resultSetCopyNumber;
+    }
+
+    @Override
+    public NamedParams getNamedParams() {
+        return namedParams;
+    }
+
+    public void setNamedParams( NamedParams params ) {
+        this.namedParams = params;
+    }
+
+    @Override
+    public Map<String, String> getParams() {
+        if ( this.namedParams == null ) {
+            return Collections.EMPTY_MAP;
+        }
+
+        Map <String, String> params = new HashMap<String, String> ();
+
+        for ( String key : this.namedParams.listParameters() ) {
+            try {
+                params.put(key, this.namedParams.getParameterValue( key ) );
+            } catch ( UnknownParamException e ) {
+                /* no-op */
+            }
+        }
+
+        return params;
+    }
+
+    @Override
+    public NamedParams getCustomNamedParams() {
+        return customNamedParams;
+    }
+
+    public void setNamedCustomParams( NamedParams customParams ) {
+        this.customNamedParams = customParams;
+    }
+
+    @Override
+    public Map<String, String> getCustomParams() {
+        if ( this.customNamedParams == null ) {
+            return Collections.EMPTY_MAP;
+        }
+
+        Map <String, String> customParams = new HashMap<String, String> ();
+
+        for ( String key : this.customNamedParams.listParameters() ) {
+            try {
+                customParams.put(key, this.customNamedParams.getParameterValue( key ) );
+            } catch ( UnknownParamException e ) {
+                /* no-op */
+            }
+        }
+
+        return customParams;
+    }
+}

--- a/engine/src/main/java/org/pentaho/di/kitchen/JobParams.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/JobParams.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class JobParams extends Params {
 
 
-  public JobParams(String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
+  public JobParams( String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
                     String inputFile, String listRepoFiles, String listRepoDirs, String exportRepo, String localFile,
                     String localJarFile, String localInitialDir, String listRepos, String listFileParams, String logLevel,
                     String maxLogLines, String maxLogTimeout, String logFile, String oldLogFile, String version,
@@ -46,49 +46,49 @@ public class JobParams extends Params {
   @Override
   public Map<String, String> asMap() {
 
-        Map<String, String> arguments = new HashMap<>();
+    Map<String, String> arguments = new HashMap<>();
 
-        arguments.putIfAbsent( "uuid", getUuid() );
-        arguments.putIfAbsent( KettleConstants.REPO, getRepoName() );
-        arguments.putIfAbsent( KettleConstants.NO_REPO, getBlockRepoConns() );
-        arguments.putIfAbsent( KettleConstants.USER, getRepoUsername() );
-        arguments.putIfAbsent( KettleConstants.TRUST_USER, getTrustRepoUser() );
-        arguments.putIfAbsent( KettleConstants.PASS, getRepoPassword() );
-        arguments.putIfAbsent( KettleConstants.DIR, getInputDir() );
-        arguments.putIfAbsent( KettleConstants.FILE, getLocalFile() );
-        arguments.putIfAbsent( KettleConstants.JARFILE, getLocalJarFile() );
-        arguments.putIfAbsent( KettleConstants.JOB, getInputFile() );
-        arguments.putIfAbsent( KettleConstants.LIST_JOBS, getListRepoFiles() );
-        arguments.putIfAbsent( KettleConstants.LIST_DIRS, getListRepoDirs() );
-        arguments.putIfAbsent( KettleConstants.EXPORT_REPO_JOB, getExportRepo() );
-        arguments.putIfAbsent( KettleConstants.INITIAL_DIR, getLocalInitialDir() );
-        arguments.putIfAbsent( KettleConstants.LIST_REPOS, getListRepos() );
-        arguments.putIfAbsent( KettleConstants.SAFEMODE, getSafeMode() );
-        arguments.putIfAbsent( KettleConstants.METRICS, getMetrics() );
-        arguments.putIfAbsent( KettleConstants.LIST_PARAMS, getListFileParams() );
-        arguments.putIfAbsent( KettleConstants.LEVEL, getLogLevel() );
-        arguments.putIfAbsent( KettleConstants.MAX_LOG_LINES, getMaxLogLines() );
-        arguments.putIfAbsent( KettleConstants.MAX_LOG_TIMEOUT, getMaxLogTimeout() );
-        arguments.putIfAbsent( KettleConstants.LOGFILE, getLogFile() );
-        arguments.putIfAbsent( KettleConstants.LOG, getOldLogFile() );
-        arguments.putIfAbsent( KettleConstants.VERSION, getVersion() );
-        arguments.putIfAbsent( KettleConstants.RESULT_SET_STEP_NAME, getResultSetStepName() );
-        arguments.putIfAbsent( KettleConstants.RESULT_SET_COPY_NUMBER, getResultSetCopyNumber() );
+    arguments.putIfAbsent( "uuid", getUuid() );
+    arguments.putIfAbsent( KettleConstants.REPO, getRepoName() );
+    arguments.putIfAbsent( KettleConstants.NO_REPO, getBlockRepoConns() );
+    arguments.putIfAbsent( KettleConstants.USER, getRepoUsername() );
+    arguments.putIfAbsent( KettleConstants.TRUST_USER, getTrustRepoUser() );
+    arguments.putIfAbsent( KettleConstants.PASS, getRepoPassword() );
+    arguments.putIfAbsent( KettleConstants.DIR, getInputDir() );
+    arguments.putIfAbsent( KettleConstants.FILE, getLocalFile() );
+    arguments.putIfAbsent( KettleConstants.JARFILE, getLocalJarFile() );
+    arguments.putIfAbsent( KettleConstants.JOB, getInputFile() );
+    arguments.putIfAbsent( KettleConstants.LIST_JOBS, getListRepoFiles() );
+    arguments.putIfAbsent( KettleConstants.LIST_DIRS, getListRepoDirs() );
+    arguments.putIfAbsent( KettleConstants.EXPORT_REPO_JOB, getExportRepo() );
+    arguments.putIfAbsent( KettleConstants.INITIAL_DIR, getLocalInitialDir() );
+    arguments.putIfAbsent( KettleConstants.LIST_REPOS, getListRepos() );
+    arguments.putIfAbsent( KettleConstants.SAFEMODE, getSafeMode() );
+    arguments.putIfAbsent( KettleConstants.METRICS, getMetrics() );
+    arguments.putIfAbsent( KettleConstants.LIST_PARAMS, getListFileParams() );
+    arguments.putIfAbsent( KettleConstants.LEVEL, getLogLevel() );
+    arguments.putIfAbsent( KettleConstants.MAX_LOG_LINES, getMaxLogLines() );
+    arguments.putIfAbsent( KettleConstants.MAX_LOG_TIMEOUT, getMaxLogTimeout() );
+    arguments.putIfAbsent( KettleConstants.LOGFILE, getLogFile() );
+    arguments.putIfAbsent( KettleConstants.LOG, getOldLogFile() );
+    arguments.putIfAbsent( KettleConstants.VERSION, getVersion() );
+    arguments.putIfAbsent( KettleConstants.RESULT_SET_STEP_NAME, getResultSetStepName() );
+    arguments.putIfAbsent( KettleConstants.RESULT_SET_COPY_NUMBER, getResultSetCopyNumber() );
 
-        if ( getParams() != null && !getParams().isEmpty() ) {
+    if ( getParams() != null && !getParams().isEmpty() ) {
 
-            getParams().keySet().stream().forEach( paramKey -> {
-                arguments.putIfAbsent( ( KettleConstants.PARAM + ":" + paramKey ), getParams().get( paramKey ) );
-            } );
-        }
-
-        if ( getCustomParams() != null && !getCustomParams().isEmpty() ) {
-
-            getCustomParams().keySet().stream().forEach( paramKey -> {
-                arguments.putIfAbsent( ( KettleConstants.CUSTOM + ":" + paramKey ), getParams().get( paramKey ) );
-            } );
-        }
-
-        return arguments;
+      getParams().keySet().stream().forEach( paramKey -> {
+        arguments.putIfAbsent( ( KettleConstants.PARAM + ":" + paramKey ), getParams().get( paramKey ) );
+      } );
     }
+
+    if ( getCustomParams() != null && !getCustomParams().isEmpty() ) {
+
+      getCustomParams().keySet().stream().forEach( paramKey -> {
+        arguments.putIfAbsent( ( KettleConstants.CUSTOM + ":" + paramKey ), getParams().get( paramKey ) );
+      } );
+    }
+
+    return arguments;
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/kitchen/JobParams.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/JobParams.java
@@ -24,7 +24,6 @@ package org.pentaho.di.kitchen;
 
 import org.pentaho.di.base.Params;
 import org.pentaho.di.base.KettleConstants;
-import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.parameters.NamedParams;
 
 import java.util.HashMap;
@@ -33,72 +32,63 @@ import java.util.Map;
 public class JobParams extends Params {
 
 
-    public JobParams(String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
-                     String inputFile, String listRepoFiles, String listRepoDirs, String exportRepo, String localFile,
-                     String localJarFile, String localInitialDir, String listRepos, String listFileParams, String logLevel,
-                     String maxLogLines, String maxLogTimeout, String logFile, String oldLogFile, String version,
-                     String resultSetStepName, String resultSetCopyNumber, NamedParams namedParams, NamedParams customParams ) {
+  public JobParams(String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
+                    String inputFile, String listRepoFiles, String listRepoDirs, String exportRepo, String localFile,
+                    String localJarFile, String localInitialDir, String listRepos, String listFileParams, String logLevel,
+                    String maxLogLines, String maxLogTimeout, String logFile, String oldLogFile, String version,
+                    String resultSetStepName, String resultSetCopyNumber, NamedParams namedParams, NamedParams customParams ) {
 
-        super( blockRepoConns, repoName, repoUsername, trustRepoUser, repoPassword, inputDir, inputFile, listRepoFiles, listRepoDirs, exportRepo,
+      super( blockRepoConns, repoName, repoUsername, trustRepoUser, repoPassword, inputDir, inputFile, listRepoFiles, listRepoDirs, exportRepo,
                 localFile, localJarFile, localInitialDir, listRepos, null, null, listFileParams, logLevel, maxLogLines,
                 maxLogTimeout, logFile, oldLogFile, version, resultSetStepName, resultSetCopyNumber, namedParams, customParams );
-    }
+  }
 
-    @Override
-    public Map<String, String> asMap() {
+  @Override
+  public Map<String, String> asMap() {
 
         Map<String, String> arguments = new HashMap<>();
 
-
-        putIfNotEmpty( arguments, "uuid", getUuid() );
-        putIfNotEmpty( arguments, KettleConstants.REPO, getRepoName() );
-        putIfNotEmpty( arguments, KettleConstants.NO_REPO, getBlockRepoConns() );
-        putIfNotEmpty( arguments, KettleConstants.USER, getRepoUsername() );
-        putIfNotEmpty( arguments, KettleConstants.TRUST_USER, getTrustRepoUser() );
-        putIfNotEmpty( arguments, KettleConstants.PASS, getRepoPassword() );
-        putIfNotEmpty( arguments, KettleConstants.DIR, getInputDir() );
-        putIfNotEmpty( arguments, KettleConstants.FILE, getLocalFile() );
-        putIfNotEmpty( arguments, KettleConstants.JARFILE, getLocalJarFile() );
-        putIfNotEmpty( arguments, KettleConstants.JOB, getInputFile() );
-        putIfNotEmpty( arguments, KettleConstants.LIST_JOBS, getListRepoFiles() );
-        putIfNotEmpty( arguments, KettleConstants.LIST_DIRS, getListRepoDirs() );
-        putIfNotEmpty( arguments, KettleConstants.EXPORT_REPO_JOB, getExportRepo() );
-        putIfNotEmpty( arguments, KettleConstants.INITIAL_DIR, getLocalInitialDir() );
-        putIfNotEmpty( arguments, KettleConstants.LIST_REPOS, getListRepos() );
-        putIfNotEmpty( arguments, KettleConstants.SAFEMODE, getSafeMode() );
-        putIfNotEmpty( arguments, KettleConstants.METRICS, getMetrics() );
-        putIfNotEmpty( arguments, KettleConstants.LIST_PARAMS, getListFileParams() );
-        putIfNotEmpty( arguments, KettleConstants.LEVEL, getLogLevel() );
-        putIfNotEmpty( arguments, KettleConstants.MAX_LOG_LINES, getMaxLogLines() );
-        putIfNotEmpty( arguments, KettleConstants.MAX_LOG_TIMEOUT, getMaxLogTimeout() );
-        putIfNotEmpty( arguments, KettleConstants.LOGFILE, getLogFile() );
-        putIfNotEmpty( arguments, KettleConstants.LOG, getOldLogFile() );
-        putIfNotEmpty( arguments, KettleConstants.VERSION, getVersion() );
-        putIfNotEmpty( arguments, KettleConstants.RESULT_SET_STEP_NAME, getResultSetStepName() );
-        putIfNotEmpty( arguments, KettleConstants.RESULT_SET_COPY_NUMBER, getResultSetCopyNumber() );
+        arguments.putIfAbsent( "uuid", getUuid() );
+        arguments.putIfAbsent( KettleConstants.REPO, getRepoName() );
+        arguments.putIfAbsent( KettleConstants.NO_REPO, getBlockRepoConns() );
+        arguments.putIfAbsent( KettleConstants.USER, getRepoUsername() );
+        arguments.putIfAbsent( KettleConstants.TRUST_USER, getTrustRepoUser() );
+        arguments.putIfAbsent( KettleConstants.PASS, getRepoPassword() );
+        arguments.putIfAbsent( KettleConstants.DIR, getInputDir() );
+        arguments.putIfAbsent( KettleConstants.FILE, getLocalFile() );
+        arguments.putIfAbsent( KettleConstants.JARFILE, getLocalJarFile() );
+        arguments.putIfAbsent( KettleConstants.JOB, getInputFile() );
+        arguments.putIfAbsent( KettleConstants.LIST_JOBS, getListRepoFiles() );
+        arguments.putIfAbsent( KettleConstants.LIST_DIRS, getListRepoDirs() );
+        arguments.putIfAbsent( KettleConstants.EXPORT_REPO_JOB, getExportRepo() );
+        arguments.putIfAbsent( KettleConstants.INITIAL_DIR, getLocalInitialDir() );
+        arguments.putIfAbsent( KettleConstants.LIST_REPOS, getListRepos() );
+        arguments.putIfAbsent( KettleConstants.SAFEMODE, getSafeMode() );
+        arguments.putIfAbsent( KettleConstants.METRICS, getMetrics() );
+        arguments.putIfAbsent( KettleConstants.LIST_PARAMS, getListFileParams() );
+        arguments.putIfAbsent( KettleConstants.LEVEL, getLogLevel() );
+        arguments.putIfAbsent( KettleConstants.MAX_LOG_LINES, getMaxLogLines() );
+        arguments.putIfAbsent( KettleConstants.MAX_LOG_TIMEOUT, getMaxLogTimeout() );
+        arguments.putIfAbsent( KettleConstants.LOGFILE, getLogFile() );
+        arguments.putIfAbsent( KettleConstants.LOG, getOldLogFile() );
+        arguments.putIfAbsent( KettleConstants.VERSION, getVersion() );
+        arguments.putIfAbsent( KettleConstants.RESULT_SET_STEP_NAME, getResultSetStepName() );
+        arguments.putIfAbsent( KettleConstants.RESULT_SET_COPY_NUMBER, getResultSetCopyNumber() );
 
         if ( getParams() != null && !getParams().isEmpty() ) {
 
             getParams().keySet().stream().forEach( paramKey -> {
-                putIfNotEmpty( arguments, ( KettleConstants.PARAM + ":" + paramKey ), getParams().get( paramKey ) );
+                arguments.putIfAbsent( ( KettleConstants.PARAM + ":" + paramKey ), getParams().get( paramKey ) );
             } );
         }
 
         if ( getCustomParams() != null && !getCustomParams().isEmpty() ) {
 
             getCustomParams().keySet().stream().forEach( paramKey -> {
-                putIfNotEmpty( arguments, ( KettleConstants.CUSTOM + ":" + paramKey ), getParams().get( paramKey ) );
+                arguments.putIfAbsent( ( KettleConstants.CUSTOM + ":" + paramKey ), getParams().get( paramKey ) );
             } );
         }
 
         return arguments;
     }
-
-    private void putIfNotEmpty( Map<String, String> map, final String key, final String value ) {
-
-        if ( map != null && !StringUtils.isEmpty( key ) && !StringUtils.isEmpty( value ) ) {
-            map.put( key, value );
-        }
-    }
-
 }

--- a/engine/src/main/java/org/pentaho/di/kitchen/JobParams.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/JobParams.java
@@ -1,0 +1,104 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.kitchen;
+
+import org.pentaho.di.base.Params;
+import org.pentaho.di.base.KettleConstants;
+import org.apache.commons.lang.StringUtils;
+import org.pentaho.di.core.parameters.NamedParams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JobParams extends Params {
+
+
+    public JobParams(String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
+                     String inputFile, String listRepoFiles, String listRepoDirs, String exportRepo, String localFile,
+                     String localJarFile, String localInitialDir, String listRepos, String listFileParams, String logLevel,
+                     String maxLogLines, String maxLogTimeout, String logFile, String oldLogFile, String version,
+                     String resultSetStepName, String resultSetCopyNumber, NamedParams namedParams, NamedParams customParams ) {
+
+        super( blockRepoConns, repoName, repoUsername, trustRepoUser, repoPassword, inputDir, inputFile, listRepoFiles, listRepoDirs, exportRepo,
+                localFile, localJarFile, localInitialDir, listRepos, null, null, listFileParams, logLevel, maxLogLines,
+                maxLogTimeout, logFile, oldLogFile, version, resultSetStepName, resultSetCopyNumber, namedParams, customParams );
+    }
+
+    @Override
+    public Map<String, String> asMap() {
+
+        Map<String, String> arguments = new HashMap<>();
+
+
+        putIfNotEmpty( arguments, "uuid", getUuid() );
+        putIfNotEmpty( arguments, KettleConstants.REPO, getRepoName() );
+        putIfNotEmpty( arguments, KettleConstants.NO_REPO, getBlockRepoConns() );
+        putIfNotEmpty( arguments, KettleConstants.USER, getRepoUsername() );
+        putIfNotEmpty( arguments, KettleConstants.TRUST_USER, getTrustRepoUser() );
+        putIfNotEmpty( arguments, KettleConstants.PASS, getRepoPassword() );
+        putIfNotEmpty( arguments, KettleConstants.DIR, getInputDir() );
+        putIfNotEmpty( arguments, KettleConstants.FILE, getLocalFile() );
+        putIfNotEmpty( arguments, KettleConstants.JARFILE, getLocalJarFile() );
+        putIfNotEmpty( arguments, KettleConstants.JOB, getInputFile() );
+        putIfNotEmpty( arguments, KettleConstants.LIST_JOBS, getListRepoFiles() );
+        putIfNotEmpty( arguments, KettleConstants.LIST_DIRS, getListRepoDirs() );
+        putIfNotEmpty( arguments, KettleConstants.EXPORT_REPO_JOB, getExportRepo() );
+        putIfNotEmpty( arguments, KettleConstants.INITIAL_DIR, getLocalInitialDir() );
+        putIfNotEmpty( arguments, KettleConstants.LIST_REPOS, getListRepos() );
+        putIfNotEmpty( arguments, KettleConstants.SAFEMODE, getSafeMode() );
+        putIfNotEmpty( arguments, KettleConstants.METRICS, getMetrics() );
+        putIfNotEmpty( arguments, KettleConstants.LIST_PARAMS, getListFileParams() );
+        putIfNotEmpty( arguments, KettleConstants.LEVEL, getLogLevel() );
+        putIfNotEmpty( arguments, KettleConstants.MAX_LOG_LINES, getMaxLogLines() );
+        putIfNotEmpty( arguments, KettleConstants.MAX_LOG_TIMEOUT, getMaxLogTimeout() );
+        putIfNotEmpty( arguments, KettleConstants.LOGFILE, getLogFile() );
+        putIfNotEmpty( arguments, KettleConstants.LOG, getOldLogFile() );
+        putIfNotEmpty( arguments, KettleConstants.VERSION, getVersion() );
+        putIfNotEmpty( arguments, KettleConstants.RESULT_SET_STEP_NAME, getResultSetStepName() );
+        putIfNotEmpty( arguments, KettleConstants.RESULT_SET_COPY_NUMBER, getResultSetCopyNumber() );
+
+        if ( getParams() != null && !getParams().isEmpty() ) {
+
+            getParams().keySet().stream().forEach( paramKey -> {
+                putIfNotEmpty( arguments, ( KettleConstants.PARAM + ":" + paramKey ), getParams().get( paramKey ) );
+            } );
+        }
+
+        if ( getCustomParams() != null && !getCustomParams().isEmpty() ) {
+
+            getCustomParams().keySet().stream().forEach( paramKey -> {
+                putIfNotEmpty( arguments, ( KettleConstants.CUSTOM + ":" + paramKey ), getParams().get( paramKey ) );
+            } );
+        }
+
+        return arguments;
+    }
+
+    private void putIfNotEmpty( Map<String, String> map, final String key, final String value ) {
+
+        if ( map != null && !StringUtils.isEmpty( key ) && !StringUtils.isEmpty( value ) ) {
+            map.put( key, value );
+        }
+    }
+
+}

--- a/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
@@ -257,10 +257,34 @@ public class Kitchen {
         }
       }
 
-      result = getCommandExecutor().execute( optionRepname.toString(), optionNorep.toString(), optionUsername.toString(),
-            optionTrustUser.toString(), optionPassword.toString(), optionDirname.toString(), optionFilename.toString(), optionJobname.toString(), optionListjobs.toString(),
-            optionListdir.toString(), optionExport.toString(), initialDir.toString(), optionListrep.toString(), optionListParam.toString(),
-            optionParams, customOptions, args.toArray( new String[ args.size() ] ) );
+      JobParams jobParams = new JobParams(
+              optionNorep.toString(),
+              optionRepname.toString(),
+              optionUsername.toString(),
+              optionTrustUser.toString(),
+              optionPassword.toString(),
+              optionDirname.toString(),
+              optionJobname.toString(),
+              optionListjobs.toString(),
+              optionListdir.toString(),
+              optionExport.toString(),
+              optionFilename.toString(),
+              "",
+              initialDir.toString(),
+              optionListrep.toString(),
+              optionListParam.toString(),
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              optionParams,
+              customOptions );
+
+      result = getCommandExecutor().execute( jobParams );
 
     } catch ( Throwable t ) {
       t.printStackTrace();

--- a/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,7 +24,6 @@ package org.pentaho.di.kitchen;
 
 import org.pentaho.di.base.AbstractBaseCommandExecutor;
 import org.pentaho.di.base.CommandExecutorCodes;
-import org.pentaho.di.base.IParams;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.exception.KettleException;
@@ -71,7 +70,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     setKettleInit( kettleInit );
   }
 
-  public Result execute( JobParams iParams ) throws Throwable {
+  public Result execute( JobParams params ) throws Throwable {
 
     getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Kitchen.Log.Starting" ) );
 
@@ -91,11 +90,11 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
       }
 
       // Read kettle job specified on command-line?
-      if ( !Utils.isEmpty( iParams.getRepoName() ) || !Utils.isEmpty( iParams.getLocalFile() ) ) {
+      if ( !Utils.isEmpty( params.getRepoName() ) || !Utils.isEmpty( params.getLocalFile() ) ) {
 
         logDebug( "Kitchen.Log.ParsingCommandLine" );
 
-        if ( !Utils.isEmpty( iParams.getRepoName() ) && !isEnabled( iParams.getBlockRepoConns() ) ) {
+        if ( !Utils.isEmpty( params.getRepoName() ) && !isEnabled( params.getBlockRepoConns() ) ) {
 
           /**
            * if set, _trust_user_ needs to be considered. See pur-plugin's:
@@ -103,27 +102,27 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
            * @link https://github.com/pentaho/pentaho-kettle/blob/8.0.0.0-R/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryConnector.java#L97-L101
            * @link https://github.com/pentaho/pentaho-kettle/blob/8.0.0.0-R/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/WebServiceManager.java#L130-L133
            */
-          if ( isEnabled( iParams.getTrustRepoUser() ) ) {
+          if ( isEnabled( params.getTrustRepoUser() ) ) {
             System.setProperty( "pentaho.repository.client.attemptTrust", YES );
           }
 
           // In case we use a repository...
           // some commands are to load a Trans from the repo; others are merely to print some repo-related information
-          RepositoryMeta repositoryMeta = loadRepositoryConnection( iParams.getRepoName(), "Kitchen.Log.LoadingRep", "Kitchen.Error.NoRepDefinied", "Kitchen.Log.FindingRep" );
+          RepositoryMeta repositoryMeta = loadRepositoryConnection( params.getRepoName(), "Kitchen.Log.LoadingRep", "Kitchen.Error.NoRepDefinied", "Kitchen.Log.FindingRep" );
 
-          repository = establishRepositoryConnection( repositoryMeta, iParams.getRepoUsername(), iParams.getRepoPassword(), RepositoryOperation.EXECUTE_JOB );
+          repository = establishRepositoryConnection( repositoryMeta, params.getRepoUsername(), params.getRepoPassword(), RepositoryOperation.EXECUTE_JOB );
 
-          job = executeRepositoryBasedCommand( repository, repositoryMeta, iParams.getInputDir(), iParams.getInputFile(), iParams.getListRepoFiles(), iParams.getListRepoDirs() );
+          job = executeRepositoryBasedCommand( repository, repositoryMeta, params.getInputDir(), params.getInputFile(), params.getListRepoFiles(), params.getListRepoDirs() );
         }
 
         // Try to load if from file anyway.
-        if ( !Utils.isEmpty( iParams.getLocalFile() ) && job == null ) {
+        if ( !Utils.isEmpty( params.getLocalFile() ) && job == null ) {
 
           // Try to load the job from file, even if it failed to load from the repository
-          job = executeFilesystemBasedCommand( iParams.getLocalInitialDir(), iParams.getLocalFile() );
+          job = executeFilesystemBasedCommand( params.getLocalInitialDir(), params.getLocalFile() );
         }
 
-      } else if ( isEnabled( iParams.getListRepos() ) ) {
+      } else if ( isEnabled( params.getListRepos() ) ) {
 
         printRepositories( loadRepositoryInfo( "Kitchen.Log.ListRep", "Kitchen.Error.NoRepDefinied" ) ); // list the repositories placed at repositories.xml
 
@@ -137,25 +136,25 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     }
 
     if ( job == null ) {
-      if ( !isEnabled( iParams.getListRepoFiles() ) && !isEnabled( iParams.getListRepoDirs() ) && !isEnabled( iParams.getListRepos() ) ) {
+      if ( !isEnabled( params.getListRepoFiles() ) && !isEnabled( params.getListRepoDirs() ) && !isEnabled( params.getListRepos() ) ) {
         System.out.println( BaseMessages.getString( getPkgClazz(), "Kitchen.Error.canNotLoadJob" ) );
       }
 
       return exitWithStatus( CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode() );
     }
 
-    if ( !Utils.isEmpty( iParams.getExportRepo() ) ) {
+    if ( !Utils.isEmpty( params.getExportRepo() ) ) {
 
       try {
         // Export the resources linked to the currently loaded file...
-        TopLevelResource topLevelResource = ResourceUtil.serializeResourceExportInterface( iParams.getExportRepo(), job.getJobMeta(), job, repository, getMetaStore() );
+        TopLevelResource topLevelResource = ResourceUtil.serializeResourceExportInterface( params.getExportRepo(), job.getJobMeta(), job, repository, getMetaStore() );
         String launchFile = topLevelResource.getResourceName();
-        String message = ResourceUtil.getExplanation( iParams.getExportRepo(), launchFile, job.getJobMeta() );
+        String message = ResourceUtil.getExplanation( params.getExportRepo(), launchFile, job.getJobMeta() );
         System.out.println();
         System.out.println( message );
 
         // Setting the list parameters option will make kitchen exit below in the parameters section
-        ( (JobParams) iParams ).setListFileParams( YES );
+        ( (JobParams) params ).setListFileParams( YES );
       } catch ( Exception e ) {
         System.out.println( Const.getStackTracker( e ) );
         return exitWithStatus( CommandExecutorCodes.Kitchen.UNEXPECTED_ERROR.getCode() );
@@ -167,7 +166,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     try {
 
       // Set the command line arguments on the job ...
-      job.setArguments( convert( iParams.asMap() ) );
+      job.setArguments( convert( params.asMap() ) );
       job.initializeVariablesFrom( null );
       job.setLogLevel( getLog().getLogLevel() );
       job.getJobMeta().setInternalKettleVariables( job );
@@ -180,9 +179,9 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
       String[] jobParams = job.getJobMeta().listParameters();
       for ( String param : jobParams ) {
         try {
-          String value = iParams.getNamedParams().getParameterValue(param);
-          if (value != null) {
-            job.getJobMeta().setParameterValue(param, value);
+          String value = params.getNamedParams().getParameterValue( param );
+          if ( value != null ) {
+            job.getJobMeta().setParameterValue( param, value );
           }
         } catch ( UnknownParamException e ) {
           /* no-op */
@@ -194,11 +193,11 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
       job.activateParameters();
 
       // Set custom options in the job extension map as Strings
-      for ( String optionName : iParams.getCustomNamedParams().listParameters() ) {
+      for ( String optionName : params.getCustomNamedParams().listParameters() ) {
         try {
-          String optionValue = iParams.getCustomNamedParams().getParameterValue(optionName);
-          if (optionName != null && optionValue != null) {
-            job.getExtensionDataMap().put(optionName, optionValue);
+          String optionValue = params.getCustomNamedParams().getParameterValue( optionName );
+          if ( optionName != null && optionValue != null ) {
+            job.getExtensionDataMap().put( optionName, optionValue );
           }
         } catch ( UnknownParamException e ) {
           /* no-op */
@@ -206,7 +205,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
       }
 
       // List the parameters defined in this job, then simply exit...
-      if ( isEnabled( iParams.getListFileParams() ) ) {
+      if ( isEnabled( params.getListFileParams() ) ) {
 
         printJobParameters( job );
 
@@ -221,7 +220,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
       if ( repository != null ) {
         repository.disconnect();
       }
-      if ( isEnabled( iParams.getTrustRepoUser() ) ) {
+      if ( isEnabled( params.getTrustRepoUser() ) ) {
         System.clearProperty( "pentaho.repository.client.attemptTrust" ); // we set it, now we sanitize it
       }
     }

--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -236,12 +236,35 @@ public class Pan {
         }
       }
 
-      Result result = getCommandExecutor().execute( optionRepname.toString(), optionNorep.toString(), optionUsername.toString(),
-              optionTrustUser.toString(), optionPassword.toString(), optionDirname.toString(), optionFilename.toString(), optionJarFilename.toString(),
-              optionTransname.toString(), optionListtrans.toString(), optionListdir.toString(), optionExprep.toString(),
-              initialDir.toString(), optionListrep.toString(), optionSafemode.toString(), optionMetrics.toString(),
-              optionListParam.toString(), optionResultSetStepName.toString(), optionResultSetCopyNumber.toString(),
-              optionParams, args.toArray( new String[ args.size() ] ) );
+      TransParams transParams = new TransParams(
+              optionNorep.toString(),
+              optionRepname.toString(),
+              optionUsername.toString(),
+              optionTrustUser.toString(),
+              optionPassword.toString(),
+              optionDirname.toString(),
+              optionTransname.toString(),
+              optionListtrans.toString(),
+              optionListdir.toString(),
+              optionExprep.toString(),
+              optionFilename.toString(),
+              optionJarFilename.toString(),
+              initialDir.toString(),
+              optionListrep.toString(),
+              optionSafemode.toString(),
+              optionMetrics.toString(),
+              optionListParam.toString(),
+              "",
+              "",
+              "",
+              "",
+              "",
+              "",
+              optionResultSetStepName.toString(),
+              optionResultSetCopyNumber.toString(),
+              optionParams );
+
+      Result result = getCommandExecutor().execute( transParams );
 
       exitJVM( result.getExitStatus() );
 

--- a/engine/src/main/java/org/pentaho/di/pan/TransParams.java
+++ b/engine/src/main/java/org/pentaho/di/pan/TransParams.java
@@ -24,7 +24,6 @@ package org.pentaho.di.pan;
 
 import org.pentaho.di.base.Params;
 import org.pentaho.di.base.KettleConstants;
-import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.parameters.NamedParams;
 
 import java.util.HashMap;
@@ -33,7 +32,7 @@ import java.util.Map;
 public class TransParams extends Params {
 
 
-    public TransParams( String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
+  public TransParams( String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
                         String inputFile, String listRepoFiles, String listRepoDirs, String exportRepo, String localFile,
                         String localJarFile, String localInitialDir, String listRepos, String safeMode, String metrics,
                         String listFileParams, String logLevel, String maxLogLines, String maxLogTimeout, String logFile,
@@ -42,57 +41,49 @@ public class TransParams extends Params {
         super( blockRepoConns, repoName, repoUsername, trustRepoUser, repoPassword, inputDir, inputFile, listRepoFiles, listRepoDirs, exportRepo,
                 localFile, localJarFile, localInitialDir, listRepos, safeMode, metrics, listFileParams, logLevel, maxLogLines,
                 maxLogTimeout, logFile, oldLogFile, version, resultSetStepName, resultSetCopyNumber, namedParams, null );
+  }
+
+  @Override
+  public Map<String, String> asMap() {
+
+    Map<String, String> arguments = new HashMap<>();
+
+    arguments.putIfAbsent(  "uuid", getUuid() );
+    arguments.putIfAbsent(  KettleConstants.REPO, getRepoName() );
+    arguments.putIfAbsent(  KettleConstants.NO_REPO, getBlockRepoConns() );
+    arguments.putIfAbsent(  KettleConstants.USER, getRepoUsername() );
+    arguments.putIfAbsent(  KettleConstants.TRUST_USER, getTrustRepoUser() );
+    arguments.putIfAbsent(  KettleConstants.PASS, getRepoPassword() );
+    arguments.putIfAbsent(  KettleConstants.DIR, getInputDir() );
+    arguments.putIfAbsent(  KettleConstants.FILE, getLocalFile() );
+    arguments.putIfAbsent(  KettleConstants.JARFILE, getLocalJarFile() );
+    arguments.putIfAbsent(  KettleConstants.TRANS, getInputFile() );
+    arguments.putIfAbsent(  KettleConstants.LIST_TRANS, getListRepoFiles() );
+    arguments.putIfAbsent(  KettleConstants.LIST_DIRS, getListRepoDirs() );
+    arguments.putIfAbsent(  KettleConstants.EXPORT_REPO_TRANS, getExportRepo() );
+    arguments.putIfAbsent(  KettleConstants.INITIAL_DIR, getLocalInitialDir() );
+    arguments.putIfAbsent(  KettleConstants.LIST_REPOS, getListRepos() );
+    arguments.putIfAbsent(  KettleConstants.SAFEMODE, getSafeMode() );
+    arguments.putIfAbsent(  KettleConstants.METRICS, getMetrics() );
+    arguments.putIfAbsent(  KettleConstants.LIST_PARAMS, getListFileParams() );
+    arguments.putIfAbsent(  KettleConstants.LEVEL, getLogLevel() );
+    arguments.putIfAbsent(  KettleConstants.MAX_LOG_LINES, getMaxLogLines() );
+    arguments.putIfAbsent(  KettleConstants.MAX_LOG_TIMEOUT, getMaxLogTimeout() );
+    arguments.putIfAbsent(  KettleConstants.LOGFILE, getLogFile() );
+    arguments.putIfAbsent(  KettleConstants.LOG, getOldLogFile() );
+    arguments.putIfAbsent(  KettleConstants.VERSION, getVersion() );
+    arguments.putIfAbsent(  KettleConstants.RESULT_SET_STEP_NAME, getResultSetStepName() );
+    arguments.putIfAbsent(  KettleConstants.RESULT_SET_COPY_NUMBER, getResultSetCopyNumber() );
+
+    if ( getParams() != null && !getParams().isEmpty() ) {
+
+      getParams().keySet().stream().forEach( paramKey -> {
+        arguments.putIfAbsent(  ( KettleConstants.PARAM + ":" + paramKey ), getParams().get( paramKey ) );
+      } );
     }
 
-    @Override
-    public Map<String, String> asMap() {
+    // KTRs do not use customParams
 
-        Map<String, String> arguments = new HashMap<>();
-
-        putIfNotEmpty( arguments, "uuid", getUuid() );
-        putIfNotEmpty( arguments, KettleConstants.REPO, getRepoName() );
-        putIfNotEmpty( arguments, KettleConstants.NO_REPO, getBlockRepoConns() );
-        putIfNotEmpty( arguments, KettleConstants.USER, getRepoUsername() );
-        putIfNotEmpty( arguments, KettleConstants.TRUST_USER, getTrustRepoUser() );
-        putIfNotEmpty( arguments, KettleConstants.PASS, getRepoPassword() );
-        putIfNotEmpty( arguments, KettleConstants.DIR, getInputDir() );
-        putIfNotEmpty( arguments, KettleConstants.FILE, getLocalFile() );
-        putIfNotEmpty( arguments, KettleConstants.JARFILE, getLocalJarFile() );
-        putIfNotEmpty( arguments, KettleConstants.TRANS, getInputFile() );
-        putIfNotEmpty( arguments, KettleConstants.LIST_TRANS, getListRepoFiles() );
-        putIfNotEmpty( arguments, KettleConstants.LIST_DIRS, getListRepoDirs() );
-        putIfNotEmpty( arguments, KettleConstants.EXPORT_REPO_TRANS, getExportRepo() );
-        putIfNotEmpty( arguments, KettleConstants.INITIAL_DIR, getLocalInitialDir() );
-        putIfNotEmpty( arguments, KettleConstants.LIST_REPOS, getListRepos() );
-        putIfNotEmpty( arguments, KettleConstants.SAFEMODE, getSafeMode() );
-        putIfNotEmpty( arguments, KettleConstants.METRICS, getMetrics() );
-        putIfNotEmpty( arguments, KettleConstants.LIST_PARAMS, getListFileParams() );
-        putIfNotEmpty( arguments, KettleConstants.LEVEL, getLogLevel() );
-        putIfNotEmpty( arguments, KettleConstants.MAX_LOG_LINES, getMaxLogLines() );
-        putIfNotEmpty( arguments, KettleConstants.MAX_LOG_TIMEOUT, getMaxLogTimeout() );
-        putIfNotEmpty( arguments, KettleConstants.LOGFILE, getLogFile() );
-        putIfNotEmpty( arguments, KettleConstants.LOG, getOldLogFile() );
-        putIfNotEmpty( arguments, KettleConstants.VERSION, getVersion() );
-        putIfNotEmpty( arguments, KettleConstants.RESULT_SET_STEP_NAME, getResultSetStepName() );
-        putIfNotEmpty( arguments, KettleConstants.RESULT_SET_COPY_NUMBER, getResultSetCopyNumber() );
-
-        if ( getParams() != null && !getParams().isEmpty() ) {
-
-            getParams().keySet().stream().forEach( paramKey -> {
-                putIfNotEmpty( arguments, ( KettleConstants.PARAM + ":" + paramKey ), getParams().get( paramKey ) );
-            } );
-        }
-
-        // KTRs do not use customParams
-
-        return arguments;
-    }
-
-    private void putIfNotEmpty( Map<String, String> map, final String key, final String value ) {
-
-        if ( map != null && !StringUtils.isEmpty( key ) && !StringUtils.isEmpty( value ) ) {
-            map.put( key, value );
-        }
-    }
-
+    return arguments;
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/pan/TransParams.java
+++ b/engine/src/main/java/org/pentaho/di/pan/TransParams.java
@@ -1,0 +1,98 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.pan;
+
+import org.pentaho.di.base.Params;
+import org.pentaho.di.base.KettleConstants;
+import org.apache.commons.lang.StringUtils;
+import org.pentaho.di.core.parameters.NamedParams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TransParams extends Params {
+
+
+    public TransParams( String blockRepoConns, String repoName, String repoUsername, String trustRepoUser, String repoPassword, String inputDir,
+                        String inputFile, String listRepoFiles, String listRepoDirs, String exportRepo, String localFile,
+                        String localJarFile, String localInitialDir, String listRepos, String safeMode, String metrics,
+                        String listFileParams, String logLevel, String maxLogLines, String maxLogTimeout, String logFile,
+                        String oldLogFile, String version, String resultSetStepName, String resultSetCopyNumber, NamedParams namedParams ) {
+
+        super( blockRepoConns, repoName, repoUsername, trustRepoUser, repoPassword, inputDir, inputFile, listRepoFiles, listRepoDirs, exportRepo,
+                localFile, localJarFile, localInitialDir, listRepos, safeMode, metrics, listFileParams, logLevel, maxLogLines,
+                maxLogTimeout, logFile, oldLogFile, version, resultSetStepName, resultSetCopyNumber, namedParams, null );
+    }
+
+    @Override
+    public Map<String, String> asMap() {
+
+        Map<String, String> arguments = new HashMap<>();
+
+        putIfNotEmpty( arguments, "uuid", getUuid() );
+        putIfNotEmpty( arguments, KettleConstants.REPO, getRepoName() );
+        putIfNotEmpty( arguments, KettleConstants.NO_REPO, getBlockRepoConns() );
+        putIfNotEmpty( arguments, KettleConstants.USER, getRepoUsername() );
+        putIfNotEmpty( arguments, KettleConstants.TRUST_USER, getTrustRepoUser() );
+        putIfNotEmpty( arguments, KettleConstants.PASS, getRepoPassword() );
+        putIfNotEmpty( arguments, KettleConstants.DIR, getInputDir() );
+        putIfNotEmpty( arguments, KettleConstants.FILE, getLocalFile() );
+        putIfNotEmpty( arguments, KettleConstants.JARFILE, getLocalJarFile() );
+        putIfNotEmpty( arguments, KettleConstants.TRANS, getInputFile() );
+        putIfNotEmpty( arguments, KettleConstants.LIST_TRANS, getListRepoFiles() );
+        putIfNotEmpty( arguments, KettleConstants.LIST_DIRS, getListRepoDirs() );
+        putIfNotEmpty( arguments, KettleConstants.EXPORT_REPO_TRANS, getExportRepo() );
+        putIfNotEmpty( arguments, KettleConstants.INITIAL_DIR, getLocalInitialDir() );
+        putIfNotEmpty( arguments, KettleConstants.LIST_REPOS, getListRepos() );
+        putIfNotEmpty( arguments, KettleConstants.SAFEMODE, getSafeMode() );
+        putIfNotEmpty( arguments, KettleConstants.METRICS, getMetrics() );
+        putIfNotEmpty( arguments, KettleConstants.LIST_PARAMS, getListFileParams() );
+        putIfNotEmpty( arguments, KettleConstants.LEVEL, getLogLevel() );
+        putIfNotEmpty( arguments, KettleConstants.MAX_LOG_LINES, getMaxLogLines() );
+        putIfNotEmpty( arguments, KettleConstants.MAX_LOG_TIMEOUT, getMaxLogTimeout() );
+        putIfNotEmpty( arguments, KettleConstants.LOGFILE, getLogFile() );
+        putIfNotEmpty( arguments, KettleConstants.LOG, getOldLogFile() );
+        putIfNotEmpty( arguments, KettleConstants.VERSION, getVersion() );
+        putIfNotEmpty( arguments, KettleConstants.RESULT_SET_STEP_NAME, getResultSetStepName() );
+        putIfNotEmpty( arguments, KettleConstants.RESULT_SET_COPY_NUMBER, getResultSetCopyNumber() );
+
+        if ( getParams() != null && !getParams().isEmpty() ) {
+
+            getParams().keySet().stream().forEach( paramKey -> {
+                putIfNotEmpty( arguments, ( KettleConstants.PARAM + ":" + paramKey ), getParams().get( paramKey ) );
+            } );
+        }
+
+        // KTRs do not use customParams
+
+        return arguments;
+    }
+
+    private void putIfNotEmpty( Map<String, String> map, final String key, final String value ) {
+
+        if ( map != null && !StringUtils.isEmpty( key ) && !StringUtils.isEmpty( value ) ) {
+            map.put( key, value );
+        }
+    }
+
+}


### PR DESCRIPTION
`Pan` and `Kitchen` uses `PanCommandExecutor` and `KitchenCommandExecutor` and passes all the parameters it receives as individual `String`.  This PR introduces pojos that represents `JobParams` and `TransParams` and makes changes to `Pan` and `Kitchen` to use pojos instead.

@pentaho/rogueone 

After merging this PR,  https://github.com/pentaho/pentaho-ee/pull/1929 needs to be merged as well ( re-trigger wingman )