### PR TITLE
[CLEANUP][TEST] Added more Pan/Kitchen UTs/ITs; refactored logic to p…

### DIFF
--- a/engine/src/it/java/org/pentaho/di/kitchen/KitchenIT.java
+++ b/engine/src/it/java/org/pentaho/di/kitchen/KitchenIT.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/it/java/org/pentaho/di/kitchen/KitchenIT.java
+++ b/engine/src/it/java/org/pentaho/di/kitchen/KitchenIT.java
@@ -21,6 +21,7 @@
  ******************************************************************************/
 package org.pentaho.di.kitchen;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +34,7 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.security.Permission;
+import java.util.Base64;
 import java.util.UUID;
 
 import static org.junit.Assert.assertFalse;
@@ -267,6 +269,31 @@ public class KitchenIT {
     }
 
     return content;
+  }
+
+  @Test
+  public void testJobExecutionFromWithinProvidedZip() throws Exception {
+
+    String testZipRelativePath = "test-kjb.zip";
+    String testKJBWithinZip = "Job.kjb";
+
+    File zipFile = null;
+
+    try {
+      zipFile = new File( getClass().getResource( testZipRelativePath ).toURI() );
+      String base64Zip = Base64.getEncoder().encodeToString( FileUtils.readFileToByteArray( zipFile ) );
+
+      Kitchen.main( new String[] {
+        "/file:" + testKJBWithinZip,
+        "/level:Basic",
+        "/zip:" + base64Zip } );
+
+    } catch ( SecurityException e ) {
+      // All OK / expected: SecurityException is purposely thrown when Kitchen triggers System.exitJVM()
+      Result result = Kitchen.getCommandExecutor().getResult();
+      assertNotNull( result );
+      assertEquals( CommandExecutorCodes.Kitchen.SUCCESS.getCode(), result.getExitStatus() );
+    }
   }
 
   public class MySecurityManager extends SecurityManager {

--- a/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
@@ -47,7 +47,6 @@ import org.pentaho.di.resource.TopLevelResource;
 import org.pentaho.di.i18n.BaseMessages;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;

--- a/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
@@ -48,6 +48,7 @@ import org.pentaho.di.i18n.BaseMessages;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
@@ -300,29 +301,17 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     return new Job( repository, jobMeta );
   }
 
