### PR TITLE
[PDI-18073] Bulk Loading steps returning NPE if previous steps does not have rows

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoader.java
@@ -580,6 +580,12 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
     return true;
   }
 
+  protected void verifyDatabaseConnection() throws KettleException {
+    if ( meta.getDatabaseMeta() == null ) {
+      throw new KettleException( BaseMessages.getString( PKG, "OraBulkLoaderMeta.GetSQL.NoConnectionDefined" ) );
+    }
+  }
+
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (OraBulkLoaderMeta) smi;
     data = (OraBulkLoaderData) sdi;
@@ -587,7 +593,16 @@ public class OraBulkLoader extends BaseStep implements StepInterface {
     Trans trans = getTrans();
     preview = trans.isPreview();
 
-    return super.init( smi, sdi );
+    if ( super.init( smi, sdi ) ) {
+      try {
+        verifyDatabaseConnection();
+      } catch ( KettleException ex ) {
+        logError( ex.getMessage() );
+        return false;
+      }
+      return true;
+    }
+    return false;
   }
 
   public void dispose( StepMetaInterface smi, StepDataInterface sdi ) {

--- a/engine/src/test/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkLoaderTest.java
@@ -45,9 +45,12 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Date;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -78,7 +81,7 @@ public class OraBulkLoaderTest {
   }
 
   @Before
-  public void setUp() throws Exception{
+  public void setUp() throws Exception {
     stepMockHelper = new StepMockHelper<OraBulkLoaderMeta, OraBulkLoaderData>( "TEST_CREATE_COMMANDLINE",
       OraBulkLoaderMeta.class, OraBulkLoaderData.class );
     when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
@@ -189,5 +192,19 @@ public class OraBulkLoaderTest {
 
     assertFalse( Files.exists( Paths.get( tempControlFilepath ) ) );
     assertFalse( Files.exists( Paths.get( tempDataFilepath ) ) );
+  }
+
+  @Test
+  public void testNoDatabaseConnection() {
+    assertFalse( oraBulkLoader.init( stepMockHelper.initStepMetaInterface, stepMockHelper.initStepDataInterface ) );
+
+    try {
+      // Verify that the database connection being set to null throws a KettleException with the following message.
+      oraBulkLoader.verifyDatabaseConnection();
+      // If the method does not throw a Kettle Exception, then the DB was set and not null for this test. Fail it.
+      fail( "Database Connection is not null, this fails the test." );
+    } catch ( KettleException aKettleException ) {
+      assertThat( aKettleException.getMessage(), containsString( "There is no connection defined in this step." ) );
+    }
   }
 }

--- a/plugins/gpload/core/src/main/java/org/pentaho/di/trans/steps/gpload/GPLoad.java
+++ b/plugins/gpload/core/src/main/java/org/pentaho/di/trans/steps/gpload/GPLoad.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.di.trans.steps.gpload;
@@ -642,6 +642,12 @@ public class GPLoad extends BaseStep implements StepInterface {
     return true;
   }
 
+  protected void verifyDatabaseConnection() throws KettleException {
+    if ( meta.getDatabaseMeta() == null ) {
+      throw new KettleException( BaseMessages.getString( PKG, "GPLoadMeta.GetSQL.NoConnectionDefined" ) );
+    }
+  }
+
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (GPLoadMeta) smi;
     data = (GPLoadData) sdi;
@@ -650,6 +656,13 @@ public class GPLoad extends BaseStep implements StepInterface {
     preview = trans.isPreview();
 
     if ( super.init( smi, sdi ) ) {
+
+      try {
+        verifyDatabaseConnection();
+      } catch ( KettleException ex ) {
+        logError( ex.getMessage() );
+        return false;
+      }
       return true;
     }
     return false;

--- a/plugins/gpload/core/src/test/java/org/pentaho/di/trans/steps/gpload/GPLoadTest.java
+++ b/plugins/gpload/core/src/test/java/org/pentaho/di/trans/steps/gpload/GPLoadTest.java
@@ -1,0 +1,76 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2019 Hitachi Vantara..  All rights reserved.
+ */
+package org.pentaho.di.trans.steps.gpload;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class GPLoadTest {
+  private StepMockHelper<GPLoadMeta, GPLoadData> stepMockHelper;
+  private GPLoad gpLoad;
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
+
+  @BeforeClass
+  public static void setupBeforeClass() throws KettleException {
+    KettleClientEnvironment.init();
+  }
+
+  @Before
+  public void setUp() {
+    stepMockHelper = new StepMockHelper<>( "TEST_GP_LOADER", GPLoadMeta.class, GPLoadData.class );
+    when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
+      stepMockHelper.logChannelInterface );
+    when( stepMockHelper.trans.isRunning() ).thenReturn( true );
+    gpLoad = spy( new GPLoad( stepMockHelper.stepMeta, stepMockHelper.stepDataInterface, 0,
+      stepMockHelper.transMeta, stepMockHelper.trans ) );
+  }
+
+  @After
+  public void cleanUp() {
+    stepMockHelper.cleanUp();
+  }
+
+  @Test
+  public void testNoDatabaseConnection() {
+    assertFalse( gpLoad.init( stepMockHelper.initStepMetaInterface, stepMockHelper.initStepDataInterface ) );
+
+    try {
+      // Verify that the database connection being set to null throws a KettleException with the following message.
+      gpLoad.verifyDatabaseConnection();
+      // If the method does not throw a Kettle Exception, then the DB was set and not null for this test. Fail it.
+      fail( "Database Connection is not null, this fails the test." );
+    } catch ( KettleException aKettleException ) {
+      assertThat( aKettleException.getMessage(), containsString( "There is no connection defined in this step." ) );
+    }
+  }
+}


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @wseyler  

* [PDI-18073] Added a database connection null check to verify that if someone fails to put in a database connection, the error log will state that's what is missing.
* [PDI-18073] Added test cases to verify this check.

Part of a set of PRs:
- https://github.com/pentaho/pentaho-kettle/pull/6798
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/49