### PR TITLE
[SP-5086] Backport of PDI-16490 - KETTLE_DEFAULT_DATE_FORMAT variable…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -83,12 +83,17 @@ import java.util.TimeZone;
 public class ValueMetaBase implements ValueMetaInterface {
 
   // region Default Numeric Types Parse Format
-  public static final String DEFAULT_INTEGER_PARSE_MASK = "####0";
-  public static final String DEFAULT_NUMBER_PARSE_MASK = "####0.0#########";
-  public static final String DEFAULT_BIGNUMBER_PARSE_MASK = "######0.0###################";
+  public static final String DEFAULT_INTEGER_PARSE_MASK = Const.NVL(
+    EnvUtil.getSystemProperty( Const.KETTLE_DEFAULT_INTEGER_FORMAT ), "####0" );
+  public static final String DEFAULT_NUMBER_PARSE_MASK = Const.NVL(
+    EnvUtil.getSystemProperty( Const.KETTLE_DEFAULT_NUMBER_FORMAT ), "####0.0#########" );
+  public static final String DEFAULT_BIGNUMBER_PARSE_MASK = Const.NVL(
+    EnvUtil.getSystemProperty( Const.KETTLE_DEFAULT_BIGNUMBER_FORMAT ), "######0.0###################" );
 
-  public static final String DEFAULT_DATE_PARSE_MASK = "yyyy/MM/dd HH:mm:ss.SSS";
-  public static final String DEFAULT_TIMESTAMP_PARSE_MASK = "yyyy/MM/dd HH:mm:ss.SSSSSSSSS";
+  public static final String DEFAULT_DATE_PARSE_MASK = Const.NVL( EnvUtil
+    .getSystemProperty( Const.KETTLE_DEFAULT_DATE_FORMAT ), "yyyy/MM/dd HH:mm:ss.SSS" );
+  public static final String DEFAULT_TIMESTAMP_PARSE_MASK = Const.NVL( EnvUtil
+    .getSystemProperty( Const.KETTLE_DEFAULT_DATE_FORMAT ), "yyyy/MM/dd HH:mm:ss.SSSSSSSSS" );
   // endregion
 
   // region Default Types Format


### PR DESCRIPTION
… not working. (8.2 Suite)

Cherry-pick: https://github.com/pentaho/pentaho-kettle/commit/c66d44b4449369a8d371f3d862e4c3c5007be99c

@smmribeiro 