### PR TITLE
[PDI-18130] PDI is not logging sub-jobs and sub-transformations consi…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/logging/LoggingRegistry.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/LoggingRegistry.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -49,8 +50,8 @@ public class LoggingRegistry {
   private final Object syncObject = new Object();
 
   private LoggingRegistry() {
-    this.map = new ConcurrentHashMap<String, LoggingObjectInterface>();
-    this.childrenMap = new ConcurrentHashMap<String, List<String>>();
+    this.map = new ConcurrentHashMap<>();
+    this.childrenMap = new ConcurrentHashMap<>();
     this.fileWriterBuffers = new ConcurrentHashMap<>();
 
     this.lastModificationTime = new Date();
@@ -165,12 +166,14 @@ public class LoggingRegistry {
   }
 
   public List<String> getLogChannelChildren( String parentLogChannelId ) {
-    if ( parentLogChannelId == null ) {
-      return null;
+    synchronized ( this.syncObject ) {
+      if ( parentLogChannelId == null ) {
+        return null;
+      }
+      List<String> list = getLogChannelChildren( new ArrayList<>(), parentLogChannelId );
+      list.add( parentLogChannelId );
+      return list;
     }
-    List<String> list = getLogChannelChildren( new ArrayList<String>(), parentLogChannelId );
-    list.add( parentLogChannelId );
-    return list;
   }
 
   private List<String> getLogChannelChildren( List<String> children, String parentLogChannelId ) {
@@ -260,12 +263,43 @@ public class LoggingRegistry {
   }
 
   public LogChannelFileWriterBuffer getLogChannelFileWriterBuffer( String id ) {
-    for ( String bufferId : this.fileWriterBuffers.keySet() ) {
-      if ( getLogChannelChildren( bufferId ).contains( id ) ) {
-        return this.fileWriterBuffers.get( bufferId );
+    synchronized ( syncObject ) {
+      LogChannelFileWriterBuffer fileWriterBuffer = this.fileWriterBuffers.get( id );
+      if ( fileWriterBuffer != null ) {
+        return fileWriterBuffer;
       }
+
+      ConcurrentHashMap<LogChannelFileWriterBuffer, List<String>> possibleWriters = new ConcurrentHashMap<>();
+
+      for ( String bufferId : this.fileWriterBuffers.keySet() ) {
+        List<String> logChannelChildren = getLogChannelChildren( bufferId );
+        if ( logChannelChildren.contains( id ) ) {
+          possibleWriters.put( this.fileWriterBuffers.get( bufferId ), logChannelChildren );
+        }
+      }
+
+      //Just one writer so just return it
+      if ( possibleWriters.size() == 1 ) {
+        return possibleWriters.keys().nextElement();
+      } else {
+        //Several possibilities, so, lets get the writer among them that is the "lowest in the chain",
+        //meaning, the one that is not a parent of the others
+        Enumeration<LogChannelFileWriterBuffer> possibleWritersIds = possibleWriters.keys();
+        while ( possibleWritersIds.hasMoreElements() ) {
+          LogChannelFileWriterBuffer writer = possibleWritersIds.nextElement();
+          Set<Map.Entry<LogChannelFileWriterBuffer, List<String>>> entries = possibleWriters.entrySet();
+          for ( Map.Entry<LogChannelFileWriterBuffer, List<String>> entry : entries ) {
+            if ( entry.getKey().equals( writer ) ) {
+              continue;
+            }
+            if ( !entry.getValue().contains( writer.getLogChannelId() ) ) {
+              return entry.getKey();
+            }
+          }
+        }
+      }
+      return null;
     }
-    return null;
   }
 
   protected Set<String> getLogChannelFileWriterBufferIds() {

--- a/core/src/test/java/org/pentaho/di/core/logging/LoggingRegistryTest.java
+++ b/core/src/test/java/org/pentaho/di/core/logging/LoggingRegistryTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,6 +25,14 @@ package org.pentaho.di.core.logging;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -89,5 +97,89 @@ public class LoggingRegistryTest {
     loggingRegistry.removeLogChannelFileWriterBuffer( id );
 
     assertNull( loggingRegistry.getLogChannelFileWriterBuffer( id ) );
+  }
+
+  @Test
+  public void getLogChannelFileWriterBufferTest() {
+    LoggingRegistry loggingRegistry = LoggingRegistry.getInstance();
+
+    Map<String, LogChannelFileWriterBuffer> fileWriterBuffers = getDummyFileWriterBuffers();
+
+    Whitebox.setInternalState( loggingRegistry, "fileWriterBuffers", fileWriterBuffers );
+    Whitebox.setInternalState( loggingRegistry, "childrenMap", getDummyChildrenMap() );
+
+    assertEquals( loggingRegistry.getLogChannelFileWriterBuffer( "dcffc35f-c74f-4e37-b463-97313998ea20" ).getLogChannelId(), "dc8c1482-30ab-4d0f-b9f6-e4c32a627bf0" );
+
+    //Switch the order of the writers
+    fileWriterBuffers.remove( "7c1526bc-789e-4f5a-8d68-1f9c39488ceb" );
+    fileWriterBuffers.put( "7c1526bc-789e-4f5a-8d68-1f9c39488ceb", new LogChannelFileWriterBuffer( "7c1526bc-789e-4f5a-8d68-1f9c39488ceb" ) );
+    Whitebox.setInternalState( loggingRegistry, "fileWriterBuffers", fileWriterBuffers );
+
+    //regardless of the order of the writers the correct the same should be selected
+    assertEquals( loggingRegistry.getLogChannelFileWriterBuffer( "dcffc35f-c74f-4e37-b463-97313998ea20" ).getLogChannelId(), "dc8c1482-30ab-4d0f-b9f6-e4c32a627bf0" );
+  }
+
+  @Test
+  public void getLogChannelFileWriterBufferOnlyOnePossibilityTest() {
+    LoggingRegistry loggingRegistry = LoggingRegistry.getInstance();
+
+    Map<String, LogChannelFileWriterBuffer> fileWriterBuffers = getDummyFileWriterBuffers();
+
+    fileWriterBuffers.remove( "7c1526bc-789e-4f5a-8d68-1f9c39488ceb" );
+
+    Whitebox.setInternalState( loggingRegistry, "fileWriterBuffers", fileWriterBuffers );
+    Whitebox.setInternalState( loggingRegistry, "childrenMap", getDummyChildrenMap() );
+
+    assertEquals( loggingRegistry.getLogChannelFileWriterBuffer( "dcffc35f-c74f-4e37-b463-97313998ea20" ).getLogChannelId(), "dc8c1482-30ab-4d0f-b9f6-e4c32a627bf0" );
+  }
+
+  @Test
+  public void getLogChannelFileWriterBufferNoPossibilityTest() {
+    LoggingRegistry loggingRegistry = LoggingRegistry.getInstance();
+
+    Map<String, LogChannelFileWriterBuffer> fileWriterBuffers = getDummyFileWriterBuffers();
+
+    fileWriterBuffers.clear();
+
+    Whitebox.setInternalState( loggingRegistry, "fileWriterBuffers", fileWriterBuffers );
+    Whitebox.setInternalState( loggingRegistry, "childrenMap", getDummyChildrenMap() );
+
+    assertNull( loggingRegistry.getLogChannelFileWriterBuffer( "dcffc35f-c74f-4e37-b463-97313998ea20" ) );
+  }
+
+  private Map<String, LogChannelFileWriterBuffer> getDummyFileWriterBuffers() {
+    Map<String, LogChannelFileWriterBuffer> dummyFileWriterBuffers = new LinkedHashMap<>(  );
+
+    dummyFileWriterBuffers.put( "7c1526bc-789e-4f5a-8d68-1f9c39488ceb", new LogChannelFileWriterBuffer( "7c1526bc-789e-4f5a-8d68-1f9c39488ceb" ) );
+    dummyFileWriterBuffers.put( "dc8c1482-30ab-4d0f-b9f6-e4c32a627bf0", new LogChannelFileWriterBuffer( "dc8c1482-30ab-4d0f-b9f6-e4c32a627bf0" ) );
+
+    return dummyFileWriterBuffers;
+  }
+
+  private Map<String, List<String>> getDummyChildrenMap() {
+    Map<String, List<String>> childrenMap = new ConcurrentHashMap<>(  );
+
+    childrenMap.put( "4d345a50-4dc7-4d90-97d2-4123aa43d28f", new ArrayList<>( Arrays.asList( "23c0f002-7071-4c08-9b4a-cc179d206540", "d4bb8bbf-c765-49b6-9b85-f03c8621ba32" ) ) );
+    childrenMap.put( "bf3eb602-01c3-48d7-b357-7c28362fe4b9", new ArrayList<>( Arrays.asList( "2f1d7562-1aab-4a5d-aa90-ff1f410b9f52", "dc8c1482-30ab-4d0f-b9f6-e4c32a627bf0" ) ) );
+    childrenMap.put( "267315ad-d616-4d1a-8116-747dcb381ed4", new ArrayList<>( Arrays.asList( "0ac4993d-ebae-453c-850b-7e733c35b28a", "486da3f1-38d5-4151-b9c4-fb5b4978afe9" ) ) );
+    childrenMap.put( "1c33fa43-9a14-4191-8124-6f929421d744", new ArrayList<>( Arrays.asList( "7f1c7986-6373-4cd1-8638-cff7a6b1e7ec" ) ) );
+    childrenMap.put( "92d7d8f7-0cb8-416c-b728-a1d7fb998b8f", new ArrayList<>( Arrays.asList( "6095cfa7-8086-4fd0-83bf-8b191d85e16f" ) ) );
+    childrenMap.put( "9f1a8771-4934-4567-8d55-1deb7f0f3640", new ArrayList<>( Arrays.asList( "f4a87ce6-ce8f-4e96-87f5-9cbfef8a0676" ) ) );
+    childrenMap.put( "d4bb8bbf-c765-49b6-9b85-f03c8621ba32", new ArrayList<>( Arrays.asList( "dc2cc8c4-bdd6-4ebe-ac9e-8794bea3f9ef" ) ) );
+    childrenMap.put( "689cd0aa-96c7-4e79-9d04-e5f81f9d6aaf", new ArrayList<>( Arrays.asList( "267315ad-d616-4d1a-8116-747dcb381ed4" ) ) );
+    childrenMap.put( "dc2cc8c4-bdd6-4ebe-ac9e-8794bea3f9ef", new ArrayList<>( Arrays.asList( "cbe78766-f334-46eb-8863-9be04f379b2e", "689cd0aa-96c7-4e79-9d04-e5f81f9d6aaf","5f8cade2-c847-4fb8-8994-f0d4410c5591" ) ) );
+    childrenMap.put( "5f8cade2-c847-4fb8-8994-f0d4410c5591", new ArrayList<>( Arrays.asList( "8a7d5e5e-ef7b-4c5d-9e41-92f46aa84a79" ) ) );
+    childrenMap.put( "f443db9e-e486-4a48-aa6f-073b53729ac3", new ArrayList<>( Arrays.asList( "305365f2-617c-4fc3-b01d-49472fd2a947", "61cfe589-7895-4030-8e15-bd1590f9888f" ) ) );
+    childrenMap.put( "6276b8a5-6fcd-40ab-a112-f97fd2175150", new ArrayList<>( Arrays.asList( "f59c3faa-e953-4d8c-888d-f364588ac2a7", "7c1526bc-789e-4f5a-8d68-1f9c39488ceb" ) ) );
+    childrenMap.put( "17bce546-76a3-42c1-a587-b49fc99dd585", new ArrayList<>( Arrays.asList( "76a0cf8e-1f16-4b70-8c26-e35fbe0e5480" ) ) );
+    childrenMap.put( "7c1526bc-789e-4f5a-8d68-1f9c39488ceb", new ArrayList<>( Arrays.asList( "bf3eb602-01c3-48d7-b357-7c28362fe4b9" ) ) );
+    childrenMap.put( "f4a87ce6-ce8f-4e96-87f5-9cbfef8a0676", new ArrayList<>( Arrays.asList( "a49e997f-c3f6-4b12-a781-570cce18ffaf", "72b88d04-9c02-41e7-8085-c81b033bcffd", "1c33fa43-9a14-4191-8124-6f929421d744" ) ) );
+    childrenMap.put( "19e59a1f-62f9-454b-86ab-b422a44382b0", new ArrayList<>( Arrays.asList( "6d22adfd-0a33-43dc-9892-193e1cc9dc5e", "9f1a8771-4934-4567-8d55-1deb7f0f3640" ) ) );
+    childrenMap.put( "72b88d04-9c02-41e7-8085-c81b033bcffd", new ArrayList<>( Arrays.asList( "f443db9e-e486-4a48-aa6f-073b53729ac3" ) ) );
+    childrenMap.put( "dc8c1482-30ab-4d0f-b9f6-e4c32a627bf0", new ArrayList<>( Arrays.asList( "dcffc35f-c74f-4e37-b463-97313998ea20" ) ) );
+    childrenMap.put( "7f1c7986-6373-4cd1-8638-cff7a6b1e7ec", new ArrayList<>( Arrays.asList( "3f1c7d85-c4f7-4c34-9e17-c97f4579361e", "17bce546-76a3-42c1-a587-b49fc99dd585" ) ) );
+    childrenMap.put( "8a7d5e5e-ef7b-4c5d-9e41-92f46aa84a79", new ArrayList<>( Arrays.asList( "ee723784-6875-4055-8be9-504f0c4bfb9e", "92d7d8f7-0cb8-416c-b728-a1d7fb998b8f" ) ) );
+
+    return childrenMap;
   }
 }


### PR DESCRIPTION
…stently

@pentaho-lmartins 

Turns out that the getLogChannelFileWriterBuffer was not deterministic. We had different results depending on the order of the writers in fileWriterBuffers. Since both writers were a possibility according to getLogChannelFileWriterBuffer and it returned as soon has a mach was found it could end up returning an incorrect writer. (sometimes it work, sometimes it didn't).
What is being done here is after getting the possible writers we see which is the "lowest in the chain", meaning which of those is not the parent of any of the others. This way the method is now deterministic, regardless of the order in which writers might have end up in fileWriterBuffers.