### PR TITLE
[PDI-15742] Unable to load a prpt from the repository in the Pentaho Reporting Output step

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/pentahoreporting/PentahoReportingOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/pentahoreporting/PentahoReportingOutput.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,7 +25,6 @@ package org.pentaho.di.trans.steps.pentahoreporting;
 import java.awt.GraphicsEnvironment;
 import java.io.OutputStream;
 import java.math.BigDecimal;
-import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/pentahoreporting/PentahoReportingOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/pentahoreporting/PentahoReportingOutput.java
@@ -178,8 +178,7 @@ public class PentahoReportingOutput extends BaseStep implements StepInterface {
     ResourceManager manager = new ResourceManager();
     manager.registerDefaults();
     FileObject fileObject = KettleVFS.getFileObject( sourceFilename );
-    URL url = new URL( fileObject.getName().getURI() );
-    Resource resource = manager.createDirectly( url, MasterReport.class );
+    Resource resource = manager.createDirectly( fileObject, MasterReport.class );
     MasterReport report = (MasterReport) resource.getResource();
 
     return report;


### PR DESCRIPTION
New implementation of `ResourceData` and `ResourceLoader` for Apache VFS's `FileObject` would load resource of type `FileObject`

@tmorgner @pentaho/rogueone 

To be merged with https://github.com/pentaho/pentaho-reporting/pull/1248