### PR TITLE
[PDI-17801] Different output fields of Table Input for MySQL and MariaDB driver

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -721,11 +721,8 @@ public class Database implements VariableSpace, LoggingObjectInterface {
    * @throws KettleDatabaseException
    */
   public void cancelQuery() throws KettleDatabaseException {
-    // Canceling statements only if we're not streaming results on MySQL with
-    // the v3 driver
-    //
-    if ( databaseMeta.isMySQLVariant()
-      && databaseMeta.isStreamingResults() && getDatabaseMetaData().getDriverMajorVersion() == 3 ) {
+    // Canceling statements only if we're not streaming results on MySQL with the v3 driver
+    if ( databaseMeta.isMySQLVariant() && databaseMeta.isStreamingResults() && getDatabaseMetaData().getDriverMajorVersion() == 3 ) {
       return;
     }
 
@@ -2646,26 +2643,24 @@ public class Database implements VariableSpace, LoggingObjectInterface {
                                                   boolean lazyConversion )
     throws KettleDatabaseException, SQLException {
     // TODO If we do lazy conversion, we need to find out about the encoding
-    //
 
     // Extract the name from the result set meta data...
-    //
-    String name;
-    if ( databaseMeta.isMySQLVariant() && getDatabaseMetaData().getDriverMajorVersion() > 3 ) {
-      name = new String( rm.getColumnLabel( i ) );
-    } else {
-      name = new String( rm.getColumnName( i ) );
+
+    String name = null;
+
+    if ( databaseMeta.isMySQLVariant() ) {
+      name = databaseMeta.getDatabaseInterface().getLegacyColumnName( getDatabaseMetaData(), rm, i );
     }
 
     // Check the name, sometimes it's empty.
-    //
+
     if ( Utils.isEmpty( name ) || Const.onlySpaces( name ) ) {
       name = "Field" + ( i + 1 );
     }
 
     // Ask all the value meta types if they want to handle the SQL type.
     // The first to reply something gets the job...
-    //
+
     ValueMetaInterface valueMeta = null;
     for ( ValueMetaInterface valueMetaClass : valueMetaPluginClasses ) {
       ValueMetaInterface v =

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
@@ -22,7 +22,9 @@
 
 package org.pentaho.di.core.database;
 
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -1248,4 +1250,16 @@ public interface DatabaseInterface extends Cloneable {
     return "";
   }
 
+  /**
+   * Allows to get the column name for JDBC drivers with different behavior for aliases depending on the connector version.
+   *
+   * @param dbMetaData
+   * @param rsMetaData
+   * @param index
+   * @return empty if the database doesn't support the legacy column name feature
+   * @throws KettleDatabaseException
+   */
+  default String getLegacyColumnName( DatabaseMetaData dbMetaData, ResultSetMetaData rsMetaData, int index ) throws KettleDatabaseException {
+    return "";
+  }
 }

--- a/core/src/main/java/org/pentaho/di/core/database/MariaDBDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/MariaDBDatabaseMeta.java
@@ -21,21 +21,22 @@
  ******************************************************************************/
 package org.pentaho.di.core.database;
 
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.util.Set;
 
 import org.pentaho.di.core.Const;
 
 import com.google.common.collect.Sets;
+import org.pentaho.di.core.exception.KettleDatabaseException;
 
 public class MariaDBDatabaseMeta extends MySQLDatabaseMeta {
   private static final Set<String> SHORT_MESSAGE_EXCEPTIONS = Sets.newHashSet( "org.mariadb.jdbc.internal.stream.MaxAllowedPacketException" );
 
-
-
   @Override public String[] getUsedLibraries() {
     return new String[] { "mariadb-java-client-1.4.6.jar" };
   }
-
 
   @Override public String getDriverClass() {
     if ( getAccessType() == DatabaseMeta.TYPE_ACCESS_ODBC ) {
@@ -62,4 +63,26 @@ public class MariaDBDatabaseMeta extends MySQLDatabaseMeta {
     return !( cause != null && SHORT_MESSAGE_EXCEPTIONS.contains( cause.getClass().getName() ) );
   }
 
+  /**
+   * Returns the column name for a MariaDB field.
+   *
+   * @param dbMetaData
+   * @param rsMetaData
+   * @param index
+   * @return The column label.
+   * @throws KettleDatabaseException
+   */
+  @Override public String getLegacyColumnName( DatabaseMetaData dbMetaData, ResultSetMetaData rsMetaData, int index ) throws KettleDatabaseException {
+    String columnName;
+
+    try {
+      columnName = rsMetaData.getColumnLabel( index );
+    } catch ( SQLException sqlException ) {
+      throw new KettleDatabaseException( "Something went wrong trying to get the legacy column name", sqlException );
+    } catch ( Exception e ) {
+      throw new KettleDatabaseException( "Something unexpected went wrong trying to get the legacy column name", e );
+    }
+
+    return columnName;
+  }
 }

--- a/core/src/main/java/org/pentaho/di/core/database/MySQLDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/MySQLDatabaseMeta.java
@@ -24,9 +24,13 @@ package org.pentaho.di.core.database;
 
 import com.google.common.collect.Sets;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.util.Utils;
 
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.util.Set;
 
 /**
@@ -479,5 +483,28 @@ public class MySQLDatabaseMeta extends BaseDatabaseMeta implements DatabaseInter
   @Override
   public int getMaxTextFieldLength() {
     return Integer.MAX_VALUE;
+  }
+
+  /**
+   * Returns the column name for a MySQL field checking if the driver major version is "greater than" or "lower or equal" to 3.
+   *
+   * @param dbMetaData
+   * @param rsMetaData
+   * @param index
+   * @return The column label if version is greater than 3 or the column name if version is lower or equal to 3.
+   * @throws KettleDatabaseException
+   */
+  public String getLegacyColumnName( DatabaseMetaData dbMetaData, ResultSetMetaData rsMetaData, int index ) throws KettleDatabaseException {
+    String columnName;
+
+    try {
+      columnName = dbMetaData.getDriverMajorVersion() > 3 ? rsMetaData.getColumnLabel( index ) : rsMetaData.getColumnName( index );
+    } catch ( SQLException sqlException ) {
+      throw new KettleDatabaseException( "Something went wrong trying to get the legacy column name", sqlException );
+    } catch ( Exception e ) {
+      throw new KettleDatabaseException( "Something unexpected went wrong trying to get the legacy column name", e );
+    }
+
+    return columnName;
   }
 }

--- a/core/src/test/java/org/pentaho/di/core/database/MariaDBDatabaseMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/MariaDBDatabaseMetaTest.java
@@ -21,24 +21,94 @@
  ******************************************************************************/
 package org.pentaho.di.core.database;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import java.sql.*;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.pentaho.di.core.exception.KettleDatabaseException;
 
-
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.*;
 
 public class MariaDBDatabaseMetaTest extends MySQLDatabaseMetaTest {
+  private DatabaseMetaData databaseMetaData;
+
+  private ResultSetMetaData resultSetMetaData, resultSetMetaDataException;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    databaseMetaData = mock( DatabaseMetaData.class );
+
+    resultSetMetaData = mock( ResultSetMetaData.class );
+
+    given( resultSetMetaData.getColumnLabel( 1 ) ).willReturn( "NUMBER" );
+    given( resultSetMetaData.getColumnLabel( 2 ) ).willReturn( "NAME" );
+    given( resultSetMetaData.getColumnLabel( 3 ) ).willReturn( "LAST_NAME" );
+    given( resultSetMetaData.getColumnLabel( 4 ) ).willReturn( "FIRST_NAME" );
+    given( resultSetMetaData.getColumnLabel( 5 ) ).willReturn( "DB" );
+    given( resultSetMetaData.getColumnLabel( 6 ) ).willReturn( "NoAliasText" );
+
+    resultSetMetaDataException = mock( ResultSetMetaData.class );
+
+    when( resultSetMetaDataException.getColumnLabel( 1 ) ).thenThrow( new SQLException() );
+    when( resultSetMetaDataException.getColumnLabel( 2 ) ).thenThrow( new SQLException() );
+    when( resultSetMetaDataException.getColumnLabel( 3 ) ).thenThrow( new SQLException() );
+    when( resultSetMetaDataException.getColumnLabel( 4 ) ).thenThrow( new SQLException() );
+    when( resultSetMetaDataException.getColumnLabel( 5 ) ).thenThrow( new SQLException() );
+    when( resultSetMetaDataException.getColumnLabel( 6 ) ).thenThrow( new SQLException() );
+  }
 
   @Test
-  public void testMysqlOverrides() throws Exception {
+  public void testGetLegacyColumnName() {
+    MariaDBDatabaseMeta nativeMeta = new MariaDBDatabaseMeta();
+
+    try {
+      assertEquals( "NUMBER", nativeMeta.getLegacyColumnName( databaseMetaData, resultSetMetaData, 1 ) );
+      assertEquals( "NAME", nativeMeta.getLegacyColumnName( databaseMetaData, resultSetMetaData, 2 ) );
+      assertEquals( "LAST_NAME", nativeMeta.getLegacyColumnName( databaseMetaData, resultSetMetaData, 3 ) );
+      assertEquals( "FIRST_NAME", nativeMeta.getLegacyColumnName( databaseMetaData, resultSetMetaData, 4 ) );
+      assertEquals( "DB", nativeMeta.getLegacyColumnName( databaseMetaData, resultSetMetaData, 5 ) );
+      assertEquals( "NoAliasText", nativeMeta.getLegacyColumnName( databaseMetaData, resultSetMetaData, 6 ) );
+    }
+    catch ( KettleDatabaseException kettleDatabaseException ) {
+
+    }
+    catch ( Exception e ) {
+
+    }
+  }
+
+  @Test
+  public void testGetLegacyColumnNameNullParametersException() throws Exception {
+    MariaDBDatabaseMeta nativeMeta = new MariaDBDatabaseMeta();
+
+    expectedException.expect( Exception.class );
+
+    nativeMeta.getLegacyColumnName( null, null, 1 );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDatabaseException() throws Exception {
+    MariaDBDatabaseMeta nativeMeta = new MariaDBDatabaseMeta();
+
+    expectedException.expect( KettleDatabaseException.class );
+
+    nativeMeta.getLegacyColumnName( databaseMetaData, resultSetMetaDataException, 1 );
+  }
+
+  @Test
+  public void testMysqlOverrides() {
     MariaDBDatabaseMeta nativeMeta = new MariaDBDatabaseMeta();
     nativeMeta.setAccessType( DatabaseMeta.TYPE_ACCESS_NATIVE );
     MariaDBDatabaseMeta odbcMeta = new MariaDBDatabaseMeta();
     odbcMeta.setAccessType( DatabaseMeta.TYPE_ACCESS_ODBC );
 
-    assertArrayEquals( new String[] { "mariadb-java-client-1.4.6.jar" },
-        nativeMeta.getUsedLibraries() );
+    assertArrayEquals( new String[] { "mariadb-java-client-1.4.6.jar" }, nativeMeta.getUsedLibraries() );
     assertEquals( 3306, nativeMeta.getDefaultDatabasePort() );
     assertEquals( -1, odbcMeta.getDefaultDatabasePort() );
 
@@ -47,8 +117,7 @@ public class MariaDBDatabaseMetaTest extends MySQLDatabaseMetaTest {
     assertEquals( "jdbc:odbc:FOO", odbcMeta.getURL(  "IGNORED", "IGNORED", "FOO" ) );
     assertEquals( "jdbc:mariadb://FOO:BAR/WIBBLE", nativeMeta.getURL( "FOO", "BAR", "WIBBLE" ) );
     assertEquals( "jdbc:mariadb://FOO/WIBBLE", nativeMeta.getURL( "FOO", "", "WIBBLE" ) );
+
     // The fullExceptionLog method is covered by another test case.
   }
-
-
 }


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @gryphendowre @wseyler 

[PDI-17801] Refactoring MariaDB and MySQL unit tests for legacy column name methods
[PDI-17801] Adding unit tests for MySQL legacy column feature
[PDI-17801] Adding unit tests for MariaDB legacy column feature
[PDI-17801] Moving MySQL logic from db class to db dialects