### PR TITLE
[BACKLOG-28164]  New database type for Snowflake

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -2172,8 +2172,7 @@ public class Database implements VariableSpace, LoggingObjectInterface {
     String cr_index = "";
     DatabaseInterface databaseInterface = databaseMeta.getDatabaseInterface();
 
-    // Exasol does not support explicit handling of indexes
-    if ( databaseInterface instanceof Exasol4DatabaseMeta ) {
+    if ( !databaseInterface.supportsIndexes() ) {
       return "";
     }
 

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
@@ -383,6 +383,13 @@ public interface DatabaseInterface extends Cloneable {
   public boolean supportsBitmapIndex();
 
   /**
+   * @return true if the database supports indexes at all.  (Exasol and Snowflake do not)
+   */
+  default boolean supportsIndexes() {
+    return true;
+  }
+
+  /**
    * @return true if the database JDBC driver supports the setLong command
    */
   public boolean supportsSetLong();

--- a/core/src/main/java/org/pentaho/di/core/database/Exasol4DatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Exasol4DatabaseMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -54,6 +54,11 @@ public class Exasol4DatabaseMeta extends BaseDatabaseMeta implements DatabaseInt
   public boolean supportsAutoInc() {
     // Exasol does support the identity column type, but does not support returning generated
     // keys on the jdbc driver
+    return false;
+  }
+
+  @Override
+  public boolean supportsIndexes() {
     return false;
   }
 

--- a/core/src/main/java/org/pentaho/di/core/database/SnowflakeHVDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/SnowflakeHVDatabaseMeta.java
@@ -1,0 +1,447 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2016-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.database;
+
+import com.google.common.base.Preconditions;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_BIGNUMBER;
+import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_BINARY;
+import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_BOOLEAN;
+import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_DATE;
+import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_INTEGER;
+import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_NUMBER;
+import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_STRING;
+import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_TIMESTAMP;
+import static org.pentaho.di.core.util.Utils.isEmpty;
+
+@SuppressWarnings ( "unused" )
+public class SnowflakeHVDatabaseMeta extends BaseDatabaseMeta implements DatabaseInterface {
+
+  private static final String ALTER_TABLE = "ALTER TABLE ";
+
+  @Override
+  public int[] getAccessTypeList() {
+    return new int[] { DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_JNDI };
+  }
+
+  @Override
+  public int getDefaultDatabasePort() {
+    if ( getAccessType() == DatabaseMeta.TYPE_ACCESS_NATIVE ) {
+      return 443;
+    }
+    return -1;
+  }
+
+  @Override
+  public String getXulOverlayFile() {
+    return "snowflake";
+  }
+
+  @Override
+  public Map<String, String> getDefaultOptions() {
+    Map<String, String> defaultOptions = new HashMap<>();
+    defaultOptions.put( getPluginId() + ".warehouse", "nowarehouse" );
+    defaultOptions.put( getPluginId() + ".ssl", "on" );
+
+    return defaultOptions;
+  }
+
+  @Override
+  public boolean isFetchSizeSupported() {
+    return false;
+  }
+
+  @Override
+  public String getDriverClass() {
+    return "com.snowflake.client.jdbc.SnowflakeDriver";
+  }
+
+  @Override
+  public String getURL( String hostname, String port, String databaseName ) {
+    String realHostname = hostname;
+    String account = hostname;
+    if ( !realHostname.contains( "." ) ) {
+      realHostname = hostname + ".snowflakecomputing.com";
+    } else {
+      account = hostname.substring( 0, hostname.indexOf( '.' ) );
+    }
+    if ( isEmpty( port ) ) {
+      return "jdbc:snowflake://" + realHostname + "/?account=" + account + "&db=" + databaseName
+        + "&user=" + getUsername() + "&password=" + getPassword();
+    } else {
+      return "jdbc:snowflake://" + realHostname + ":" + port + "/?account=" + account + "&db=" + databaseName
+        + "&user=" + getUsername() + "&password=" + getPassword();
+    }
+  }
+
+  /**
+   * Generates the SQL statement to add a column to the specified table
+   *
+   * @param tablename  The table to add
+   * @param v          The column defined as a value
+   * @param tk         the name of the technical key field
+   * @param useAutoinc whether or not this field uses auto increment
+   * @param pk         the name of the primary key field
+   * @param semicolon  whether or not to add a semi-colon behind the statement.
+   * @return the SQL statement to add a column to the specified table
+   */
+  @Override
+  public String getAddColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc,
+                                       String pk, boolean semicolon ) {
+    return ALTER_TABLE + tablename + " ADD COLUMN " + getFieldDefinition( v, tk, pk, useAutoinc, true, false );
+  }
+
+  /**
+   * Generates the SQL statement to drop a column from the specified table
+   *
+   * @param tablename  The table to add
+   * @param v          The column defined as a value
+   * @param tk         the name of the technical key field
+   * @param useAutoinc whether or not this field uses auto increment
+   * @param pk         the name of the primary key field
+   * @param semicolon  whether or not to add a semi-colon behind the statement.
+   * @return the SQL statement to drop a column from the specified table
+   */
+  @Override
+  public String getDropColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc,
+                                        String pk, boolean semicolon ) {
+    return ALTER_TABLE + tablename + " DROP COLUMN " + v.getName() + Const.CR;
+  }
+
+  @Override
+  public String getSQLListOfSchemas() {
+    return "SELECT SCHEMA_NAME AS \"name\" FROM " + getDatabaseName() + ".INFORMATION_SCHEMA.SCHEMATA";
+  }
+
+  /**
+   * Generates the SQL statement to modify a column in the specified table
+   *
+   * @param tableName  The table to add
+   * @param v          The column defined as a value
+   * @param tk         the name of the technical key field
+   * @param useAutoinc whether or not this field uses auto increment
+   * @param pk         the name of the primary key field
+   * @param semicolon  whether or not to add a semi-colon behind the statement.
+   * @return the SQL statement to modify a column in the specified table
+   */
+  @Override
+  public String getModifyColumnStatement( String tableName, ValueMetaInterface v, String tk,
+                                          boolean useAutoinc, String pk, boolean semicolon ) {
+    return ALTER_TABLE + tableName + " MODIFY COLUMN " + getFieldDefinition( v, tk, pk, useAutoinc, true, false );
+  }
+
+  @Override
+  public String getFieldDefinition( ValueMetaInterface v, String surrogateKey, String primaryKey, boolean useAutoinc,
+                                    boolean addFieldname, boolean addCr ) {
+    String fieldDefinitionDdl = "";
+
+    String newline = addCr ? Const.CR : "";
+
+    String fieldname = v.getName();
+    int length = v.getLength();
+    int precision = v.getPrecision();
+    int type = v.getType();
+
+    boolean isKeyField = fieldname.equalsIgnoreCase( surrogateKey ) || fieldname.equalsIgnoreCase( primaryKey );
+
+    if ( addFieldname ) {
+      fieldDefinitionDdl += fieldname + " ";
+    }
+    if ( isKeyField ) {
+      Preconditions.checkState( type == TYPE_NUMBER || type == TYPE_INTEGER || type == TYPE_BIGNUMBER );
+      return ddlForPrimaryKey( useAutoinc ) + newline;
+    }
+    switch ( type ) {
+      case TYPE_TIMESTAMP:
+      case TYPE_DATE:
+        // timestamp w/ local timezone
+        fieldDefinitionDdl += "TIMESTAMP_LTZ";
+        break;
+      case TYPE_BOOLEAN:
+        fieldDefinitionDdl += ddlForBooleanValue();
+        break;
+      case TYPE_NUMBER:
+      case TYPE_INTEGER:
+      case TYPE_BIGNUMBER:
+        if ( precision == 0 ) {
+          fieldDefinitionDdl += ddlForIntegerValue( length );
+        } else {
+          fieldDefinitionDdl += ddlForFloatValue( length, precision );
+        }
+        break;
+      case TYPE_STRING:
+        if ( length <= 0 ) {
+          fieldDefinitionDdl += "VARCHAR";
+        } else {
+          fieldDefinitionDdl += "VARCHAR(" + length + ")";
+        }
+        break;
+      case TYPE_BINARY:
+        fieldDefinitionDdl += "VARIANT";
+        break;
+      default:
+        fieldDefinitionDdl += " UNKNOWN";
+        break;
+    }
+    return fieldDefinitionDdl + newline;
+  }
+
+  private String ddlForBooleanValue() {
+    if ( supportsBooleanDataType() ) {
+      return "BOOLEAN";
+    } else {
+      return "CHAR(1)";
+    }
+  }
+
+  private String ddlForIntegerValue( int length ) {
+    if ( length > 9 ) {
+      if ( length < 19 ) {
+        // can hold signed values between -9223372036854775808 and 9223372036854775807
+        // 18 significant digits
+        return "BIGINT";
+      } else {
+        return "NUMBER(" + length + ", 0 )";
+      }
+    } else {
+      return "INT";
+    }
+  }
+
+  private String ddlForFloatValue( int length, int precision ) {
+    if ( length > 15 ) {
+      return "NUMBER(" + length + ", " + precision + ")";
+    } else {
+      return "FLOAT";
+    }
+  }
+
+  private String ddlForPrimaryKey( boolean useAutoinc ) {
+    if ( useAutoinc ) {
+      return "BIGINT AUTOINCREMENT NOT NULL PRIMARY KEY";
+    } else {
+      return "BIGINT NOT NULL PRIMARY KEY";
+    }
+  }
+
+  @Override
+  public String[] getUsedLibraries() {
+    return new String[] { "snowflake_jdbc.jar" };
+  }
+
+  @Override
+  public String getLimitClause( int nrRows ) {
+    return " LIMIT " + nrRows;
+  }
+
+  /**
+   * Returns the minimal SQL to launch in order to determine the layout of the resultset for a given database table
+   *
+   * @param tableName The name of the table to determine the layout for
+   * @return The SQL to launch.
+   */
+  @Override
+  public String getSQLQueryFields( String tableName ) {
+    return "SELECT * FROM " + tableName + " LIMIT 0";
+  }
+
+  @Override
+  public String getSQLTableExists( String tablename ) {
+    return getSQLQueryFields( tablename );
+  }
+
+  @Override
+  public String getSQLColumnExists( String columnname, String tablename ) {
+    return getSQLQueryColumnFields( columnname, tablename );
+  }
+
+  public String getSQLQueryColumnFields( String columnname, String tableName ) {
+    return "SELECT " + columnname + " FROM " + tableName + " LIMIT 0";
+  }
+
+  /**
+   * @see org.pentaho.di.core.database.DatabaseInterface#getNotFoundTK(boolean)
+   */
+  @Override
+  public int getNotFoundTK( boolean useAutoinc ) {
+    if ( supportsAutoInc() && useAutoinc ) {
+      return 1;
+    }
+    return super.getNotFoundTK( useAutoinc );
+  }
+
+  /**
+   * @return The extra option separator in database URL for this platform (usually this is semicolon ; )
+   */
+  @Override
+  public String getExtraOptionSeparator() {
+    return "&";
+  }
+
+  /**
+   * @return This indicator separates the normal URL from the options
+   */
+  @Override
+  public String getExtraOptionIndicator() {
+    return "&";
+  }
+
+  /**
+   * @return true if the database supports transactions.
+   */
+  @Override
+  public boolean supportsTransactions() {
+    return false;
+  }
+
+  /**
+   * @return true if the database supports bitmap indexes
+   */
+  @Override
+  public boolean supportsBitmapIndex() {
+    return false;
+  }
+
+  /**
+   * @return true if the database supports views
+   */
+  @Override
+  public boolean supportsViews() {
+    return true;
+  }
+
+  /**
+   * @return true if the database supports synonyms
+   */
+  @Override
+  public boolean supportsSynonyms() {
+    return false;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.di.core.database.DatabaseInterface#getReservedWords()
+   */
+  @Override
+  public String[] getReservedWords() {
+    return new String[] { "ALL", "ALTER", "AND", "ANY", "AS", "ASC", "BETWEEN", "BY", "CASE", "CAST", "CHECK",
+      "CLUSTER",
+      "COLUMN", "CONNECT", "CREATE", "CROSS", "CURRENT", "DELETE", "DESC", "DISTINCT", "DROP", "ELSE", "EXCLUSIVE",
+      "EXISTS", "FALSE", "FOR", "FROM", "FULL", "GRANT", "GROUP", "HAVING", "IDENTIFIED", "IMMEDIATE", "IN",
+      "INCREMENT", "INNER", "INSERT", "INTERSECT", "INTO", "IS", "JOIN", "LATERAL", "LEFT", "LIKE", "LOCK",
+      "LONG", "MAXEXTENTS", "MINUS", "MODIFY", "NATURAL", "NOT", "NULL", "OF", "ON", "OPTION", "OR", "ORDER",
+      "REGEXP", "RENAME", "REVOKE", "RIGHT", "RLIKE", "ROW", "ROWS", "SELECT", "SET", "SOME", "START", "TABLE",
+      "THEN", "TO", "TRIGGER", "TRUE", "UNION", "UNIQUE", "UPDATE", "USING", "VALUES", "WHEN", "WHENEVER",
+      "WHERE", "WITH" };
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.di.core.database.DatabaseInterface#getStartQuote()
+   */
+  @Override
+  public String getStartQuote() {
+    return "'";
+  }
+
+  /**
+   * Simply add an underscore in the case of MySQL!
+   *
+   * @see org.pentaho.di.core.database.DatabaseInterface#getEndQuote()
+   */
+  @Override
+  public String getEndQuote() {
+    return "'";
+  }
+
+  /**
+   * @return extra help text on the supported options on the selected database platform.
+   */
+  @Override
+  public String getExtraOptionsHelpText() {
+    return "https://docs.snowflake.net/manuals/user-guide/jdbc-configure.html";
+  }
+
+  /**
+   * Get the SQL to insert a new empty unknown record in a dimension.
+   *
+   * @param schemaTable  the schema-table name to insert into
+   * @param keyField     The key field
+   * @param versionField the version field
+   * @return the SQL to insert the unknown record into the SCD.
+   */
+  @Override
+  public String getSQLInsertAutoIncUnknownDimensionRow( String schemaTable, String keyField,
+                                                        String versionField ) {
+    return "insert into " + schemaTable + "(" + keyField + ", " + versionField + ") values (1, 1)";
+  }
+
+  @Override
+  public boolean supportsIndexes() {
+    // https://www.snowflake.com/blog/automatic-query-optimization-no-tuning/
+    return false;
+  }
+
+  /**
+   * @param string The String to escape
+   * @return A string that is properly quoted for use in a SQL statement (insert, update, delete, etc)
+   */
+  @Override
+  public String quoteSQLString( String string ) {
+    string = string.replaceAll( "'", "\\\\'" );
+    string = string.replaceAll( "\\n", "\\\\n" );
+    string = string.replaceAll( "\\r", "\\\\r" );
+    return "'" + string + "'";
+  }
+
+  @Override
+  public boolean releaseSavepoint() {
+    return false;
+  }
+
+  @Override
+  public boolean supportsErrorHandlingOnBatchUpdates() {
+    return true;
+  }
+
+  @Override
+  public boolean isRequiringTransactionsOnQueries() {
+    return false;
+  }
+
+  /**
+   * @return true if Kettle can create a repository on this type of database.
+   */
+  @Override
+  public boolean supportsRepository() {
+    return false;
+  }
+
+}

--- a/core/src/main/resources/kettle-database-types.xml
+++ b/core/src/main/resources/kettle-database-types.xml
@@ -220,4 +220,9 @@
     <classname>org.pentaho.di.core.database.GoogleBigQueryDatabaseMeta</classname>
   </database-type>
 
+  <database-type id="SNOWFLAKEHV">
+    <description>Snowflake</description>
+    <classname>org.pentaho.di.core.database.SnowflakeHVDatabaseMeta</classname>
+  </database-type>
+
  </database-types>

--- a/engine/src/main/java/org/pentaho/di/trans/steps/gettablenames/GetTableNames.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/gettablenames/GetTableNames.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -249,7 +249,7 @@ public class GetTableNames extends BaseStep implements StepInterface {
               data.db.getTableFieldsMeta( data.realSchemaName, tableName ),
               null, false, pk, true );
 
-        if ( pkc != null ) {
+        if ( pkc != null && pkc.length > 0 ) {
           // add composite primary key (several fields in primary key)
           int IndexOfLastClosedBracket = sql.lastIndexOf( ")" );
           if ( IndexOfLastClosedBracket > -1 ) {


### PR DESCRIPTION
Naming SNOWFLAKEHV to avoid collision with the Inquidia marketplace
plugin.
This plugin is mostly the same as the inquidia version with minor
corrections to DDL generation.
Also added  a supportsIndexes() method to the interface, with
snowflake and exasol being the only current dbs where this is false.

https://jira.pentaho.com/browse/BACKLOG-28164