### PR TITLE
[PDI-15323] PDI - export XML can't export an XML job (when you change…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -6105,12 +6105,16 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     }
 
     FileListener listener = null;
-    // match by extension first
+    // match by extension first - this results into PDI-15323
+    // So to fix PDI-15323, we let the fileListener for the default extension for this meta
+    // handle the request, commenting out the code that finds the listener by extension type
+    /*
     int idx = filename.lastIndexOf( '.' );
     if ( idx != -1 ) {
       String extension = filename.substring( idx + 1 );
       listener = fileExtensionMap.get( extension );
     }
+    */
     if ( listener == null ) {
       String xt = meta.getDefaultExtension();
       listener = fileExtensionMap.get( xt );


### PR DESCRIPTION
… the appendix of the file name)

During initialization of Spoon, `JobFileListener` and `TransFileListener` are registered. Both of these listeners have `xml` as supported file type. But only `TransFileListener` is being mapped to `xml` extension in `addFileListener` method . So when exporting a `kjb` as `xml` or `all files`, `TransFileListener.save()`  is getting called instead of `JobFileListener.save() ` and a `ClassCastException` is thrown.

This is fixed by letting the default listener for `TransMeta` or `JobMeta` 's default extension handle the request.

@pentaho/rogueone @bmorrise 