### PR TITLE
[BACKLOG-28706] - Provide mechanism to transport/identify Empty Varia…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1508,7 +1508,7 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
       }
 
       if ( Utils.isEmpty( value ) ) {
-        setVariable( key, defValue );
+        setVariable( key, Const.NVL( defValue, "" ) );
       } else {
         setVariable( key, value );
       }

--- a/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -566,9 +566,12 @@ public class AbstractMetaTest {
     NamedParams newParams = new NamedParamsDefault();
     newParams.addParameterDefinition( "var3", "default", "description" );
     newParams.setParameterValue( "var3", "a" );
+    newParams.addParameterDefinition( "emptyVar", "", "emptyDesc" );
+    newParams.setParameterValue( "emptyVar", "" );
     meta.copyParametersFrom( newParams );
     meta.activateParameters();
     assertEquals( "default", meta.getParameterDefault( "var3" ) );
+    assertEquals( "", meta.getParameterDefault( "emptyVar" ) );
   }
 
   @Test
@@ -779,7 +782,7 @@ public class AbstractMetaTest {
   public void testMultithreadHammeringOfListener() throws Exception {
 
     CountDownLatch latch = new CountDownLatch( 3 );
-    AbstractMetaListenerThread th1 = new AbstractMetaListenerThread( meta, 2000, latch); // do 2k random add/delete/fire
+    AbstractMetaListenerThread th1 = new AbstractMetaListenerThread( meta, 2000, latch ); // do 2k random add/delete/fire
     AbstractMetaListenerThread th2 = new AbstractMetaListenerThread( meta, 2000, latch ); // do 2k random add/delete/fire
     AbstractMetaListenerThread th3 = new AbstractMetaListenerThread( meta, 2000, latch ); // do 2k random add/delete/fire
 
@@ -892,7 +895,7 @@ public class AbstractMetaTest {
     CountDownLatch whenDone;
     String message;
 
-    AbstractMetaListenerThread ( AbstractMeta aMeta, int times, CountDownLatch latch ) {
+    AbstractMetaListenerThread( AbstractMeta aMeta, int times, CountDownLatch latch ) {
       this.metaToWork = aMeta;
       this.times = times;
       this.whenDone = latch;
@@ -901,7 +904,7 @@ public class AbstractMetaTest {
     @Override public void run() {
       for ( int i = 0; i < times; i++ ) {
         int randomNum = ThreadLocalRandom.current().nextInt( 0, 3 );
-        switch( randomNum ) {
+        switch ( randomNum ) {
           case 0: {
             try {
               metaToWork.addFilenameChangedListener( mock( FilenameChangedListener.class ) );


### PR DESCRIPTION
…ble Values being Passed to Sub Job when run in AEL

* As far ConcurrentHashMap does not allow null values, initialize variables as blank in case they are empty.

@pentaho/bb-8 Please review
**Note:** This is the complimentary PR for already merged https://github.com/pentaho/pentaho-ee/pull/2089 .