### PR TITLE
[PDI-18086] Transformation Executor - Passing variables using Row Gro…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/transexecutor/TransExecutor.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.steps.transexecutor;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ArrayList;
@@ -119,7 +120,7 @@ public class TransExecutor extends BaseStep implements StepInterface {
           Object groupFieldData = row[ transExecutorData.groupFieldIndex ];
           if ( transExecutorData.prevGroupFieldData != null ) {
             if ( transExecutorData.groupFieldMeta.compare( transExecutorData.prevGroupFieldData, groupFieldData ) != 0 ) {
-              executeTransformation( incomingFieldValues );
+              executeTransformation( getLastIncomingFieldValues() );
             }
           }
           transExecutorData.prevGroupFieldData = groupFieldData;
@@ -208,9 +209,16 @@ public class TransExecutor extends BaseStep implements StepInterface {
 
     Trans executorTrans = createInternalTrans();
     transExecutorData.setExecutorTrans( executorTrans );
+    if ( incomingFieldValues != null ) {
+      // Pass parameter values
+      passParametersToTrans( incomingFieldValues );
+    } else {
+      List<String> lastIncomingFieldValues = getLastIncomingFieldValues();
+      // incomingFieldValues == null-  There are no more rows - Last Case - pass previous values if exists
+      // If not still pass the null parameter values
+      passParametersToTrans( lastIncomingFieldValues != null && !lastIncomingFieldValues.isEmpty() ? lastIncomingFieldValues : incomingFieldValues );
+    }
 
-    // Pass parameter values
-    passParametersToTrans( incomingFieldValues );
 
     // keep track for drill down in Spoon...
     getTrans().addActiveSubTransformation( getStepname(), executorTrans );
@@ -317,8 +325,9 @@ public class TransExecutor extends BaseStep implements StepInterface {
     // For all parameters declared in transExecutor
     for ( int i = 0; i < parameters.getVariable().length; i++ ) {
       String currentVariableToUpdate = (String) resolvingValuesMap.keySet().toArray()[i];
+      boolean hasIncomingFieldValues = incomingFieldValues != null && !incomingFieldValues.isEmpty();
       try {
-        if ( i < fieldsToUse.size() && incomingFields.contains( fieldsToUse.get( i ) )
+        if ( i < fieldsToUse.size() && incomingFields.contains( fieldsToUse.get( i ) ) && hasIncomingFieldValues
           && ( !Utils.isEmpty( Const.trim( incomingFieldValues.get( incomingFields.indexOf( fieldsToUse.get( i ) ) ) ) ) ) ) {
           // if field to use is defined on previous steps ( incomingFields ) and is not empty - put that value
           resolvingValuesMap.put( currentVariableToUpdate, incomingFieldValues.get( incomingFields.indexOf( fieldsToUse.get( i ) ) ) );
@@ -334,8 +343,8 @@ public class TransExecutor extends BaseStep implements StepInterface {
               resolvingValuesMap.put( currentVariableToUpdate, "" );
               this.setVariable( parameters.getVariable()[i], resolvingValuesMap.get( parameters.getVariable()[i] ) );
             } else {
-              if ( !Utils.isEmpty( Const.trim( this.getVariable( parameters.getVariable()[i] ) ) ) ) {
-                // if everything is empty, then check for last option - parent variables, if exists - put that value
+              if ( !Utils.isEmpty( Const.trim( this.getVariable( parameters.getVariable()[i] ) ) ) && meta.getParameters().isInheritingAllVariables() ) {
+                // if everything is empty, then check for last option - parent variables if isInheriting is checked - if exists - put that value
                 resolvingValuesMap.put( currentVariableToUpdate, this.getVariable( parameters.getVariable()[i] ) );
               } else {
                 // last case - if no variables defined - put "" value ( not null)
@@ -536,4 +545,23 @@ public class TransExecutor extends BaseStep implements StepInterface {
   private void setData( TransExecutorData data ) {
     this.data = data;
   }
+
+  protected List<String> getLastIncomingFieldValues( ) {
+    TransExecutorData transExecutorData = getData();
+    List<String> lastIncomingFieldValues = new ArrayList<>();
+    if ( transExecutorData == null || transExecutorData.groupBuffer.isEmpty() ) {
+      return null;
+    }
+
+    int lastIncomingFieldIndex = transExecutorData.groupBuffer.size() - 1;
+    ArrayList lastGroupBufferData = new ArrayList( Arrays.asList( transExecutorData.groupBuffer.get( lastIncomingFieldIndex ).getData() ) );
+    lastGroupBufferData.removeAll( Collections.singleton( null ) );
+
+    for ( int i = 0; i < lastGroupBufferData.size(); i++ ) {
+      lastIncomingFieldValues.add( lastGroupBufferData.get( i ).toString() );
+    }
+    return lastIncomingFieldValues;
+  }
+
+
 }


### PR DESCRIPTION
…uping

There were two problems in this passing parameters logic :

1- When you know that the actual group has changed, you are already on the next group row - so you should send the previous value to resolve parameters, and not the actual one.
2- The end case - when there are no more rows to process - was always sending null params to resolve. We should send the previous group value once more.

These fixes goes with the actual existing code logic- that row grouping should be always declared sequentially.

@pentaho-lmartins 