### PR TITLE
[PDI-17759] XSD Validator step and job entry are vulnerable to XXE hacks

### DIFF
--- a/plugins/xml/core/src/main/java/org/pentaho/di/trans/steps/xsdvalidator/XsdValidator.java
+++ b/plugins/xml/core/src/main/java/org/pentaho/di/trans/steps/xsdvalidator/XsdValidator.java
@@ -35,6 +35,7 @@ import javax.xml.validation.Validator;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.provider.AbstractFileObject;
+import org.apache.xerces.xni.parser.XMLEntityResolver;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowDataUtil;
@@ -236,8 +237,14 @@ public class XsdValidator extends BaseStep implements StepInterface {
         // Prevent against XML Entity Expansion (XEE) attacks.
         // https://www.owasp.org/index.php/XML_Security_Cheat_Sheet#XML_Entity_Expansion
         if ( !meta.isAllowExternalEntities() ) {
-          xsdValidator.setProperty( XMLConstants.ACCESS_EXTERNAL_DTD, "" );
-          xsdValidator.setProperty( XMLConstants.ACCESS_EXTERNAL_SCHEMA, "" );
+          xsdValidator.setFeature( "http://apache.org/xml/features/disallow-doctype-decl", true );
+          xsdValidator.setFeature( "http://xml.org/sax/features/external-general-entities", false );
+          xsdValidator.setFeature( "http://xml.org/sax/features/external-parameter-entities", false );
+          xsdValidator.setProperty( "http://apache.org/xml/properties/internal/entity-resolver",
+            (XMLEntityResolver) xmlResourceIdentifier -> {
+              String message = BaseMessages.getString( PKG, "XsdValidator.Exception.DisallowedDocType" );
+              throw new IOException( message );
+            } );
         }
 
         // Validate XML / XSD

--- a/plugins/xml/core/src/main/resources/org/pentaho/di/job/entries/xsdvalidator/messages/messages_en_US.properties
+++ b/plugins/xml/core/src/main/resources/org/pentaho/di/job/entries/xsdvalidator/messages/messages_en_US.properties
@@ -22,3 +22,4 @@ JobEntryXSDValidator.Title=XSD validator
 JobEntryXSDValidator.ErrorXSDValidator.Label=Error occurred while processing the XSD file
 JobEntryXSDValidator.ErrorXSD1.Label=XSD file [
 JobEntryXSDValidator.AllowExternalEntities.Label=Enable external entity for XSD validation\:
+JobEntryXSDValidator.Error.DisallowedDocType=DOCTYPE is disallowed when the feature http://apache.org/xml/features/disallow-doctype-decl set to true.

--- a/plugins/xml/core/src/main/resources/org/pentaho/di/trans/steps/xsdvalidator/messages/messages_en_US.properties
+++ b/plugins/xml/core/src/main/resources/org/pentaho/di/trans/steps/xsdvalidator/messages/messages_en_US.properties
@@ -71,3 +71,5 @@ XsdValidatorDialog.XSDSource.Label=XSD Source
 XsdValidator.Log.Error.XSDFieldMissing=XSD field empty
 XsdValidatorDialog.TestFailed.DialogMessage=Unable to get fields from previous steps because of an error
 XsdValidator.Exception.CannotCreateSchema=The schema cannot be created by a {0}
+XsdValidator.Exception.DisallowedDocType=DOCTYPE is disallowed when the feature http://apache.org/xml/features/disallow-doctype-decl set to true.
+


### PR DESCRIPTION
Our version of xerces doesn't support JAXP 1.5. Earlier implementations of JAXP do not support ACCESS_EXTERNAL_DTD and ACCESS_EXTERNAL_SCHEMA properties. Thus, to block access to external entities, we need to write our own EntityResolver, by always throwing an IOException.

@pentaho/tatooine 
@pentaho-lmartins @ssamora 