### PR TITLE
[BACKLOG-29166] - moving messageDataType into sub-classes.  Kafka doe…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMeta.java
@@ -48,8 +48,6 @@ import org.pentaho.metastore.api.IMetaStore;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_STRING;
-
 public abstract class BaseStreamStepMeta extends StepWithMappingMeta implements StepMetaInterface, ISubTransAwareMeta {
 
 
@@ -75,9 +73,6 @@ public abstract class BaseStreamStepMeta extends StepWithMappingMeta implements 
 
   @Injection( name =  PARALLELISM )
   protected String parallelism = "1";
-
-  @Injection( name = MESSAGE_DATA_TYPE )
-  public int messageDataType = TYPE_STRING;
 
   MappingMetaRetriever mappingMetaRetriever = TransExecutorMeta::loadMappingMeta;
 
@@ -113,7 +108,6 @@ public abstract class BaseStreamStepMeta extends StepWithMappingMeta implements 
     batchSize = "1000";
     batchDuration = "1000";
     parallelism = "1";
-    messageDataType = TYPE_STRING;
   }
 
   public String getTransformationPath() {
@@ -133,7 +127,7 @@ public abstract class BaseStreamStepMeta extends StepWithMappingMeta implements 
   }
 
   public int getMessageDataType() {
-    return messageDataType;
+    throw new UnsupportedOperationException();
   }
 
   @Override public void replaceFileName( String fileName ) {

--- a/engine/src/test/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/streaming/common/BaseStreamStepMetaTest.java
@@ -46,7 +46,6 @@ import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
@@ -226,7 +225,6 @@ public class BaseStreamStepMetaTest {
     meta.setBatchDuration( "1000" );
     meta.setBatchSize( "100" );
     meta.setTransformationPath( "aPath" );
-    meta.messageDataType = ValueMetaInterface.TYPE_BINARY;
     testRoundTrip( meta );
   }
 
@@ -360,6 +358,5 @@ public class BaseStreamStepMetaTest {
     assertThat( startingMeta.getParallelism(), equalTo( metaToRoundTrip.getParallelism() ) );
 
     assertThat( startingMeta.stuff, equalTo( metaToRoundTrip.stuff ) );
-    assertThat( startingMeta.messageDataType, equalTo( metaToRoundTrip.messageDataType ) );
   }
 }

--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerMeta.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerMeta.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
+import static org.pentaho.di.core.row.ValueMetaInterface.TYPE_STRING;
 import static org.pentaho.di.core.util.serialization.ConfigHelper.conf;
 import static org.pentaho.di.i18n.BaseMessages.getString;
 import static org.pentaho.di.trans.step.mqtt.MQTTClientBuilder.DEFAULT_SSL_OPTS;
@@ -164,6 +165,9 @@ public class MQTTConsumerMeta extends BaseStreamStepMeta implements StepMetaInte
   @Injection ( name = AUTOMATIC_RECONNECT )
   private String automaticReconnect = "";
 
+  @Injection( name = MESSAGE_DATA_TYPE )
+  public int messageDataType = TYPE_STRING;
+
   public MQTTConsumerMeta() {
     super();
     setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
@@ -191,6 +195,12 @@ public class MQTTConsumerMeta extends BaseStreamStepMeta implements StepMetaInte
     serverUris = "";
     mqttVersion = "";
     automaticReconnect = "";
+    messageDataType = TYPE_STRING;
+  }
+
+  @Override
+  public int getMessageDataType() {
+    return messageDataType;
   }
 
   @Override public String getFileName() {


### PR DESCRIPTION
…sn't use it, but ends up displaying in MDI