### PR TITLE
[SP-5180] Backport of PDI-17759 - XSD Validator step and job entry ar…

### DIFF
--- a/plugins/kettle-xml-plugin/src/org/pentaho/di/job/entries/xsdvalidator/JobEntryXSDValidator.java
+++ b/plugins/kettle-xml-plugin/src/org/pentaho/di/job/entries/xsdvalidator/JobEntryXSDValidator.java
@@ -190,7 +190,6 @@ public class JobEntryXSDValidator extends JobEntryBase implements Cloneable, Job
           // Prevent against XML Entity Expansion (XEE) attacks.
           // https://www.owasp.org/index.php/XML_Security_Cheat_Sheet#XML_Entity_Expansion
           if ( !isAllowExternalEntities() ) {
-            xsdValidator.setFeature( "http://apache.org/xml/features/disallow-doctype-decl", true );
             xsdValidator.setFeature( "http://xml.org/sax/features/external-general-entities", false );
             xsdValidator.setFeature( "http://xml.org/sax/features/external-parameter-entities", false );
             xsdValidator.setProperty( "http://apache.org/xml/properties/internal/entity-resolver",

--- a/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xsdvalidator/XsdValidator.java
+++ b/plugins/kettle-xml-plugin/src/org/pentaho/di/trans/steps/xsdvalidator/XsdValidator.java
@@ -237,7 +237,6 @@ public class XsdValidator extends BaseStep implements StepInterface {
         // Prevent against XML Entity Expansion (XEE) attacks.
         // https://www.owasp.org/index.php/XML_Security_Cheat_Sheet#XML_Entity_Expansion
         if ( !meta.isAllowExternalEntities() ) {
-          xsdValidator.setFeature( "http://apache.org/xml/features/disallow-doctype-decl", true );
           xsdValidator.setFeature( "http://xml.org/sax/features/external-general-entities", false );
           xsdValidator.setFeature( "http://xml.org/sax/features/external-parameter-entities", false );
           xsdValidator.setProperty( "http://apache.org/xml/properties/internal/entity-resolver",


### PR DESCRIPTION
…e vulnerable to XXE hacks (7.1 Suite)

@pentaho/tatooine
@pentaho-lmartins @ssamora

In 7.1 we use a Xerces version older than 2.3.0, for that reason http://apache.org/xml/features/disallow-doctype-decl feature didn't exist yet.

https://github.com/pentaho/pentaho-kettle/pull/6772