### PR TITLE
[PDI-17774] Database Connection dialog - display language does not fo…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -728,7 +728,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     StringBuilder optionLogLevel = getCommandLineOption( options, "level" ).getArgument();
 
     // Set default Locale:
-    Locale.setDefault( Const.DEFAULT_LOCALE );
+    Locale.setDefault( LanguageChoice.getInstance().getDefaultLocale() );
 
     if ( !Utils.isEmpty( optionLogFile ) ) {
       fileLoggingEventListener = new FileLoggingEventListener( optionLogFile.toString(), true );


### PR DESCRIPTION
…llow Preferred Language option of PDI

Only some frames/Dialogs were being located accordingly to Kettle LanguageChoice. The main kettle frame was always system defined by default. So every child frame/dialog from those main Kettle frames were, by parent relation, system defined also. This PR changes that logic and forces Kettle to look for LanguageChoice first. 

Please let me know if you find any problem with this fix, since it is a "spoon.java" change.

@pentaho-lmartins @mbatchelor @mkambol 