### PR TITLE
[BACKLOG-22191] Decouple cubeinput step from Kettle engine

### DIFF
--- a/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/cubeinput/messages/messages_de_DE.properties
+++ b/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/cubeinput/messages/messages_de_DE.properties
@@ -4,13 +4,13 @@ CubeInput.Description=Liest Datenzeilen aus einem Datenkubus
 CubeInput.Log.LineNumber=Zeilennr 
 CubeInput.Log.UnableToReadMetadata=INIT: Konnte die Meta-Daten nicht von der Cube-Datei lesen: 
 CubeInput.Log.ErrorReadingFromDataCube=Fehler beim Lesen der Cube-Daten: 
-CubeInput.Log.ErrorClosingCube=Fehler beim Schlie�en der Cube Inputdatei:
+CubeInput.Log.ErrorClosingCube=Fehler beim Schlie\u00DFen der Cube Inputdatei:
 
 ############# CubeInputMeta  #################
 CubeInputMeta.Exception.UnableToLoadStepInfo=Konnte die Schrittinformationen nicht von der XML-Datei laden
 CubeInputMeta.Exception.UnableToReadMetaData=Konnte die Metadaten nicht von der Cubedatei lesen
-CubeInputMeta.Exception.ErrorOpeningOrReadingCubeFile=Fehler beim �ffnen / Lesen der Cubedatei
-CubeInputMeta.Exception.UnableToCloseCubeFile=Konnte die Cubedatei nicht schlie�en
+CubeInputMeta.Exception.ErrorOpeningOrReadingCubeFile=Fehler beim \u00D6ffnen / Lesen der Cubedatei
+CubeInputMeta.Exception.UnableToCloseCubeFile=Konnte die Cubedatei nicht schlie\u00DFen
 CubeInputMeta.Exception.UnexpectedErrorWhileReadingStepInfo=Ein unerwarteter Fehler trat beim Lesen der Schrittinfomationen aus dem Repository auf
-CubeInputMeta.Exception.UnableToSaveStepInfo=Konnte die Schrittinformationen nicht ins Repository speichern f�r den ID_Schritt=
-CubeInputMeta.CheckResult.FileSpecificationsNotChecked=Dateispezifikationen wurden nicht ausgew�hlt.
+CubeInputMeta.Exception.UnableToSaveStepInfo=Konnte die Schrittinformationen nicht ins Repository speichern f\u00FCr den ID_Schritt=
+CubeInputMeta.CheckResult.FileSpecificationsNotChecked=Dateispezifikationen wurden nicht ausgew\u00E4hlt.

--- a/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/cubeinput/messages/messages_es_ES.properties
+++ b/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/cubeinput/messages/messages_es_ES.properties
@@ -1,16 +1,16 @@
 ############# CubeInput  #################
 CubeInput.Name=Des-Serializacion desde Fichero
 CubeInput.Description=Leer filas de datos de un cubo.
-CubeInput.Log.LineNumber=N�mero de l�nea 
-CubeInput.Log.UnableToReadMetadata=INICIO: No se ha podido leer metainformaci�n del cubo: 
+CubeInput.Log.LineNumber=N\u00FAmero de l\u00EDnea
+CubeInput.Log.UnableToReadMetadata=INICIO: No se ha podido leer metainformaci\u00F3n del cubo:
 CubeInput.Log.ErrorReadingFromDataCube=Error leyendo datos del cubo : 
 CubeInput.Log.ErrorClosingCube=Error cerrando cubo de entrada:
 
 ############# CubeInputMeta  #################
-CubeInputMeta.Exception.UnableToLoadStepInfo=No se ha podido cargar informaci�n del paso desde XML
-CubeInputMeta.Exception.UnableToReadMetaData=No se ha podido leer metainformaci�n del cubo
+CubeInputMeta.Exception.UnableToLoadStepInfo=No se ha podido cargar informaci\u00F3n del paso desde XML
+CubeInputMeta.Exception.UnableToReadMetaData=No se ha podido leer metainformaci\u00F3n del cubo
 CubeInputMeta.Exception.ErrorOpeningOrReadingCubeFile=Error abriendo/leyendo cubo
 CubeInputMeta.Exception.UnableToCloseCubeFile=No se ha podido cerrar cubo
