### PR TITLE
[BACKLOG-29252] Connection name being passed as null instead of null

### DIFF
--- a/core/src/main/java/org/pentaho/di/connections/ConnectionManager.java
+++ b/core/src/main/java/org/pentaho/di/connections/ConnectionManager.java
@@ -215,7 +215,7 @@ public class ConnectionManager {
   }
 
   public ConnectionDetails getConnectionDetails( String key, String name ) {
-    if ( metaStoreSupplier.get() == null ) {
+    if ( metaStoreSupplier == null || metaStoreSupplier.get() == null ) {
       return null;
     }
     return getConnectionDetails( metaStoreSupplier.get(), key, name );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
@@ -65,7 +65,9 @@ public class JobFileListener implements FileListener, ConnectionListener {
       jobMeta.setRepositoryDirectory( spoon.getDefaultSaveLocation( jobMeta ) );
       jobMeta.setRepository( spoon.getRepository() );
       jobMeta.setMetaStore( spoon.getMetaStore() );
-      jobMeta.setVariable( Spoon.CONNECTION, connection );
+      if ( connection != null ) {
+        jobMeta.setVariable( Spoon.CONNECTION, connection );
+      }
       spoon.setJobMetaVariables( jobMeta );
       spoon.getProperties()
         .addLastFile( LastUsedFile.FILE_TYPE_JOB, fname, null, false, null, null, new Date(), connection );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -1897,9 +1897,11 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       // read from a repository...
       //
       try {
-        String connection = lastUsedFile.getConnection();
+        String connection = getLastUsedConnection( lastUsedFile );
         Variables variables = new Variables();
-        variables.setVariable( CONNECTION, connection );
+        if ( connection != null ) {
+          variables.setVariable( CONNECTION, connection );
+        }
         loadLastUsedFile( lastUsedFile, rep == null ? null : rep.getName() );
         addMenuLast();
       } catch ( KettleException ke ) {
@@ -8212,7 +8214,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
 
     // open files stored locally, not in the repository
     if ( !lastUsedFile.isSourceRepository() && !Utils.isEmpty( lastUsedFile.getFilename() ) ) {
-      String connection = lastUsedFile.getConnection();
+      String connection = getLastUsedConnection( lastUsedFile );
       Variables variables = null;
       if ( connection != null ) {
         variables = new Variables();
@@ -8226,6 +8228,13 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       }
       refreshTree();
     }
+  }
+
+  private String getLastUsedConnection( LastUsedFile lastUsedFile ) {
+    if ( !Utils.isEmpty( lastUsedFile.getConnection() ) && !lastUsedFile.getConnection().equals( "null" ) ) {
+      return lastUsedFile.getConnection();
+    }
+    return null;
   }
 
   /**

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/TransFileListener.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/TransFileListener.java
@@ -97,7 +97,9 @@ public class TransFileListener implements FileListener, ConnectionListener {
       transMeta.setRepositoryDirectory( spoon.getDefaultSaveLocation( transMeta ) );
       transMeta.setRepository( spoon.getRepository() );
       transMeta.setMetaStore( spoon.getMetaStore() );
-      transMeta.setVariable( Spoon.CONNECTION, connection );
+      if ( connection != null ) {
+        transMeta.setVariable( Spoon.CONNECTION, connection );
+      }
       spoon.setTransMetaVariables( transMeta );
       spoon.getProperties().addLastFile( LastUsedFile.FILE_TYPE_TRANSFORMATION, fname, null, false, null );
       spoon.addMenuLast();


### PR DESCRIPTION
Master: https://github.com/pentaho/pentaho-kettle/pull/6572
8.3: https://github.com/pentaho/pentaho-kettle/pull/6587
8.3.0.0: https://github.com/pentaho/pentaho-kettle/pull/6586