### PR TITLE
[PDI-17005] Issues with Carte Jobs API executeJob endpoint in Pentaho…

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -930,17 +930,6 @@
       <version>${xmlunit.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.sun.xml.ws</groupId>
-      <artifactId>jaxws-rt</artifactId>
-      <version>2.1.3</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <build>

--- a/engine/src/main/java/org/pentaho/di/repository/KettleAuthenticationException.java
+++ b/engine/src/main/java/org/pentaho/di/repository/KettleAuthenticationException.java
@@ -1,0 +1,56 @@
+/*! ******************************************************************************
+ *
+ *
+ * Pentaho Data Integration
+ * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.repository;
+
+/**
+ * This exception is thrown when there was an authentication error, while connecting into a repository.
+ */
+public class KettleAuthenticationException extends RuntimeException {
+
+  private static final long serialVersionUID = -8636766532491093338L;
+
+  public KettleAuthenticationException() {
+    super();
+  }
+
+  /**
+   * @param message
+   * @param cause
+   */
+  public KettleAuthenticationException( String message, Throwable cause ) {
+    super( message, cause );
+  }
+
+  /**
+   * @param message
+   */
+  public KettleAuthenticationException( String message ) {
+    super( message );
+  }
+
+  /**
+   * @param cause
+   */
+  public KettleAuthenticationException( Throwable cause ) {
+    super( cause );
+  }
+}

--- a/engine/src/main/java/org/pentaho/di/repository/KettleRepositoryNotFoundException.java
+++ b/engine/src/main/java/org/pentaho/di/repository/KettleRepositoryNotFoundException.java
@@ -1,0 +1,59 @@
+/*! ******************************************************************************
+ *
+ *
+ * Pentaho Data Integration
+ * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.repository;
+
+import org.pentaho.di.core.exception.KettleException;
+
+/**
+ * This exception is thrown when repository wasn't found.
+ */
+public class KettleRepositoryNotFoundException extends KettleException {
+
+  private static final long serialVersionUID = 5920594838763107082L;
+
+  public KettleRepositoryNotFoundException() {
+    super();
+  }
+
+  /**
+   * @param message
+   * @param cause
+   */
+  public KettleRepositoryNotFoundException( String message, Throwable cause ) {
+    super( message, cause );
+  }
+
+  /**
+   * @param message
+   */
+  public KettleRepositoryNotFoundException( String message ) {
+    super( message );
+  }
+
+  /**
+   * @param cause
+   */
+  public KettleRepositoryNotFoundException( Throwable cause ) {
+    super( cause );
+  }
+
+}

--- a/engine/src/test/java/org/pentaho/di/www/ExecuteJobServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/ExecuteJobServletTest.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.di.www;
 
-import com.sun.xml.ws.client.ClientTransportException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +33,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.empty.JobEntryEmpty;
 import org.pentaho.di.job.entry.JobEntryCopy;
+import org.pentaho.di.repository.KettleAuthenticationException;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.core.encryption.Encr;
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -214,8 +215,9 @@ public class ExecuteJobServletTest {
     PowerMockito.mockStatic( Encr.class );
     when( Encr.decryptPasswordOptionallyEncrypted( PASSWORD ) ).thenReturn( PASSWORD );
 
-    ClientTransportException cte = mock( ClientTransportException.class );
-    KettleException ke = new KettleException( cte );
+    KettleAuthenticationException kae = new KettleAuthenticationException( );
+    ExecutionException ee = new ExecutionException( kae );
+    KettleException ke = new KettleException( ee );
     doThrow( ke ).when( spyExecuteJobServlet ).openRepository( REPOSITORY_NAME, UNAUTHORIZED_USER, PASSWORD );
 
     StringWriter out = mockWriter();

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryConnector.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryConnector.java
@@ -18,7 +18,6 @@ package org.pentaho.di.repository.pur;
 
 import com.pentaho.pdi.ws.IRepositorySyncWebService;
 import com.pentaho.pdi.ws.RepositorySyncException;
-import com.sun.xml.ws.client.ClientTransportException;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
@@ -229,9 +228,6 @@ public class PurRepositoryConnector implements IRepositoryConnector {
             // this message will be presented to the user in spoon
             result.setConnectMessage( e.getMessage() );
             return null;
-          } catch ( ClientTransportException e ) {
-            // caused by authentication errors, etc
-            return e;
           } catch ( WebServiceException e ) {
             // if we can speak to the repository okay but not the sync service, assume we're talking to a BA Server
             log.logError( e.getMessage(), e );

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/UnifiedRepositoryInvocationHandler.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/UnifiedRepositoryInvocationHandler.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.ConnectException;
 
+import com.sun.xml.ws.client.ClientTransportException;
+import org.pentaho.di.repository.KettleAuthenticationException;
 import org.pentaho.di.repository.KettleRepositoryLostException;
 
 class UnifiedRepositoryInvocationHandler<T> implements InvocationHandler {
@@ -42,6 +44,10 @@ class UnifiedRepositoryInvocationHandler<T> implements InvocationHandler {
         throw new KettleRepositoryLostException( ex.getCause() );
       }
 
+      if ( lookupAuthenticationException( ex ) ) {
+        throw new KettleAuthenticationException( ex.getCause() );
+      }
+
       throw ex.getCause();
     }
   }
@@ -49,6 +55,18 @@ class UnifiedRepositoryInvocationHandler<T> implements InvocationHandler {
   private boolean lookupConnectException( Throwable root ) {
     while ( root != null ) {
       if ( root instanceof ConnectException ) {
+        return true;
+      } else {
+        root = root.getCause();
+      }
+    }
+
+    return false;
+  }
+
+  private boolean lookupAuthenticationException( Throwable root ) {
+    while ( root != null ) {
+      if ( root instanceof ClientTransportException ) {
         return true;
       } else {
         root = root.getCause();


### PR DESCRIPTION
… REST API

@bantonio82 identified an error while trying to connect into a repository, via PDI.
That was because I added jaxws-rt in kettle-engine pom. But in compile scope, not in provided scope. Thus, we didn't have jaxws-rt on runtime.   
Nevertheless, I created a KettleClientTransportException. This way, we don't need to have jaxws-rt in kettle-engine runtime.  

@smmribeiro  Can you review this please, since you helped me on that? :)
@pentaho/tatooine @pentaho-lmartins @bantonio82 