### PR TITLE
[PDI-17977] Set Variables in Job as blank returns null error if varia…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -251,10 +251,13 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
             PKG, "JobEntrySetVariables.Error.UnableReadPropertiesFile", realFilename ) );
         }
       }
-      for ( int i = 0; i < variableName.length; i++ ) {
-        variables.add( variableName[i] );
-        variableValues.add( variableValue[i] );
-        variableTypes.add( variableType[i] );
+
+      if ( variableName != null ) {
+        for ( int i = 0; i < variableName.length; i++ ) {
+          variables.add( variableName[ i ] );
+          variableValues.add( variableValue[ i ] );
+          variableTypes.add( variableType[ i ] );
+        }
       }
 
       // if parentJob exists - clear/reset all entrySetVariables before applying the actual ones

--- a/engine/src/main/java/org/pentaho/di/job/entry/JobEntryBase.java
+++ b/engine/src/main/java/org/pentaho/di/job/entry/JobEntryBase.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.AttributesInterface;
 import org.pentaho.di.core.CheckResultInterface;
@@ -1538,7 +1539,14 @@ public class JobEntryBase implements Cloneable, VariableSpace, CheckResultSource
    *
    */
   public void setEntryStepSetVariable( String variableName, String variableValue ) {
-    entryStepSetVariablesMap.put( variableName, variableValue );
+    // ConcurrentHashMap does not allow null keys and null values.
+    if ( variableName != null ) {
+      if ( variableValue != null ) {
+        entryStepSetVariablesMap.put( variableName, variableValue );
+      } else {
+        entryStepSetVariablesMap.put( variableName, StringUtils.EMPTY );
+      }
+    }
   }
 
   /**

--- a/engine/src/test/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -90,7 +90,6 @@ public class JobEntrySetVariablesTest {
   public void testASCIIText() throws Exception {
     // properties file with native2ascii
     entry.setFilename( "src/test/resources/org/pentaho/di/job/entries/setvariables/ASCIIText.properties" );
-    entry.setVariableName( new String[] {} ); // For absence of null check in execute method
     entry.setReplaceVars( true );
     Result result = entry.execute( new Result(), 0 );
     assertTrue( "Result should be true", result.getResult() );
@@ -103,7 +102,6 @@ public class JobEntrySetVariablesTest {
   public void testUTF8Text() throws Exception {
     // properties files without native2ascii
     entry.setFilename( "src/test/resources/org/pentaho/di/job/entries/setvariables/UTF8Text.properties" );
-    entry.setVariableName( new String[] {} ); // For absence of null check in execute method
     entry.setReplaceVars( true );
     Result result = entry.execute( new Result(), 0 );
     assertTrue( "Result should be true", result.getResult() );
@@ -116,7 +114,6 @@ public class JobEntrySetVariablesTest {
     // properties files without native2ascii
     String propertiesFilename = "src/test/resources/org/pentaho/di/job/entries/setvariables/UTF8Text.properties";
     entry.setFilename( propertiesFilename );
-    entry.setVariableName( new String[] {} ); // For absence of null check in execute method
     entry.setReplaceVars( true );
     Result result = entry.execute( new Result(), 0 );
     assertTrue( "Result should be true", result.getResult() );
@@ -137,7 +134,6 @@ public class JobEntrySetVariablesTest {
 
   @Test
   public void testParentJobVariablesExecutingFilePropertiesThatChangesVariablesAndParameters() throws Exception {
-    entry.setVariableName( new String[] {} ); // For absence of null check in execute method
     entry.setReplaceVars( true );
     entry.setFileVariableType( 1 );
 
@@ -190,10 +186,22 @@ public class JobEntrySetVariablesTest {
     List<SlaveServer> slaveServers = mock( List.class );
     Repository repository = mock( Repository.class );
     IMetaStore metaStore = mock( IMetaStore.class );
-    entry.loadXML( getEntryNode( "nullVariable", null ), databases, slaveServers, repository, metaStore );
+    entry.loadXML( getEntryNode( "nullVariable", null, "JVM" ), databases, slaveServers, repository, metaStore );
     Result result = entry.execute( new Result(), 0 );
     assertTrue( "Result should be true", result.getResult() );
     assertNull( System.getProperty( "nullVariable" )  );
+  }
+
+  @Test
+  public void testJobEntrySetVariablesExecute_VARIABLE_TYPE_CURRENT_JOB_NullVariable() throws Exception {
+    List<DatabaseMeta> databases = mock( List.class );
+    List<SlaveServer> slaveServers = mock( List.class );
+    Repository repository = mock( Repository.class );
+    IMetaStore metaStore = mock( IMetaStore.class );
+    entry.loadXML( getEntryNode( "nullVariable", null, "CURRENT_JOB" ), databases, slaveServers, repository, metaStore );
+    Result result = entry.execute( new Result(), 0 );
+    assertTrue( "Result should be true", result.getResult() );
+    assertNull( entry.getVariable( "nullVariable" )  );
   }
 
   @Test
@@ -202,15 +210,28 @@ public class JobEntrySetVariablesTest {
     List<SlaveServer> slaveServers = mock( List.class );
     Repository repository = mock( Repository.class );
     IMetaStore metaStore = mock( IMetaStore.class );
-    entry.loadXML( getEntryNode( "variableNotNull", "someValue" ), databases, slaveServers, repository, metaStore );
+    entry.loadXML( getEntryNode( "variableNotNull", "someValue", "JVM" ), databases, slaveServers, repository, metaStore );
     assertNull( System.getProperty( "variableNotNull" )  );
     Result result = entry.execute( new Result(), 0 );
     assertTrue( "Result should be true", result.getResult() );
     assertEquals( "someValue", System.getProperty( "variableNotNull" ) );
   }
 
+  @Test
+  public void testJobEntrySetVariablesExecute_VARIABLE_TYPE_CURRENT_JOB_VariableNotNull() throws Exception {
+    List<DatabaseMeta> databases = mock( List.class );
+    List<SlaveServer> slaveServers = mock( List.class );
+    Repository repository = mock( Repository.class );
+    IMetaStore metaStore = mock( IMetaStore.class );
+    entry.loadXML( getEntryNode( "variableNotNull", "someValue", "CURRENT_JOB" ), databases, slaveServers, repository, metaStore );
+    assertNull( System.getProperty( "variableNotNull" )  );
+    Result result = entry.execute( new Result(), 0 );
+    assertTrue( "Result should be true", result.getResult() );
+    assertEquals( "someValue", entry.getVariable( "variableNotNull" ) );
+  }
+
   //prepare xml for use
-  public Node getEntryNode( String variable_name, String variable_value )
+  public Node getEntryNode( String variable_name, String variable_value, String variable_type )
     throws ParserConfigurationException, SAXException, IOException {
     StringBuilder sb = new StringBuilder();
     sb.append( XMLHandler.openTag( "job" ) );
@@ -219,6 +240,10 @@ public class JobEntrySetVariablesTest {
     sb.append( "      " ).append( XMLHandler.addTagValue( "variable_name", variable_name ) );
     if ( variable_value != null ) {
       sb.append( "      " ).append( XMLHandler.addTagValue( "variable_value", variable_value ) );
+    }
+    if ( variable_type != null ) {
+      sb.append( "          " ).append(
+        XMLHandler.addTagValue( "variable_type", variable_type ) );
     }
     sb.append( "      " ).append( XMLHandler.closeTag( "field" ) );
     sb.append( "      " ).append( XMLHandler.closeTag( "fields" ) );


### PR DESCRIPTION
…ble scope type is set to: Valid in the current job

ConcurrentHashMap does not allow null keys and null values.

@pentaho/tatooine @pentaho-lmartins @ppatricio 
@bantonio82 Can you take a look at this, since this is similar to PDI-17536?