### PR TITLE
[BACKLOG-29127]  PRD - Snowflake warehouse value does not save

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/SnowflakeHVDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/SnowflakeHVDatabaseMeta.java
@@ -88,16 +88,16 @@ public class SnowflakeHVDatabaseMeta extends BaseDatabaseMeta implements Databas
     } else {
       account = hostname.substring( 0, hostname.indexOf( '.' ) );
     }
+    // set the warehouse attribute as an "extra" option so it will be appended to the url.
+    addExtraOption( getPluginId(), WAREHOUSE, getAttribute( WAREHOUSE, "" ) );
     return "jdbc:snowflake://"
       + realHostname
       + getParamIfSet( ":", port )
       + "/?account=" + account
       + "&db=" + databaseName
       + "&user=" + getUsername()
-      + "&password=" + getPassword()
-      + getParamIfSet( "&warehouse=", getAttributes().getProperty( WAREHOUSE ) );
+      + "&password=" + getPassword();
   }
-
 
   private String getParamIfSet( String param, String val ) {
     if ( !isEmpty( val ) ) {


### PR DESCRIPTION
Adding a special case workaround in DataHandler which will
set warehouse as an "extra" option.  This will allow PRDs custom
metadata handling to capture the val.

https://jira.pentaho.com/browse/BACKLOG-29127

(cherry picked from commit 730f03973c07436fcb36a566b02300d99566cc96)

@kcruzada - validated on master (9.0-16).