### PR TITLE
[PDI-15259] Wrong architecture name for FreeBSD in spoon.sh

### DIFF
--- a/assemblies/core/static/src/main/resources-filtered/spoon.sh
+++ b/assemblies/core/static/src/main/resources-filtered/spoon.sh
@@ -191,23 +191,11 @@ case `uname -s` in
 		# linux compatibility packages installed
 	    ARCH=`uname -m`
 		case $ARCH in
-			x86_64)
-				LIBPATH=$CURRENTDIR/../libswt/linux/x86_64/
-				echo "I'm sorry, this FreeBSD platform [$ARCH] is not yet supported!"
-				exit
-				;;
-
 			i[3-6]86)
 				LIBPATH=$CURRENTDIR/../libswt/linux/x86/
 				;;
 
-			ppc)
-				LIBPATH=$CURRENTDIR/../libswt/linux/ppc/
-				echo "I'm sorry, this FreeBSD platform [$ARCH] is not yet supported!"
-				exit
-				;;
-
-			*)	
+			*)
 				echo "I'm sorry, this FreeBSD platform [$ARCH] is not yet supported!"
 				exit
 				;;

--- a/assemblies/static/src/main/resources-filtered/spoon.sh
+++ b/assemblies/static/src/main/resources-filtered/spoon.sh
@@ -191,23 +191,11 @@ case `uname -s` in
 		# linux compatibility packages installed
 	    ARCH=`uname -m`
 		case $ARCH in
-			x86_64)
-				LIBPATH=$CURRENTDIR/../libswt/linux/x86_64/
-				echo "I'm sorry, this FreeBSD platform [$ARCH] is not yet supported!"
-				exit
-				;;
-
 			i[3-6]86)
 				LIBPATH=$CURRENTDIR/../libswt/linux/x86/
 				;;
 
-			ppc)
-				LIBPATH=$CURRENTDIR/../libswt/linux/ppc/
-				echo "I'm sorry, this FreeBSD platform [$ARCH] is not yet supported!"
-				exit
-				;;
-
-			*)	
+			*)
 				echo "I'm sorry, this FreeBSD platform [$ARCH] is not yet supported!"
 				exit
 				;;

--- a/translator.sh
+++ b/translator.sh
@@ -112,24 +112,12 @@ case `uname -s` in
 	FreeBSD)
 	    ARCH=`uname -m`
 		case $ARCH in
-			x86_64)
-				LIBPATH=$BASEDIR/libswt/freebsd/x86_64/
-				echo "I'm sorry, this Linux platform [$ARCH] is not yet supported!"
-				exit
-				;;
-
 			i[3-6]86)
 				LIBPATH=$BASEDIR/libswt/freebsd/x86/
 				;;
 
-			ppc)
-				LIBPATH=$BASEDIR/libswt/freebsd/ppc/
-				echo "I'm sorry, this Linux platform [$ARCH] is not yet supported!"
-				exit
-				;;
-
-			*)	
-				echo "I'm sorry, this Linux platform [$ARCH] is not yet supported!"
+			*)
+				echo "I'm sorry, this FreeBSD platform [$ARCH] is not yet supported!"
 				exit
 				;;
 		esac


### PR DESCRIPTION
Removed the case options that were superfluous as they all basically had the behaviour that the default case has.


@pentaho/tatooine @pentaho-lmartins @ppatricio 