### PR TITLE
[PDI-18227] Nulls do not initialize variables when passed

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1693,7 +1693,10 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       // Set fieldNameParameter only if exists and if it is not declared any staticValue( parameterValues array )
       //
       String thisValue = namedParam.getParameterValue( parameters[ idx ] );
-      // Set value only if is not empty at namedParam and exists in parameterFieldNames
+      // Default Case - init with null: for blanks ( Strings ) or nulls ( other types ) cases to reset/clean previous
+      // values of the same parameter
+      jobEntryTrans.setVariable( parameters[ idx ], null );
+      // Then set value only if is not empty at namedParam and exists in parameterFieldNames
       if ( !Utils.isEmpty( thisValue ) && idx < parameterFieldNames.length ) {
         // If exists then ask if is not empty
         if ( !Utils.isEmpty( Const.trim( parameterFieldNames[ idx ] ) ) ) {

--- a/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
@@ -266,6 +266,55 @@ public class JobEntryTransTest {
   }
 
   @Test
+  public void testPrepareFieldNamesParametersWithNulls() throws UnknownParamException {
+    // array of params
+    String[] parameterNames = new String[5];
+    parameterNames[0] = "param1";
+    parameterNames[1] = "param2";
+    parameterNames[2] = "param3";
+    parameterNames[3] = "param4";
+    parameterNames[4] = "param5";
+
+    // array of fieldNames params
+    String[] parameterFieldNames = new String[5];
+    parameterFieldNames[0] = null;
+    parameterFieldNames[2] = "ValueParam3";
+    parameterFieldNames[3] = "FieldValueParam4";
+    parameterFieldNames[4] = "FieldValueParam5";
+
+    // array of parameterValues params
+    String[] parameterValues = new String[5];
+    parameterValues[1] = "ValueParam2";
+    parameterValues[3] = "";
+    parameterValues[4] = "StaticValueParam5";
+
+
+    JobEntryTrans jet = new JobEntryTrans();
+    VariableSpace variableSpace = new Variables();
+    jet.copyVariablesFrom( variableSpace );
+
+    //at this point StreamColumnNameParams are already inserted in namedParams
+    NamedParams namedParam = Mockito.mock( NamedParamsDefault.class );
+    Mockito.doReturn( "value1" ).when( namedParam ).getParameterValue(  "param1" );
+    Mockito.doReturn( "value2" ).when( namedParam ).getParameterValue(  "param2" );
+    Mockito.doReturn( "value3" ).when( namedParam ).getParameterValue(  "param3" );
+    Mockito.doReturn( "value4" ).when( namedParam ).getParameterValue(  "param4" );
+    Mockito.doReturn( "value5" ).when( namedParam ).getParameterValue(  "param5" );
+
+    jet.prepareFieldNamesParameters( parameterNames, parameterFieldNames, parameterValues, namedParam, jet );
+    // "param1" has parameterFieldName value = null and no parameterValues defined so it should be null
+    Assert.assertEquals( null, jet.getVariable( "param1" ) );
+    // "param2" has only parameterValues defined and no parameterFieldName value so it should be null
+    Assert.assertEquals( null, jet.getVariable( "param2" ) );
+    // "param3" has only the parameterFieldName defined so it should return the mocked value
+    Assert.assertEquals( "value3", jet.getVariable( "param3" ) );
+    // "param4" has parameterFieldName and also an empty parameterValues defined so it should return the mocked value
+    Assert.assertEquals( "value4", jet.getVariable( "param4" ) );
+    // "param5" has parameterFieldName and also parameterValues defined with a not empty value so it should return null
+    Assert.assertEquals( null, jet.getVariable( "param5" ) );
+  }
+
+  @Test
   public void testGetTransMeta() throws KettleException {
     String param1 = "param1";
     String param2 = "param2";


### PR DESCRIPTION
This case is related with a non-existing condition of clearing out previous values from previous executions in case of actual values are empty or null.
That logic was added in this PR.

A new test was added for the actual possible parameter definition combinations on a JobEntryTrans Step

@ssamora 