### PR TITLE
[PDI-17801] Different output fields of Table Input for MySQL and MariaDB driver

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -2651,8 +2651,8 @@ public class Database implements VariableSpace, LoggingObjectInterface {
     // Extract the name from the result set meta data...
     //
     String name;
-    if ( databaseMeta.isMySQLVariant() && getDatabaseMetaData().getDriverMajorVersion() > 3 ) {
-      name = new String( rm.getColumnLabel( i ) );
+    if ( databaseMeta.isMySQLVariant() ) {
+      name = databaseMeta.getDatabaseInterface().getLegacyColumnName( getDatabaseMetaData(), rm, i );
     } else {
       name = new String( rm.getColumnName( i ) );
     }

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
@@ -22,7 +22,9 @@
 
 package org.pentaho.di.core.database;
 
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -1248,4 +1250,16 @@ public interface DatabaseInterface extends Cloneable {
     return "";
   }
 
+  /**
+   * Allows to get the column name for JDBC drivers with different behavior for aliases depending on the connector version.
+   *
+   * @param dbMetaData
+   * @param rsMetaData
+   * @param index
+   * @return empty if the database doesn't support the legacy column name feature
+   * @throws KettleDatabaseException
+   */
+  default String getLegacyColumnName( DatabaseMetaData dbMetaData, ResultSetMetaData rsMetaData, int index ) throws KettleDatabaseException {
+    return "";
+  }
 }

--- a/core/src/main/java/org/pentaho/di/core/database/MariaDBDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/MariaDBDatabaseMeta.java
@@ -21,21 +21,25 @@
  ******************************************************************************/
 package org.pentaho.di.core.database;
 
-import java.util.Set;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSetMetaData;
 
-import org.pentaho.di.core.Const;
+import java.util.Set;
 
 import com.google.common.collect.Sets;
 
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.i18n.BaseMessages;
+
 public class MariaDBDatabaseMeta extends MySQLDatabaseMeta {
+  private static final Class<?> PKG = MariaDBDatabaseMeta.class;
+
   private static final Set<String> SHORT_MESSAGE_EXCEPTIONS = Sets.newHashSet( "org.mariadb.jdbc.internal.stream.MaxAllowedPacketException" );
-
-
 
   @Override public String[] getUsedLibraries() {
     return new String[] { "mariadb-java-client-1.4.6.jar" };
   }
-
 
   @Override public String getDriverClass() {
     if ( getAccessType() == DatabaseMeta.TYPE_ACCESS_ODBC ) {
@@ -62,4 +66,28 @@ public class MariaDBDatabaseMeta extends MySQLDatabaseMeta {
     return !( cause != null && SHORT_MESSAGE_EXCEPTIONS.contains( cause.getClass().getName() ) );
   }
 
+  /**
+   * Returns the column name for a MariaDB field.
+   *
+   * @param dbMetaData
+   * @param rsMetaData
+   * @param index
+   * @return The column label.
+   * @throws KettleDatabaseException
+   */
+  @Override public String getLegacyColumnName( DatabaseMetaData dbMetaData, ResultSetMetaData rsMetaData, int index ) throws KettleDatabaseException {
+    if ( dbMetaData == null ) {
+      throw new KettleDatabaseException( BaseMessages.getString( PKG, "MySQLDatabaseMeta.Exception.LegacyColumnNameNoDBMetaDataException" ) );
+    }
+
+    if ( rsMetaData == null ) {
+      throw new KettleDatabaseException( BaseMessages.getString( PKG, "MySQLDatabaseMeta.Exception.LegacyColumnNameNoRSMetaDataException" ) );
+    }
+
+    try {
+      return rsMetaData.getColumnLabel( index );
+    } catch ( Exception e ) {
+      throw new KettleDatabaseException( String.format( "%s: %s", BaseMessages.getString( PKG, "MySQLDatabaseMeta.Exception.LegacyColumnNameException" ), e.getMessage() ), e );
+    }
+  }
 }

--- a/core/src/main/resources/org/pentaho/di/core/database/messages/messages_en_US.properties
+++ b/core/src/main/resources/org/pentaho/di/core/database/messages/messages_en_US.properties
@@ -63,3 +63,6 @@ DatabaseMeta.BadDatabaseName=Please specify the name of the database
 GoogleBigQueryDatabaseMeta.UnsupportedTableOutputMessage=The Simba driver for a Google Big Query database connection does not support regular DDL statements. Please use the GBQ Bulk Loader step to create your table.
 Database.Exception.EmptyConnectionError=Error connecting to database [{0}]
 Database.Exception.UnableToGetMetadata=Unable to get database metadata from this database connection
+MySQLDatabaseMeta.Exception.LegacyColumnNameNoDBMetaDataException="Please provide a valid DatabaseMetaData object"
+MySQLDatabaseMeta.Exception.LegacyColumnNameNoRSMetaDataException="Please provide a valid ResultSetMetaData object"
+MySQLDatabaseMeta.Exception.LegacyColumnNameException=Something unexpected went wrong trying to get the legacy column name

--- a/core/src/test/java/org/pentaho/di/core/database/MariaDBDatabaseMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/MariaDBDatabaseMetaTest.java
@@ -21,24 +21,120 @@
  ******************************************************************************/
 package org.pentaho.di.core.database;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 
 import org.junit.Test;
 
+import org.pentaho.di.core.exception.KettleDatabaseException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+
+import static org.mockito.BDDMockito.doReturn;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.mock;
 
 public class MariaDBDatabaseMetaTest extends MySQLDatabaseMetaTest {
+  /**
+   *
+   * @return
+   * @throws Exception
+   */
+  private ResultSetMetaData getResultSetMetaData() throws Exception {
+    ResultSetMetaData resultSetMetaData = mock( ResultSetMetaData.class );
+
+    /**
+     * Fields setup around the following query:
+     *
+     * select
+     *   CUSTOMERNUMBER as NUMBER
+     * , CUSTOMERNAME as NAME
+     * , CONTACTLASTNAME as LAST_NAME
+     * , CONTACTFIRSTNAME as FIRST_NAME
+     * , 'MariaDB' as DB
+     * , 'NoAliasText'
+     * from CUSTOMERS
+     * ORDER BY CUSTOMERNAME;
+     */
+
+    doReturn( "NUMBER" ).when( resultSetMetaData ).getColumnLabel( 1 );
+    doReturn( "NAME" ).when( resultSetMetaData ).getColumnLabel( 2 );
+    doReturn( "LAST_NAME" ).when( resultSetMetaData ).getColumnLabel( 3 );
+    doReturn( "FIRST_NAME" ).when( resultSetMetaData ).getColumnLabel( 4 );
+    doReturn( "DB" ).when( resultSetMetaData ).getColumnLabel( 5 );
+    doReturn( "NoAliasText" ).when( resultSetMetaData ).getColumnLabel( 6 );
+
+    return resultSetMetaData;
+  }
+
+  /**
+   *
+   * @return
+   * @throws Exception
+   */
+  private ResultSetMetaData getResultSetMetaDataException() throws Exception {
+    ResultSetMetaData resultSetMetaData = mock( ResultSetMetaData.class );
+
+    doThrow( new SQLException() ).when( resultSetMetaData ).getColumnLabel( 1 );
+
+    return resultSetMetaData;
+  }
 
   @Test
-  public void testMysqlOverrides() throws Exception {
+  public void testGetLegacyColumnNameFieldNumber() throws Exception {
+    assertEquals( "NUMBER", new MariaDBDatabaseMeta().getLegacyColumnName( mock( DatabaseMetaData.class ), getResultSetMetaData(), 1 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameFieldName() throws Exception {
+    assertEquals( "NAME", new MariaDBDatabaseMeta().getLegacyColumnName( mock( DatabaseMetaData.class ), getResultSetMetaData(), 2 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameFieldLastName() throws Exception {
+    assertEquals( "LAST_NAME", new MariaDBDatabaseMeta().getLegacyColumnName( mock( DatabaseMetaData.class ), getResultSetMetaData(), 3 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameFieldFirstName() throws Exception {
+    assertEquals( "FIRST_NAME", new MariaDBDatabaseMeta().getLegacyColumnName( mock( DatabaseMetaData.class ), getResultSetMetaData(), 4 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameFieldDB() throws Exception {
+    assertEquals( "DB", new MariaDBDatabaseMeta().getLegacyColumnName( mock( DatabaseMetaData.class ), getResultSetMetaData(), 5 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameNoAliasText() throws Exception {
+    assertEquals( "NoAliasText", new MariaDBDatabaseMeta().getLegacyColumnName( mock( DatabaseMetaData.class ), getResultSetMetaData(), 6 ) );
+  }
+
+  @Test( expected = KettleDatabaseException.class )
+  public void testGetLegacyColumnNameNullDBMetaDataException() throws Exception {
+    new MariaDBDatabaseMeta().getLegacyColumnName( null, getResultSetMetaData(), 1 );
+  }
+
+  @Test( expected = KettleDatabaseException.class )
+  public void testGetLegacyColumnNameNullRSMetaDataException() throws Exception {
+    new MariaDBDatabaseMeta().getLegacyColumnName( mock( DatabaseMetaData.class ), null, 1 );
+  }
+
+  @Test( expected = KettleDatabaseException.class )
+  public void testGetLegacyColumnNameDatabaseException() throws Exception {
+    new MariaDBDatabaseMeta().getLegacyColumnName( mock( DatabaseMetaData.class ), getResultSetMetaDataException(), 1 );
+  }
+
+  @Test
+  public void testMysqlOverrides() {
     MariaDBDatabaseMeta nativeMeta = new MariaDBDatabaseMeta();
     nativeMeta.setAccessType( DatabaseMeta.TYPE_ACCESS_NATIVE );
     MariaDBDatabaseMeta odbcMeta = new MariaDBDatabaseMeta();
     odbcMeta.setAccessType( DatabaseMeta.TYPE_ACCESS_ODBC );
 
-    assertArrayEquals( new String[] { "mariadb-java-client-1.4.6.jar" },
-        nativeMeta.getUsedLibraries() );
+    assertArrayEquals( new String[] { "mariadb-java-client-1.4.6.jar" }, nativeMeta.getUsedLibraries() );
     assertEquals( 3306, nativeMeta.getDefaultDatabasePort() );
     assertEquals( -1, odbcMeta.getDefaultDatabasePort() );
 
@@ -47,8 +143,7 @@ public class MariaDBDatabaseMetaTest extends MySQLDatabaseMetaTest {
     assertEquals( "jdbc:odbc:FOO", odbcMeta.getURL(  "IGNORED", "IGNORED", "FOO" ) );
     assertEquals( "jdbc:mariadb://FOO:BAR/WIBBLE", nativeMeta.getURL( "FOO", "BAR", "WIBBLE" ) );
     assertEquals( "jdbc:mariadb://FOO/WIBBLE", nativeMeta.getURL( "FOO", "", "WIBBLE" ) );
+
     // The fullExceptionLog method is covered by another test case.
   }
-
-
 }

--- a/core/src/test/java/org/pentaho/di/core/database/MySQLDatabaseMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/MySQLDatabaseMetaTest.java
@@ -26,8 +26,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import static org.mockito.BDDMockito.doReturn;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.Mockito.doThrow;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.row.value.ValueMetaBigNumber;
 import org.pentaho.di.core.row.value.ValueMetaBinary;
 import org.pentaho.di.core.row.value.ValueMetaBoolean;
@@ -37,6 +42,10 @@ import org.pentaho.di.core.row.value.ValueMetaInternetAddress;
 import org.pentaho.di.core.row.value.ValueMetaNumber;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.row.value.ValueMetaTimestamp;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 
 public class MySQLDatabaseMetaTest {
   MySQLDatabaseMeta nativeMeta, odbcMeta;
@@ -223,4 +232,178 @@ public class MySQLDatabaseMetaTest {
     assertEquals( "insert into FOO(FOOKEY, FOOVERSION) values (1, 1)", nativeMeta.getSQLInsertAutoIncUnknownDimensionRow( "FOO", "FOOKEY", "FOOVERSION" ) );
   }
 
+  /**
+   *
+   * @return
+   * @throws Exception
+   */
+  private ResultSetMetaData getResultSetMetaData() throws Exception {
+    ResultSetMetaData resultSetMetaData = mock( ResultSetMetaData.class );
+
+    /**
+     * Fields setup around the following query:
+     *
+     * select
+     *   CUSTOMERNUMBER as NUMBER
+     * , CUSTOMERNAME as NAME
+     * , CONTACTLASTNAME as LAST_NAME
+     * , CONTACTFIRSTNAME as FIRST_NAME
+     * , 'MySQL' as DB
+     * , 'NoAliasText'
+     * from CUSTOMERS
+     * ORDER BY CUSTOMERNAME;
+     */
+
+    doReturn( "NUMBER" ).when( resultSetMetaData ).getColumnLabel( 1 );
+    doReturn( "NAME" ).when( resultSetMetaData ).getColumnLabel( 2 );
+    doReturn( "LAST_NAME" ).when( resultSetMetaData ).getColumnLabel( 3 );
+    doReturn( "FIRST_NAME" ).when( resultSetMetaData ).getColumnLabel( 4 );
+    doReturn( "DB" ).when( resultSetMetaData ).getColumnLabel( 5 );
+    doReturn( "NoAliasText" ).when( resultSetMetaData ).getColumnLabel( 6 );
+
+    doReturn( "CUSTOMERNUMBER" ).when( resultSetMetaData ).getColumnName( 1 );
+    doReturn( "CUSTOMERNAME" ).when( resultSetMetaData ).getColumnName( 2 );
+    doReturn( "CONTACTLASTNAME" ).when( resultSetMetaData ).getColumnName( 3 );
+    doReturn( "CONTACTFIRSTNAME" ).when( resultSetMetaData ).getColumnName( 4 );
+    doReturn( "MySQL" ).when( resultSetMetaData ).getColumnName( 5 );
+    doReturn( "NoAliasText" ).when( resultSetMetaData ).getColumnName( 6 );
+
+    return resultSetMetaData;
+  }
+
+  /**
+   *
+   * @return
+   * @throws Exception
+   */
+  private ResultSetMetaData getResultSetMetaDataException() throws Exception {
+    ResultSetMetaData resultSetMetaData = mock( ResultSetMetaData.class );
+
+    doThrow( new SQLException() ).when( resultSetMetaData ).getColumnLabel( 1 );
+    doThrow( new SQLException() ).when( resultSetMetaData ).getColumnName( 1 );
+
+    return resultSetMetaData;
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverGreaterThanThreeFieldNumber() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 5 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "NUMBER", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 1 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverGreaterThanThreeFieldName() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 5 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "NAME", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 2 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverGreaterThanThreeFieldLastName() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 5 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "LAST_NAME", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 3 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverGreaterThanThreeFieldFirstName() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 5 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "FIRST_NAME", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 4 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverGreaterThanThreeFieldDB() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 5 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "DB", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 5 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverGreaterThanThreeFieldNoAliasText() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 5 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "NoAliasText", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 6 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverLessOrEqualToThreeFieldCustomerNumber() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 3 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "CUSTOMERNUMBER", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 1 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverLessOrEqualToThreeFieldCustomerName() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 3 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "CUSTOMERNAME", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 2 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverLessOrEqualToThreeFieldContactLastName() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 3 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "CONTACTLASTNAME", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 3 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverLessOrEqualToThreeFieldContactFirstName() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 3 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "CONTACTFIRSTNAME", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 4 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverLessOrEqualToThreeFieldMySQL() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 3 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "MySQL", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 5 ) );
+  }
+
+  @Test
+  public void testGetLegacyColumnNameDriverLessOrEqualToThreeFieldNoAliasText() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 3 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    assertEquals( "NoAliasText", new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaData(), 6 ) );
+  }
+
+  @Test( expected = KettleDatabaseException.class )
+  public void testGetLegacyColumnNameNullDBMetaDataException() throws Exception {
+    new MySQLDatabaseMeta().getLegacyColumnName( null, getResultSetMetaData(), 1 );
+  }
+
+  @Test( expected = KettleDatabaseException.class )
+  public void testGetLegacyColumnNameNullRSMetaDataException() throws Exception {
+    new MySQLDatabaseMeta().getLegacyColumnName( mock( DatabaseMetaData.class ), null, 1 );
+  }
+
+  @Test( expected = KettleDatabaseException.class )
+  public void testGetLegacyColumnNameDriverGreaterThanThreeException() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 5 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaDataException(), 1 );
+  }
+
+  @Test( expected = KettleDatabaseException.class )
+  public void testGetLegacyColumnNameDriverLessOrEqualToThreeException() throws Exception {
+    DatabaseMetaData databaseMetaData = mock( DatabaseMetaData.class );
+    doReturn( 3 ).when( databaseMetaData ).getDriverMajorVersion();
+
+    new MySQLDatabaseMeta().getLegacyColumnName( databaseMetaData, getResultSetMetaDataException(), 1 );
+  }
 }


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @gryphendowre @wseyler

[PDI-17801] Moving MySQL logic from db class to db dialects
[PDI-17801] Adding unit tests for MariaDB legacy column feature
[PDI-17801] Adding unit tests for MySQL legacy column feature
[PDI-17801] Refactoring MariaDB and MySQL unit tests for legacy column name methods
[PDI-17801] Changing try catch block to match code style
[PDI-17801] Changing try catch code style