-CubeInputMeta.Exception.UnexpectedErrorWhileReadingStepInfo=Error desconocido leyendo informaci�n del paso desde el cat�logo
-CubeInputMeta.Exception.UnableToSaveStepInfo=No se ha podido guardar la informaci�n del paso id_step=
-CubeInputMeta.CheckResult.FileSpecificationsNotChecked=Especificaciones de fichero no est�n marcadas.
+CubeInputMeta.Exception.UnexpectedErrorWhileReadingStepInfo=Error desconocido leyendo informaci\u00F3n del paso desde el cat\u00E1logo
+CubeInputMeta.Exception.UnableToSaveStepInfo=No se ha podido guardar la informaci\u00F3n del paso id_step=
+CubeInputMeta.CheckResult.FileSpecificationsNotChecked=Especificaciones de fichero no est\u00E1n marcadas.

--- a/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/cubeinput/messages/messages_pt_BR.properties
+++ b/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/cubeinput/messages/messages_pt_BR.properties
@@ -2,15 +2,15 @@
 CubeInput.Name=De-serialize from file
 CubeInput.Description=Read rows of data from a data cube.
 CubeInput.Log.LineNumber=linha nr 
-CubeInput.Log.UnableToReadMetadata=INIT: N�o foi poss�vel ler metadados do arquivo cubo: 
+CubeInput.Log.UnableToReadMetadata=INIT: N\u00E3o foi poss\u00EDvel ler metadados do arquivo cubo:
 CubeInput.Log.ErrorReadingFromDataCube=Erro lendo do cubo de dados : 
-CubeInput.Log.ErrorClosingCube=Erro fechando o arquivo de entrada do cubo: 
+CubeInput.Log.ErrorClosingCube=Erro fechando o arquivo de entrada do cubo:
 
 ############# CubeInputMeta  #################
-CubeInputMeta.Exception.UnableToLoadStepInfo=N�o foi poss�vel carregar informa��o do step do XML
-CubeInputMeta.Exception.UnableToReadMetaData=N�o foi poss�vel ler metadados do arquivo cubo
+CubeInputMeta.Exception.UnableToLoadStepInfo=N\u00E3o foi poss\u00EDvel carregar a informa\u00E7\u00E3o do step do XML
+CubeInputMeta.Exception.UnableToReadMetaData=N\u00E3o foi poss\u00EDvel ler metadados do arquivo cubo
 CubeInputMeta.Exception.ErrorOpeningOrReadingCubeFile=Erro abrindo/lendo arquivo cubo
-CubeInputMeta.Exception.UnableToCloseCubeFile=N�o foi poss�vel fechar o arquivo cubo
-CubeInputMeta.Exception.UnexpectedErrorWhileReadingStepInfo=Erro inesperado lendo informa��o do step do reposit�rio
-CubeInputMeta.Exception.UnableToSaveStepInfo=N�o foi poss�vel gravar informa��o do step para o id_step=
-CubeInputMeta.CheckResult.FileSpecificationsNotChecked=Especifica��es do arquivo n�o est�o checadas.
+CubeInputMeta.Exception.UnableToCloseCubeFile=N\u00E3o foi poss\u00EDvel fechar o arquivo cubo
+CubeInputMeta.Exception.UnexpectedErrorWhileReadingStepInfo=Erro inesperado lendo informa\u00E7\u00E3o do step do reposit\u00F3rio
+CubeInputMeta.Exception.UnableToSaveStepInfo=N\u00E3o foi poss\u00EDvel gravar informa\u00E7\u00E3o do step para o id_step=
+CubeInputMeta.CheckResult.FileSpecificationsNotChecked=Especifica\u00E7\u00E3o dos arquivos n\u00E3o est\u00E3o checadas.

--- a/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/cubeinput/messages/messages_pt_PT.properties
+++ b/plugins/core/impl/src/main/resources/org/pentaho/di/trans/steps/cubeinput/messages/messages_pt_PT.properties
@@ -2,15 +2,15 @@
 CubeInput.Name=De-serialize from file
 CubeInput.Description=Read rows of data from a data cube.
 CubeInput.Log.LineNumber=linha nr 
