### PR TITLE
[BACKLOG-28866] Unable to edit redshift bulk job entry saved in repo

### DIFF
--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/JobDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/JobDelegate.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -293,7 +293,7 @@ public class JobDelegate extends AbstractDelegate implements ISharedObjectsTrans
       // And read the job entry copy group attributes map
       AttributesMapUtil.loadAttributesMap( copyNode, copy, PROP_ATTRIBUTES_JOB_ENTRY_COPY );
 
-      jobMeta.getJobCopies().add( copy );
+      jobMeta.addJobEntry( copy );
     }
 
     if ( jobMeta.getJobCopies().size() != nrCopies ) {


### PR DESCRIPTION
The redshift bulk load dialog assumes that the parentjobmeta has been
set.  When loaded from the filesystem this was true, but not from
repo.  Issue was the jobentry was being added to its the list
of entries directly in JobDelegate, rather than via the
.addJobEntry() method.

https://jira.pentaho.com/browse/BACKLOG-28866