### PR TITLE
[PDI-17407] Translator2 can't crawling multiline `BaseMessages.getStr…

### DIFF
--- a/Translator.bat
+++ b/Translator.bat
@@ -22,6 +22,8 @@ REM limitations under the License.
 REM
 REM *****************************************************************************
 
+setlocal 
+
 set XMLFILE=%1%
 set SRCDIR=%2%
 
@@ -70,8 +72,7 @@ REM ** Set java runtime options                                     **
 REM ** Change 512m to higher values in case you run out of memory   **
 REM ******************************************************************
 
-set PENTAHO_DI_JAVA_OPTIONS="-Xmx512m" "-XX:MaxPermSize=256m"
-set OPT=
+set OPT="-Xmx512m" "-XX:MaxPermSize=256m"
 
 REM ***************
 REM ** Run...    **

--- a/Translator.bat
+++ b/Translator.bat
@@ -1,4 +1,4 @@
-@echo on
+@echo off
 
 REM *****************************************************************************
 REM
@@ -22,19 +22,11 @@ REM limitations under the License.
 REM
 REM *****************************************************************************
 
-REM **************************************************
-REM ** Libraries used by Kettle:                    **
-REM **************************************************
+set XMLFILE=%1%
+set SRCDIR=%2%
 
-set RUNDIR=%CD%\dist
-set XMLFILE=%CD%\%1%
-set SRCDIR=%CD%\%2%
-
-echo RUNDIR=%RUNDIR%
 echo XMLFILE=%XMLFILE%
 echo SRCDIR=%SRCDIR%
-
-cd dist
 
 set IS64BITJAVA=0
 
@@ -64,7 +56,6 @@ REM ===========================================
 REM Using 32bit Java, so include 32bit SWT Jar
 REM ===========================================
 set LIBSPATH=libswt\win32
-
 GOTO :CONTINUE
 :USE64
 REM ===========================================
@@ -72,30 +63,15 @@ REM Using 64bit java, so include 64bit SWT Jar
 REM ===========================================
 set LIBSPATH=libswt\win64
 set SWTJAR=..\libswt\win64
-
 :CONTINUE
-
-
-REM **********************
-REM   Collect arguments
-REM **********************
-
-set _cmdline=
-:TopArg
-if %1!==! goto EndArg
-set _cmdline=%_cmdline% %1
-shift
-goto TopArg
-:EndArg
 
 REM ******************************************************************
 REM ** Set java runtime options                                     **
 REM ** Change 512m to higher values in case you run out of memory   **
-REM ** or set the PENTAHO_DI_JAVA_OPTIONS environment variable      **
 REM ******************************************************************
 
 set PENTAHO_DI_JAVA_OPTIONS="-Xmx512m" "-XX:MaxPermSize=256m"
-set OPT="-Djava.library.path=%LIBSPATH%" "-DKETTLE_HOME=%KETTLE_HOME%" "-DKETTLE_REPOSITORY=%KETTLE_REPOSITORY%" "-DKETTLE_USER=%KETTLE_USER%" "-DKETTLE_PASSWORD=%KETTLE_PASSWORD%" "-DKETTLE_PLUGIN_PACKAGES=%KETTLE_PLUGIN_PACKAGES%" "-DKETTLE_LOG_SIZE_LIMIT=%KETTLE_LOG_SIZE_LIMIT%" "-DKETTLE_JNDI_ROOT=%KETTLE_JNDI_ROOT%"
+set OPT=
 
 REM ***************
 REM ** Run...    **
@@ -105,7 +81,5 @@ REM Eventually call java instead of javaw and do not run in a separate window
 set TRANSLATOR_START_OPTION=start "Translator"
 
 @echo on
-%TRANSLATOR_START_OPTION% java %OPT% -jar launcher\launcher-1.0.0.jar -lib ..\%LIBSPATH% -main org.pentaho.di.ui.i18n.editor.Translator2 %XMLFILE% %SRCDIR%
+%TRANSLATOR_START_OPTION% java %OPT% -jar launcher\launcher.jar -lib ..\%LIBSPATH% -main org.pentaho.di.ui.i18n.editor.Translator2 %XMLFILE% %SRCDIR%
 @echo off
-
-cd %RUNDIR%\..

--- a/translator.xml
+++ b/translator.xml
@@ -20,7 +20,7 @@
   </source-directories>
   
   <scan-phrases>
