### PR TITLE
[PDI-15207] Oracle Bulk Loader don't parse internal variable

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoader.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -35,6 +35,7 @@ package org.pentaho.di.trans.steps.orabulkloader;
 //
 //
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.vfs2.FileObject;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
@@ -44,6 +45,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
@@ -196,7 +198,7 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
    */
   public String getControlFileContents( OraBulkLoaderMeta meta, RowMetaInterface rm, Object[] r ) throws KettleException {
     DatabaseMeta dm = meta.getDatabaseMeta();
-    String inputName = "'" + environmentSubstitute( meta.getDataFile() ) + "'";
+    String inputName = "'" + getFilename( getFileObject( meta.getDataFile(), getTransMeta() ) ) + "'";
 
     String loadAction = meta.getLoadAction();
 
@@ -311,10 +313,12 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
    * @throws KettleException
    */
   public void createControlFile( String filename, Object[] row, OraBulkLoaderMeta meta ) throws KettleException {
-    File controlFile = new File( filename );
     FileWriter fw = null;
 
     try {
+      File controlFile = new File( getFileObject( filename, getTransMeta() ).getURL().getFile() );
+      // Need to ensure that the parent directory they set exists for the control file.
+      controlFile.getParentFile().mkdirs();
       controlFile.createNewFile();
       fw = new FileWriter( controlFile );
       fw.write( getControlFileContents( meta, getInputRowMeta(), row ) );
@@ -350,8 +354,8 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
     if ( meta.getSqlldr() != null ) {
       try {
         FileObject fileObject =
-          KettleVFS.getFileObject( environmentSubstitute( meta.getSqlldr() ), getTransMeta() );
-        String sqlldr = KettleVFS.getFilename( fileObject );
+          getFileObject( meta.getSqlldr(), getTransMeta() );
+        String sqlldr = getFilename( fileObject );
         sb.append( sqlldr );
       } catch ( KettleFileException ex ) {
         throw new KettleException( "Error retrieving sqlldr string", ex );
@@ -363,10 +367,10 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
     if ( meta.getControlFile() != null ) {
       try {
         FileObject fileObject =
-          KettleVFS.getFileObject( environmentSubstitute( meta.getControlFile() ), getTransMeta() );
+          getFileObject( meta.getControlFile(), getTransMeta() );
 
         sb.append( " control=\'" );
-        sb.append( KettleVFS.getFilename( fileObject ) );
+        sb.append( getFilename( fileObject ) );
         sb.append( "\'" );
       } catch ( KettleFileException ex ) {
         throw new KettleException( "Error retrieving controlfile string", ex );
@@ -382,10 +386,10 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
     if ( meta.getLogFile() != null ) {
       try {
         FileObject fileObject =
-          KettleVFS.getFileObject( environmentSubstitute( meta.getLogFile() ), getTransMeta() );
+          getFileObject( meta.getLogFile(), getTransMeta() );
 
         sb.append( " log=\'" );
-        sb.append( KettleVFS.getFilename( fileObject ) );
+        sb.append( getFilename( fileObject ) );
         sb.append( "\'" );
       } catch ( KettleFileException ex ) {
         throw new KettleException( "Error retrieving logfile string", ex );
@@ -395,10 +399,10 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
     if ( meta.getBadFile() != null ) {
       try {
         FileObject fileObject =
-          KettleVFS.getFileObject( environmentSubstitute( meta.getBadFile() ), getTransMeta() );
+          getFileObject( meta.getBadFile(), getTransMeta() );
 
         sb.append( " bad=\'" );
-        sb.append( KettleVFS.getFilename( fileObject ) );
+        sb.append( getFilename( fileObject ) );
         sb.append( "\'" );
       } catch ( KettleFileException ex ) {
         throw new KettleException( "Error retrieving badfile string", ex );
@@ -408,10 +412,10 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
     if ( meta.getDiscardFile() != null ) {
       try {
         FileObject fileObject =
-          KettleVFS.getFileObject( environmentSubstitute( meta.getDiscardFile() ), getTransMeta() );
+          getFileObject( meta.getDiscardFile(), getTransMeta() );
 
         sb.append( " discard=\'" );
-        sb.append( KettleVFS.getFilename( fileObject ) );
+        sb.append( getFilename( fileObject ) );
         sb.append( "\'" );
       } catch ( KettleFileException ex ) {
         throw new KettleException( "Error retrieving discardfile string", ex );
@@ -629,12 +633,12 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
       if ( OraBulkLoaderMeta.METHOD_AUTO_END.equals( method ) ) {
         if ( meta.getControlFile() != null ) {
           try {
-            fileObject = KettleVFS.getFileObject( environmentSubstitute( meta.getControlFile() ), getTransMeta() );
+            fileObject = getFileObject( meta.getControlFile(), getTransMeta() );
             fileObject.delete();
             fileObject.close();
           } catch ( Exception ex ) {
             logError( "Error deleting control file \'"
-              + KettleVFS.getFilename( fileObject ) + "\': " + ex.getMessage(), ex );
+              + getFilename( fileObject ) + "\': " + ex.getMessage(), ex );
           }
         }
       }
@@ -643,12 +647,12 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
         // In concurrent mode the data is written to the control file.
         if ( meta.getDataFile() != null ) {
           try {
-            fileObject = KettleVFS.getFileObject( environmentSubstitute( meta.getDataFile() ), getTransMeta() );
+            fileObject = getFileObject( meta.getDataFile(), getTransMeta() );
             fileObject.delete();
             fileObject.close();
           } catch ( Exception ex ) {
             logError( "Error deleting data file \'"
-              + KettleVFS.getFilename( fileObject ) + "\': " + ex.getMessage(), ex );
+              + getFilename( fileObject ) + "\': " + ex.getMessage(), ex );
           }
         }
       }
@@ -657,5 +661,14 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
         logBasic( "Deletion of files is not compatible with \'manual load method\'" );
       }
     }
+  }
+  @VisibleForTesting
+  String getFilename( FileObject fileObject ) {
+    return KettleVFS.getFilename( fileObject );
+  }
+
+  @VisibleForTesting
+  FileObject getFileObject( String vfsFilename, VariableSpace space ) throws KettleFileException {
+    return KettleVFS.getFileObject( environmentSubstitute( vfsFilename ), space );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkDataOutputTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkDataOutputTest.java
@@ -1,0 +1,105 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.trans.steps.orabulkloader;
+
+import org.apache.commons.vfs2.provider.local.LocalFile;
+import org.apache.poi.util.TempFile;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class OraBulkDataOutputTest {
+  private static final String loadMethod = "AUTO_END";
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
+  private OraBulkLoaderMeta oraBulkLoaderMeta;
+  private OraBulkDataOutput oraBulkDataOutput;
+  private Process sqlldrProcess;
+  private VariableSpace space;
+
+  @BeforeClass
+  public static void setupBeforeClass() throws KettleException {
+    KettleEnvironment.init();
+  }
+
+  @Before
+  public void setUp() {
+    String recTerm = Const.CR;
+    sqlldrProcess = mock( Process.class );
+    space = mock( VariableSpace.class );
+    oraBulkLoaderMeta = mock( OraBulkLoaderMeta.class );
+    oraBulkDataOutput = spy( new OraBulkDataOutput( oraBulkLoaderMeta, recTerm ) );
+
+    when( oraBulkLoaderMeta.getLoadMethod() ).thenReturn( loadMethod );
+    when( oraBulkLoaderMeta.getEncoding() ).thenReturn( null );
+  }
+
+  @Test
+  public void testOpen() {
+    try {
+      File tempFile = TempFile.createTempFile( "temp", "test" );
+      String tempFilePath = tempFile.getAbsolutePath();
+      String dataFileVfsPath = "file:///" + tempFilePath;
+      LocalFile tempFileObject = mock( LocalFile.class );
+
+      tempFile.deleteOnExit();
+
+      doReturn( dataFileVfsPath ).when( oraBulkLoaderMeta ).getDataFile();
+      doReturn( tempFilePath ).when( space ).environmentSubstitute( dataFileVfsPath );
+      doReturn( tempFileObject ).when( oraBulkDataOutput ).getFileObject( tempFilePath, space );
+      doReturn( tempFilePath ).when( oraBulkDataOutput ).getFilename( tempFileObject );
+
+      oraBulkDataOutput.open( space, sqlldrProcess );
+      oraBulkDataOutput.close();
+
+    } catch ( Exception ex ) {
+      fail( "If any exception occurs, this test fails: " + ex );
+    }
+  }
+
+  @Test
+  public void testOpenFileException() {
+    doThrow( IOException.class ).when( oraBulkLoaderMeta ).getDataFile();
+    try {
+      oraBulkDataOutput.open( space, sqlldrProcess );
+      fail( "An IOException was supposed to be thrown, failing test" );
+    } catch ( KettleException kex ) {
+      assertTrue( kex.getMessage().contains( "IO exception occured:" ) );
+    }
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,30 +21,55 @@
  ******************************************************************************/
 package org.pentaho.di.trans.steps.orabulkloader;
 
+import org.apache.poi.util.TempFile;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
  * User: Dzmitry Stsiapanau Date: 4/8/14 Time: 1:44 PM
  */
 public class OraBulkLoaderTest {
+  private static final String expectedDataContents1 = "OPTIONS(" + Const.CR + "  ERRORS='null'" + Const.CR + "  , "
+    + "ROWS='null'" + Const.CR + ")" + Const.CR + "LOAD DATA" + Const.CR + "INFILE '";
+  private static final String expectedDataContents2 = "'" + Const.CR + "INTO TABLE null" + Const.CR + "null"
+    + Const.CR + "FIELDS TERMINATED BY ',' " + "ENCLOSED BY '\"'" + Const.CR + "(null, " + Const.CR + "null CHAR)";
   private StepMockHelper<OraBulkLoaderMeta, OraBulkLoaderData> stepMockHelper;
+  private OraBulkLoader oraBulkLoader;
+  private File tempControlFile;
+  private File tempDataFile;
+  private String tempControlFilepath;
+  private String tempDataFilepath;
+  private String tempControlVfsFilepath;
+  private String tempDataVfsFilepath;
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
 
   @BeforeClass
@@ -53,11 +78,23 @@ public class OraBulkLoaderTest {
   }
 
   @Before
-  public void setUp() {
-    stepMockHelper = new StepMockHelper<OraBulkLoaderMeta, OraBulkLoaderData>( "TEST_CREATE_COMMANDLINE", OraBulkLoaderMeta.class, OraBulkLoaderData.class );
+  public void setUp() throws Exception{
+    stepMockHelper = new StepMockHelper<OraBulkLoaderMeta, OraBulkLoaderData>( "TEST_CREATE_COMMANDLINE",
+      OraBulkLoaderMeta.class, OraBulkLoaderData.class );
     when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
       stepMockHelper.logChannelInterface );
     when( stepMockHelper.trans.isRunning() ).thenReturn( true );
+    oraBulkLoader = spy( new OraBulkLoader( stepMockHelper.stepMeta, stepMockHelper.stepDataInterface, 0,
+      stepMockHelper.transMeta, stepMockHelper.trans ) );
+
+    tempControlFile = TempFile.createTempFile( "control", "test" );
+    tempControlFile.deleteOnExit();
+    tempDataFile = TempFile.createTempFile( "data", "test" );
+    tempDataFile.deleteOnExit();
+    tempControlFilepath = tempControlFile.getAbsolutePath();
+    tempDataFilepath = tempDataFile.getAbsolutePath();
+    tempControlVfsFilepath = "file:///" + tempControlFilepath;
+    tempDataVfsFilepath = "file:///" + tempDataFilepath;
   }
 
   @After
@@ -66,10 +103,60 @@ public class OraBulkLoaderTest {
   }
 
   @Test
+  public void testGetControlFileContents() throws Exception {
+    String[] streamFields = { "id", "name" };
+    String[] streamTable = { "id", "name" };
+    String[] dateMask = { "", "" };
+    DatabaseMeta databaseMeta = mock( DatabaseMeta.class );
+    Object[] rowData = { 1, "rowdata", new Date() };
+    RowMetaInterface rowMetaInterface = mock( RowMetaInterface.class );
+    TransMeta transMeta = spy( new TransMeta( ) );
+    ValueMetaInterface idVmi = new ValueMetaNumber( "id" );
+    ValueMetaInterface nameVmi = new ValueMetaString( "name", 20, -1 );
+
+    OraBulkLoaderMeta oraBulkLoaderMeta = spy( new OraBulkLoaderMeta() );
+    oraBulkLoaderMeta.setDatabaseMeta( databaseMeta );
+    oraBulkLoaderMeta.setControlFile( tempControlVfsFilepath );
+    oraBulkLoaderMeta.setDataFile( tempDataVfsFilepath );
+
+    doReturn( transMeta ).when( oraBulkLoader ).getTransMeta();
+    doReturn( streamFields ).when( oraBulkLoaderMeta ).getFieldStream();
+    doReturn( streamTable ).when( oraBulkLoaderMeta ).getFieldTable();
+    doReturn( dateMask ).when( oraBulkLoaderMeta ).getDateMask();
+    doReturn( 0 ).when( rowMetaInterface ).indexOfValue( "id" );
+    doReturn( idVmi ).when( rowMetaInterface ).getValueMeta( 0 );
+    doReturn( 1 ).when( rowMetaInterface ).indexOfValue( "name" );
+    doReturn( nameVmi ).when( rowMetaInterface ).getValueMeta( 1 );
+
+    String expectedDataContents = expectedDataContents1 + tempDataFilepath + expectedDataContents2;
+    String actualDataContents = oraBulkLoader.getControlFileContents( oraBulkLoaderMeta, rowMetaInterface, rowData );
+    assertEquals( "The Expected Control File Contents do not match Actual Contents", expectedDataContents,
+      actualDataContents );
+  }
+
+  @Test
+  public void testCreateControlFile() throws Exception {
+    // Create a tempfile, so we can use the temp file path when we run the createControlFile method
+    String tempTrueControlFilepath = tempControlFile.getAbsolutePath() + "A.txt";
+    String expectedControlContents = "test";
+    OraBulkLoaderMeta oraBulkLoaderMeta = mock( OraBulkLoaderMeta.class );
+    RowMetaInterface rowMetaInterface = mock( RowMetaInterface.class );
+    Object[] objectRow = {};
+
+    doReturn( rowMetaInterface ).when( oraBulkLoader ).getInputRowMeta();
+    doReturn( expectedControlContents ).when( oraBulkLoader ).getControlFileContents( oraBulkLoaderMeta, rowMetaInterface, objectRow );
+    oraBulkLoader.createControlFile( tempTrueControlFilepath,  objectRow, oraBulkLoaderMeta );
+
+    assertTrue( Files.exists( Paths.get( tempTrueControlFilepath ) ) );
+
+    File tempTrueControlFile = new File( tempTrueControlFilepath );
+    String tempTrueControlFileContents = new String( Files.readAllBytes( tempTrueControlFile.toPath() ) );
+    assertEquals( expectedControlContents, tempTrueControlFileContents );
+    tempTrueControlFile.delete();
+  }
+
+  @Test
   public void testCreateCommandLine() throws Exception {
-    OraBulkLoader oraBulkLoader =
-      new OraBulkLoader( stepMockHelper.stepMeta, stepMockHelper.stepDataInterface, 0, stepMockHelper.transMeta,
-        stepMockHelper.trans );
     File tmp = File.createTempFile( "testCreateCOmmandLine", "tmp" );
     tmp.deleteOnExit();
     OraBulkLoaderMeta meta = new OraBulkLoaderMeta();
@@ -82,5 +169,25 @@ public class OraBulkLoaderTest {
     String cmd = oraBulkLoader.createCommandLine( meta, true );
     String expected = tmp.getAbsolutePath() + " control='" + tmp.getAbsolutePath() + "' userid=user/PENTAHO@";
     assertEquals( "Comandline for oracle bulkloader is not as expected", expected, cmd );
+  }
+
+  @Test
+  public void testDispose() throws Exception {
+    TransMeta transMeta = spy( new TransMeta( ) );
+    OraBulkLoaderData oraBulkLoaderData = new OraBulkLoaderData();
+    OraBulkLoaderMeta oraBulkLoaderMeta = new OraBulkLoaderMeta();
+    oraBulkLoaderMeta.setDataFile( tempDataVfsFilepath );
+    oraBulkLoaderMeta.setControlFile( tempControlVfsFilepath );
+    oraBulkLoaderMeta.setEraseFiles( true );
+    oraBulkLoaderMeta.setLoadMethod( "AUTO_END" );
+
+    assertTrue( Files.exists( Paths.get( tempControlFilepath ) ) );
+    assertTrue( Files.exists( Paths.get( tempDataFilepath ) ) );
+
+    doReturn( transMeta ).when( oraBulkLoader ).getTransMeta();
+    oraBulkLoader.dispose( oraBulkLoaderMeta, oraBulkLoaderData );
+
+    assertFalse( Files.exists( Paths.get( tempControlFilepath ) ) );
+    assertFalse( Files.exists( Paths.get( tempDataFilepath ) ) );
   }
 }


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @wseyler 

* [PDI-15207] Adding in KettleVFS calls to the control/data file, and logs.  So it can handle the file:/// calls better
* [PDI-15207] Cleaned up method calls for getFileObject
* [PDI-15207] Cleaned up inputName retrieval, verified it can also use the internal variables per the ticket
* [PDI-15207] Added Tests, methods and new file.