### PR TITLE
[PDI-17862] Spoon - Scan of plugin jars at startup does not handle exceptions gracefully

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/plugins/BasePluginType.java
+++ b/core/src/main/java/org/pentaho/di/core/plugins/BasePluginType.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -392,15 +392,20 @@ public abstract class BasePluginType implements PluginTypeInterface {
 
       if ( pluginFolder.isPluginAnnotationsFolder() ) {
 
+        FileObject[] fileObjects = null;
         try {
           // Get all the jar files in the plugin folder...
           //
-          FileObject[] fileObjects = jarFileCache.getFileObjects( pluginFolder );
-          if ( fileObjects != null ) {
-            for ( FileObject fileObject : fileObjects ) {
+          fileObjects = jarFileCache.getFileObjects( pluginFolder );
+        } catch ( Exception e ) {
+          e.printStackTrace();
+        }
 
-              // These are the jar files : find annotations in it...
-              //
+        if ( fileObjects != null ) {
+          for ( FileObject fileObject : fileObjects ) {
+            // These are the jar files : find annotations in it...
+            //
+            try {
               AnnotationDB annotationDB = jarFileCache.getAnnotationDB( fileObject );
               Set<String> impls = annotationDB.getAnnotationIndex().get( annotationClassName );
               if ( impls != null ) {
@@ -410,11 +415,13 @@ public abstract class BasePluginType implements PluginTypeInterface {
                     .getParent().getURL() ) );
                 }
               }
+            } catch ( Exception jarPluginLoadError ) {
+              LogChannel.GENERAL.logError( "Error while finding annotations for jar plugin: '"
+                + fileObject + "'" );
+              LogChannel.GENERAL.logDebug( "Error while finding annotations for jar plugin: '"
+                + fileObject + "'", jarPluginLoadError );
             }
-
           }
-        } catch ( Exception e ) {
-          e.printStackTrace();
         }
       }
     }

--- a/core/src/test/java/org/pentaho/di/core/plugins/BasePluginTypeTest.java
+++ b/core/src/test/java/org/pentaho/di/core/plugins/BasePluginTypeTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,19 +22,29 @@
 
 package org.pentaho.di.core.plugins;
 
+import org.apache.commons.vfs2.FileObject;
 import org.junit.Test;
 import org.pentaho.di.core.encryption.TwoWayPasswordEncoderPluginType;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.powermock.reflect.Whitebox;
 
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doNothing;
 
 public class BasePluginTypeTest {
+  private static final String BASE_RAM_DIR = "ram:/basePluginTypeTest/";
+
   @Test
   public void testRegisterNativesCloseResAsStream() throws Exception {
     BasePluginType bpt = spy( DatabasePluginType.getInstance() );
@@ -63,5 +73,34 @@ public class BasePluginTypeTest {
     bpt.registerNatives();
 
     verify( is ).close();
+  }
+
+  /*
+   * [PDI-17862] Testing issue with a bad attempt to find annotations and the graceful reporting it completes.
+   */
+  @Test
+  public void findAnnotatedClassFilesFailTest() throws Exception {
+    LogChannel generalLog = mock( LogChannel.class );
+    Whitebox.setInternalState( LogChannel.class, "GENERAL", generalLog );
+
+    FileObject fileObj1 = KettleVFS.getFileObject( BASE_RAM_DIR + "testJar1.jar" );
+    FileObject fileObj2 = KettleVFS.getFileObject( BASE_RAM_DIR + "testJar2.jar" );
+    FileObject[] fileObjects = { fileObj1, fileObj2 };
+
+    BasePluginType bpt = spy( DatabasePluginType.getInstance() );
+    List<PluginFolderInterface> pluginFolders = new ArrayList<>();
+    PluginFolder pluginFolder =
+      spy( new PluginFolder( BASE_RAM_DIR, false, true, false ) );
+    pluginFolders.add( pluginFolder );
+    bpt.setPluginFolders( pluginFolders );
+
+    doReturn( fileObjects ).when( pluginFolder ).findJarFiles();
+    doNothing().when( generalLog ).logError( any() );
+    doNothing().when( generalLog ).logDebug( any(), any() );
+
+    bpt.findAnnotatedClassFiles( "testClassName" );
+
+    verify( generalLog, times( 2 ) ).logError( any() );
+    verify( generalLog, times( 2 ) ).logDebug( any(), any() );
   }
 }


### PR DESCRIPTION
@pentaho/tatooine @wseyler @pentaho-lmartins 
* [PDI-17862] Cleaned up try/catch methods. Split it into 2, kept the original stack trace for the FileObject. Added in the try/catch as it's scanning each plugin jar, so that if an error occurs, it'll send a general error to the console and continue (if in debug mode, the full error gets printed)
* [PDI-17862] Added a test to verify that the try/catch allows a graceful log and continues to scan.