### PR TITLE
[CLEANUP] Refactor work on PanCommandExecutor/KitchenCommandExecutor …

### DIFF
--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
@@ -216,7 +216,7 @@ public class KitchenTest {
 
       Result result = Kitchen.getCommandExecutor().getResult();
       assertNotNull( result );
-      assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode() );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.SUCCESS.getCode() );
 
     } finally {
       // sanitize
@@ -264,7 +264,7 @@ public class KitchenTest {
 
       Result result = Kitchen.getCommandExecutor().getResult();
       assertNotNull( result );
-      assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode() );
+      assertEquals( result.getExitStatus(), CommandExecutorCodes.Kitchen.SUCCESS.getCode() );
 
     } finally {
       // sanitize


### PR DESCRIPTION
…to promote code reuse

This pull request holds zero changes to the logic. It's a mere refactor work aimed at promoting code reuse.

- Promoted util method `convert( Map<String, String> map )` to `AbstractBaseCommandExecutor`, rather than being duplicated in `PanCommandExecutor` / `KitchenCommandExecutor`
- `executeRepositoryBasedCommand( ... )` was doing both the _"print repos"_, _"list repos"_, etc... type of operations, as well as the action of loading a Trans/Job from the Repository
  - decoupled the 2: now `executeRepositoryBasedCommand( ... )` addresses the _"print repos"_, _"list repos"_, etc... while action of loading the Trans/Job from the Repository is now in `loadTransFromRepository( ...)` /  `loadJobFromRepository( ...)`
- Centralized and promoted method `loadRepositoryDirectory( repo, dirName )` to `AbstractBaseCommandExecutor`, rather than having its logic copy/pasted in `PanCommandExecutor` / `KitchenCommandExecutor`

### **Also**

- Checkstyle and copyright header year fixes
- Fixed a broken test method in `Kitchen` test, as it was asserting the output against a `COULD_NOT_LOAD_JOB` status code, when it should be against a `SUCCESS` one. 


### **To test Pan / Kitchen**

- `mvn clean verify -Dtest=PanTest -DrunITs -Dit.test=PanIT`
- `mvn clean verify -Dtest=KitchenTest -DrunITs -Dit.test=KitchenIT`


@pentaho/rogueone please review
