### PR TITLE
[BACKLOG-27839] Replace In String Metadata Injection Boolean Values E…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/replacestring/ReplaceString.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/replacestring/ReplaceString.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -190,14 +190,8 @@ public class ReplaceString extends BaseStep implements StepInterface {
         }
 
         data.outStreamNrs[i] = environmentSubstitute( meta.getFieldOutStream()[i] );
-
-        data.patterns[i] =
-          buildPattern(
-            meta.getUseRegEx()[i] != ReplaceStringMeta.USE_REGEX_YES,
-            meta.getCaseSensitive()[i] == ReplaceStringMeta.CASE_SENSITIVE_YES,
-            meta.getWholeWord()[i] == ReplaceStringMeta.WHOLE_WORD_YES, environmentSubstitute( meta
-              .getReplaceString()[i] ),
-            meta.isUnicode()[i] == ReplaceStringMeta.IS_UNICODE_YES );
+        data.patterns[i] = buildPattern( meta.getUseRegEx()[i], meta.getCaseSensitive()[i],
+            meta.getWholeWord()[i], environmentSubstitute( meta.getReplaceString()[i] ), meta.isUnicode()[i] );
 
         String field = meta.getFieldReplaceByString()[i];
         if ( !Utils.isEmpty( field ) ) {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/replacestring/ReplaceStringData.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/replacestring/ReplaceStringData.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -38,7 +38,7 @@ public class ReplaceStringData extends BaseStepData implements StepDataInterface
 
   public String[] outStreamNrs;
 
-  public int[] useRegEx;
+  public boolean[] useRegEx;
 
   public String[] replaceString;
 
@@ -48,11 +48,11 @@ public class ReplaceStringData extends BaseStepData implements StepDataInterface
 
   public int[] replaceFieldIndex;
 
-  public int[] wholeWord;
+  public boolean[] wholeWord;
 
-  public int[] caseSensitive;
+  public boolean[] caseSensitive;
 
-  public int[] isUnicode;
+  public boolean[] isUnicode;
 
   public String realChangeField;
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/replacestring/ReplaceStringMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/replacestring/ReplaceStringMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -67,7 +67,7 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
   private String[] fieldOutStream;
 
   @Injection( name = "USE_REGEX", group = "FIELDS" )
-  private int[] useRegEx;
+  private boolean[] useRegEx;
 
   @Injection( name = "REPLACE_STRING", group = "FIELDS" )
   private String[] replaceString;
@@ -83,49 +83,16 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
   private String[] replaceFieldByString;
 
   @Injection( name = "REPLACE_WHOLE_WORD", group = "FIELDS" )
-  private int[] wholeWord;
+  private boolean[] wholeWord;
 
   @Injection( name = "CASE_SENSITIVE", group = "FIELDS" )
-  private int[] caseSensitive;
+  private boolean[] caseSensitive;
 
   @Injection( name = "IS_UNICODE", group = "FIELDS" )
-  private int[] isUnicode;
+  private boolean[] isUnicode;
 
-  public static final String[] caseSensitiveCode = { "no", "yes" };
-
-  public static final String[] isUnicodeCode = { "no", "yes" };
-
-  public static final String[] caseSensitiveDesc = new String[] {
+  public static final String[] flagDescriptor = new String[] {
     BaseMessages.getString( PKG, "System.Combo.No" ), BaseMessages.getString( PKG, "System.Combo.Yes" ) };
-
-  public static final String[] isUnicodeDesc = new String[] {
-    BaseMessages.getString( PKG, "System.Combo.No" ), BaseMessages.getString( PKG, "System.Combo.Yes" ) };
-
-  public static final int CASE_SENSITIVE_NO = 0;
-
-  public static final int CASE_SENSITIVE_YES = 1;
-
-  public static final int IS_UNICODE_NO = 0;
-
-  public static final int IS_UNICODE_YES = 1;
-
-  public static final String[] wholeWordDesc = new String[] {
-    BaseMessages.getString( PKG, "System.Combo.No" ), BaseMessages.getString( PKG, "System.Combo.Yes" ) };
-
-  public static final String[] wholeWordCode = { "no", "yes" };
-
-  public static final int WHOLE_WORD_NO = 0;
-
-  public static final int WHOLE_WORD_YES = 1;
-
-  public static final String[] useRegExDesc = new String[] {
-    BaseMessages.getString( PKG, "System.Combo.No" ), BaseMessages.getString( PKG, "System.Combo.Yes" ) };
-
-  public static final String[] useRegExCode = { "no", "yes" };
-
-  public static final int USE_REGEX_NO = 0;
-
-  public static final int USE_REGEX_YES = 1;
 
   public ReplaceStringMeta() {
     super(); // allocate BaseStepMeta
@@ -146,27 +113,27 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
     this.fieldInStream = keyStream;
   }
 
-  public int[] getCaseSensitive() {
+  public boolean[] getCaseSensitive() {
     return caseSensitive;
   }
 
-  public int[] isUnicode() {
+  public boolean[] isUnicode() {
     return isUnicode;
   }
 
-  public int[] getWholeWord() {
+  public boolean[] getWholeWord() {
     return wholeWord;
   }
 
-  public void setWholeWord( int[] wholeWord ) {
+  public void setWholeWord( boolean[] wholeWord ) {
     this.wholeWord = wholeWord;
   }
 
-  public int[] getUseRegEx() {
+  public boolean[] getUseRegEx() {
     return useRegEx;
   }
 
-  public void setUseRegEx( int[] useRegEx ) {
+  public void setUseRegEx( boolean[] useRegEx ) {
     this.useRegEx = useRegEx;
   }
 
@@ -224,11 +191,11 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
     this.replaceFieldByString = replaceFieldByString;
   }
 
-  public void setCaseSensitive( int[] caseSensitive ) {
+  public void setCaseSensitive( boolean[] caseSensitive ) {
     this.caseSensitive = caseSensitive;
   }
 
-  public void setIsUnicode( int[] isUnicode ) {
+  public void setIsUnicode( boolean[] isUnicode ) {
     this.isUnicode = isUnicode;
   }
 
@@ -239,14 +206,14 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
   public void allocate( int nrkeys ) {
     fieldInStream = new String[nrkeys];
     fieldOutStream = new String[nrkeys];
-    useRegEx = new int[nrkeys];
+    useRegEx = new boolean[nrkeys];
     replaceString = new String[nrkeys];
     replaceByString = new String[nrkeys];
     setEmptyString = new boolean[nrkeys];
     replaceFieldByString = new String[nrkeys];
-    wholeWord = new int[nrkeys];
-    caseSensitive = new int[nrkeys];
-    isUnicode = new int[nrkeys];
+    wholeWord = new boolean[nrkeys];
+    caseSensitive = new boolean[nrkeys];
+    isUnicode = new boolean[nrkeys];
   }
 
   public Object clone() {
@@ -282,18 +249,18 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
 
         fieldInStream[i] = Const.NVL( XMLHandler.getTagValue( fnode, "in_stream_name" ), "" );
         fieldOutStream[i] = Const.NVL( XMLHandler.getTagValue( fnode, "out_stream_name" ), "" );
-        useRegEx[i] = getCaseSensitiveByCode( Const.NVL( XMLHandler.getTagValue( fnode, "use_regex" ), "" ) );
+        useRegEx[i] = getFlagFromString( Const.NVL( XMLHandler.getTagValue( fnode, "use_regex" ), "" ) );
         replaceString[i] = Const.NVL( XMLHandler.getTagValue( fnode, "replace_string" ), "" );
         replaceByString[i] = Const.NVL( XMLHandler.getTagValue( fnode, "replace_by_string" ), "" );
         String emptyString = XMLHandler.getTagValue( fnode, "set_empty_string" );
 
         setEmptyString[i] = !Utils.isEmpty( emptyString ) && "Y".equalsIgnoreCase( emptyString );
         replaceFieldByString[i] = Const.NVL( XMLHandler.getTagValue( fnode, "replace_field_by_string" ), "" );
-        wholeWord[i] = getWholeWordByCode( Const.NVL( XMLHandler.getTagValue( fnode, "whole_word" ), "" ) );
+        wholeWord[i] = getFlagFromString( Const.NVL( XMLHandler.getTagValue( fnode, "whole_word" ), "" ) );
         caseSensitive[i] =
-          getCaseSensitiveByCode( Const.NVL( XMLHandler.getTagValue( fnode, "case_sensitive" ), "" ) );
+          getFlagFromString( Const.NVL( XMLHandler.getTagValue( fnode, "case_sensitive" ), "" ) );
         isUnicode[i] =
-          getIsUniCodeByCode( Const.NVL( XMLHandler.getTagValue( fnode, "is_unicode" ), "" ) );
+          getFlagFromString( Const.NVL( XMLHandler.getTagValue( fnode, "is_unicode" ), "" ) );
 
       }
     } catch ( Exception e ) {
@@ -302,17 +269,8 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
     }
   }
 
-  private static int getIsUniCodeByCode( String tt ) {
-    if ( tt == null ) {
-      return 0;
-    }
-
-    for ( int i = 0; i < isUnicodeCode.length; i++ ) {
-      if ( isUnicodeCode[i].equalsIgnoreCase( tt ) ) {
-        return i;
-      }
-    }
-    return 0;
+  private static boolean getFlagFromString( String tt ) {
+    return ( "Y".equalsIgnoreCase( tt ) || "yes".equalsIgnoreCase( tt )  || "true".equalsIgnoreCase( tt ) );
   }
 
   public void setDefault() {
@@ -332,18 +290,17 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
       retval.append( "      <field>" ).append( Const.CR );
       retval.append( "        " ).append( XMLHandler.addTagValue( "in_stream_name", fieldInStream[i] ) );
       retval.append( "        " ).append( XMLHandler.addTagValue( "out_stream_name", fieldOutStream[i] ) );
-      retval.append( "        " ).append( XMLHandler.addTagValue( "use_regex", getUseRegExCode( useRegEx[i] ) ) );
+      retval.append( "        " ).append( XMLHandler.addTagValue( "use_regex", getFlagTagValue( useRegEx[i] ) ) );
       retval.append( "        " ).append( XMLHandler.addTagValue( "replace_string", replaceString[i] ) );
       retval.append( "        " ).append( XMLHandler.addTagValue( "replace_by_string", replaceByString[i] ) );
       retval.append( "        " ).append( XMLHandler.addTagValue( "set_empty_string", setEmptyString[i] ) );
       retval.append( "        " ).append(
         XMLHandler.addTagValue( "replace_field_by_string", replaceFieldByString[i] ) );
-      retval
-        .append( "        " ).append( XMLHandler.addTagValue( "whole_word", getWholeWordCode( wholeWord[i] ) ) );
+      retval.append( "        " ).append( XMLHandler.addTagValue( "whole_word", getFlagTagValue( wholeWord[i] ) ) );
+      retval.append( "        " )
+        .append( XMLHandler.addTagValue( "case_sensitive", getFlagTagValue( caseSensitive[i] ) ) );
       retval.append( "        " ).append(
-        XMLHandler.addTagValue( "case_sensitive", getCaseSensitiveCode( caseSensitive[i] ) ) );
-      retval.append( "        " ).append(
-        XMLHandler.addTagValue( "is_unicode", getIsUniCodeCode( isUnicode[i] ) ) );
+        XMLHandler.addTagValue( "is_unicode", getFlagTagValue( isUnicode[i] ) ) );
       retval.append( "      </field>" ).append( Const.CR );
     }
 
@@ -352,11 +309,9 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
     return retval.toString();
   }
 
-  private static String getIsUniCodeCode( int i ) {
-    if ( i < 0 || i >= isUnicodeCode.length ) {
-      return isUnicodeCode[0];
-    }
-    return isUnicodeCode[i];
+  /** BACKLOG-27839 Outputs Flags that were previously int as "yes" or "no" for Backwards Compatibility in XML. **/
+  private static String getFlagTagValue( boolean flag ) {
+    return ( flag ? "yes" : "no" );
   }
 
   public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases ) throws KettleException {
@@ -368,18 +323,18 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
         fieldInStream[i] = Const.NVL( rep.getStepAttributeString( id_step, i, "in_stream_name" ), "" );
         fieldOutStream[i] = Const.NVL( rep.getStepAttributeString( id_step, i, "out_stream_name" ), "" );
         useRegEx[i] =
-          getCaseSensitiveByCode( Const.NVL( rep.getStepAttributeString( id_step, i, "use_regex" ), "" ) );
+          getFlagFromString( Const.NVL( rep.getStepAttributeString( id_step, i, "use_regex" ), "" ) );
         replaceString[i] = Const.NVL( rep.getStepAttributeString( id_step, i, "replace_string" ), "" );
         replaceByString[i] = Const.NVL( rep.getStepAttributeString( id_step, i, "replace_by_string" ), "" );
         setEmptyString[i] = rep.getStepAttributeBoolean( id_step, i, "set_empty_string", false );
         replaceFieldByString[i] =
           Const.NVL( rep.getStepAttributeString( id_step, i, "replace_field_by_string" ), "" );
         wholeWord[i] =
-          getWholeWordByCode( Const.NVL( rep.getStepAttributeString( id_step, i, "whole_world" ), "" ) );
+          getFlagFromString( Const.NVL( rep.getStepAttributeString( id_step, i, "whole_world" ), "" ) );
         caseSensitive[i] =
-          getCaseSensitiveByCode( Const.NVL( rep.getStepAttributeString( id_step, i, "case_sensitive" ), "" ) );
+          getFlagFromString( Const.NVL( rep.getStepAttributeString( id_step, i, "case_sensitive" ), "" ) );
         isUnicode[i] =
-          getIsUniCodeByCode( Const.NVL( rep.getStepAttributeString( id_step, i, "is_unicode" ), "" ) );
+          getFlagFromString( Const.NVL( rep.getStepAttributeString( id_step, i, "is_unicode" ), "" ) );
 
       }
     } catch ( Exception e ) {
@@ -393,16 +348,14 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
       for ( int i = 0; i < fieldInStream.length; i++ ) {
         rep.saveStepAttribute( id_transformation, id_step, i, "in_stream_name", fieldInStream[i] );
         rep.saveStepAttribute( id_transformation, id_step, i, "out_stream_name", fieldOutStream[i] );
-        rep.saveStepAttribute( id_transformation, id_step, i, "use_regex", getUseRegExCode( useRegEx[i] ) );
+        rep.saveStepAttribute( id_transformation, id_step, i, "use_regex", useRegEx[i] );
         rep.saveStepAttribute( id_transformation, id_step, i, "replace_string", replaceString[i] );
         rep.saveStepAttribute( id_transformation, id_step, i, "replace_by_string", replaceByString[i] );
         rep.saveStepAttribute( id_transformation, id_step, i, "set_empty_string", setEmptyString[i] );
         rep.saveStepAttribute( id_transformation, id_step, i, "replace_field_by_string", replaceFieldByString[i] );
-        rep.saveStepAttribute( id_transformation, id_step, i, "whole_world", getWholeWordCode( wholeWord[i] ) );
-        rep.saveStepAttribute(
-          id_transformation, id_step, i, "case_sensitive", getCaseSensitiveCode( caseSensitive[i] ) );
-        rep.saveStepAttribute(
-          id_transformation, id_step, i, "is_unicode", getIsUniCodeCode( isUnicode[i] ) );
+        rep.saveStepAttribute( id_transformation, id_step, i, "whole_world", wholeWord[i] );
+        rep.saveStepAttribute( id_transformation, id_step, i, "case_sensitive", caseSensitive[i] );
+        rep.saveStepAttribute( id_transformation, id_step, i, "is_unicode", isUnicode[i] );
 
       }
     } catch ( Exception e ) {
@@ -546,154 +499,6 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
     return true;
   }
 
-  private static String getCaseSensitiveCode( int i ) {
-    if ( i < 0 || i >= caseSensitiveCode.length ) {
-      return caseSensitiveCode[0];
-    }
-    return caseSensitiveCode[i];
-  }
-
-  private static String getWholeWordCode( int i ) {
-    if ( i < 0 || i >= wholeWordCode.length ) {
-      return wholeWordCode[0];
-    }
-    return wholeWordCode[i];
-  }
-
-  private static String getUseRegExCode( int i ) {
-    if ( i < 0 || i >= useRegExCode.length ) {
-      return useRegExCode[0];
-    }
-    return useRegExCode[i];
-  }
-
-  public static String getCaseSensitiveDesc( int i ) {
-    if ( i < 0 || i >= caseSensitiveDesc.length ) {
-      return caseSensitiveDesc[0];
-    }
-    return caseSensitiveDesc[i];
-  }
-
-  public static String getIsUnicodeDesc( int i ) {
-    if ( i < 0 || i >= isUnicodeDesc.length ) {
-      return isUnicodeDesc[0];
-    }
-    return isUnicodeDesc[i];
-  }
-
-  public static String getWholeWordDesc( int i ) {
-    if ( i < 0 || i >= wholeWordDesc.length ) {
-      return wholeWordDesc[0];
-    }
-    return wholeWordDesc[i];
-  }
-
-  public static String getUseRegExDesc( int i ) {
-    if ( i < 0 || i >= useRegExDesc.length ) {
-      return useRegExDesc[0];
-    }
-    return useRegExDesc[i];
-  }
-
-  private static int getCaseSensitiveByCode( String tt ) {
-    if ( tt == null ) {
-      return 0;
-    }
-
-    for ( int i = 0; i < caseSensitiveCode.length; i++ ) {
-      if ( caseSensitiveCode[i].equalsIgnoreCase( tt ) ) {
-        return i;
-      }
-    }
-    return 0;
-  }
-
-  private static int getWholeWordByCode( String tt ) {
-    if ( tt == null ) {
-      return 0;
-    }
-
-    for ( int i = 0; i < wholeWordCode.length; i++ ) {
-      if ( wholeWordCode[i].equalsIgnoreCase( tt ) ) {
-        return i;
-      }
-    }
-    return 0;
-  }
-
-  private static int getRegExByCode( String tt ) {
-    if ( tt == null ) {
-      return 0;
-    }
-
-    for ( int i = 0; i < useRegExCode.length; i++ ) {
-      if ( useRegExCode[i].equalsIgnoreCase( tt ) ) {
-        return i;
-      }
-    }
-    return 0;
-  }
-
-  public static int getCaseSensitiveByDesc( String tt ) {
-    if ( tt == null ) {
-      return 0;
-    }
-
-    for ( int i = 0; i < caseSensitiveDesc.length; i++ ) {
-      if ( caseSensitiveDesc[i].equalsIgnoreCase( tt ) ) {
-        return i;
-      }
-    }
-
-    // If this fails, try to match using the code.
-    return getCaseSensitiveByCode( tt );
-  }
-
-  public static int getIsUnicodeByDesc( String tt ) {
-    if ( tt == null ) {
-      return 0;
-    }
-
-    for ( int i = 0; i < isUnicodeDesc.length; i++ ) {
-      if ( isUnicodeDesc[i].equalsIgnoreCase( tt ) ) {
-        return i;
-      }
-    }
-
-    // If this fails, try to match using the code.
-    return getIsUniCodeByCode( tt );
-  }
-
-  public static int getWholeWordByDesc( String tt ) {
-    if ( tt == null ) {
-      return 0;
-    }
-
-    for ( int i = 0; i < wholeWordDesc.length; i++ ) {
-      if ( wholeWordDesc[i].equalsIgnoreCase( tt ) ) {
-        return i;
-      }
-    }
-
-    // If this fails, try to match using the code.
-    return getWholeWordByCode( tt );
-  }
-
-  public static int getUseRegExByDesc( String tt ) {
-    if ( tt == null ) {
-      return 0;
-    }
-
-    for ( int i = 0; i < useRegExDesc.length; i++ ) {
-      if ( useRegExDesc[i].equalsIgnoreCase( tt ) ) {
-        return i;
-      }
-    }
-
-    // If this fails, try to match using the code.
-    return getRegExByCode( tt );
-  }
-
   private void nullToEmpty( String [] strings ) {
     for ( int i = 0; i < strings.length; i++ ) {
       if ( strings[ i ] == null ) {
@@ -722,14 +527,13 @@ public class ReplaceStringMeta extends BaseStepMeta implements StepMetaInterface
     nullToEmpty( replaceByString );
     nullToEmpty( replaceFieldByString );
 
-    int[][] rtnIntArrays = Utils.normalizeArrays( nrFields, useRegEx, wholeWord, caseSensitive, isUnicode );
-    useRegEx = rtnIntArrays[ 0 ];
-    wholeWord = rtnIntArrays[ 1 ];
-    caseSensitive = rtnIntArrays[ 2 ];
-    isUnicode = rtnIntArrays[ 3 ];
-
-    boolean[][] rtnBooleanArrays = Utils.normalizeArrays( nrFields, setEmptyString );
-    setEmptyString = rtnBooleanArrays[ 0 ];
+    boolean[][] rtnBooleanArrays =
+      Utils.normalizeArrays( nrFields, useRegEx, setEmptyString, wholeWord, caseSensitive, isUnicode );
+    useRegEx = rtnBooleanArrays[ 0 ];
+    setEmptyString = rtnBooleanArrays[ 1 ];
+    wholeWord = rtnBooleanArrays[ 2 ];
+    caseSensitive = rtnBooleanArrays[ 3 ];
+    isUnicode = rtnBooleanArrays[ 4 ];
   }
 
 }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/replacestring/ReplaceStringMetaInjectionTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/replacestring/ReplaceStringMetaInjectionTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -51,8 +51,8 @@ public class ReplaceStringMetaInjectionTest extends BaseMetadataInjectionTest<Re
         return meta.getFieldOutStream()[ 0 ];
       }
     } );
-    check( "USE_REGEX", new IntGetter() {
-      @Override public int get() {
+    check( "USE_REGEX", new BooleanGetter() {
+      @Override public boolean get() {
         return meta.getUseRegEx()[ 0 ];
       }
     } );
@@ -76,18 +76,18 @@ public class ReplaceStringMetaInjectionTest extends BaseMetadataInjectionTest<Re
         return meta.getFieldReplaceByString()[ 0 ];
       }
     } );
-    check( "REPLACE_WHOLE_WORD", new IntGetter() {
-      @Override public int get() {
+    check( "REPLACE_WHOLE_WORD", new BooleanGetter() {
+      @Override public boolean get() {
         return meta.getWholeWord()[ 0 ];
       }
     } );
-    check( "CASE_SENSITIVE", new IntGetter() {
-      @Override public int get() {
+    check( "CASE_SENSITIVE", new BooleanGetter() {
+      @Override public boolean get() {
         return meta.getCaseSensitive()[ 0 ];
       }
     } );
-    check( "IS_UNICODE", new IntGetter() {
-      @Override public int get() {
+    check( "IS_UNICODE", new BooleanGetter() {
+      @Override public boolean get() {
         return meta.isUnicode()[ 0 ];
       }
     } );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/replacestring/ReplaceStringTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/replacestring/ReplaceStringTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -119,9 +119,9 @@ public class ReplaceStringTest {
 
     meta.setFieldInStream( new String[] { "input1", "input2" } );
     meta.setFieldOutStream( new String[] { "out" } );
-    meta.setUseRegEx( new int[] { 1 } );
-    meta.setCaseSensitive( new int[] { 0 } );
-    meta.setWholeWord( new int[] { 1 } );
+    meta.setUseRegEx( new boolean[] { true } );
+    meta.setCaseSensitive( new boolean[] { false } );
+    meta.setWholeWord( new boolean[] { true } );
     meta.setReplaceString( new String[] { "string" } );
     meta.setReplaceByString( new String[] { "string" } );
     meta.setEmptyString( new boolean[] { true } );
@@ -133,13 +133,13 @@ public class ReplaceStringTest {
     Assert.assertEquals( StringUtils.EMPTY, meta.getFieldOutStream()[ 1 ] );
 
     Assert.assertEquals( meta.getFieldInStream().length, meta.getUseRegEx().length );
-    Assert.assertEquals( 0, meta.getUseRegEx()[ 1 ] );
+    Assert.assertEquals( false, meta.getUseRegEx()[ 1 ] );
 
     Assert.assertEquals( meta.getFieldInStream().length, meta.getCaseSensitive().length );
-    Assert.assertEquals( 0, meta.getCaseSensitive()[ 1 ] );
+    Assert.assertEquals( false, meta.getCaseSensitive()[ 1 ] );
 
     Assert.assertEquals( meta.getFieldInStream().length, meta.getWholeWord().length );
-    Assert.assertEquals( 0, meta.getWholeWord()[ 1 ] );
+    Assert.assertEquals( false, meta.getWholeWord()[ 1 ] );
 
     Assert.assertEquals( meta.getFieldInStream().length, meta.getReplaceString().length );
     Assert.assertEquals( StringUtils.EMPTY, meta.getReplaceString()[ 1 ] );
@@ -179,7 +179,7 @@ public class ReplaceStringTest {
     RowMetaInterface inputRowMeta = new RowMeta();
     byte[] array = { 0, 97, 0, 65, -1, 65, -1, 33 };
     byte[] matcharray = { -1, 33 };
-    String match = new String( matcharray , "UTF-16BE" );
+    String match = new String( matcharray, "UTF-16BE" );
     Object[] _row = new Object[] { new String( array, "UTF-16BE" ), "another data" };
     doReturn( _row ).when( replaceString ).getRow();
     inputRowMeta.addValueMeta( 0, new ValueMetaString( "string" ) );
@@ -187,11 +187,10 @@ public class ReplaceStringTest {
 
     doReturn( new String[] { "string" }  ).when( meta ).getFieldInStream();
     doReturn( new String[] { "output" }  ).when( meta ).getFieldOutStream();
-
-    doReturn( new int[] { 1 } ).when( meta ).isUnicode();
-    doReturn( new int[] { 0 } ).when( meta ).getUseRegEx();
-    doReturn( new int[] { 0 } ).when( meta ).getCaseSensitive();
-    doReturn( new int[] { 0 } ).when( meta ).getWholeWord();
+    doReturn( new boolean[] { true } ).when( meta ).isUnicode();
+    doReturn( new boolean[] { false } ).when( meta ).getUseRegEx();
+    doReturn( new boolean[] { false } ).when( meta ).getCaseSensitive();
+    doReturn( new boolean[] { false } ).when( meta ).getWholeWord();
     doReturn( new String[] { match } ).when( meta ).getReplaceString();
     doReturn( new String[] { "" } ).when( meta ).getFieldReplaceByString();
     doReturn( new String[] { "matched" } ).when( meta ).getReplaceByString();
@@ -210,7 +209,7 @@ public class ReplaceStringTest {
 
     replaceString.processRow( meta, data );
     System.out.println( replaceString.getRow()[1] );
-    assertTrue( "Expected: aAmatchedmatched","aAmatchedmatched".equals( replaceString.getRow()[1] ) );
+    assertTrue( "Expected: aAmatchedmatched", "aAmatchedmatched".equals( replaceString.getRow()[1] ) );
   }
 }
 

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/replacestring/ReplaceStringDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/replacestring/ReplaceStringDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -157,7 +157,7 @@ public class ReplaceStringDialog extends BaseStepDialog implements StepDialogInt
     ciKey[2] =
       new ColumnInfo(
         BaseMessages.getString( PKG, "ReplaceStringDialog.ColumnInfo.useRegEx" ),
-        ColumnInfo.COLUMN_TYPE_CCOMBO, ReplaceStringMeta.useRegExDesc );
+        ColumnInfo.COLUMN_TYPE_CCOMBO, ReplaceStringMeta.flagDescriptor );
     ciKey[3] =
       new ColumnInfo(
         BaseMessages.getString( PKG, "ReplaceStringDialog.ColumnInfo.Replace" ), ColumnInfo.COLUMN_TYPE_TEXT,
@@ -168,10 +168,7 @@ public class ReplaceStringDialog extends BaseStepDialog implements StepDialogInt
     ciKey[5] =
       new ColumnInfo(
         BaseMessages.getString( PKG, "ReplaceStringDialog.ColumnInfo.SetEmptyString" ),
-        ColumnInfo.COLUMN_TYPE_CCOMBO,
-        new String[] {
-          BaseMessages.getString( PKG, "System.Combo.Yes" ), BaseMessages.getString( PKG, "System.Combo.No" ) } );
-
+        ColumnInfo.COLUMN_TYPE_CCOMBO, ReplaceStringMeta.flagDescriptor );
     ciKey[6] =
       new ColumnInfo(
         BaseMessages.getString( PKG, "ReplaceStringDialog.ColumnInfo.FieldReplaceBy" ),
@@ -180,15 +177,15 @@ public class ReplaceStringDialog extends BaseStepDialog implements StepDialogInt
     ciKey[7] =
       new ColumnInfo(
         BaseMessages.getString( PKG, "ReplaceStringDialog.ColumnInfo.WholeWord" ),
-        ColumnInfo.COLUMN_TYPE_CCOMBO, ReplaceStringMeta.wholeWordDesc );
+        ColumnInfo.COLUMN_TYPE_CCOMBO, ReplaceStringMeta.flagDescriptor );
     ciKey[8] =
       new ColumnInfo(
         BaseMessages.getString( PKG, "ReplaceStringDialog.ColumnInfo.CaseSensitive" ),
-        ColumnInfo.COLUMN_TYPE_CCOMBO, ReplaceStringMeta.caseSensitiveDesc );
+        ColumnInfo.COLUMN_TYPE_CCOMBO, ReplaceStringMeta.flagDescriptor );
     ciKey[9] =
       new ColumnInfo(
         BaseMessages.getString( PKG, "ReplaceStringDialog.ColumnInfo.IsUnicode" ),
-        ColumnInfo.COLUMN_TYPE_CCOMBO, ReplaceStringMeta.isUnicodeDesc );
+        ColumnInfo.COLUMN_TYPE_CCOMBO, ReplaceStringMeta.flagDescriptor );
 
     ciKey[1].setToolTip( BaseMessages.getString( PKG, "ReplaceStringDialog.ColumnInfo.OutStreamField.Tooltip" ) );
     ciKey[1].setUsingVariables( true );
@@ -329,25 +326,23 @@ public class ReplaceStringDialog extends BaseStepDialog implements StepDialogInt
         if ( input.getFieldOutStream()[i] != null ) {
           item.setText( 2, input.getFieldOutStream()[i] );
         }
-        item.setText( 3, ReplaceStringMeta.getUseRegExDesc( input.getUseRegEx()[i] ) );
+
+        item.setText( 3, getFlagDescriptor( input.getUseRegEx()[i] ) );
         if ( input.getReplaceString()[i] != null ) {
           item.setText( 4, input.getReplaceString()[i] );
         }
         if ( input.getReplaceByString()[i] != null ) {
           item.setText( 5, input.getReplaceByString()[i] );
         }
-        item
-          .setText( 6, input.isSetEmptyString()[i]
-            ? BaseMessages.getString( PKG, "System.Combo.Yes" ) : BaseMessages.getString(
-              PKG, "System.Combo.No" ) );
+        item.setText( 6, getFlagDescriptor( input.isSetEmptyString()[i] ) );
 
         if ( input.getFieldReplaceByString()[i] != null ) {
           item.setText( 7, input.getFieldReplaceByString()[i] );
         }
 
-        item.setText( 8, ReplaceStringMeta.getWholeWordDesc( input.getWholeWord()[i] ) );
-        item.setText( 9, ReplaceStringMeta.getCaseSensitiveDesc( input.getCaseSensitive()[i] ) );
-        item.setText( 10, ReplaceStringMeta.getIsUnicodeDesc( input.isUnicode()[i] ) );
+        item.setText( 8, getFlagDescriptor( input.getWholeWord()[i] ) );
+        item.setText( 9, getFlagDescriptor( input.getCaseSensitive()[i] ) );
+        item.setText( 10, getFlagDescriptor( input.isUnicode()[i] ) );
       }
     }
 
@@ -377,12 +372,11 @@ public class ReplaceStringDialog extends BaseStepDialog implements StepDialogInt
       TableItem item = wFields.getNonEmpty( i );
       inf.getFieldInStream()[i] = item.getText( 1 );
       inf.getFieldOutStream()[i] = item.getText( 2 );
-      inf.getUseRegEx()[i] = ReplaceStringMeta.getUseRegExByDesc( item.getText( 3 ) );
+      inf.getUseRegEx()[i] = checkFlagDescriptor( item.getText( 3 ) );
       inf.getReplaceString()[i] = item.getText( 4 );
       inf.getReplaceByString()[i] = item.getText( 5 );
 
-      inf.isSetEmptyString()[i] =
-        BaseMessages.getString( PKG, "System.Combo.Yes" ).equalsIgnoreCase( item.getText( 6 ) );
+      inf.isSetEmptyString()[i] = checkFlagDescriptor( item.getText( 6 ) );
       if ( inf.isSetEmptyString()[i] ) {
         inf.getReplaceByString()[i] = "";
       }
@@ -391,12 +385,21 @@ public class ReplaceStringDialog extends BaseStepDialog implements StepDialogInt
         inf.getReplaceByString()[i] = "";
       }
 
-      inf.getWholeWord()[i] = ReplaceStringMeta.getWholeWordByDesc( item.getText( 8 ) );
-      inf.getCaseSensitive()[i] = ReplaceStringMeta.getCaseSensitiveByDesc( item.getText( 9 ) );
-      inf.isUnicode()[i] = ReplaceStringMeta.getIsUnicodeByDesc( item.getText( 10 ) );
+      inf.getWholeWord()[i] = checkFlagDescriptor( item.getText( 8 ) );
+      inf.getCaseSensitive()[i] = checkFlagDescriptor( item.getText( 9 ) );
+      inf.isUnicode()[i] = checkFlagDescriptor( item.getText( 10 ) );
     }
 
     stepname = wStepname.getText(); // return value
+  }
+
+  private static String getFlagDescriptor( boolean flag ) {
+    return ( flag ? BaseMessages.getString( PKG, "System.Combo.Yes" ) : BaseMessages.getString(
+      PKG, "System.Combo.No" ) );
+  }
+
+  private static boolean checkFlagDescriptor( String text ) {
+    return BaseMessages.getString( PKG, "System.Combo.Yes" ).equalsIgnoreCase( text );
   }
 
   private void ok() {


### PR DESCRIPTION
…rror

Updated Replace in String Step, changing the following fields from int arrays to boolean arrays:
- use_regex
- whole_world
- case_sensitive
- is_unicode

Update fixes Metadata injection as well as, accepts "Y", "yes", "true" from the .ktr where previously only "yes" worked. Output of XML uses "yes" / "no" for backwards compatibility.