-CubeInput.Log.UnableToReadMetadata=INIT: N�o foi poss�vel ler metadados do arquivo cubo: 
+CubeInput.Log.UnableToReadMetadata=INIT: N\u00E3o foi poss\u00EDvel ler metadados do arquivo cubo:
 CubeInput.Log.ErrorReadingFromDataCube=Erro lendo do cubo de dados : 
-CubeInput.Log.ErrorClosingCube=Erro fechando o arquivo de entrada do cubo: 
+CubeInput.Log.ErrorClosingCube=Erro fechando o arquivo de entrada do cubo:
 
 ############# CubeInputMeta  #################
-CubeInputMeta.Exception.UnableToLoadStepInfo=N�o foi poss�vel carregar informa��o do step do XML
-CubeInputMeta.Exception.UnableToReadMetaData=N�o foi poss�vel ler metadados do arquivo cubo
+CubeInputMeta.Exception.UnableToLoadStepInfo=N\u00E3o foi poss\u00EDvel carregar a informa\u00E7\u00E3o do step do XML
+CubeInputMeta.Exception.UnableToReadMetaData=N\u00E3o foi poss\u00EDvel ler metadados do arquivo cubo
 CubeInputMeta.Exception.ErrorOpeningOrReadingCubeFile=Erro abrindo/lendo arquivo cubo
-CubeInputMeta.Exception.UnableToCloseCubeFile=N�o foi poss�vel fechar o arquivo cubo
-CubeInputMeta.Exception.UnexpectedErrorWhileReadingStepInfo=Erro inesperado lendo informa��o do step do reposit�rio
-CubeInputMeta.Exception.UnableToSaveStepInfo=N�o foi poss�vel gravar informa��o do step para o id_step=
-CubeInputMeta.CheckResult.FileSpecificationsNotChecked=Especifica��es do arquivo n�o est�o checadas.
+CubeInputMeta.Exception.UnableToCloseCubeFile=N\u00E3o foi poss\u00EDvel fechar o arquivo cubo
+CubeInputMeta.Exception.UnexpectedErrorWhileReadingStepInfo=Erro inesperado lendo informa\u00E7\u00E3o do step do reposit\u00F3rio
+CubeInputMeta.Exception.UnableToSaveStepInfo=N\u00E3o foi poss\u00EDvel gravar informa\u00E7\u00E3o do step para o id_step=
+CubeInputMeta.CheckResult.FileSpecificationsNotChecked=Especifica\u00E7\u00E3o dos arquivos n\u00E3o est\u00E3o checadas.

--- a/plugins/core/ui/src/main/resources/org/pentaho/di/ui/trans/steps/cubeinput/messages/messages_de_DE.properties
+++ b/plugins/core/ui/src/main/resources/org/pentaho/di/ui/trans/steps/cubeinput/messages/messages_de_DE.properties
@@ -4,7 +4,7 @@
 CubeInputDialog.Shell.Title=Cube-Datei-Input
 CubeInputDialog.Stepname.Label=Schrittname
 CubeInputDialog.Filename.Label=Dateiname 
-CubeInputDialog.FilenameButton.Label=&Durchf�hren...
+CubeInputDialog.FilenameButton.Label=&Durchf\u00FChren...
 CubeInputDialog.Limit.Label=Limit size 
 CubeInputDialog.FilterNames.CubeFiles=Cubedateien
 CubeInputDialog.FilterNames.AllFiles=Alle Dateien

--- a/plugins/core/ui/src/main/resources/org/pentaho/di/ui/trans/steps/cubeinput/messages/messages_es_ES.properties
+++ b/plugins/core/ui/src/main/resources/org/pentaho/di/ui/trans/steps/cubeinput/messages/messages_es_ES.properties
@@ -5,6 +5,6 @@ CubeInputDialog.Shell.Title=Cubo de Entrada
 CubeInputDialog.Stepname.Label=Nombre de paso 
 CubeInputDialog.Filename.Label=Nombre de fichero 
 CubeInputDialog.FilenameButton.Label=&Examinar...
-CubeInputDialog.Limit.Label=Limitar tama�o 
+CubeInputDialog.Limit.Label=Limitar tama\u00F1o
 CubeInputDialog.FilterNames.CubeFiles=Cubos
 CubeInputDialog.FilterNames.AllFiles=Todos los ficheros


### PR DESCRIPTION
Fixed *.properties files that had incorrect byte-encoding.