### PR TITLE
[PDI-18105] Sub-Job that called by Job Executor from a transformation…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1351,7 +1351,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
         //  When the child parameter does exist in the parent parameters, overwrite the child parameter by the
         // parent parameter.
 
-        StepWithMappingMeta.replaceVariableValues( transMeta, space );
+        StepWithMappingMeta.replaceVariableValues( transMeta, space, "Trans" );
         if ( isPassingAllParameters() ) {
           // All other parent parameters need to get copied into the child parameters  (when the 'Inherit all
           // variables from the transformation?' option is checked)

--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -433,21 +433,34 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
     }
   }
 
-  public static void replaceVariableValues( VariableSpace childTransMeta, VariableSpace replaceBy ) {
+  public static void replaceVariableValues( VariableSpace childTransMeta, VariableSpace replaceBy, String type ) {
     if ( replaceBy == null ) {
       return;
     }
     String[] variableNames = replaceBy.listVariables();
     for ( String variableName : variableNames ) {
-      if ( childTransMeta.getVariable( variableName ) != null && !isInternalVariable( variableName ) ) {
+      if ( childTransMeta.getVariable( variableName ) != null && !isInternalVariable( variableName, type ) ) {
         childTransMeta.setVariable( variableName, replaceBy.getVariable( variableName ) );
       }
     }
   }
 
-  private static boolean isInternalVariable( String variableName ) {
-    return ( Arrays.asList( Const.INTERNAL_JOB_VARIABLES ).contains( variableName )
-      || Arrays.asList( Const.INTERNAL_TRANS_VARIABLES ).contains( variableName ) );
+  public static void replaceVariableValues( VariableSpace childTransMeta, VariableSpace replaceBy ) {
+    replaceVariableValues(  childTransMeta,  replaceBy, "" );
+  }
+
+  private static boolean isInternalVariable( String variableName, String type ) {
+    return type.equals( "Trans" ) ? isTransInternalVariable( variableName )
+      : type.equals( "Job" ) ? isJobInternalVariable( variableName )
+      : isJobInternalVariable( variableName ) || isTransInternalVariable( variableName );
+  }
+
+  private static boolean isTransInternalVariable( String variableName ) {
+    return ( Arrays.asList( Const.INTERNAL_TRANS_VARIABLES ).contains( variableName ) );
+  }
+
+  private static boolean isJobInternalVariable( String variableName ) {
+    return ( Arrays.asList( Const.INTERNAL_JOB_VARIABLES ).contains( variableName ) );
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -707,7 +707,7 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
 
     //  When the child parameter does exist in the parent parameters, overwrite the child parameter by the
     // parent parameter.
-    StepWithMappingMeta.replaceVariableValues( mappingJobMeta, space );
+    StepWithMappingMeta.replaceVariableValues( mappingJobMeta, space, "Job" );
     if ( executorMeta.getParameters().isInheritingAllVariables() ) {
       // All other parent parameters need to get copied into the child parameters  (when the 'Inherit all
       // variables from the transformation?' option is checked)


### PR DESCRIPTION
… that called from a Job does not execute job entries

To preserve some old behaviors since internal variables for Jobs and Transformations are deprecated, we can now overwrite all internal variables that are not exclusive. 

That means:
If we are running a **job**, we can now overwrite **internal.transformation** variables
If we are running a **transformation**, we can now overwrite **internal.job** variables

This makes particular sense when we are running multiple combinations of jobs calling transformations that can call another job that can call another transformation. This way, even we are in a transformation context, we can access to the internal.job variables defined by his parent job.