### PR TITLE
[PDI-18205] 'Copy Rows to Result' step is not passing rows to later t…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1257,7 +1257,9 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
     Result newResult = trans.getResult();
     result.clear(); // clear only the numbers, NOT the files or rows.
     result.add( newResult );
-    result.setRows( newResult.getRows() );
+    if ( !Utils.isEmpty( newResult.getRows() ) || trans.isResultRowsSet() ) {
+      result.setRows( newResult.getRows() );
+    }
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -282,6 +282,11 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
   private List<StepMetaDataCombi> steps;
 
   /**
+   * Indicates if the result rows have been set
+   */
+  private boolean resultRowsSet;
+
+  /**
    * The class number.
    */
   public int class_nr;
@@ -5669,6 +5674,14 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
       backwardChange = false;
 
     } // finished sorting
+  }
+
+  public void setResultRowSet( boolean resultRowsSet ) {
+    this.resultRowsSet = resultRowsSet;
+  }
+
+  public boolean isResultRowsSet() {
+    return resultRowsSet;
   }
 
   @Override

--- a/engine/src/main/java/org/pentaho/di/trans/steps/rowstoresult/RowsToResult.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/rowstoresult/RowsToResult.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -57,9 +57,8 @@ public class RowsToResult extends BaseStep implements StepInterface {
 
     Object[] r = getRow(); // get row, set busy!
     if ( r == null ) { // no more input to be expected...
-
       getTrans().getResultRows().addAll( data.rows );
-
+      getTrans().setResultRowSet( true );
       setOutputDone();
       return false;
     }

--- a/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
@@ -357,26 +357,54 @@ public class JobEntryTransTest {
 
   @Test
   public void updateResultTest() {
-    updateResultTest( 3, 5 );
+    JobEntryTrans jobEntryTrans = spy( getJobEntryTrans() );
+    Trans transMock = mock( Trans.class );
+    setInternalState( jobEntryTrans, "trans", transMock );
+    //Transformation returns result with 5 rows
+    when( transMock.getResult() ).thenReturn( generateDummyResult( 5 ) );
+    //Previous result has 3 rows
+    Result resultToBeUpdated = generateDummyResult( 3 );
+    //Update the result
+    jobEntryTrans.updateResult( resultToBeUpdated );
+    //Result should have 5 number of rows since the trans result has 5 rows (meaning 5 rows were returned)
+    assertEquals( resultToBeUpdated.getRows().size(), 5 );
   }
 
   @Test
   public void updateResultTestWithZeroRows() {
-    updateResultTest( 3, 0 );
-  }
-
-  private void updateResultTest( int previousRowsResult, int newRowsResult ) {
     JobEntryTrans jobEntryTrans = spy( getJobEntryTrans() );
     Trans transMock = mock( Trans.class );
     setInternalState( jobEntryTrans, "trans", transMock );
-    //Transformation returns result with <newRowsResult> rows
-    when( transMock.getResult() ).thenReturn( generateDummyResult( newRowsResult ) );
-    //Previous result has <previousRowsResult> rows
-    Result resultToBeUpdated = generateDummyResult( previousRowsResult );
+    //Transformation returns result with 0 rows
+    when( transMock.getResult() ).thenReturn( generateDummyResult( 0 ) );
+    //Previous result has 3 rows
+    Result resultToBeUpdated = generateDummyResult( 3 );
     //Update the result
     jobEntryTrans.updateResult( resultToBeUpdated );
-    //Result should have the number of rows of the transformation result
-    assertEquals( resultToBeUpdated.getRows().size(), newRowsResult );
+    //Result should have 3 number of rows since the trans result has no rows (meaning nothing was done)
+    assertEquals( resultToBeUpdated.getRows().size(), 3 );
+  }
+
+  @Test
+  public void updateResultTestWithZeroRowsForced() {
+    JobEntryTrans jobEntryTrans = spy( getJobEntryTrans() );
+    Trans transMock = mock( Trans.class );
+    setInternalState( jobEntryTrans, "trans", transMock );
+    //Transformation returns result with 0 rows
+    when( transMock.getResult() ).thenReturn( generateDummyResult( 0 ) );
+    //Previous result has 3 rows
+    Result resultToBeUpdated = generateDummyResult( 3 );
+    //Result Set Was updated
+    when( transMock.isResultRowsSet() ).thenReturn( true );
+    //Update the result
+    jobEntryTrans.updateResult( resultToBeUpdated );
+    //Result should have zero number of rows since the result rows has no rows but the result set was in fact updated
+    //(meaning something was done that resulted in zero rows.
+    assertEquals( resultToBeUpdated.getRows().size(), 0 );
+  }
+
+  private void updateResultTest( int previousRowsResult, int newRowsResult ) {
+
   }
 
   private Result generateDummyResult( int nRows ) {


### PR DESCRIPTION
…ransformation in job if transformations in between do not use 'Copy Rows to Result'

@smmribeiro @pentaho/tatooine @ppatricio @bantonio82

This error was introduced by PDI-17926. Before PDI-17926 if a result set of rows of a transformation did not had any rows, the rows were not changed in the result of the Job. The problem is that if Tranformation did some kind of filtering that ended up in zero rows and Copied the Results, those results were not copied. The change was to also copy for zero rows. This caused the error reported here because we could have zero rows also if nothing is done. 
We had no way to distinguish if a result with zero rows is  just because nothing was done (and should be ignored) or if it is a result of some kind of filtering and it is exactly the expected result (and should set the result to zero). This PR solves both cases.