### PR TITLE
[PDI-18211] JSON Input Step Performance Degradation in 8.3

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
@@ -51,6 +51,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.Comparator;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class KettleVFS {
   public static final String TEMP_DIR = System.getProperty( "java.io.tmpdir" );
@@ -118,82 +120,123 @@ public class KettleVFS {
     return getFileObject( vfsFilename, defaultVariableSpace, fsOptions );
   }
 
-  public static FileObject getFileObject( String vfsFilename, VariableSpace space, FileSystemOptions fsOptions )
-    throws KettleFileException {
+  private static boolean hasScheme( String path ) {
+    return path != null && path.contains( "://" );
+  }
+  //For PPP-4374 - hdfs provider was not loaded in time and it caused a false positive for relativePath boolean
+  private static boolean isMarkedAsRelativePathButSillHasScheme( String path ) {
+    return isRelativePath( path ) && hasScheme( path );
+  }
+
+  protected static boolean isRelativePath( String path ) {
+    // We have one problem with VFS: if the file is in a subdirectory of the current one: somedir/somefile
+    // In that case, VFS doesn't parse the file correctly.
+    // We need to put file: in front of it to make it work.
+    // However, how are we going to verify this?
+    //
+    // We are going to see if the filename starts with one of the known protocols like file: zip: ram: smb: jar: etc.
+    // If not, we are going to assume it's a file.
+    //
+    FileSystemManager fsManager = getInstance().getFileSystemManager();
+    String[] initialSchemes = fsManager.getSchemes();
+
+    boolean relativeFilename = true;
+
+    for ( int i = 0; i < initialSchemes.length && relativeFilename; i++ ) {
+      if ( path != null && path.startsWith( initialSchemes[ i ] + ":" ) ) {
+        relativeFilename = false;
+      }
+    }
+
+    return relativeFilename;
+  }
+  //For PDI-18211 - now we validate/throw an exception when we have invalid formats
+  protected static String getScheme( String absolutePath ) throws KettleFileException {
+    String scheme;
     try {
-      fsOptionsForScheme = fsOptions;
-      FileSystemManager fsManager = getInstance().getFileSystemManager();
+      scheme = new URI( absolutePath.replace( "\\", "/" ) ).getScheme();
+    } catch ( URISyntaxException e ) {
+      throw new KettleFileException( "Invalid URI to get VFS File object '"
+        + cleanseFilename( absolutePath ) + "' : " + e.getMessage(), e );
+    }
+    return scheme;
+  }
 
-      // We have one problem with VFS: if the file is in a subdirectory of the current one: somedir/somefile
-      // In that case, VFS doesn't parse the file correctly.
-      // We need to put file: in front of it to make it work.
-      // However, how are we going to verify this?
-      //
-      // We are going to see if the filename starts with one of the known protocols like file: zip: ram: smb: jar: etc.
-      // If not, we are going to assume it's a file.
-      //
-      boolean relativeFilename = true;
-      String[] initialSchemes = fsManager.getSchemes();
+  protected static String normalizePath( String path ) {
+    String normalizedPath = path;
 
-      relativeFilename = checkForScheme( initialSchemes, relativeFilename, vfsFilename, space, fsOptionsForScheme );
+    if ( path.startsWith( "\\\\" ) ) {
+      File file = new File( path );
+      normalizedPath = file.toURI().toString();
+    } else if ( isRelativePath(  path ) ) {
+      File file = new File( path );
+      normalizedPath = file.getAbsolutePath();
+    }
 
-      int timeOut = TIMEOUT_LIMIT;
+    return normalizedPath;
+  }
 
-      boolean hasScheme = vfsFilename != null && vfsFilename.contains( "://" ); // check for bigData providers
-      //we have to check for hasScheme even if it is marked as a relative path because that scheme could not
-      //be available by getSchemes at the time we validate our relativeFilename flag.
-      //So we check if even it is marked as relative path if it contains a possible scheme format
-      //if it does, then give it some time to be loaded, until we get it our timeout is up.
+  protected static FileObject myGetFileObject( String vfsFilename, VariableSpace space, FileSystemOptions fsOptions )
+    throws IOException, KettleFileException {
+    String absolutePath = normalizePath( vfsFilename );
+    String scheme = getScheme( absolutePath );
 
-      while ( relativeFilename && hasScheme && timeOut > 0 ) {
-        String[] schemes = fsManager.getSchemes();
+    FileSystemManager fsManager = getInstance().getFileSystemManager();
+
+    if ( scheme != null && !scheme.isEmpty() ) {
+      // All other providers
+      fsOptionsForScheme = buildFsOptions( space, fsOptions, absolutePath, scheme );
+      return fsManager.resolveFile( absolutePath, fsOptions );
+    }
+
+    return fsManager.resolveFile( absolutePath );
+
+  }
+
+  protected static FileObject myWaitGetFileObject( String vfsFilename, VariableSpace space, FileSystemOptions fsOptions,
+                                                 int timeOut )
+    throws KettleFileException {
+
+    try {
+      boolean isRelativePath = isRelativePath( vfsFilename );
+      String scheme = getScheme( vfsFilename );
+
+      // Wait for scheme to be available for FileObject
+      while ( isRelativePath && hasScheme( vfsFilename ) && scheme != null && timeOut > 0  ) {
+        int timeoutStep = TIME_TO_SLEEP_STEP;
+        timeOut -= timeoutStep;
         try {
-          Thread.sleep( TIME_TO_SLEEP_STEP );
-          timeOut -= TIME_TO_SLEEP_STEP;
-          relativeFilename = checkForScheme( schemes, relativeFilename, vfsFilename, space, fsOptionsForScheme );
+          Thread.sleep( timeoutStep );
+          //check again for relativePath boolean:
+          //true - keeps the loop running - scheme not found yet - still a relativePath
+          //false - end loop - a scheme was found - it was a false relativePath
+          isRelativePath = isRelativePath( vfsFilename );
         } catch ( InterruptedException e ) {
-          relativeFilename = false;
+          isRelativePath = false;
           Thread.currentThread().interrupt();
           break;
         }
       }
 
-      String filename;
-      if ( vfsFilename.startsWith( "\\\\" ) ) {
-        File file = new File( vfsFilename );
-        filename = file.toURI().toString();
-      } else {
-        if ( relativeFilename ) {
-          File file = new File( vfsFilename );
-          filename = file.getAbsolutePath();
-        } else {
-          filename = vfsFilename;
-        }
+      // time is up or provider found
+      if ( isMarkedAsRelativePathButSillHasScheme( vfsFilename ) ) {
+        throw new KettleFileException( "Unable to get Scheme for filename: " + cleanseFilename( vfsFilename ) );
       }
 
-      if ( fsOptionsForScheme != null ) {
-        return fsManager.resolveFile( filename, fsOptionsForScheme );
-      } else {
-        return fsManager.resolveFile( filename );
-      }
-    } catch ( IOException e ) {
+      return myGetFileObject( vfsFilename, space, fsOptions );
+
+    } catch ( IOException | KettleFileException e ) {
       throw new KettleFileException( "Unable to get VFS File object for filename '"
         + cleanseFilename( vfsFilename ) + "' : " + e.getMessage(), e );
     }
+
   }
 
-  protected static boolean checkForScheme( String[] initialSchemes, boolean relativeFilename, String vfsFilename,
-                                         VariableSpace space, FileSystemOptions fsOptions )
-    throws IOException {
-    for ( int i = 0; i < initialSchemes.length && relativeFilename; i++ ) {
-      if ( vfsFilename.startsWith( initialSchemes[ i ] + ":" ) ) {
-        relativeFilename = false;
-        // We have a VFS URL, load any options for the file system driver
-        fsOptionsForScheme = buildFsOptions( space, fsOptions, vfsFilename, initialSchemes[ i ] );
-      }
-    }
-    return relativeFilename;
+  public static FileObject getFileObject( String vfsFilename, VariableSpace space, FileSystemOptions fsOptions ) throws KettleFileException {
+    fsOptionsForScheme = fsOptions;
+    return myWaitGetFileObject(  vfsFilename,  space,  fsOptions, TIMEOUT_LIMIT );
   }
+
 
   /**
    * Private method for stripping password from filename when a FileObject

--- a/core/src/test/java/org/pentaho/di/core/vfs/KettleVFSTest.java
+++ b/core/src/test/java/org/pentaho/di/core/vfs/KettleVFSTest.java
@@ -22,17 +22,13 @@
 
 package org.pentaho.di.core.vfs;
 
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
-
-
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleFileException;
 
-
-import java.io.IOException;
-
+import java.io.File;
 
 public class KettleVFSTest {
 
@@ -52,23 +48,75 @@ public class KettleVFSTest {
 
 
   @Test
-  public void testCheckForSchemeSuccess() throws KettleFileException, IOException {
-    String[] schemes = {"hdfs"};
+  public void testCheckForSchemeSuccess() throws KettleFileException {
     String vfsFilename = "hdfs://hsbcmaster.labs.eag.hitachivantara.com:8020/tmp/acltest/";
 
-    boolean test = KettleVFS.checkForScheme(schemes, true, vfsFilename, null, null);
-    assertFalse( test );
+    boolean test = "hdfs".equals( KettleVFS.getScheme( vfsFilename ) );
+    assertTrue( test );
+  }
 
+  @Test( expected = KettleFileException.class )
+  public void testCheckForSchemeFailWithException() throws KettleFileException {
+    String invalidVfsFilename = "{\"textMessage\":{\"textMessage\":\" textMessage"
+      + "textMessage \",\"textMessage\":{textMessage}}}";
+
+    KettleVFS.getScheme( invalidVfsFilename );
   }
 
   @Test
-  public void testCheckForSchemeFail() throws KettleFileException, IOException {
-    String[] schemes = {"file"};
+  public void testCheckForSchemeFail() throws KettleFileException {
     String vfsFilename = "hdfs://hsbcmaster.labs.eag.hitachivantara.com:8020/tmp/acltest/";
 
-    boolean test = KettleVFS.checkForScheme(schemes, true, vfsFilename, null, null);
-    assertTrue( test );
+    boolean test = "file".equals( KettleVFS.getScheme( vfsFilename ) );
+    assertFalse( test );
+  }
 
+  @Test
+  public void testIfSchemeIsRelativePath() {
+    String vfsFilename = "file://hsbcmaster.labs.eag.hitachivantara.com:8020/tmp/acltest/";
+
+    boolean testVfsFilename =  KettleVFS.isRelativePath( vfsFilename );
+    assertFalse( testVfsFilename );
+  }
+
+  @Test
+  public void testIfRelativePathIsRelativePath() {
+    String relativePathVfsFilename = "/tmp/acltest/";
+
+    boolean testRelativePathVfsFilename =  KettleVFS.isRelativePath( relativePathVfsFilename );
+    assertTrue( testRelativePathVfsFilename );
+  }
+
+  @Test
+  public void testIfBlankIsRelativePath() {
+    String blankVfsFilename =  "";
+
+    boolean testBlankVfsFilename =  KettleVFS.isRelativePath( blankVfsFilename );
+    assertTrue( testBlankVfsFilename );
+  }
+
+  @Test
+  public void testIfNullIsRelativePath() {
+    String nullVfsFilename = null;
+
+    boolean testNullVfsFilename = KettleVFS.isRelativePath( nullVfsFilename );
+    assertTrue( testNullVfsFilename );
+  }
+
+  @Test
+  public void testNormalizePathWithFile() {
+    String vfsFilename = "\\\\tmp/acltest.txt";
+
+    String testNormalizePath = KettleVFS.normalizePath( vfsFilename );
+    assertTrue( testNormalizePath.startsWith( "file:/" )  );
+  }
+
+  @Test
+  public void testNormalizePath() {
+    String vfsFilename = "tmp/acltest";
+
+    String testNormalizePath = KettleVFS.normalizePath( vfsFilename );
+    assertEquals( new File( vfsFilename ).getAbsolutePath(), testNormalizePath );
   }
 
 }


### PR DESCRIPTION
The PPP-4374 case ( https://github.com/pentaho/pentaho-kettle/pull/6641 ) popped up some invalid getObject calls. For instance, it looks likes kettleAnalyzerUtil.java (pentaho-metaverse) calls KettleVFS and then saves the result as resource even if **it is not a valid file path**, so we should be validating if we really want to request a "getFileObject" from a whole json string as argument, and not just validating if it is empty:
https://github.com/pentaho/pentaho-metaverse/blob/master/api/src/main/java/org/pentaho/metaverse/api/analyzer/kettle/KettleAnalyzerUtil.java#L156

At the same time KettleVFS should also be prepared to deal with this. And we have more cases where this also happen. This PR added a scheme validation (getScheme function) that now throws an exception with invalid paths instead of a valid fileObject (that in fact does not exists...)

A refactoring was also made and a few more tests were added/adapted to the new behavior.

@mkambol @pentaho-lmartins 