### PR TITLE
[BACKLOG-28357] Updates derby version, retrieved from parent POM

### DIFF
--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -30,7 +30,6 @@
         <pentaho-hadoop-shims-api.version>8.3.0.0-SNAPSHOT</pentaho-hadoop-shims-api.version>
 
         <!-- third party -->
-        <derby.version>10.2.1.6</derby.version>
         <derbyclient.version>10.2.1.6</derbyclient.version>
         <hsqldb.version>2.3.2</hsqldb.version>
         <jaybird.version>2.1.6</jaybird.version>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -29,7 +29,6 @@
     <pentaho-hadoop-shims-api.version>8.3.0.0-SNAPSHOT</pentaho-hadoop-shims-api.version>
 
     <!-- third party -->
-    <derby.version>10.2.1.6</derby.version>
     <derbyclient.version>10.2.1.6</derbyclient.version>
     <hsqldb.version>2.3.2</hsqldb.version>
     <jaybird.version>2.1.6</jaybird.version>


### PR DESCRIPTION
Removal of the Apache Derby version in favor of retrieving a unified version from the Maven parent POM. At the time of this PR, the latest version of Apache Derby is 10.15.1.3. Other PRs related to this one are listed below:

https://github.com/pentaho/maven-parent-poms/pull/122
https://github.com/pentaho/pentaho-platform/pull/4399
https://github.com/pentaho/pentaho-kettle/pull/6402
https://github.com/pentaho/pentaho-reporting/pull/1256
https://github.com/pentaho/data-access/pull/1053

**NOTE:** Should we also upgrade the derbyclient.version as well?