### PR TITLE
[SP-5202] Backport of BACKLOG-29956 - AEL: Hive Warehouse Connector d…

### DIFF
--- a/engine/src/main/resources/org/pentaho/di/trans/steps/tableinput/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/tableinput/messages/messages_en_US.properties
@@ -34,6 +34,7 @@ TableInputDialog.ExecuteForEachRow=Execute for each row?
 TableInputDialog.DialogCaptionError=ERROR
 TableInputDialog.SQL=SQL 
 TableInputDialog.LazyConversion=Enable lazy conversion
+TableInputDialog.CacheRowMeta=Store column info in step meta data
 TableInputDialog.ButtonPreview=\ &Preview 
 TableInputDialog.DialogCaptionQuestion=Question?
 TableInputDialog.NumberOfRowsToPreview=Enter the number of rows you would like to preview\:

--- a/engine/src/test/java/org/pentaho/di/trans/steps/tableinput/TableInputMetaInjectionTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/tableinput/TableInputMetaInjectionTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -61,6 +61,11 @@ public class TableInputMetaInjectionTest extends BaseMetadataInjectionTest<Table
     check( "LAZY_CONVERSION", new BooleanGetter() {
       public boolean get() {
         return meta.isLazyConversionActive();
+      }
+    } );
+    check( "CACHED_ROW_META", new BooleanGetter() {
+      public boolean get() {
+        return meta.isCachedRowMetaActive();
       }
     } );
     skipPropertyTest( "CONNECTIONNAME" );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/tableinput/TableInputMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/tableinput/TableInputMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -72,7 +72,8 @@ public class TableInputMetaTest {
     KettleEnvironment.init();
     PluginRegistry.init( false );
     List<String> attributes =
-        Arrays.asList( "databaseMeta", "sQL", "rowLimit", "executeEachInputRow", "variableReplacementActive", "lazyConversionActive" );
+      Arrays.asList( "databaseMeta", "sQL", "rowLimit", "executeEachInputRow", "variableReplacementActive",
+        "lazyConversionActive", "cachedRowMetaActive" );
 
     Map<String, String> getterMap = new HashMap<String, String>();
     Map<String, String> setterMap = new HashMap<String, String>();
@@ -82,7 +83,7 @@ public class TableInputMetaTest {
     Map<String, FieldLoadSaveValidator<?>> typeValidatorMap = new HashMap<String, FieldLoadSaveValidator<?>>();
 
     loadSaveTester =
-        new LoadSaveTester( testMetaClass, attributes, getterMap, setterMap, attrValidatorMap, typeValidatorMap );
+      new LoadSaveTester( testMetaClass, attributes, getterMap, setterMap, attrValidatorMap, typeValidatorMap );
   }
 
   @Test

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/tableinput/TableInputDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/tableinput/TableInputDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -105,6 +105,10 @@ public class TableInputDialog extends BaseStepDialog implements StepDialogInterf
   private Label wlLazyConversion;
   private Button wLazyConversion;
   private FormData fdlLazyConversion, fdLazyConversion;
+
+  private Label wlCachedRowMeta;
+  private Button wCachedRowMeta;
+  private FormData fdlCachedRowMeta, fdCachedRowMeta;
 
   private Button wbTable;
   private FormData fdbTable;
@@ -297,12 +301,35 @@ public class TableInputDialog extends BaseStepDialog implements StepDialogInterf
       }
     } );
 
+    // Cached Row Meta conversion?
+    //
+    wlCachedRowMeta = new Label( shell, SWT.RIGHT );
+    wlCachedRowMeta.setText( BaseMessages.getString( PKG, "TableInputDialog.CacheRowMeta" ) );
+    props.setLook( wlCachedRowMeta );
+    fdlCachedRowMeta = new FormData();
+    fdlCachedRowMeta.left = new FormAttachment( 0, 0 );
+    fdlCachedRowMeta.right = new FormAttachment( middle, -margin );
+    fdlCachedRowMeta.bottom = new FormAttachment( wLazyConversion, -margin );
+    wlCachedRowMeta.setLayoutData( fdlCachedRowMeta );
+    wCachedRowMeta = new Button( shell, SWT.CHECK );
+    props.setLook( wCachedRowMeta );
+    fdCachedRowMeta = new FormData();
+    fdCachedRowMeta.left = new FormAttachment( middle, 0 );
+    fdCachedRowMeta.right = new FormAttachment( 100, 0 );
+    fdCachedRowMeta.bottom = new FormAttachment( wLazyConversion, -margin );
+    wCachedRowMeta.setLayoutData( fdCachedRowMeta );
+    wCachedRowMeta.addSelectionListener( new SelectionAdapter() {
+      public void widgetSelected( SelectionEvent arg0 ) {
+        input.setChanged();
+      }
+    } );
+
     wlPosition = new Label( shell, SWT.NONE );
     props.setLook( wlPosition );
     fdlPosition = new FormData();
     fdlPosition.left = new FormAttachment( 0, 0 );
     fdlPosition.right = new FormAttachment( 100, 0 );
-    fdlPosition.bottom = new FormAttachment( wLazyConversion, -margin );
+    fdlPosition.bottom = new FormAttachment( wCachedRowMeta, -margin );
     wlPosition.setLayoutData( fdlPosition );
 
     // Table line...
@@ -485,6 +512,7 @@ public class TableInputDialog extends BaseStepDialog implements StepDialogInterf
 
     wVariables.setSelection( input.isVariableReplacementActive() );
     wLazyConversion.setSelection( input.isLazyConversionActive() );
+    wCachedRowMeta.setSelection( input.isCachedRowMetaActive() );
 
     setSQLToolTip();
     setFlags();
@@ -523,6 +551,7 @@ public class TableInputDialog extends BaseStepDialog implements StepDialogInterf
     meta.setExecuteEachInputRow( wEachRow.getSelection() );
     meta.setVariableReplacementActive( wVariables.getSelection() );
     meta.setLazyConversionActive( wLazyConversion.getSelection() );
+    meta.setCachedRowMetaActive( wCachedRowMeta.getSelection() );
   }
 
   private void ok() {
@@ -534,6 +563,7 @@ public class TableInputDialog extends BaseStepDialog implements StepDialogInterf
     // copy info to TextFileInputMeta class (input)
 
     getInfo( input, false );
+    input.updateCachedRowMeta();
 
     if ( input.getDatabaseMeta() == null ) {
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );


### PR DESCRIPTION
…oes not work in secure environment (8.3 Suite)

* [BACKLOG-29956]  Added cache flag/checkbox so we do not access the database every time getFields is called by down streams steps (useful in AEL / Spark)

* [BACKLOG-29956] Fixing formatting / license issues

* [BACKLOG-29956]  Fixed bug in UI where the downstream getFields methods were not returning the new values if columns changed.

@pentaho/tatooine 
@ssamora 
@RPAraujo @smmribeiro
@baudekin @ccaspanello 