### PR TITLE
[PDI-16770] Use of vulnerable component Apache xmlrpc 1.3.1 CVE-2016-…

### DIFF
--- a/assemblies/plugins/pom.xml
+++ b/assemblies/plugins/pom.xml
@@ -24,7 +24,6 @@
     <kettle-drools5-plugin.version>${project.version}</kettle-drools5-plugin.version>
     <kettle-gpload-plugin.version>${project.version}</kettle-gpload-plugin.version>
     <kettle-hl7-plugin.version>${project.version}</kettle-hl7-plugin.version>
-    <kettle-openerp-plugin.version>${project.version}</kettle-openerp-plugin.version>
     <kettle-palo-plugin.version>${project.version}</kettle-palo-plugin.version>
     <kettle5-log4j-plugin.version>${project.version}</kettle5-log4j-plugin.version>
     <pdi-google-analytics-plugin.version>8.3.0.0-SNAPSHOT</pdi-google-analytics-plugin.version>
@@ -134,18 +133,6 @@
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>kettle-hl7-plugin</artifactId>
       <version>${kettle-hl7-plugin.version}</version>
-      <type>zip</type>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho.di.plugins</groupId>
-      <artifactId>kettle-openerp-plugin</artifactId>
-      <version>${kettle-openerp-plugin.version}</version>
       <type>zip</type>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
…5002 CVE-2016-5003 CVE-2016-5004

Openerp Plugin removed from Kettle core plugins (1/3 PRs):
Also check:
https://github.com/pentaho/pentaho-platform/pull/4406
https://github.com/pentaho/marketplace-metadata/pull/701

@pamval @pentaho-lmartins 