-    <scan-phrase>BaseMessages.getString( PKG,</scan-phrase>
+    <scan-phrase>BaseMessages.getString(PKG,</scan-phrase>
   </scan-phrases>
   
   <locale-list>

--- a/ui/src/main/java/org/pentaho/di/ui/i18n/MessagesSourceCrawler.java
+++ b/ui/src/main/java/org/pentaho/di/ui/i18n/MessagesSourceCrawler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.hitachivantara.com
  *
  *******************************************************************************
  *
@@ -22,32 +22,15 @@
 
 package org.pentaho.di.ui.i18n;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
+import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileSelector;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.fileinput.FileInputList;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -56,15 +39,93 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * This class takes care of crawling through the source code
  *
  * @author matt
- *
  */
 public class MessagesSourceCrawler {
 
-  private String[] scanPhrases;
+  /**
+   * When searching for a scanPhrase, it may exist over more than one source line. This string contains the characters
+   * to be considered in the calculation of the different splits that each scanPhrase may have.
+   *
+   * @see #SPLIT_CHARACTERS
+   * @see #SPLITTER_AND_WHITESPACES_PATTERN
+   */
+  private static final String SPLIT_CHARACTERS_STRING = ".(,";
+
+  /**
+   * When searching for a scanPhrase, it may exist over more than one source line. These are the characters to be
+   * considered in the calculation of the different splits that each scanPhrase may have.
+   *
+   * @see #SPLIT_CHARACTERS_STRING
+   * @see #SPLITTER_AND_WHITESPACES_PATTERN
+   */
+  private static final char[] SPLIT_CHARACTERS = SPLIT_CHARACTERS_STRING.toCharArray();
+
+  /**
+   * Pattern to be used to ignore whitespaces around split characters.
+   *
+   * @see #SPLIT_CHARACTERS
+   * @see #SPLIT_CHARACTERS_STRING
+   */
+  private static final String SPLITTER_AND_WHITESPACES_PATTERN = "\\s*[%c]\\s*";
+
+  /**
+   * Pattern to be used on the calculation of the regex to split the scanPhrase considering all split characters
+   */
+  private static final String SPLIT_AND_KEEP_DELIMITER_PATTERN = "((?<=[%1$c])|(?=[%1$c]))";
+
+  /**
+   * Format string to be used as a match pattern in identifying an incomplete scanPhrase (when it exists over more than
+   * one source line).
+   */
+  private static final String SPLIT_LINE_PHRASE_FORMAT = ".*%s$";
+
+  private static final String EMPTY_STRING = "";
+  private static final String ASTERISK = "*";
+  private static final String DOT = ".";
+  private static final String DOLLAR_SIGN = "$";
+  private static final String QUESTION_MARK = "?";
+  private static final String N_STRING = "N";
+  private static final String YES_STRING = "yes";
+  private static final String DOT_CLASS_STRING = ".class";
+  private static final String IMPORT_STRING = "import";
+  private static final int IMPORT_STRING_LENGTH = IMPORT_STRING.length();
+  private static final String JAVA_EXTENSION = "java";
+  private static final String MESSAGES_PACKAGE_END_STRING = ".Messages;";
+  private static final String ORG_PENTAHO_STRING = "org.pentaho.";
+  private static final String SYSTEM_DOT_STRING = "System.";
+
+  //REGEX expressions to be compiled
+  private static final String PACKAGE_PATTERN = "^\\s*package\\s*.*;\\s*$";
+  private static final String IMPORT_PATTERN = "^\\s*import\\s*[a-z._0-9]*\\.([*]|([A-Z][a-z._0-9]*))\\s*;\\s*$";
+  private static final String IMPORT_MESSAGES_PATTERN = "^\\s*import\\s*[a-z._0-9]*\\.Messages;\\s*$";
+  private static final String STRING_PKG_PATTERN = "^.*private static String PKG.*=.*$";
+  private static final String CLASS_PKG_PATTERN = "^.*private static Class.*\\sPKG\\s*=.*$";
+
+  /**
+   * All phrases to scan for.
+   */
+  private String[] scanPhrases = {};
 
   /**
    * The source directories to crawl through
@@ -74,12 +135,12 @@ public class MessagesSourceCrawler {
   /**
    * Source folder - package name - all the key occurrences in there
    */
-  private Map<String, Map<String, List<KeyOccurrence>>> sourcePackageOccurrences;
+  private Map<String, Map<String, List<KeyOccurrence>>> sourcePackageOccurrences = new HashMap<>();
 
   /**
    * The file names to avoid (base names)
    */
-  private List<String> filesToAvoid;
+  private List<String> filesToAvoid = new ArrayList<>();
 
   private String singleMessagesFile;
 
@@ -88,115 +149,77 @@ public class MessagesSourceCrawler {
    */
   private List<SourceCrawlerXMLFolder> xmlFolders;
 
-  private Pattern packagePattern;
-  private Pattern importPattern;
-  private Pattern importMessagesPattern;
-  private Pattern stringPkgPattern;
-  private Pattern classPkgPattern;
+  private Pattern packagePattern = Pattern.compile( PACKAGE_PATTERN );
+  private Pattern importPattern = Pattern.compile( IMPORT_PATTERN );
+  private Pattern importMessagesPattern = Pattern.compile( IMPORT_MESSAGES_PATTERN );
+  private Pattern stringPkgPattern = Pattern.compile( STRING_PKG_PATTERN );
+  private Pattern classPkgPattern = Pattern.compile( CLASS_PKG_PATTERN );
 
   private LogChannelInterface log;
 
   /**
-   * @param sourceDirectories
-   *          The source directories to crawl through
-   * @param singleMessagesFile
-   *          the messages file if there is only one, otherwise: null
+   * @param sourceDirectories  The source directories to crawl through
+   * @param singleMessagesFile the messages file if there is only one, otherwise: null
    */
   public MessagesSourceCrawler( LogChannelInterface log, List<String> sourceDirectories,
-    String singleMessagesFile, List<SourceCrawlerXMLFolder> xmlFolders ) {
+                                String singleMessagesFile, List<SourceCrawlerXMLFolder> xmlFolders ) {
     super();
     this.log = log;
-    this.sourceDirectories = sourceDirectories;
+    this.sourceDirectories = ( null != sourceDirectories ) ? sourceDirectories : new ArrayList<>();
     this.singleMessagesFile = singleMessagesFile;
-    this.filesToAvoid = new ArrayList<String>();
-    this.xmlFolders = xmlFolders;
-
-    this.sourcePackageOccurrences = new HashMap<String, Map<String, List<KeyOccurrence>>>();
-
-    packagePattern = Pattern.compile( "^\\s*package .*;[ \t]*$" );
-    importPattern = Pattern.compile( "^\\s*import [a-z\\._0-9]*\\.[A-Z].*;[ \t]*$" );
-    importMessagesPattern = Pattern.compile( "^\\s*import [a-z\\._0-9]*\\.Messages;[ \t]*$" );
-    stringPkgPattern = Pattern.compile( "^.*private static String PKG.*=.*$" );
-    classPkgPattern = Pattern.compile( "^.*private static Class.*\\sPKG\\s*=.*$" );
-  }
-
-  /**
-   * @return The source directories to crawl through
-   */
-  public List<String> getSourceDirectories() {
-    return sourceDirectories;
-  }
-
-  /**
-   * @param sourceDirectories
-   *          The source directories to crawl through
-   */
-  public void setSourceDirectories( List<String> sourceDirectories ) {
-    this.sourceDirectories = sourceDirectories;
-  }
-
-  /**
-   * @return the files to avoid
-   */
-  public List<String> getFilesToAvoid() {
-    return filesToAvoid;
-  }
-
-  /**
-   * @param filesToAvoid
-   *          the files to avoid
-   */
-  public void setFilesToAvoid( List<String> filesToAvoid ) {
-    this.filesToAvoid = filesToAvoid;
+    this.xmlFolders = ( null != xmlFolders ) ? xmlFolders : new ArrayList<>();
   }
 
   /**
    * Add a key occurrence to the list of occurrences. The list is kept sorted on key and message package. If the key
    * already exists, we increment the number of occurrences.
    *
-   * @param occ
-   *          The key occurrence to add
+   * @param occ The key occurrence to add
    */
   public void addKeyOccurrence( KeyOccurrence occ ) {
+    if ( null != occ ) {
+      String sourceFolder = occ.getSourceFolder();
+      if ( sourceFolder == null ) {
+        throw new RuntimeException( "No source folder found for key: "
+          + occ.getKey() + " in package " + occ.getMessagesPackage() );
+      }
+      String messagesPackage = occ.getMessagesPackage();
 
-    // System.out.println("Adding key occurrence : folder="+occ.getSourceFolder()+",
-    // pkg="+occ.getMessagesPackage()+", key="+occ.getKey());
+      // Do we have a map for the source folders?
+      // If not, add one...
+      //
+      Map<String, List<KeyOccurrence>> packageOccurrences = sourcePackageOccurrences.get( sourceFolder );
+      if ( packageOccurrences == null ) {
+        packageOccurrences = new HashMap<>();
+        sourcePackageOccurrences.put( sourceFolder, packageOccurrences );
+      }
 
-    String sourceFolder = occ.getSourceFolder();
-    if ( sourceFolder == null ) {
-      throw new RuntimeException( "No source folder found for key: "
-        + occ.getKey() + " in package " + occ.getMessagesPackage() );
-    }
-    String messagesPackage = occ.getMessagesPackage();
-
-    // Do we have a map for the source folders?
-    // If not, add one...
-    //
-    Map<String, List<KeyOccurrence>> packageOccurrences = sourcePackageOccurrences.get( sourceFolder );
-    if ( packageOccurrences == null ) {
-      packageOccurrences = new HashMap<String, List<KeyOccurrence>>();
-      sourcePackageOccurrences.put( sourceFolder, packageOccurrences );
-    }
-
-    // Do we have a map entry for the occurrences list in the source folder?
-    // If not, add a list for the messages package
-    //
-    List<KeyOccurrence> occurrences = packageOccurrences.get( messagesPackage );
-    if ( occurrences == null ) {
-      occurrences = new ArrayList<KeyOccurrence>();
-      occurrences.add( occ );
-      packageOccurrences.put( messagesPackage, occurrences );
-    } else {
-      int index = Collections.binarySearch( occurrences, occ );
-      if ( index < 0 ) {
-        // Add it to the list, keep it sorted...
-        //
-        occurrences.add( -index - 1, occ );
+      // Do we have a map entry for the occurrences list in the source folder?
+      // If not, add a list for the messages package
+      //
+      List<KeyOccurrence> occurrences = packageOccurrences.get( messagesPackage );
+      if ( occurrences == null ) {
+        occurrences = new ArrayList<>();
+        occurrences.add( occ );
+        packageOccurrences.put( messagesPackage, occurrences );
+      } else {
+        int index = Collections.binarySearch( occurrences, occ );
+        if ( index < 0 ) {
+          // Add it to the list, keep it sorted...
+          //
+          occurrences.add( -index - 1, occ );
+        }
       }
     }
   }
 
   public void crawl() throws Exception {
+    crawlSourceDirectories();
+    // Also search for keys in the XUL files...
+    crawlXmlFolders();
+  }
+
+  public void crawlSourceDirectories() throws Exception {
 
     for ( final String sourceDirectory : sourceDirectories ) {
       FileObject folder = KettleVFS.getFileObject( sourceDirectory );
@@ -208,38 +231,28 @@ public class MessagesSourceCrawler {
 
         @Override
         public boolean includeFile( FileSelectInfo info ) throws Exception {
-          return info.getFile().getName().getExtension().equals( "java" );
+          FileObject file = info.getFile();
+          FileName fileName = file.getName();
+
+          return file.isFile() && JAVA_EXTENSION.equals( fileName.getExtension() ) && !filesToAvoid
+            .contains( fileName.getBaseName() );
         }
       } );
 
+      // Look for keys in each of the found files...
       for ( FileObject javaFile : javaFiles ) {
-
-        /**
-         * We don't want the Messages.java files, there is nothing in there for us.
-         */
-        boolean skip = false;
-        for ( String filename : filesToAvoid ) {
-          if ( javaFile.getName().getBaseName().equals( filename ) ) {
-            skip = true;
-          }
-        }
-        if ( skip ) {
-          continue; // don't process this file.
-        }
-
-        // For each of these files we look for keys...
-        //
         lookForOccurrencesInFile( sourceDirectory, javaFile );
       }
     }
+  }
 
-    // Also search for keys in the XUL files...
-    //
+  protected void crawlXmlFolders() throws Exception {
+
     for ( SourceCrawlerXMLFolder xmlFolder : xmlFolders ) {
-      String[] xmlDirs = { xmlFolder.getFolder(), };
-      String[] xmlMasks = { xmlFolder.getWildcard(), };
-      String[] xmlReq = { "N", };
-      boolean[] xmlSubdirs = { true, }; // search sub-folders too
+      String[] xmlDirs = { xmlFolder.getFolder() };
+      String[] xmlMasks = { xmlFolder.getWildcard() };
+      String[] xmlReq = { N_STRING };
+      boolean[] xmlSubdirs = { true }; // search sub-folders too
 
       FileInputList xulFileInputList =
         FileInputList.createFileList( new Variables(), xmlDirs, xmlMasks, xmlReq, xmlSubdirs );
@@ -264,16 +277,16 @@ public class MessagesSourceCrawler {
   }
 
   private void addLabelOccurrences( String sourceFolder, FileObject fileObject, NodeList nodeList,
-    String keyPrefix, String tag, String attribute, String defaultPackage,
-    List<SourceCrawlerPackageException> packageExcpeptions ) throws Exception {
+                                    String keyPrefix, String tag, String attribute, String defaultPackage,
+                                    List<SourceCrawlerPackageException> packageExcpeptions ) throws Exception {
     if ( nodeList == null ) {
       return;
     }
 
     TransformerFactory transformerFactory = TransformerFactory.newInstance();
     Transformer transformer = transformerFactory.newTransformer();
-    transformer.setOutputProperty( OutputKeys.OMIT_XML_DECLARATION, "yes" );
-    transformer.setOutputProperty( OutputKeys.INDENT, "yes" );
+    transformer.setOutputProperty( OutputKeys.OMIT_XML_DECLARATION, YES_STRING );
+    transformer.setOutputProperty( OutputKeys.INDENT, YES_STRING );
 
     for ( int i = 0; i < nodeList.getLength(); i++ ) {
       Node node = nodeList.item( i );
@@ -285,14 +298,9 @@ public class MessagesSourceCrawler {
         labelString = XMLHandler.getTagValue( node, tag );
       }
 
-      // TODO : Set the prefix in the right place
-      keyPrefix = "$";
-
-      if ( labelString != null && labelString.startsWith( keyPrefix ) ) {
-        String key = labelString.substring( 1 );
-        // TODO : maybe not the right place ...
+      if ( labelString != null && labelString.startsWith( DOLLAR_SIGN ) ) {
         // just removed ${} around the key
-        key = labelString.substring( 2, labelString.length() - 1 ).trim();
+        String key = labelString.substring( 2, labelString.length() - 1 ).trim();
 
         String messagesPackage = defaultPackage;
         for ( SourceCrawlerPackageException packageException : packageExcpeptions ) {
@@ -306,179 +314,294 @@ public class MessagesSourceCrawler {
         String xml = bodyXML.getBuffer().toString();
 
         KeyOccurrence keyOccurrence =
-          new KeyOccurrence( fileObject, sourceFolder, messagesPackage, -1, -1, key, "?", xml );
+          new KeyOccurrence( fileObject, sourceFolder, messagesPackage, -1, -1, key, QUESTION_MARK, xml );
         addKeyOccurrence( keyOccurrence );
       }
     }
   }
 
   /**
-   * Look for additional occurrences of keys in the specified file.
+   * Look for occurrences of keys in the specified file.
    *
-   * @param sourceFolder
-   *          The folder the java file and messages files live in
-   *
-   * @param javaFile
-   *          The java source file to examine
-   * @throws IOException
-   *           In case there is a problem accessing the specified source file.
+   * @param sourceFolder The folder the java file and messages files live in
+   * @param javaFile     The java source file to examine
+   * @throws IOException In case there is a problem accessing the specified source file.
    */
   public void lookForOccurrencesInFile( String sourceFolder, FileObject javaFile ) throws IOException {
 
-    BufferedReader reader = new BufferedReader( new InputStreamReader( KettleVFS.getInputStream( javaFile ) ) );
+    try ( InputStreamReader is = new InputStreamReader( KettleVFS.getInputStream( javaFile ) );
+          BufferedReader reader = new BufferedReader( is ) ) {
+      String messagesPackage = null;
+      String classPackage = null;
+      int row = 0;
 
-    String messagesPackage = null;
-    int row = 0;
-    String classPackage = null;
+      Map<String, String> importedClasses = new HashMap<>(); // Remember the imports we do...
 
-    Map<String, String> importedClasses = new Hashtable<String, String>(); // Remember the imports we do...
+      String line = reader.readLine();
+      List<String> splitLinePhrases = getSplitLinePhrases( scanPhrases );
 
-    String line = reader.readLine();
-    while ( line != null ) {
-      row++;
-      String line2 = line;
-      boolean extraLine;
-      do {
-        extraLine = false;
-        for ( String joinPhrase : new String[] { "BaseMessages.getString(", "BaseMessages.getString( PKG," } ) {
-          if ( line2.endsWith( joinPhrase ) ) {
-            extraLine = true;
-            break;
-          }
+      while ( line != null ) {
+        row++;
+
+        line = getCompleteLine( reader, line, splitLinePhrases );
+
+        for ( String scanPhrase : scanPhrases ) {
+          line = line.replaceAll( getWhitespacesSanitizeRegex( scanPhrase ), scanPhrase );
         }
-        if ( extraLine ) {
-          line2 = reader.readLine();
-          line += line2;
-        }
-      } while ( extraLine );
 
-      // Examine the line...
+        // Examine the line...
 
-      // What we first look for is the import of the messages package.
-      //
-      // "package org.pentaho.di.trans.steps.sortedmerge;"
-      //
-      if ( packagePattern.matcher( line ).matches() ) {
-        int beginIndex = line.indexOf( "org.pentaho." );
-        int endIndex = line.indexOf( ';' );
-        if ( beginIndex >= 0 && endIndex >= 0 ) {
-          messagesPackage = line.substring( beginIndex, endIndex ); // this is the default
-          classPackage = messagesPackage;
-        }
-      }
-
-      // Remember all the imports...
-      //
-      if ( importPattern.matcher( line ).matches() ) {
-        int beginIndex = line.indexOf( "import" ) + "import".length() + 1;
-        int endIndex = line.indexOf( ";", beginIndex );
-        String expression = line.substring( beginIndex, endIndex );
-        // The last word is the Class imported...
-        // If it's * we ignore it.
+        // What we first look for is the import of the messages package.
         //
-        int lastDotIndex = expression.lastIndexOf( '.' );
-        if ( lastDotIndex > 0 ) {
-          String packageName = expression.substring( 0, lastDotIndex );
-          String className = expression.substring( lastDotIndex + 1 );
-          if ( !"*".equals( className ) ) {
-            importedClasses.put( className, packageName );
-          }
-        }
-      }
-
-      // This is the alternative location of the messages package:
-      //
-      // "import org.pentaho.di.trans.steps.sortedmerge.Messages;"
-      //
-      if ( importMessagesPattern.matcher( line ).matches() ) {
-        int beginIndex = line.indexOf( "org.pentaho." );
-        int endIndex = line.indexOf( ".Messages;" );
-        messagesPackage = line.substring( beginIndex, endIndex ); // if there is any specified, we take this one.
-      }
-
-      // Look for the value of the PKG value...
-      //
-      // private static String PKG = "org.pentaho.foo.bar.somepkg";
-      //
-      if ( stringPkgPattern.matcher( line ).matches() ) {
-        int beginIndex = line.indexOf( '"' ) + 1;
-        int endIndex = line.indexOf( '"', beginIndex );
-        messagesPackage = line.substring( beginIndex, endIndex );
-      }
-
-      // Look for the value of the PKG value as a fully qualified class...
-      //
-      // private static Class<?> PKG = Abort.class;
-      //
-      if ( classPackage != null && classPkgPattern.matcher( line ).matches() ) {
-
-        int fromIndex = line.indexOf( '=' ) + 1;
-        int toIndex = line.indexOf( ".class", fromIndex );
-        String expression = Const.trim( line.substring( fromIndex, toIndex ) );
-        // System.out.println("expression : "+expression);
-
-        // If the expression doesn't contain any package, we'll look up the package in the imports. If not found there,
-        // it's a local package.
+        // "package org.pentaho.di.trans.steps.sortedmerge;"
         //
-        if ( expression.contains( "." ) ) {
-          int lastDotIndex = expression.lastIndexOf( '.' );
-          messagesPackage = expression.substring( 0, lastDotIndex );
-        } else {
-          String packageName = importedClasses.get( expression );
-          if ( packageName == null ) {
-            messagesPackage = classPackage; // Local package
-          } else {
-            messagesPackage = packageName; // imported
+        if ( packagePattern.matcher( line ).matches() ) {
+          int beginIndex = line.indexOf( ORG_PENTAHO_STRING );
+          int endIndex = line.indexOf( ';' );
+          if ( beginIndex >= 0 && endIndex > beginIndex ) {
+            messagesPackage = line.substring( beginIndex, endIndex ); // this is the default
+            classPackage = messagesPackage;
           }
         }
 
-      }
+        // Remember all the imports...
+        //
+        if ( importPattern.matcher( line ).matches() ) {
+          int beginIndex = line.indexOf( IMPORT_STRING ) + IMPORT_STRING_LENGTH + 1;
+          int endIndex = line.indexOf( ';', beginIndex );
+          if ( beginIndex >= 0 && endIndex > beginIndex ) {
+            String expression = line.substring( beginIndex, endIndex );
+            // The last word is the Class imported...
+            // If it's * we ignore it.
+            //
+            int lastDotIndex = expression.lastIndexOf( '.' );
+            if ( lastDotIndex > 0 ) {
+              String packageName = expression.substring( 0, lastDotIndex );
+              String className = expression.substring( lastDotIndex + 1 );
+              if ( !ASTERISK.equals( className ) ) {
+                importedClasses.put( className, packageName );
+              }
+            }
+          }
+        }
 
-      // Now look for occurrences of "Messages.getString(", "BaseMessages.getString(PKG", ...
-      //
-      for ( String scanPhrase : scanPhrases ) {
-        int index = line.indexOf( scanPhrase );
-        while ( index >= 0 ) {
-          // see if there's a character [a-z][A-Z] before the search string...
-          // Otherwise we're looking at BaseMessages.getString(), etc.
+        // This is the alternative location of the messages package:
+        //
+        // "import org.pentaho.di.trans.steps.sortedmerge.Messages;"
+        //
+        if ( importMessagesPattern.matcher( line ).matches() ) {
+          int beginIndex = line.indexOf( ORG_PENTAHO_STRING );
+          int endIndex = line.indexOf( MESSAGES_PACKAGE_END_STRING );
+          if ( beginIndex >= 0 && endIndex > beginIndex ) {
+            messagesPackage = line.substring( beginIndex, endIndex ); // if there is any specified, we take this one.
+          }
+        }
+
+        // Look for the value of the PKG value...
+        //
+        // private static String PKG = "org.pentaho.foo.bar.somepkg";
+        //
+        if ( stringPkgPattern.matcher( line ).matches() ) {
+          int beginIndex = line.indexOf( '"' ) + 1;
+          int endIndex = line.indexOf( '"', beginIndex );
+          if ( beginIndex >= 0 && endIndex > beginIndex ) {
+            messagesPackage = line.substring( beginIndex, endIndex );
+          }
+        }
+
+        // Look for the value of the PKG value as a fully qualified class...
+        //
+        // private static Class<?> PKG = Abort.class;
+        //
+        if ( classPackage != null && classPkgPattern.matcher( line ).matches() ) {
+          int fromIndex = line.indexOf( '=' ) + 1;
+          int toIndex = line.indexOf( DOT_CLASS_STRING, fromIndex );
+          String expression = Const.trim( line.substring( fromIndex, toIndex ) );
+
+          // If the expression doesn't contain any package, we'll look up the package in the imports. If not found
+          // there,
+          // it's a local package.
           //
-          if ( index == 0 || ( index > 0 & !Character.isJavaIdentifierPart( line.charAt( index - 1 ) ) ) ) {
-            addLineOccurrence( sourceFolder, javaFile, messagesPackage, line, row, index, scanPhrase );
+          if ( expression.contains( DOT ) ) {
+            int lastDotIndex = expression.lastIndexOf( '.' );
+            messagesPackage = expression.substring( 0, lastDotIndex );
+          } else {
+            String packageName = importedClasses.get( expression );
+            if ( packageName == null ) {
+              messagesPackage = classPackage; // Local package
+            } else {
+              messagesPackage = packageName; // imported
+            }
           }
-          index = line.indexOf( scanPhrase, index + 1 );
+        }
+
+        // Now look for occurrences of "Messages.getString(", "BaseMessages.getString(PKG", ...
+        //
+        lookForOccurrencesInLine( sourceFolder, javaFile, messagesPackage, row, line );
+
+        line = reader.readLine();
+      }
+    }
+  }
+
+  protected String getCompleteLine( BufferedReader reader, String line, List<String> splitLinePhrases )
+    throws IOException {
+    boolean extraLine;
+
+    do {
+      String line2 = line;
+      extraLine = false;
+      for ( String joinPhrase : splitLinePhrases ) {
+        if ( line2.matches( joinPhrase ) ) {
+          extraLine = true;
+          break;
         }
       }
+      if ( extraLine ) {
+        line2 = reader.readLine();
+        if ( null == line2 ) {
+          break;
+        }
 
-      line = reader.readLine();
+        line += line2;
+      }
+    } while ( extraLine );
+
+    return line;
+  }
+
+  /**
+   * Look for occurrences of keys in the specified line.
+   *
+   * @param sourceFolder    the folder where the file that contains the line to examine exists
+   * @param javaFile        the java source file that contains the line to examine
+   * @param messagesPackage the message package used
+   * @param row             the row number
+   * @param line            the line to examine
+   */
+  protected void lookForOccurrencesInLine( String sourceFolder, FileObject javaFile, String messagesPackage, int row,
+                                           String line ) {
+    for ( String scanPhrase : scanPhrases ) {
+      int index = line.indexOf( scanPhrase );
+      while ( index >= 0 ) {
+        // see if there's a character [a-z][A-Z] before the search string...
+        // Otherwise we're looking at BaseMessages.getString(), etc.
+        //
+        if ( index == 0 || !Character.isJavaIdentifierPart( line.charAt( index - 1 ) ) ) {
+          addLineOccurrence( sourceFolder, javaFile, messagesPackage, line, row, index, scanPhrase );
+        }
+        index = line.indexOf( scanPhrase, index + 1 );
+      }
+    }
+  }
+
+  /**
+   * <p>Returns all regex expressions to detect an incomplete scanPhrase (when it exists over more than one source
+   * line).</p>
+   *
+   * @param scanPhrases an array containing all scanPhrases to consider
+   * @return all regex expressions to detect an incomplete scanPhrase
+   * @see #getSplitLinePhrases(String)
+   */
+  private List<String> getSplitLinePhrases( String[] scanPhrases ) {
+    List<String> joinPhrases = new ArrayList<>();
+
+    if ( null != scanPhrases ) {
+      for ( String scanPhrase : scanPhrases ) {
+        joinPhrases.addAll( getSplitLinePhrases( scanPhrase ) );
+      }
     }
 
-    reader.close();
+    return joinPhrases;
+  }
+
+  /**
+   * <p>Returns all regex expressions to detect when the given scanPhrase is incomplete (existing over more than one
+   * source line).</p>
+   *
+   * @param scanPhrase the scanPhrase to consider
+   * @return all regex expressions to detect when the given scanPhrase is incomplete
+   * @see #getSplitLinePhrases(String[])
+   */
+  protected List<String> getSplitLinePhrases( String scanPhrase ) {
+    List<String> joinPhrases = new ArrayList<>();
+
+    // First split the phrase
+    String regex = getSplitWithDelimitersRegex( SPLIT_CHARACTERS );
+    String[] splitTmp = scanPhrase.split( regex );
+
+    for ( String splitPart : splitTmp ) {
+      StringBuilder sb = new StringBuilder();
+      // If it's a split character, handle with care
+      if ( 1 != splitPart.length() && !SPLIT_CHARACTERS_STRING.contains( splitPart ) ) {
+        sb.append( splitPart.trim() ).append( "\\s*" );
+      } else {
+        sb.append( String.format( "[%s]\\s*", splitPart ) );
+      }
+
+      joinPhrases.add( String.format( SPLIT_LINE_PHRASE_FORMAT, sb.toString() ) );
+    }
+
+    return joinPhrases;
+  }
+
+  private String getSplitWithDelimitersRegex( char[] delimiters ) {
+    StringBuilder regex = new StringBuilder();
+    boolean notFirstTime = false;
+
+    for ( char delimiter : delimiters ) {
+      if ( notFirstTime ) {
+        regex.append( '|' );
+      }
+
+      regex.append( String.format( SPLIT_AND_KEEP_DELIMITER_PATTERN, delimiter ) );
+      notFirstTime = true;
+    }
+
+    return regex.toString();
+  }
+
+
+  /**
+   * <p>Calculates a regex to identify the given text considering all possible {@link #SPLIT_CHARACTERS} can be
+   * surrounded by whitespaces.</p>
+   *
+   * @param str the text to be used
+   * @return regex to identify the given text considering all possible {@link #SPLIT_CHARACTERS} can be surrounded by
+   * whitespaces
+   */
+  protected String getWhitespacesSanitizeRegex( String str ) {
+    String whitespacesSanitizeRegex = str;
+
+    if ( null != whitespacesSanitizeRegex ) {
+      for ( char splitChar : SPLIT_CHARACTERS ) {
+        String patternMatcher = String.format( SPLITTER_AND_WHITESPACES_PATTERN, splitChar );
+
+        whitespacesSanitizeRegex =
+          whitespacesSanitizeRegex.replaceAll( patternMatcher, Matcher.quoteReplacement( patternMatcher ) );
+      }
+    }
+
+    return whitespacesSanitizeRegex;
   }
 
   /**
    * Extract the needed information from the line and the index on which Messages.getString() occurs.
    *
-   * @param sourceFolder
-   *          The source folder the messages and java files live in
-   *
-   * @param fileObject
-   *          the file we're reading
-   * @param messagesPackage
-   *          the messages package
-   * @param line
-   *          the line
-   * @param row
-   *          the row number
-   * @param index
-   *          the index in the line on which "Messages.getString(" is located.
+   * @param sourceFolder    the source folder the messages and java files live in
+   * @param fileObject      the file we're reading
+   * @param messagesPackage the messages package
+   * @param line            the line
+   * @param row             the row number
+   * @param index           the index in the line on which "Messages.getString(" is located.
    */
   private void addLineOccurrence( String sourceFolder, FileObject fileObject, String messagesPackage, String line,
-    int row, int index, String scanPhrase ) {
+                                  int row, int index, String scanPhrase ) {
     // Right after the "Messages.getString(" string is the key, quoted (")
     // until the next comma...
     //
     int column = index + scanPhrase.length();
-    String arguments = "";
+    String arguments = EMPTY_STRING;
 
     // we start at the double quote...
     //
@@ -497,7 +620,7 @@ public class MessagesSourceCrawler {
       //
       int bracketIndex = endKeyIndex;
       int nrOpen = 1;
-      while ( bracketIndex < line.length() && nrOpen != 0 ) {
+      while ( nrOpen != 0 && bracketIndex < line.length() ) {
         int c = line.charAt( bracketIndex );
         if ( c == '(' ) {
           nrOpen++;
@@ -513,7 +636,6 @@ public class MessagesSourceCrawler {
       } else {
         arguments = line.substring( endKeyIndex + 1 );
       }
-
     } else {
       key = line.substring( startKeyIndex );
     }
@@ -528,7 +650,7 @@ public class MessagesSourceCrawler {
     //
     // Make sure we pass the System key occurrences to the correct package.
     //
-    if ( key.startsWith( "System." ) ) {
+    if ( key.startsWith( SYSTEM_DOT_STRING ) ) {
       String i18nPackage = BaseMessages.class.getPackage().getName();
       KeyOccurrence keyOccurrence =
         new KeyOccurrence( fileObject, sourceFolder, i18nPackage, row, column, key, arguments, line );
@@ -552,11 +674,11 @@ public class MessagesSourceCrawler {
   }
 
   /**
-   * @return A sorted list of distinct occurrences of the used message package names
+   * @return A sorted {@link List} of distinct occurrences of the used message package names
    */
   public List<String> getMessagesPackagesList( String sourceFolder ) {
     Map<String, List<KeyOccurrence>> packageOccurrences = sourcePackageOccurrences.get( sourceFolder );
-    List<String> list = new ArrayList<String>( packageOccurrences.keySet() );
+    List<String> list = new ArrayList<>( packageOccurrences.keySet() );
     Collections.sort( list );
     return list;
   }
@@ -564,17 +686,12 @@ public class MessagesSourceCrawler {
   /**
    * Get all the key occurrences for a certain messages package.
    *
-   * @param sourceFolder
-   *          the source folder to reference
-   * @param messagesPackage
-   *          the package to hunt for
+   * @param messagesPackage the package to hunt for
    * @return all the key occurrences for a certain messages package.
    */
   public List<KeyOccurrence> getOccurrencesForPackage( String messagesPackage ) {
-    List<KeyOccurrence> list = new ArrayList<KeyOccurrence>();
-
-    for ( String sourceFolder : sourcePackageOccurrences.keySet() ) {
-      Map<String, List<KeyOccurrence>> po = sourcePackageOccurrences.get( sourceFolder );
+    List<KeyOccurrence> list = new ArrayList<>();
+    for ( Map<String, List<KeyOccurrence>> po : sourcePackageOccurrences.values() ) {
       List<KeyOccurrence> occurrences = po.get( messagesPackage );
       if ( occurrences != null ) {
         list.addAll( occurrences );
@@ -584,8 +701,7 @@ public class MessagesSourceCrawler {
   }
 
   public KeyOccurrence getKeyOccurrence( String key, String selectedMessagesPackage ) {
-    for ( String sourceFolder : sourcePackageOccurrences.keySet() ) {
-      Map<String, List<KeyOccurrence>> po = sourcePackageOccurrences.get( sourceFolder );
+    for ( Map<String, List<KeyOccurrence>> po : sourcePackageOccurrences.values() ) {
       if ( po != null ) {
         List<KeyOccurrence> occurrences = po.get( selectedMessagesPackage );
         if ( occurrences != null ) {
@@ -602,50 +718,12 @@ public class MessagesSourceCrawler {
   }
 
   /**
-   * @return the singleMessagesFile
-   */
-  public String getSingleMessagesFile() {
-    return singleMessagesFile;
-  }
-
-  /**
-   * @param singleMessagesFile
-   *          the singleMessagesFile to set
-   */
-  public void setSingleMessagesFile( String singleMessagesFile ) {
-    this.singleMessagesFile = singleMessagesFile;
-  }
-
-  /**
-   * @return the scanPhrases
-   */
-  public String[] getScanPhrases() {
-    return scanPhrases;
-  }
-
-  /**
-   * @param scanPhrases
-   *          the scanPhrases to set
-   */
-  public void setScanPhrases( String[] scanPhrases ) {
-    this.scanPhrases = scanPhrases;
-  }
-
-  public Map<String, Map<String, List<KeyOccurrence>>> getSourcePackageOccurrences() {
-    return sourcePackageOccurrences;
-  }
-
-  public void setSourcePackageOccurrences( Map<String, Map<String, List<KeyOccurrence>>> sourcePackageOccurrences ) {
-    this.sourcePackageOccurrences = sourcePackageOccurrences;
-  }
-
-  /**
    * Get the unique package-key
    *
    * @param sourceFolder
    */
   public List<KeyOccurrence> getKeyOccurrences( String sourceFolder ) {
-    Map<String, KeyOccurrence> map = new HashMap<String, KeyOccurrence>();
+    Map<String, KeyOccurrence> map = new HashMap<>();
     Map<String, List<KeyOccurrence>> po = sourcePackageOccurrences.get( sourceFolder );
     if ( po != null ) {
       for ( List<KeyOccurrence> keyOccurrences : po.values() ) {
@@ -656,6 +734,76 @@ public class MessagesSourceCrawler {
       }
     }
 
-    return new ArrayList<KeyOccurrence>( map.values() );
+    return new ArrayList<>( map.values() );
+  }
+
+  /**
+   * @return the {@link List} of source directories to crawl through
+   */
+  public List<String> getSourceDirectories() {
+    return sourceDirectories;
+  }
+
+  /**
+   * @param sourceDirectories the {@link List} of source directories to crawl through
+   */
+  public void setSourceDirectories( List<String> sourceDirectories ) {
+    this.sourceDirectories = ( null != sourceDirectories ) ? sourceDirectories : new ArrayList<>();
+  }
+
+  /**
+   * @return the {@link List} of files to avoid
+   */
+  public List<String> getFilesToAvoid() {
+    return filesToAvoid;
+  }
+
+  /**
+   * @param filesToAvoid the {@link List} of files to avoid
+   */
+  public void setFilesToAvoid( List<String> filesToAvoid ) {
+    this.filesToAvoid = ( null != filesToAvoid ) ? filesToAvoid : new ArrayList<>();
+  }
+
+  /**
+   * @return the singleMessagesFile
+   */
+  public String getSingleMessagesFile() {
+    return singleMessagesFile;
+  }
+
+  /**
+   * @param singleMessagesFile the singleMessagesFile to set
+   */
+  public void setSingleMessagesFile( String singleMessagesFile ) {
+    this.singleMessagesFile = singleMessagesFile;
+  }
+
+  /**
+   * @return the scanPhrases to search for
+   */
+  public String[] getScanPhrases() {
+    return scanPhrases;
+  }
+
+  /**
+   * @param scanPhrases the scanPhrases to search for
+   */
+  public void setScanPhrases( String[] scanPhrases ) {
+    this.scanPhrases = ( null != scanPhrases ) ? scanPhrases : new String[] {};
+  }
+
+  /**
+   * @return the sourcePackageOccurrences
+   */
+  public Map<String, Map<String, List<KeyOccurrence>>> getSourcePackageOccurrences() {
+    return sourcePackageOccurrences;
+  }
+
+  /**
+   * @param sourcePackageOccurrences the sourcePackageOccurrences to set
+   */
+  public void setSourcePackageOccurrences( Map<String, Map<String, List<KeyOccurrence>>> sourcePackageOccurrences ) {
+    this.sourcePackageOccurrences = ( null != sourcePackageOccurrences ) ? sourcePackageOccurrences : new HashMap<>();
   }
 }

--- a/ui/src/main/java/org/pentaho/di/ui/i18n/MessagesSourceCrawler.java
+++ b/ui/src/main/java/org/pentaho/di/ui/i18n/MessagesSourceCrawler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.hitachivantara.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -64,8 +64,8 @@ import java.util.regex.Pattern;
 public class MessagesSourceCrawler {
 
   /**
-   * When searching for a scanPhrase, it may exist over more than one source line. This string contains the characters
-   * to be considered in the calculation of the different splits that each scanPhrase may have.
+   * When searching for a scanPhrase, it may be spread over more than one source line. This string contains the
+   * characters to be considered in the calculation of the different splits that each scanPhrase may have.
    *
    * @see #SPLIT_CHARACTERS
    * @see #SPLITTER_AND_WHITESPACES_PATTERN
@@ -73,7 +73,7 @@ public class MessagesSourceCrawler {
   private static final String SPLIT_CHARACTERS_STRING = ".(,";
 
   /**
-   * When searching for a scanPhrase, it may exist over more than one source line. These are the characters to be
+   * When searching for a scanPhrase, it may be spread over more than one source line. These are the characters to be
    * considered in the calculation of the different splits that each scanPhrase may have.
    *
    * @see #SPLIT_CHARACTERS_STRING
@@ -102,25 +102,27 @@ public class MessagesSourceCrawler {
 
   private static final String EMPTY_STRING = "";
   private static final String ASTERISK = "*";
-  private static final String DOT = ".";
   private static final String DOLLAR_SIGN = "$";
+  private static final String DOT = ".";
   private static final String QUESTION_MARK = "?";
-  private static final String N_STRING = "N";
-  private static final String YES_STRING = "yes";
-  private static final String DOT_CLASS_STRING = ".class";
-  private static final String IMPORT_STRING = "import";
-  private static final int IMPORT_STRING_LENGTH = IMPORT_STRING.length();
+  private static final String SPACE = " ";
+  private static final String TAB = "\t";
+  private static final String N = "N";
+  private static final String YES = "yes";
+  private static final String DOT_CLASS = ".class";
+  private static final String IMPORT_TOKEN = "import";
+  private static final int IMPORT_TOKEN_LENGTH = IMPORT_TOKEN.length();
   private static final String JAVA_EXTENSION = "java";
-  private static final String MESSAGES_PACKAGE_END_STRING = ".Messages;";
-  private static final String ORG_PENTAHO_STRING = "org.pentaho.";
-  private static final String SYSTEM_DOT_STRING = "System.";
+  private static final String PACKAGE_END_MESSAGES = ".Messages;";
+  private static final String PACKAGE_START_ORG_PENTAHO = "org.pentaho.";
+  private static final String PACKAGE_START_SYSTEM = "System.";
 
   //REGEX expressions to be compiled
-  private static final String PACKAGE_PATTERN = "^\\s*package\\s*.*;\\s*$";
-  private static final String IMPORT_PATTERN = "^\\s*import\\s*[a-z._0-9]*\\.([*]|([A-Z][a-z._0-9]*))\\s*;\\s*$";
-  private static final String IMPORT_MESSAGES_PATTERN = "^\\s*import\\s*[a-z._0-9]*\\.Messages;\\s*$";
-  private static final String STRING_PKG_PATTERN = "^.*private static String PKG.*=.*$";
-  private static final String CLASS_PKG_PATTERN = "^.*private static Class.*\\sPKG\\s*=.*$";
+  private static final String PATTERN_PACKAGE_DECLARATION = "^\\s*package\\s*.*;\\s*$";
+  private static final String PATTERN_ANY_PACKAGE_IMPORT =          "^\\s*import\\s*[a-z._0-9]*\\.([*]|([A-Z][a-z._0-9]*))\\s*;\\s*$";
+  private static final String PATTERN_MESSAGES_PACKAGE_IMPORT = "^\\s*import\\s*[a-z._0-9]*\\.Messages;\\s*$";
+  private static final String PATTERN_STRING_PKG_VARIABLE_DECLARATION = "^.*private static String PKG.*=.*$";
+  private static final String PATTERN_CLASS_PKG_VARIABLE_DECLARATION = "^.*private static Class.*\\sPKG\\s*=.*$";
 
   /**
    * All phrases to scan for.
@@ -149,11 +151,11 @@ public class MessagesSourceCrawler {
    */
   private List<SourceCrawlerXMLFolder> xmlFolders;
 
-  private Pattern packagePattern = Pattern.compile( PACKAGE_PATTERN );
-  private Pattern importPattern = Pattern.compile( IMPORT_PATTERN );
-  private Pattern importMessagesPattern = Pattern.compile( IMPORT_MESSAGES_PATTERN );
-  private Pattern stringPkgPattern = Pattern.compile( STRING_PKG_PATTERN );
-  private Pattern classPkgPattern = Pattern.compile( CLASS_PKG_PATTERN );
+  private static Pattern packagePattern = Pattern.compile( PATTERN_PACKAGE_DECLARATION );
+  private static Pattern importPattern = Pattern.compile( PATTERN_ANY_PACKAGE_IMPORT );
+  private static Pattern importMessagesPattern = Pattern.compile( PATTERN_MESSAGES_PACKAGE_IMPORT );
+  private static Pattern stringPkgPattern = Pattern.compile( PATTERN_STRING_PKG_VARIABLE_DECLARATION );
+  private static Pattern classPkgPattern = Pattern.compile( PATTERN_CLASS_PKG_VARIABLE_DECLARATION );
 
   private LogChannelInterface log;
 
@@ -251,7 +253,7 @@ public class MessagesSourceCrawler {
     for ( SourceCrawlerXMLFolder xmlFolder : xmlFolders ) {
       String[] xmlDirs = { xmlFolder.getFolder() };
       String[] xmlMasks = { xmlFolder.getWildcard() };
-      String[] xmlReq = { N_STRING };
+      String[] xmlReq = { N };
       boolean[] xmlSubdirs = { true }; // search sub-folders too
 
       FileInputList xulFileInputList =
@@ -285,8 +287,8 @@ public class MessagesSourceCrawler {
 
     TransformerFactory transformerFactory = TransformerFactory.newInstance();
     Transformer transformer = transformerFactory.newTransformer();
-    transformer.setOutputProperty( OutputKeys.OMIT_XML_DECLARATION, YES_STRING );
-    transformer.setOutputProperty( OutputKeys.INDENT, YES_STRING );
+    transformer.setOutputProperty( OutputKeys.OMIT_XML_DECLARATION, YES );
+    transformer.setOutputProperty( OutputKeys.INDENT, YES );
 
     for ( int i = 0; i < nodeList.getLength(); i++ ) {
       Node node = nodeList.item( i );
@@ -356,7 +358,7 @@ public class MessagesSourceCrawler {
         // "package org.pentaho.di.trans.steps.sortedmerge;"
         //
         if ( packagePattern.matcher( line ).matches() ) {
-          int beginIndex = line.indexOf( ORG_PENTAHO_STRING );
+          int beginIndex = line.indexOf( PACKAGE_START_ORG_PENTAHO );
           int endIndex = line.indexOf( ';' );
           if ( beginIndex >= 0 && endIndex > beginIndex ) {
             messagesPackage = line.substring( beginIndex, endIndex ); // this is the default
@@ -367,7 +369,7 @@ public class MessagesSourceCrawler {
         // Remember all the imports...
         //
         if ( importPattern.matcher( line ).matches() ) {
-          int beginIndex = line.indexOf( IMPORT_STRING ) + IMPORT_STRING_LENGTH + 1;
+          int beginIndex = line.indexOf( IMPORT_TOKEN ) + IMPORT_TOKEN_LENGTH + 1;
           int endIndex = line.indexOf( ';', beginIndex );
           if ( beginIndex >= 0 && endIndex > beginIndex ) {
             String expression = line.substring( beginIndex, endIndex );
@@ -390,8 +392,8 @@ public class MessagesSourceCrawler {
         // "import org.pentaho.di.trans.steps.sortedmerge.Messages;"
         //
         if ( importMessagesPattern.matcher( line ).matches() ) {
-          int beginIndex = line.indexOf( ORG_PENTAHO_STRING );
-          int endIndex = line.indexOf( MESSAGES_PACKAGE_END_STRING );
+          int beginIndex = line.indexOf( PACKAGE_START_ORG_PENTAHO );
+          int endIndex = line.indexOf( PACKAGE_END_MESSAGES );
           if ( beginIndex >= 0 && endIndex > beginIndex ) {
             messagesPackage = line.substring( beginIndex, endIndex ); // if there is any specified, we take this one.
           }
@@ -415,7 +417,7 @@ public class MessagesSourceCrawler {
         //
         if ( classPackage != null && classPkgPattern.matcher( line ).matches() ) {
           int fromIndex = line.indexOf( '=' ) + 1;
-          int toIndex = line.indexOf( DOT_CLASS_STRING, fromIndex );
+          int toIndex = line.indexOf( DOT_CLASS, fromIndex );
           String expression = Const.trim( line.substring( fromIndex, toIndex ) );
 
           // If the expression doesn't contain any package, we'll look up the package in the imports. If not found
@@ -642,7 +644,7 @@ public class MessagesSourceCrawler {
 
     // Sanity check...
     //
-    if ( key.contains( "\t" ) || key.contains( " " ) ) {
+    if ( key.contains( TAB ) || key.contains( SPACE ) ) {
       System.out.println( "Suspect key found: [" + key + "] in file [" + fileObject + "]" );
     }
 
@@ -650,7 +652,7 @@ public class MessagesSourceCrawler {
     //
     // Make sure we pass the System key occurrences to the correct package.
     //
-    if ( key.startsWith( SYSTEM_DOT_STRING ) ) {
+    if ( key.startsWith( PACKAGE_START_SYSTEM ) ) {
       String i18nPackage = BaseMessages.class.getPackage().getName();
       KeyOccurrence keyOccurrence =
         new KeyOccurrence( fileObject, sourceFolder, i18nPackage, row, column, key, arguments, line );

--- a/ui/src/main/java/org/pentaho/di/ui/i18n/editor/Translator2.java
+++ b/ui/src/main/java/org/pentaho/di/ui/i18n/editor/Translator2.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.hitachivantara.com
  *
  *******************************************************************************
  *
@@ -21,16 +21,6 @@
  ******************************************************************************/
 
 package org.pentaho.di.ui.i18n.editor;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.vfs2.FileObject;
 import org.eclipse.swt.SWT;
@@ -56,13 +46,13 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -86,6 +76,16 @@ import org.pentaho.di.ui.trans.step.BaseStepDialog;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
 /**
  * Class to allow non-developers to edit translation messages files.
  *
@@ -97,6 +97,8 @@ public class Translator2 {
   private static Class<?> PKG = Translator2.class;
 
   public static final String APP_NAME = BaseMessages.getString( PKG, "i18nDialog.ApplicationName" );
+
+  private static final String EMPTY_STRING = "";
 
   private Display display;
   private Shell shell;
@@ -136,10 +138,6 @@ public class Translator2 {
 
   private Button wSearchV;
   private Button wNextV;
-
-  /*
-   * private Button wSearchG; private Button wNextG;
-   */
 
   private Button wAll;
 
@@ -184,15 +182,14 @@ public class Translator2 {
 
       // What are the statistics?
       //
-      Map<String, int[]> folderKeyCounts = new HashMap<String, int[]>();
-      Map<String, Integer> nrKeysPerFolder = new HashMap<String, Integer>();
+      Map<String, int[]> folderKeyCounts = new HashMap<>();
+      Map<String, Integer> nrKeysPerFolder = new HashMap<>();
 
       for ( String sourceFolder : rootDirectories ) {
         folderKeyCounts.put( sourceFolder, new int[localeList.size()] );
       }
 
       for ( String sourceFolder : rootDirectories ) {
-
         int[] keyCounts = folderKeyCounts.get( sourceFolder );
         int nrKeys = 0;
 
@@ -216,7 +213,7 @@ public class Translator2 {
             }
           }
         }
-        nrKeysPerFolder.put( sourceFolder, new Integer( nrKeys ) );
+        nrKeysPerFolder.put( sourceFolder, nrKeys );
       }
 
       DecimalFormat pctFormat = new DecimalFormat( "#00.00" );
@@ -228,11 +225,11 @@ public class Translator2 {
         System.out.println( "-------------------------------------" );
 
         int nrKeys = nrKeysPerFolder.get( sourceFolder );
-        System.out.println( BaseMessages.getString( PKG, "i18n.Log.NumberOfKeysFound", "" + nrKeys ) );
+        System.out.println( BaseMessages.getString( PKG, "i18n.Log.NumberOfKeysFound", EMPTY_STRING + nrKeys ) );
 
         int[] keyCounts = folderKeyCounts.get( sourceFolder );
 
-        String[] locales = localeList.toArray( new String[localeList.size()] );
+        String[] locales = localeList.toArray( new String[] {} );
         for ( int i = 0; i < locales.length; i++ ) {
           for ( int j = 0; j < locales.length - 1; j++ ) {
             if ( keyCounts[j] < keyCounts[j + 1] ) {
@@ -252,30 +249,28 @@ public class Translator2 {
           int missingKeys = nrKeys - keyCounts[i];
           String statusKeys =
             "# "
-              + nrFormat.format( i + 1 ) + " : " + locales[i] + " : " + pctFormat.format( donePct ) + "% "
+              + nrFormat.format( i + 1L ) + " : " + locales[i] + " : " + pctFormat.format( donePct ) + "% "
               + BaseMessages.getString( PKG, "i18n.Log.CompleteKeys", keyCounts[i] )
-              + ( missingKeys != 0 ? BaseMessages.getString( PKG, "i18n.Log.MissingKeys", missingKeys ) : "" );
+              + ( missingKeys != 0 ? BaseMessages.getString( PKG, "i18n.Log.MissingKeys", missingKeys ) : EMPTY_STRING );
           System.out.println( statusKeys );
         }
       }
     } catch ( Exception e ) {
       throw new KettleFileException( BaseMessages.getString( PKG, "i18n.Log.UnableToGetFiles", rootDirectories
         .toString() ), e );
-
     }
   }
 
   public void loadConfiguration( String configFile, String sourceFolder ) throws Exception {
     // What are the locale to handle?
     //
-    localeList = new ArrayList<String>();
-    rootDirectories = new ArrayList<String>();
-    filesToAvoid = new ArrayList<String>();
-    xmlFolders = new ArrayList<SourceCrawlerXMLFolder>();
+    localeList = new ArrayList<>();
+    rootDirectories = new ArrayList<>();
+    filesToAvoid = new ArrayList<>();
+    xmlFolders = new ArrayList<>();
 
     FileObject file = KettleVFS.getFileObject( configFile );
     if ( file.exists() ) {
-
       try {
         Document doc = XMLHandler.loadXMLFile( file );
         Node configNode = XMLHandler.getSubNode( doc, "translator-config" );
@@ -412,12 +407,14 @@ public class Translator2 {
   private void addListeners() {
     // In case someone dares to press the [X] in the corner ;-)
     shell.addShellListener( new ShellAdapter() {
+      @Override
       public void shellClosed( ShellEvent e ) {
         e.doit = quitFile();
       }
     } );
 
     wReload.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent arg0 ) {
         int[] idx = wPackages.table.getSelectionIndices();
         reload();
@@ -426,12 +423,14 @@ public class Translator2 {
     } );
 
     wZip.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent arg0 ) {
         saveFilesToZip();
       }
     } );
 
     wClose.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent arg0 ) {
         quitFile();
       }
@@ -453,10 +452,10 @@ public class Translator2 {
 
   public boolean quitFile() {
     java.util.List<MessagesStore> changedMessagesStores = store.getChangedMessagesStores();
-    if ( changedMessagesStores.size() > 0 ) {
+    if ( !changedMessagesStores.isEmpty() ) {
       MessageBox mb = new MessageBox( shell, SWT.YES | SWT.NO | SWT.ICON_WARNING );
       mb.setMessage( BaseMessages.getString( PKG, "i18nDialog.ChangedFilesWhenExit", changedMessagesStores.size()
-        + "" ) );
+        + EMPTY_STRING ) );
       mb.setText( BaseMessages.getString( PKG, "i18nDialog.Warning" ) );
 
       int answer = mb.open();
@@ -515,11 +514,13 @@ public class Translator2 {
 
     // Add a selection listener.
     wLocale.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         refreshGrid();
       }
     } );
     wPackages.table.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         refreshGrid();
       }
@@ -549,16 +550,6 @@ public class Translator2 {
 
     BaseStepDialog.positionBottomButtons(
       composite, new Button[] { wReload, wSave, wZip, wClose, }, Const.MARGIN * 3, null );
-
-    /*
-     * wSearchG = new Button(composite, SWT.PUSH); wSearchG.setText("   Search &key  "); FormData fdSearchG = new
-     * FormData(); fdSearchG.left = new FormAttachment(0, 0); fdSearchG.bottom = new FormAttachment(100, 0);
-     * wSearchG.setLayoutData(fdSearchG);
-     *
-     * wNextG = new Button(composite, SWT.PUSH); wNextG.setText("   Next ke&y  "); FormData fdNextG = new FormData();
-     * fdNextG.left = new FormAttachment(wSearchG, Const.MARGIN); fdNextG.bottom = new FormAttachment(100, 0);
-     * wNextG.setLayoutData(fdNextG);
-     */
 
     int left = 25;
     int middle = 40;
@@ -717,12 +708,14 @@ public class Translator2 {
     wNextV.setLayoutData( fdNextV );
 
     wAll.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         refreshGrid();
       }
     } );
 
     wTodo.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         // If someone clicks on the todo list, we set the appropriate values
         //
@@ -749,42 +742,49 @@ public class Translator2 {
     } );
 
     wApply.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         applyChangedValue();
       }
     } );
 
     wRevert.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         revertChangedValue();
       }
     } );
 
     wSave.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent event ) {
         saveFiles();
       }
     } );
 
     wSearch.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         search( referenceLocale );
       }
     } );
 
     wNext.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         searchAgain( referenceLocale );
       }
     } );
 
     wSearchV.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         search( selectedLocale );
       }
     } );
 
     wNextV.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         searchAgain( selectedLocale );
       }
@@ -794,7 +794,7 @@ public class Translator2 {
 
   protected boolean saveFiles() {
     java.util.List<MessagesStore> changedMessagesStores = store.getChangedMessagesStores();
-    if ( changedMessagesStores.size() > 0 ) {
+    if ( !changedMessagesStores.isEmpty() ) {
 
       StringBuilder msg = new StringBuilder();
       for ( MessagesStore messagesStore : changedMessagesStores ) {
@@ -828,7 +828,6 @@ public class Translator2 {
       } else {
         return false;
       }
-
     } else {
       // Nothing was saved.
       // TODO: disable the button if nothing changed.
@@ -840,7 +839,7 @@ public class Translator2 {
   protected void saveFilesToZip() {
     if ( saveFiles() ) {
       java.util.List<MessagesStore> messagesStores = store.getMessagesStores( selectedLocale, null );
-      if ( messagesStores.size() > 0 ) {
+      if ( !messagesStores.isEmpty() ) {
 
         StringBuilder msg = new StringBuilder();
         for ( MessagesStore messagesStore : messagesStores ) {
@@ -885,9 +884,7 @@ public class Translator2 {
               shell, BaseMessages.getString( PKG, "i18n.UnexpectedError" ),
               "There was an error saving the changed messages files:", e );
           }
-
         }
-
       }
     }
   }
@@ -896,9 +893,9 @@ public class Translator2 {
     // Ask for the search string...
     //
     EnterStringDialog dialog =
-      new EnterStringDialog( shell, Const.NVL( searchString, "" ), BaseMessages.getString(
+      new EnterStringDialog( shell, Const.NVL( searchString, EMPTY_STRING ), BaseMessages.getString(
         PKG, "i18nDialog.SearchKey" ), BaseMessages.getString( PKG, "i18nDialog.SearchLocale1" )
-        + " '" + Const.NVL( searchLocale, "" ) + "' "
+        + " '" + Const.NVL( searchLocale, EMPTY_STRING ) + "' "
         + BaseMessages.getString( PKG, "i18nDialog.SearchLocale2" ) );
     searchString = dialog.open();
 
@@ -927,7 +924,7 @@ public class Translator2 {
         for ( String key : messagesStore.getMessagesMap().keySet() ) {
           String value = messagesStore.getMessagesMap().get( key );
           String upperValue = value.toUpperCase();
-          if ( upperValue.indexOf( upperSearchString ) >= 0 ) {
+          if ( upperValue.contains( upperSearchString ) ) {
             // OK, we found a key worthy of our attention...
             //
             if ( lastKeyFound ) {
@@ -946,12 +943,10 @@ public class Translator2 {
         }
       }
     }
-
   }
 
   protected void showKeySelection( String key ) {
     if ( !key.equals( selectedKey ) ) {
-
       applyChangedValue();
     }
 
@@ -961,9 +956,9 @@ public class Translator2 {
       KeyOccurrence keyOccurrence = crawler.getKeyOccurrence( key, selectedMessagesPackage );
 
       wKey.setText( key );
-      wMain.setText( Const.NVL( mainValue, "" ) );
-      wValue.setText( Const.NVL( value, "" ) );
-      wSource.setText( Const.NVL( keyOccurrence.getSourceLine(), "" ) );
+      wMain.setText( Const.NVL( mainValue, EMPTY_STRING ) );
+      wValue.setText( Const.NVL( value, EMPTY_STRING ) );
+      wSource.setText( Const.NVL( keyOccurrence.getSourceLine(), EMPTY_STRING ) );
 
       // Focus on the entry field
       // Put the cursor all the way at the back
@@ -985,10 +980,10 @@ public class Translator2 {
     applyChangedValue();
 
     wTodo.removeAll();
-    wKey.setText( "" );
-    wMain.setText( "" );
-    wValue.setText( "" );
-    wSource.setText( "" );
+    wKey.setText( EMPTY_STRING );
+    wMain.setText( EMPTY_STRING );
+    wValue.setText( EMPTY_STRING );
+    wSource.setText( EMPTY_STRING );
 
     selectedLocale = wLocale.getSelectionCount() == 0 ? null : wLocale.getSelection()[0];
     selectedSourceFolder =
@@ -1018,7 +1013,7 @@ public class Translator2 {
     // Get the list of keys that need a translation...
     //
     java.util.List<KeyOccurrence> keys = crawler.getOccurrencesForPackage( messagesPackage );
-    java.util.List<KeyOccurrence> todo = new ArrayList<KeyOccurrence>();
+    java.util.List<KeyOccurrence> todo = new ArrayList<>();
     for ( KeyOccurrence keyOccurrence : keys ) {
       // Avoid the System keys. Those are taken care off in a different package
       //
@@ -1110,12 +1105,12 @@ public class Translator2 {
             item.setBackground( GUIResource.getInstance().getColorYellow() );
           } else if ( todo.size() > 5 ) {
             item.setBackground( GUIResource.getInstance().getColorBlue() );
-          } else if ( todo.size() > 0 ) {
+          } else if ( !todo.isEmpty() ) {
             item.setBackground( GUIResource.getInstance().getColorGreen() );
           }
         }
       }
-      if ( messagesPackages.size() == 0 ) {
+      if ( messagesPackages.isEmpty() ) {
         new TableItem( wPackages.table, SWT.NONE );
       } else {
         wPackages.setRowNums();
@@ -1133,7 +1128,7 @@ public class Translator2 {
   public void refreshLocale() {
     // OK, we have a distinct list of locale to work with...
     wLocale.removeAll();
-    wLocale.setItems( localeList.toArray( new String[localeList.size()] ) );
+    wLocale.setItems( localeList.toArray( new String[] {} ) );
   }
 
   public String toString() {
@@ -1173,5 +1168,4 @@ public class Translator2 {
       log.logError( Const.getStackTracker( e ) );
     }
   }
-
 }

--- a/ui/src/test/java/org/pentaho/di/ui/i18n/MessagesSourceCrawlerTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/i18n/MessagesSourceCrawlerTest.java
@@ -1,0 +1,329 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2019 by Hitachi Vantara : http://www.hitachivantara.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.i18n;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSelectInfo;
+import org.apache.commons.vfs2.FileSelector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.internal.verification.Times;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.vfs.KettleVFS;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author sribeiro
+ */
+public class MessagesSourceCrawlerTest {
+
+  private static final String DUMMY_CONTENT = "Dummy content!";
+
+  private TemporaryFolder temporaryFolder = null;
+
+  @Before
+  public void setup() throws Exception {
+    temporaryFolder = new TemporaryFolder();
+    temporaryFolder.create();
+  }
+
+  @After
+  public void cleanup() {
+    if ( null != temporaryFolder ) {
+      temporaryFolder.delete();
+      temporaryFolder = null;
+    }
+  }
+
+  @Test
+  public void testGetSetSourceDirectories() {
+    MessagesSourceCrawler messagesSourceCrawler = new MessagesSourceCrawler( null, null, null, null );
+
+    // Check that what is set is returned
+    List<String> sourceDirectories = new ArrayList<>();
+    messagesSourceCrawler.setSourceDirectories( sourceDirectories );
+    List<String> res = messagesSourceCrawler.getSourceDirectories();
+    assertEquals( sourceDirectories, res );
+
+    // Check that setting null, a new object is created and returned
+    messagesSourceCrawler.setSourceDirectories( null );
+    res = messagesSourceCrawler.getSourceDirectories();
+    assertNotNull( res );
+    assertEquals( 0, res.size() );
+  }
+
+  @Test
+  public void testGetSetFilesToAvoid() {
+    MessagesSourceCrawler messagesSourceCrawler = new MessagesSourceCrawler( null, null, null, null );
+
+    // Check that what is set is returned
+    List<String> filesToAvoid = new ArrayList<>();
+    messagesSourceCrawler.setFilesToAvoid( filesToAvoid );
+    List<String> res = messagesSourceCrawler.getFilesToAvoid();
+    assertEquals( filesToAvoid, res );
+
+    // Check that setting null, a new object is created and returned
+    messagesSourceCrawler.setFilesToAvoid( null );
+    res = messagesSourceCrawler.getFilesToAvoid();
+    assertNotNull( res );
+    assertEquals( 0, res.size() );
+  }
+
+  @Test
+  public void testGetSetSourcePackageOccurrences() {
+    MessagesSourceCrawler messagesSourceCrawler = new MessagesSourceCrawler( null, null, null, null );
+
+    // Check that what is set is returned
+    Map<String, Map<String, List<KeyOccurrence>>> sourcePackageOccurrences = new HashMap<>();
+    messagesSourceCrawler.setSourcePackageOccurrences( sourcePackageOccurrences );
+    Map<String, Map<String, List<KeyOccurrence>>> res = messagesSourceCrawler.getSourcePackageOccurrences();
+    assertEquals( sourcePackageOccurrences, res );
+
+    // Check that setting null, a new object is created and returned
+    messagesSourceCrawler.setSourcePackageOccurrences( null );
+    res = messagesSourceCrawler.getSourcePackageOccurrences();
+    assertNotNull( res );
+    assertEquals( 0, res.size() );
+  }
+
+  @Test
+  public void testGetSetSingleMessagesFile() {
+    MessagesSourceCrawler messagesSourceCrawler = new MessagesSourceCrawler( null, null, null, null );
+
+    // Check that what is set is returned
+    messagesSourceCrawler.setSingleMessagesFile( DUMMY_CONTENT );
+    String res = messagesSourceCrawler.getSingleMessagesFile();
+    assertEquals( DUMMY_CONTENT, res );
+
+    // Setting null, null is kept and returned
+    messagesSourceCrawler.setSingleMessagesFile( null );
+    assertNull( messagesSourceCrawler.getSingleMessagesFile() );
+  }
+
+  @Test
+  public void testGetSetScanPhrases() {
+    MessagesSourceCrawler messagesSourceCrawler = new MessagesSourceCrawler( null, null, null, null );
+
+    // Check that what is set is returned
+    String[] scanPhrases = { DUMMY_CONTENT };
+    messagesSourceCrawler.setScanPhrases( scanPhrases );
+    String[] res = messagesSourceCrawler.getScanPhrases();
+    assertArrayEquals( scanPhrases, res );
+
+    // Check that setting null, a new object is created and returned
+    messagesSourceCrawler.setScanPhrases( null );
+    res = messagesSourceCrawler.getScanPhrases();
+    assertNotNull( res );
+    assertEquals( 0, res.length );
+  }
+
+  @Test
+  public void testCrawl() throws Exception {
+    // Prepare the mock for this test
+    MessagesSourceCrawler messagesSourceCrawler = mock( MessagesSourceCrawler.class );
+
+    doNothing().when( messagesSourceCrawler ).crawlSourceDirectories();
+    doNothing().when( messagesSourceCrawler ).crawlXmlFolders();
+    doCallRealMethod().when( messagesSourceCrawler ).crawl();
+
+    // Test
+    messagesSourceCrawler.crawl();
+
+    // Check results
+    verify( messagesSourceCrawler ).crawlSourceDirectories();
+    verify( messagesSourceCrawler ).crawlXmlFolders();
+  }
+
+  @Test
+  public void testCrawlSourceDirectories() throws Exception {
+    // Prepare the mock for this test
+    MessagesSourceCrawler messagesSourceCrawler = mock( MessagesSourceCrawler.class );
+
+    doCallRealMethod().when( messagesSourceCrawler ).setFilesToAvoid( any() );
+    doCallRealMethod().when( messagesSourceCrawler ).setSourceDirectories( any() );
+    doCallRealMethod().when( messagesSourceCrawler ).crawlSourceDirectories();
+    doNothing().when( messagesSourceCrawler ).lookForOccurrencesInFile( any(), any() );
+    messagesSourceCrawler
+      .setScanPhrases( new String[] { "Not relevant for this scenario!" } );
+
+    // Create and populate the filder to use in this test
+    List<String> sourceDirectories = new ArrayList<>();
+    sourceDirectories.add( temporaryFolder.getRoot().getPath() );
+    createDummyFiles( temporaryFolder,
+      new String[] { "a.txt", "b.txt", "c.txt", "d.txt", "a.java", "b.java", "c.java", "d.java" }, DUMMY_CONTENT );
+    messagesSourceCrawler.setSourceDirectories( sourceDirectories );
+
+    // The files set to be ignored
+    messagesSourceCrawler.setFilesToAvoid( Arrays.asList( "a.txt", "b.java", "c.java" ) );
+
+    // Test
+    messagesSourceCrawler.crawlSourceDirectories();
+
+    // Check results
+    verify( messagesSourceCrawler, new Times( 2 ) ).lookForOccurrencesInFile( any(), any() );
+  }
+
+  @Test
+  public void testLookForOccurrencesInFile_SplitLines() throws Exception {
+    // Prepare the mock for this test
+    LogChannelInterface log = mock( LogChannelInterface.class );
+    doNothing().when( log ).logError( anyString() );
+    List<String> sourceDirectories = new ArrayList<>();
+    sourceDirectories.add( temporaryFolder.getRoot().getPath() );
+
+    MessagesSourceCrawler messagesSourceCrawler =
+      new MessagesSourceCrawler( log, sourceDirectories, null, null );
+
+    messagesSourceCrawler
+      .setScanPhrases( new String[] { "SomeOtherMessages.getString(PKG,", "BaseMessages.getString( PKG," } );
+
+    // Test
+    messagesSourceCrawler
+      .lookForOccurrencesInFile( "keyOccurrences", createFileObjectFromResource( "split_lines_scenarios.txt" ) );
+
+    // Check results
+    List<KeyOccurrence> keyOccurrences = messagesSourceCrawler.getKeyOccurrences( "keyOccurrences" );
+    assertNotNull( keyOccurrences );
+    assertEquals( 50, keyOccurrences.size() );
+  }
+
+  @Test
+  public void testAddKeyOccurrence_null() throws Exception {
+
+    MessagesSourceCrawler messagesSourceCrawler =
+      new MessagesSourceCrawler( null, null, null, null );
+
+    messagesSourceCrawler.setSourcePackageOccurrences( null );
+
+    messagesSourceCrawler.addKeyOccurrence( null );
+
+    Map<String, Map<String, List<KeyOccurrence>>> sourcePackageOccurrences =
+      messagesSourceCrawler.getSourcePackageOccurrences();
+    assertNotNull( sourcePackageOccurrences );
+    assertEquals( 0, sourcePackageOccurrences.size() );
+  }
+
+  @Test
+  public void testAddKeyOccurrence() throws Exception {
+
+    MessagesSourceCrawler messagesSourceCrawler =
+      new MessagesSourceCrawler( null, null, null, null );
+
+    // After adding an occurrence stating "Source Folder" and "Message Package", it should be retrieved
+    final String thePackage = "a.b.c.Package";
+    KeyOccurrence keyOccurrence =
+      new KeyOccurrence( null, "Some Source Folder", thePackage, 1, 2, null, null, null );
+
+    messagesSourceCrawler.addKeyOccurrence( keyOccurrence );
+
+    // Check results
+    List<KeyOccurrence> messagesPackage = messagesSourceCrawler.getOccurrencesForPackage( thePackage );
+    assertNotNull( messagesPackage );
+    assertEquals( 1, messagesPackage.size() );
+    assertEquals( keyOccurrence, messagesPackage.get( 0 ) );
+  }
+
+  @Test( expected = RuntimeException.class )
+  public void testAddKeyOccurrence_invalidParameter() throws Exception {
+
+    MessagesSourceCrawler messagesSourceCrawler =
+      new MessagesSourceCrawler( null, null, null, null );
+
+    // After adding an occurrence stating "Source Folder" and "Message Package", it should be retrieved
+    final String thePackage = "a.b.c.Package";
+    KeyOccurrence keyOccurrence =
+      new KeyOccurrence( null, null, thePackage, 1, 2, null, null, null );
+
+    // Test
+    messagesSourceCrawler.addKeyOccurrence( keyOccurrence );
+
+    // An exception should have been raised.
+    fail( "It should not have reached here!" );
+  }
+
+  private FileObject createFileObjectFromResource( String resourceName ) throws Exception {
+
+    File tempFile = temporaryFolder.newFile();
+    tempFile.deleteOnExit();
+
+    InputStream fileScenarios = getClass().getResourceAsStream( resourceName );
+    FileUtils.copyInputStreamToFile( fileScenarios, tempFile );
+    FileObject folder = KettleVFS.getFileObject( temporaryFolder.getRoot().getAbsolutePath() );
+    FileObject[] javaFiles = folder.findFiles( new FileSelector() {
+      @Override
+      public boolean traverseDescendents( FileSelectInfo info ) throws Exception {
+        return true;
+      }
+
+      @Override
+      public boolean includeFile( FileSelectInfo info ) throws Exception {
+        return info.getFile().isFile();
+      }
+    } );
+
+    return javaFiles[ 0 ];
+  }
+
+  /**
+   * <p>Given an array with file names, a corresponding file is created in the stated folder. Each file will contain
+   * some dummy content.</p>
+   *
+   * @param temporaryFolder the folder where the files are to be created
+   * @param filesToCreate   array containing the names for the files to be created
+   * @param content         the content to write to the created file(s)
+   * @throws IOException
+   */
+  private void createDummyFiles( TemporaryFolder temporaryFolder, String[] filesToCreate, String content )
+    throws IOException {
+    for ( String fileToCreate : filesToCreate ) {
+      File tempFile = temporaryFolder.newFile( fileToCreate );
+      try ( PrintWriter pw = new PrintWriter( tempFile ) ) {
+        pw.println( content );
+      }
+    }
+  }
+}

--- a/ui/src/test/resources/org/pentaho/di/ui/i18n/split_lines_scenarios.txt
+++ b/ui/src/test/resources/org/pentaho/di/ui/i18n/split_lines_scenarios.txt
@@ -1,0 +1,411 @@
+// Dummy content here
+// and here
+// and here also!
+
+ package 	org.pentaho.c.d.e	;
+
+
+ import some.import.here  ;
+    import    another.import.here  ;
+
+ import yet.another.import.here  ;
+import and.a.final.import.here;
+
+import now.one.ending.in.Messages;
+// Some real imports to have coverage:
+ import				org.pentaho.Xpto ;
+import				org.pentaho.something.Messages;
+
+// Some imports ending in *
+ import				org.pentaho.*;
+import	a.b.*;
+
+
+
+public class SomeClass {
+
+  private static Class<?> PKG = Xpto.class; // for i18n
+  private static Class<?> PKG = a.b.c.Xyz.class    ; // for i18n
+
+    private static String PKG = "alfa/beta/gama/delta/";
+
+
+
+
+/* ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
+ * ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
+ *
+ *  "BaseMessages" scenarios: all should be detected and counted!
+ *
+ * ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
+ * ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****/
+
+
+BaseMessages One line  1: + ypto( BaseMessages.getString( PKG, \"basemessages_getstring_pkg.lines.01.scenario.01\" ) );
+
+BaseMessages One line  2: + ypto( BaseMessages.  getString( PKG, \"basemessages_getstring_pkg.lines.01.scenario.02\" ) );
+
+BaseMessages One line  3: + ypto( BaseMessages. 	 getString( PKG, \"basemessages_getstring_pkg.lines.01.scenario.03\" ) );
+
+BaseMessages One line  4: + ypto( BaseMessages.getString   ( PKG, \"basemessages_getstring_pkg.lines.01.scenario.04\" ) );
+
+BaseMessages One line  5: + ypto( BaseMessages.getString  	 ( PKG, \"basemessages_getstring_pkg.lines.01.scenario.05\" ) );
+
+BaseMessages One line  6: + ypto( BaseMessages.getString(    PKG, \"basemessages_getstring_pkg.lines.01.scenario.06\" ) );
+
+BaseMessages One line  7: + ypto( BaseMessages.getString(  	  PKG, \"basemessages_getstring_pkg.lines.01.scenario.07\" ) );
+
+
+
+BaseMessages Two lines  1: + ypto( BaseMessages 	
+ 			 . getString	( PKG, \"basemessages_getstring_pkg.lines.02.scenario.01\" ) );
+
+BaseMessages Two lines  2: + ypto( BaseMessages.
+ 			 getString( PKG, \"basemessages_getstring_pkg.lines.02.scenario.02\" ) );
+
+BaseMessages Two lines  3: + ypto( BaseMessages.getString
+ 		( PKG, \"basemessages_getstring_pkg.lines.02.scenario.03\" ) );
+
+BaseMessages Two lines  4: + ypto( BaseMessages.getString(
+ 	 PKG, \"basemessages_getstring_pkg.lines.02.scenario.04\" ) );
+
+BaseMessages Two lines  5: + ypto( BaseMessages.getString( PKG
+,  \"basemessages_getstring_pkg.lines.02.scenario.05\" ) );
+
+BaseMessages Two lines  6: + ypto( BaseMessages.getString( PKG,
+					\"basemessages_getstring_pkg.lines.02.scenario.06\" ) );
+
+
+
+BaseMessages Three lines  1: + ypto( BaseMessages
+ 			 .getString(
+  	 PKG, \"basemessages_getstring_pkg.lines.03.scenario.01\" ) );
+
+BaseMessages Three lines  2: + ypto( BaseMessages
+    .
+ 			 getString(  	 PKG, \"basemessages_getstring_pkg.lines.03.scenario.02\" ) );
+
+BaseMessages Three lines  3: + ypto( BaseMessages. 			 getString
+  (	 PKG, \"basemessages_getstring_pkg.lines.03.scenario.03\" ) );
+
+
+
+BaseMessages Four lines  1: + ypto( BaseMessages
+.
+ 			 getString(
+  	 PKG, \"basemessages_getstring_pkg.lines.04.scenario.01\" ) );
+
+BaseMessages Four lines  2: + ypto( BaseMessages	.		
+ 			 getString
+			 (
+  	 PKG, \"basemessages_getstring_pkg.lines.04.scenario.02\" ) );
+
+BaseMessages Four lines  3: + ypto( BaseMessages .
+ 			 getString
+			 (  	 PKG
+			 , \"basemessages_getstring_pkg.lines.04.scenario.03\" ) );
+
+
+
+BaseMessages Five lines  1: + ypto( BaseMessages
+.
+ 			 getString
+ 			      (
+  	 PKG, \"basemessages_getstring_pkg.lines.05.scenario.01\" ) );
+
+BaseMessages Five lines  2: + ypto( BaseMessages.	
+ 			 getString	
+ 			      (  	 
+	PKG
+	, \"basemessages_getstring_pkg.lines.05.scenario.02\" ) );
+
+
+
+BaseMessages Six lines  1: + ypto( BaseMessages
+.
+ 			 getString
+ 			      (
+  	 PKG
+  	 ,         \"basemessages_getstring_pkg.lines.06.scenario.01\" ) );
+
+BaseMessages Six lines  2: + ypto( BaseMessages
+
+.
+ 			 getString
+ 			      (
+  	 PKG  	 ,         \"basemessages_getstring_pkg.lines.06.scenario.02\" ) );
+
+BaseMessages Six lines  3: + ypto( BaseMessages
+
+
+. 			 getString
+ 			      (
+  	 PKG  	 ,         \"basemessages_getstring_pkg.lines.06.scenario.03\" ) );
+
+
+
+BaseMessages Seven lines  1: + ypto( BaseMessages
+.
+ 			 getString
+ 			      (
+  	 PKG
+  ,
+\"basemessages_getstring_pkg.lines.07.scenario.01\" ) );
+
+
+
+BaseMessages Incomplete source: + ypto( BaseMessages.get_String( PKG,
+
+
+
+
+/* ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
+ * ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
+ *
+ *  "SomeOtherMessages" scenarios: all should be detected and counted!
+ *
+ * ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
+ * ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****/
+
+
+SomeOtherMessages One line  1: + ypto( SomeOtherMessages.getString( PKG, \"someothermessages_getstring_pkg.lines.01.scenario.01\" ) );
+
+SomeOtherMessages One line  2: + ypto( SomeOtherMessages.  getString( PKG, \"someothermessages_getstring_pkg.lines.01.scenario.02\" ) );
+
+SomeOtherMessages One line  3: + ypto( SomeOtherMessages. 	 getString( PKG, \"someothermessages_getstring_pkg.lines.01.scenario.03\" ) );
+
+SomeOtherMessages One line  4: + ypto( SomeOtherMessages.getString   ( PKG, \"someothermessages_getstring_pkg.lines.01.scenario.04\" ) );
+
+SomeOtherMessages One line  5: + ypto( SomeOtherMessages.getString  	 ( PKG, \"someothermessages_getstring_pkg.lines.01.scenario.05\" ) );
+
+SomeOtherMessages One line  6: + ypto( SomeOtherMessages.getString(    PKG, \"someothermessages_getstring_pkg.lines.01.scenario.06\" ) );
+
+SomeOtherMessages One line  7: + ypto( SomeOtherMessages.getString(  	  PKG, \"someothermessages_getstring_pkg.lines.01.scenario.07\" ) );
+
+
+
+SomeOtherMessages Two lines  1: + ypto( SomeOtherMessages 	
+ 			 . getString	( PKG, \"someothermessages_getstring_pkg.lines.02.scenario.01\" ) );
+
+SomeOtherMessages Two lines  2: + ypto( SomeOtherMessages.
+ 			 getString( PKG, \"someothermessages_getstring_pkg.lines.02.scenario.02\" ) );
+
+SomeOtherMessages Two lines  3: + ypto( SomeOtherMessages.getString
+ 		( PKG, \"someothermessages_getstring_pkg.lines.02.scenario.03\" ) );
+
+SomeOtherMessages Two lines  4: + ypto( SomeOtherMessages.getString(
+ 	 PKG, \"someothermessages_getstring_pkg.lines.02.scenario.04\" ) );
+
+SomeOtherMessages Two lines  5: + ypto( SomeOtherMessages.getString( PKG
+,  \"someothermessages_getstring_pkg.lines.02.scenario.05\" ) );
+
+SomeOtherMessages Two lines  6: + ypto( SomeOtherMessages.getString( PKG,
+					\"someothermessages_getstring_pkg.lines.02.scenario.06\" ) );
+
+
+
+SomeOtherMessages Three lines  1: + ypto( SomeOtherMessages
+ 			 .getString(
+  	 PKG, \"someothermessages_getstring_pkg.lines.03.scenario.01\" ) );
+
+SomeOtherMessages Three lines  2: + ypto( SomeOtherMessages
+    .
+ 			 getString(  	 PKG, \"someothermessages_getstring_pkg.lines.03.scenario.02\" ) );
+
+SomeOtherMessages Three lines  3: + ypto( SomeOtherMessages. 			 getString
+  (	 PKG, \"someothermessages_getstring_pkg.lines.03.scenario.03\" ) );
+
+
+
+SomeOtherMessages Four lines  1: + ypto( SomeOtherMessages
+.
+ 			 getString(
+  	 PKG, \"someothermessages_getstring_pkg.lines.04.scenario.01\" ) );
+
+SomeOtherMessages Four lines  2: + ypto( SomeOtherMessages	.		
+ 			 getString
+			 (
+  	 PKG, \"someothermessages_getstring_pkg.lines.04.scenario.02\" ) );
+
+SomeOtherMessages Four lines  3: + ypto( SomeOtherMessages .
+ 			 getString
+			 (  	 PKG
+			 , \"someothermessages_getstring_pkg.lines.04.scenario.03\" ) );
+
+
+
+SomeOtherMessages Five lines  1: + ypto( SomeOtherMessages
+.
+ 			 getString
+ 			      (
+  	 PKG, \"someothermessages_getstring_pkg.lines.05.scenario.01\" ) );
+
+SomeOtherMessages Five lines  2: + ypto( SomeOtherMessages.	
+ 			 getString	
+ 			      (  	 
+	PKG
+	, \"someothermessages_getstring_pkg.lines.05.scenario.02\" ) );
+
+
+
+SomeOtherMessages Six lines  1: + ypto( SomeOtherMessages
+.
+ 			 getString
+ 			      (
+  	 PKG
+  	 ,         \"someothermessages_getstring_pkg.lines.06.scenario.01\" ) );
+
+SomeOtherMessages Six lines  2: + ypto( SomeOtherMessages
+
+.
+ 			 getString
+ 			      (
+  	 PKG  	 ,         \"someothermessages_getstring_pkg.lines.06.scenario.02\" ) );
+
+SomeOtherMessages Six lines  3: + ypto( SomeOtherMessages
+
+
+. 			 getString
+ 			      (
+  	 PKG  	 ,         \"someothermessages_getstring_pkg.lines.06.scenario.03\" ) );
+
+
+
+SomeOtherMessages Seven lines  1: + ypto( SomeOtherMessages
+.
+ 			 getString
+ 			      (
+  	 PKG
+  ,
+\"someothermessages_getstring_pkg.lines.07.scenario.01\" ) );
+
+
+
+SomeOtherMessages Incomplete source: + ypto( SomeOtherMessages.get_String( PKG,
+
+
+
+
+/* ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
+ * ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
+ *
+ *  "NotToBeDetectedMessages" scenarios: all should be detected and counted!
+ *
+ * ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
+ * ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** *****/
+
+
+NotToBeDetectedMessages One line  1: + ypto( NotToBeDetectedMessages.getString( PKG, \"nottobedetectedmessages_getstring_pkg.lines.01.scenario.01\" ) );
+
+NotToBeDetectedMessages One line  2: + ypto( NotToBeDetectedMessages.  getString( PKG, \"nottobedetectedmessages_getstring_pkg.lines.01.scenario.02\" ) );
+
+NotToBeDetectedMessages One line  3: + ypto( NotToBeDetectedMessages. 	 getString( PKG, \"nottobedetectedmessages_getstring_pkg.lines.01.scenario.03\" ) );
+
+NotToBeDetectedMessages One line  4: + ypto( NotToBeDetectedMessages.getString   ( PKG, \"nottobedetectedmessages_getstring_pkg.lines.01.scenario.04\" ) );
+
+NotToBeDetectedMessages One line  5: + ypto( NotToBeDetectedMessages.getString  	 ( PKG, \"nottobedetectedmessages_getstring_pkg.lines.01.scenario.05\" ) );
+
+NotToBeDetectedMessages One line  6: + ypto( NotToBeDetectedMessages.getString(    PKG, \"nottobedetectedmessages_getstring_pkg.lines.01.scenario.06\" ) );
+
+NotToBeDetectedMessages One line  7: + ypto( NotToBeDetectedMessages.getString(  	  PKG, \"nottobedetectedmessages_getstring_pkg.lines.01.scenario.07\" ) );
+
+
+
+NotToBeDetectedMessages Two lines  1: + ypto( NotToBeDetectedMessages 	
+ 			 . getString	( PKG, \"nottobedetectedmessages_getstring_pkg.lines.02.scenario.01\" ) );
+
+NotToBeDetectedMessages Two lines  2: + ypto( NotToBeDetectedMessages.
+ 			 getString( PKG, \"nottobedetectedmessages_getstring_pkg.lines.02.scenario.02\" ) );
+
+NotToBeDetectedMessages Two lines  3: + ypto( NotToBeDetectedMessages.getString
+ 		( PKG, \"nottobedetectedmessages_getstring_pkg.lines.02.scenario.03\" ) );
+
+NotToBeDetectedMessages Two lines  4: + ypto( NotToBeDetectedMessages.getString(
+ 	 PKG, \"nottobedetectedmessages_getstring_pkg.lines.02.scenario.04\" ) );
+
+NotToBeDetectedMessages Two lines  5: + ypto( NotToBeDetectedMessages.getString( PKG
+,  \"nottobedetectedmessages_getstring_pkg.lines.02.scenario.05\" ) );
+
+NotToBeDetectedMessages Two lines  6: + ypto( NotToBeDetectedMessages.getString( PKG,
+					\"nottobedetectedmessages_getstring_pkg.lines.02.scenario.06\" ) );
+
+
+
+NotToBeDetectedMessages Three lines  1: + ypto( NotToBeDetectedMessages
+ 			 .getString(
+  	 PKG, \"nottobedetectedmessages_getstring_pkg.lines.03.scenario.01\" ) );
+
+NotToBeDetectedMessages Three lines  2: + ypto( NotToBeDetectedMessages
+    .
+ 			 getString(  	 PKG, \"nottobedetectedmessages_getstring_pkg.lines.03.scenario.02\" ) );
+
+NotToBeDetectedMessages Three lines  3: + ypto( NotToBeDetectedMessages. 			 getString
+  (	 PKG, \"nottobedetectedmessages_getstring_pkg.lines.03.scenario.03\" ) );
+
+
+
+NotToBeDetectedMessages Four lines  1: + ypto( NotToBeDetectedMessages
+.
+ 			 getString(
+  	 PKG, \"nottobedetectedmessages_getstring_pkg.lines.04.scenario.01\" ) );
+
+NotToBeDetectedMessages Four lines  2: + ypto( NotToBeDetectedMessages	.		
+ 			 getString
+			 (
+  	 PKG, \"nottobedetectedmessages_getstring_pkg.lines.04.scenario.02\" ) );
+
+NotToBeDetectedMessages Four lines  3: + ypto( NotToBeDetectedMessages .
+ 			 getString
+			 (  	 PKG
+			 , \"nottobedetectedmessages_getstring_pkg.lines.04.scenario.03\" ) );
+
+
+
+NotToBeDetectedMessages Five lines  1: + ypto( NotToBeDetectedMessages
+.
+ 			 getString
+ 			      (
+  	 PKG, \"nottobedetectedmessages_getstring_pkg.lines.05.scenario.01\" ) );
+
+NotToBeDetectedMessages Five lines  2: + ypto( NotToBeDetectedMessages.	
+ 			 getString	
+ 			      (  	 
+	PKG
+	, \"nottobedetectedmessages_getstring_pkg.lines.05.scenario.02\" ) );
+
+
+
+NotToBeDetectedMessages Six lines  1: + ypto( NotToBeDetectedMessages
+.
+ 			 getString
+ 			      (
+  	 PKG
+  	 ,         \"nottobedetectedmessages_getstring_pkg.lines.06.scenario.01\" ) );
+
+NotToBeDetectedMessages Six lines  2: + ypto( NotToBeDetectedMessages
+
+.
+ 			 getString
+ 			      (
+  	 PKG  	 ,         \"nottobedetectedmessages_getstring_pkg.lines.06.scenario.02\" ) );
+
+NotToBeDetectedMessages Six lines  3: + ypto( NotToBeDetectedMessages
+
+
+. 			 getString
+ 			      (
+  	 PKG  	 ,         \"nottobedetectedmessages_getstring_pkg.lines.06.scenario.03\" ) );
+
+
+
+NotToBeDetectedMessages Seven lines  1: + ypto( NotToBeDetectedMessages
+.
+ 			 getString
+ 			      (
+  	 PKG
+  ,
+\"nottobedetectedmessages_getstring_pkg.lines.07.scenario.01\" ) );
+
+
+
+NotToBeDetectedMessages Incomplete source: + ypto( NotToBeDetectedMessages.get_String( PKG,


### PR DESCRIPTION
…ing(` \n ... "message"

The issue had a PR [(pentaho-kettle#4955)](https://github.com/pentaho/pentaho-kettle/pull/4955) contributed by the community (@Valeran86), however, while fixing the problem, it was only considering one possible scanPhrase (by hard-coding the scanPhrase "BaseMessages.getString( PKG,") - something one can't do because, by design, the translation system can work with several scanPhrases!

So I've changed the code in a more aggressive manner to calculate, for each scanPhrase configured, all the ways that it could be split over more than one source-code line. Now, each scanPhrase can have a new line both before and after any Java element and can be spread for more than two source-code line.

As the source change is big, I've added unit tests to guarantee the behaviour with one- to seven-line scenarios.


@pentaho/tatooine @pentaho-lmartins @ssamora 
