### PR TITLE
add a type test to the equals method

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/RowMetaAndData.java
+++ b/core/src/main/java/org/pentaho/di/core/RowMetaAndData.java
@@ -120,7 +120,12 @@ public class RowMetaAndData implements Cloneable {
   @Override
   public boolean equals( Object obj ) {
     try {
-      return rowMeta.compare( data, ( (RowMetaAndData) obj ).getData() ) == 0;
+      if(! (obj instanceof RowMetaAndData)){
+        return false;
+      }
+      else{
+        return rowMeta.compare( data, ( (RowMetaAndData) obj ).getData() ) == 0;
+      }
     } catch ( KettleValueException e ) {
       throw new RuntimeException(
         "Row metadata and data: unable to compare rows because of a data conversion problem", e );


### PR DESCRIPTION
hello, i find a Code Quality Issue(CQI, so-called violation), detected by SonarQube.
Because the equals method takes a generic Object as a parameter, any type of object may be passed to it. The method should not assume it will only be used to `RowMetaAndData` objects of its class type. It must instead check the parameter's type. It may throw unhandled exception.
see details in [https://rules.sonarsource.com/java/RSPEC-2097](url)