### PR TITLE
[SP-4966] Backport of PDI-17984 - Problem in parameters - the pass pa…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -205,10 +205,11 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
       return null;
     }
 
-    //  When the child parameter does exist in the parent parameters, overwrite the child parameter by the
-    // parent parameter.
-    replaceVariableValues( mappingTransMeta, space );
+
     if ( share ) {
+      //  When the child parameter does exist in the parent parameters, overwrite the child parameter by the
+      // parent parameter.
+      replaceVariableValues( mappingTransMeta, space );
       // All other parent parameters need to get copied into the child parameters  (when the 'Inherit all
       // variables from the transformation?' option is checked)
       addMissingVariables( mappingTransMeta, space );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutor.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -381,7 +381,7 @@ public class JobExecutor extends BaseStep implements StepInterface {
     }
 
     StepWithMappingMeta.activateParams( data.executorJob, data.executorJob, this, data.executorJob.listParameters(),
-      parameters.getVariable(), parameters.getInput() );
+      parameters.getVariable(), parameters.getInput(), meta.getParameters().isInheritingAllVariables() );
   }
 
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/mapping/Mapping.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/mapping/Mapping.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -537,7 +537,7 @@ public class Mapping extends BaseStep implements StepInterface {
     if ( mappingParameters != null ) {
       StepWithMappingMeta
         .activateParams( data.mappingTrans, data.mappingTrans, this, data.mappingTransMeta.listParameters(),
-          mappingParameters.getVariable(), mappingParameters.getInputField() );
+          mappingParameters.getVariable(), mappingParameters.getInputField(), meta.getMappingParameters().isInheritingAllVariables() );
     }
 
   }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/simplemapping/SimpleMapping.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/simplemapping/SimpleMapping.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -143,7 +143,7 @@ public class SimpleMapping extends BaseStep implements StepInterface {
     // Set the parameters values in the mapping.
     //
     StepWithMappingMeta.activateParams( simpleMappingData.mappingTrans, simpleMappingData.mappingTrans, this, simpleMappingData.mappingTransMeta.listParameters(),
-      meta.getMappingParameters().getVariable(), meta.getMappingParameters().getInputField() );
+      meta.getMappingParameters().getVariable(), meta.getMappingParameters().getInputField(), meta.getMappingParameters().isInheritingAllVariables() );
     if ( simpleMappingData.mappingTransMeta.getTransformationType() != TransformationType.Normal ) {
       simpleMappingData.mappingTrans.getTransMeta().setUsingThreadPriorityManagment( false );
     }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/simplemapping/SimpleMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/simplemapping/SimpleMappingMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -294,7 +294,7 @@ public class SimpleMappingMeta extends StepWithMappingMeta implements StepMetaIn
       // This just means: set a number of variables or parameter values:
       //
       StepWithMappingMeta.activateParams( mappingTransMeta, mappingTransMeta, space, mappingTransMeta.listParameters(),
-        mappingParameters.getVariable(), mappingParameters.getInputField() );
+        mappingParameters.getVariable(), mappingParameters.getInputField(), mappingParameters.isInheritingAllVariables() );
     }
 
     // Keep track of all the fields that need renaming...

--- a/engine/src/main/java/org/pentaho/di/trans/steps/singlethreader/SingleThreader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/singlethreader/SingleThreader.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -165,7 +165,7 @@ public class SingleThreader extends BaseStep implements StepInterface {
     //
     StepWithMappingMeta
       .activateParams( getData().mappingTrans, getData().mappingTrans, this, getData().mappingTrans.listParameters(),
-        meta.getParameters(), meta.getParameterValues() );
+        meta.getParameters(), meta.getParameterValues(), meta.isPassingAllParameters() );
     getData().mappingTrans.activateParameters();
 
     // Disable thread priority managment as it will slow things down needlessly.

--- a/engine/src/main/java/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
@@ -341,7 +341,7 @@ public class TransExecutor extends BaseStep implements StepInterface {
 
     Trans trans = getExecutorTrans();
     StepWithMappingMeta
-        .activateParams( trans, trans, this, trans.listParameters(), parameters.getVariable(), inputFieldValues );
+        .activateParams( trans, trans, this, trans.listParameters(), parameters.getVariable(), inputFieldValues, meta.getParameters().isInheritingAllVariables() );
   }
 
   @VisibleForTesting

--- a/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
@@ -264,7 +264,7 @@ public class StepWithMappingMetaTest {
 
     String[] parameters = childVariableSpace.listParameters();
     StepWithMappingMeta.activateParams( childVariableSpace, childVariableSpace, parent,
-      parameters, new String[] { childParam, paramOverwrite }, new String[] { childValue, stepValue } );
+      parameters, new String[] { childParam, paramOverwrite }, new String[] { childValue, stepValue }, true );
 
     Assert.assertEquals( childValue, childVariableSpace.getVariable( childParam ) );
     // the step parameter prevails
@@ -348,7 +348,7 @@ public class StepWithMappingMetaTest {
     String[] parameters = childVariableSpace.listParameters();
 
     StepWithMappingMeta.activateParams( childVariableSpace, childVariableSpace, parentMeta,
-      parameters, new String[] { newParam }, new String[] { parentValue } );
+      parameters, new String[] { newParam }, new String[] { parentValue }, true );
 
     Assert.assertEquals( parentValue, childVariableSpace.getParameterValue( newParam ) );
   }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/mapping/MappingParametersTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/mapping/MappingParametersTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -69,9 +69,10 @@ public class MappingParametersTest {
     MappingParameters param = Mockito.mock( MappingParameters.class );
     Mockito.when( param.getVariable() ).thenReturn( new String[] { "a", "b" } );
     Mockito.when( param.getInputField() ).thenReturn( new String[] { "11", "12" } );
+    Mockito.when(  param.isInheritingAllVariables() ).thenReturn( true );
     when( transMeta.listParameters() ).thenReturn( new String[] { "a" } );
     StepWithMappingMeta
-      .activateParams( trans, trans, step, transMeta.listParameters(), param.getVariable(), param.getInputField() );
+      .activateParams( trans, trans, step, transMeta.listParameters(), param.getVariable(), param.getInputField(), param.isInheritingAllVariables() );
     // parameters was overridden 2 times
     // new call of setParameterValue added in StepWithMappingMeta - wantedNumberOfInvocations is now to 2
     Mockito.verify( trans, Mockito.times( 2 ) ).setParameterValue( Mockito.anyString(), Mockito.anyString() );


### PR DESCRIPTION
…rent parameters to subtrans/subJob checkbox is not considered, parent values always prevails over child (8.2 Suite)

Cherry-pick of https://github.com/pentaho/pentaho-kettle/pull/6329

@bantonio82 