### PR TITLE
[BACKLOG-28773] Add default timeout of 10 seconds to Redshift DB

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/RedshiftDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/RedshiftDatabaseMeta.java
@@ -36,6 +36,7 @@ public class RedshiftDatabaseMeta extends PostgreSQLDatabaseMeta {
 
   public RedshiftDatabaseMeta() {
     addExtraOption( "REDSHIFT", "tcpKeepAlive", "true" );
+    addExtraOption( "REDSHIFT", "loginTimeout", "10" );
   }
 
   @Override


### PR DESCRIPTION
connections.