-  public Job loadJobFromFilesystem( String initialDir, String filename, String base64Zip ) throws Exception {
+  public Job loadJobFromFilesystem( String initialDir, String filename, Serializable base64Zip ) throws Exception {
 
     if ( Utils.isEmpty( filename ) ) {
       System.out.println( BaseMessages.getString( getPkgClazz(), "Kitchen.Error.canNotLoadJob" ) );
       return null;
     }
 
-    if ( !Utils.isEmpty( base64Zip ) ) {
-      //expected form of filename "*.kjb"
-      String zipPath = Const.getUserHomeDirectory() + File.separator + java.util.UUID.randomUUID().toString() + ".zip";
-      filename = "zip:file:" + File.separator + File.separator + zipPath + "!" + filename;
-      File zipFile;
-
-      //responsibly attempt to write to file
-      try {
-        zipFile = decodeBase64StringToFile( base64Zip, zipPath );
-      } catch ( IOException e ) {
-        getLog().logError( e.toString() + "\n" );
-        e.printStackTrace();
-        return null;
-      }
-
-      zipFile.deleteOnExit();
+    File zip;
+    if ( base64Zip != null && ( zip = decodeBase64ToZipFile( base64Zip, true ) ) != null ) {
+      // update filename to a meaningful, 'ETL-file-within-zip' syntax
+      filename = "zip:file:" + File.separator + File.separator + zip.getAbsolutePath() + "!" + filename;
     }
 
     blockAndThrow( getKettleInit() );

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -55,8 +55,8 @@ import org.pentaho.di.trans.step.StepInterface;
 import org.w3c.dom.Document;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -330,27 +330,14 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
     return trans; // return transformation loaded from the repo
   }
 
-  public Trans loadTransFromFilesystem( String initialDir, String filename, String jarFilename, String base64Zip )
-    throws Exception {
+  public Trans loadTransFromFilesystem( String initialDir, String filename, String jarFilename, Serializable base64Zip ) throws Exception {
 
     Trans trans = null;
 
-    if ( !Utils.isEmpty( base64Zip ) ) {
-      //expected form of filename "*.ktr"
-      String zipPath = Const.getUserHomeDirectory() + File.separator + java.util.UUID.randomUUID().toString() + ".zip";
-      filename = "zip:file:" + File.separator + File.separator + zipPath + "!" + filename;
-      File zipFile;
-
-      //responsibly attempt to write to file
-      try {
-        zipFile = decodeBase64StringToFile( base64Zip, zipPath );
-      } catch ( IOException e ) {
-        getLog().logError( e.toString() + "\n" );
-        e.printStackTrace();
-        return null;
-      }
-
-      zipFile.deleteOnExit();
+    File zip;
+    if ( base64Zip != null && ( zip = decodeBase64ToZipFile( base64Zip, true ) ) != null ) {
+      // update filename to a meaningful, 'ETL-file-within-zip' syntax
+      filename = "zip:file:" + File.separator + File.separator + zip.getAbsolutePath() + "!" + filename;
     }
 
     // Try to load the transformation from file

--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenCommandExecutorTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenCommandExecutorTest.java
@@ -26,14 +26,13 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.job.Job;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Base64;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -41,17 +40,18 @@ import static org.mockito.Mockito.when;
 
 public class KitchenCommandExecutorTest {
 
-  private MockedKitchenCommandExecutor mockedKitchenCommandExecutor;
+  private KitchenCommandExecutor mockedKitchenCommandExecutor;
 
   @Before
   public void setUp() throws Exception {
 
-    mockedKitchenCommandExecutor = mock( MockedKitchenCommandExecutor.class );
+    mockedKitchenCommandExecutor = mock( KitchenCommandExecutor.class );
 
     // call real methods for loadTransFromFilesystem(), loadTransFromRepository();
-    when( mockedKitchenCommandExecutor.loadJobFromFilesystem( anyString(), anyString(), anyString() ) ).thenCallRealMethod();
+    when( mockedKitchenCommandExecutor.loadJobFromFilesystem( anyString(), anyString(), anyObject() ) ).thenCallRealMethod();
     when( mockedKitchenCommandExecutor.loadJobFromRepository( anyObject(), anyString(), anyString() ) ).thenCallRealMethod();
-    when( mockedKitchenCommandExecutor.decodeBase64StringToFile( anyString(), anyString() ) ).thenCallRealMethod();
+    when( mockedKitchenCommandExecutor.decodeBase64ToZipFile( anyObject(), anyBoolean() ) ).thenCallRealMethod();
+    when( mockedKitchenCommandExecutor.decodeBase64ToZipFile( anyObject(), anyString() ) ).thenCallRealMethod();
   }
 
   @After
@@ -64,22 +64,7 @@ public class KitchenCommandExecutorTest {
     String fileName = "hello-world.kjb";
     File zipFile = new File( getClass().getResource( "testKjbArchive.zip" ).toURI() );
     String base64Zip = Base64.getEncoder().encodeToString( FileUtils.readFileToByteArray( zipFile ) );
-    Job job = mockedKitchenCommandExecutor.loadJobFromFilesystem( Const.getDIHomeDirectory(), fileName, base64Zip );
+    Job job = mockedKitchenCommandExecutor.loadJobFromFilesystem( null, fileName, base64Zip );
     assertNotNull( job );
-  }
-
-  /**
-   * Inner class, used solely for the purpose of raising methods visibility ( so that we are able to test those )
-   */
-  private class MockedKitchenCommandExecutor extends KitchenCommandExecutor {
-
-    public MockedKitchenCommandExecutor( Class<?> pkgClazz ) {
-      super( pkgClazz );
-    }
-
-    @Override
-    public File decodeBase64StringToFile( String base64String, String filePath ) throws IOException {
-      return super.decodeBase64StringToFile( base64String, filePath );
-    }
   }
 }

--- a/engine/src/test/java/org/pentaho/di/pan/PanCommandExecutorTest.java
+++ b/engine/src/test/java/org/pentaho/di/pan/PanCommandExecutorTest.java
@@ -26,7 +26,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.trans.Trans;
@@ -35,7 +34,6 @@ import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.stores.delegate.DelegatingMetaStore;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Base64;
 
 import static org.junit.Assert.assertEquals;
@@ -60,7 +58,7 @@ public class PanCommandExecutorTest {
   private IMetaStore fsMetaStore;
   private IMetaStore repoMetaStore;
   private RepositoryDirectoryInterface directoryInterface;
-  private MockedPanCommandExecutor mockedPanCommandExecutor;
+  private PanCommandExecutor mockedPanCommandExecutor;
 
   @Before
   public void setUp() throws Exception {
@@ -69,7 +67,7 @@ public class PanCommandExecutorTest {
     fsMetaStore = mock( IMetaStore.class );
     repoMetaStore = mock( IMetaStore.class );
     directoryInterface = mock( RepositoryDirectoryInterface.class );
-    mockedPanCommandExecutor = mock( MockedPanCommandExecutor.class );
+    mockedPanCommandExecutor = mock( PanCommandExecutor.class );
 
     // mock actions from Metastore
     when( fsMetaStore.getName() ).thenReturn( FS_METASTORE_NAME );
@@ -85,9 +83,10 @@ public class PanCommandExecutorTest {
             .thenReturn( directoryInterface );
 
     // call real methods for loadTransFromFilesystem(), loadTransFromRepository();
-    when( mockedPanCommandExecutor.loadTransFromFilesystem( anyString(), anyString(), anyString(), anyString() ) ).thenCallRealMethod();
+    when( mockedPanCommandExecutor.loadTransFromFilesystem( anyString(), anyString(), anyString(), anyObject() ) ).thenCallRealMethod();
     when( mockedPanCommandExecutor.loadTransFromRepository( anyObject(), anyString(), anyString() ) ).thenCallRealMethod();
-    when( mockedPanCommandExecutor.decodeBase64StringToFile( anyString(), anyString() ) ).thenCallRealMethod();
+    when( mockedPanCommandExecutor.decodeBase64ToZipFile( anyObject(), anyBoolean() ) ).thenCallRealMethod();
+    when( mockedPanCommandExecutor.decodeBase64ToZipFile( anyObject(), anyString() ) ).thenCallRealMethod();
   }
 
   @After
@@ -153,22 +152,7 @@ public class PanCommandExecutorTest {
     String fileName = "test.ktr";
     File zipFile = new File( getClass().getResource( "testKtrArchive.zip" ).toURI() );
     String base64Zip = Base64.getEncoder().encodeToString( FileUtils.readFileToByteArray( zipFile ) );
-    Trans trans = mockedPanCommandExecutor.loadTransFromFilesystem( Const.getDIHomeDirectory(), fileName, "", base64Zip );
+    Trans trans = mockedPanCommandExecutor.loadTransFromFilesystem( null, fileName, null, base64Zip );
     assertNotNull( trans );
-  }
-
-  /**
-   * Inner class, used solely for the purpose of raising methods visibility ( so that we are able to test those )
-   */
-  private class MockedPanCommandExecutor extends PanCommandExecutor {
-
-    public MockedPanCommandExecutor( Class<?> pkgClazz ) {
-      super( pkgClazz );
-    }
-
-    @Override
-    public File decodeBase64StringToFile( String base64String, String filePath ) throws IOException {
-      return super.decodeBase64StringToFile( base64String, filePath );
-    }
   }
 }


### PR DESCRIPTION
…romote code reuse

- Added ITs for the execution of base64 provided zip files
- Code refactor:
  - dropped those `e.printStackTrace()` mentions
  - dropped unneeded `MockedPanCommandExecutor`, as we can directly mock `PanCommandExecutor `
  - centralized more logic onto `AbstractBaseCommandExecutor` for `decodeBase64ToZipFile` , which allows for more logic reuse in `PanCommandExecutor.loadFromFilesystem()` ,`KitchenCommandExecutor.loadFromFilesystem()`
- Checkstyle and copyright header year fixes 

### To test Pan / Kitchen
- `mvn clean verify -Dtest=PanCommanExecutorTest`
- `mvn clean verify -Dtest=PanTest -DrunITs -Dit.test=PanIT`
- `mvn clean verify -Dtest=KitchenCommanExecutorTest`
- `mvn clean verify -Dtest=KitchenTest -DrunITs -Dit.test=KitchenIT`

@pentaho/rogueone 
