### PR TITLE
[BACKLOG-28164]  Addressing issue with NULL date vals using Snowflake

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/SnowflakeHVDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/SnowflakeHVDatabaseMeta.java
@@ -326,6 +326,12 @@ public class SnowflakeHVDatabaseMeta extends BaseDatabaseMeta implements Databas
     return false;
   }
 
+
+  @Override
+  public boolean supportsTimeStampToDateConversion() {
+    return false; // The 3.6.9 driver _does_ support conversion, but errors when value is null.
+  }
+
   /**
    * @return true if the database supports bitmap indexes
    */


### PR DESCRIPTION
With the snowflake jdbc driver, .getTimestamp throws NPE when a Date
field has a NULL value.

https://jira.pentaho.com/browse/BACKLOG-28164