### PR TITLE
[PDI-17667] Use of vulnerable component jetty 8.1.15, CVE-2017-9735, …

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,7 +30,6 @@
     <commons-io.version>2.2</commons-io.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-pool.version>1.5.7</commons-pool.version>
-    <jetty-util.version>8.1.15.v20140411</jetty-util.version>
     <jug-lgpl.version>2.0.0</jug-lgpl.version>
     <jsch.version>0.1.54</jsch.version>
     <jzlib.version>1.0.7</jzlib.version>
@@ -353,7 +352,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>${jetty-util.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -80,12 +80,6 @@
     <mstor.version>0.9.13</mstor.version>
     <snappy-java.version>1.1.0</snappy-java.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <jetty-plus.version>8.1.15.v20140411</jetty-plus.version>
-    <jetty-server.version>8.1.15.v20140411</jetty-server.version>
-    <jetty-security.version>8.1.15.v20140411</jetty-security.version>
-    <jetty-servlet.version>8.1.15.v20140411</jetty-servlet.version>
-    <jetty-xml.version>8.1.15.v20140411</jetty-xml.version>
-    <jetty-webapp.version>8.1.15.v20140411</jetty-webapp.version>
     <log4jdbc.version>1.2</log4jdbc.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <oro.version>2.0.8</oro.version>
@@ -761,7 +755,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-plus</artifactId>
-      <version>${jetty-plus.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -772,7 +765,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>${jetty-server.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty.orbit</groupId>
@@ -783,7 +775,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
-      <version>${jetty-security.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -794,7 +785,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>${jetty-servlet.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -805,7 +795,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-xml</artifactId>
-      <version>${jetty-xml.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -816,7 +805,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
-      <version>${jetty-webapp.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -17,7 +17,6 @@
   </parent>
 
   <properties>
-    <test-jetty-servlet.version>8.1.15.v20140411</test-jetty-servlet.version>
     <nekohtml.version>1.9.7</nekohtml.version>
     <sshd-sftp.version>0.11.0</sshd-sftp.version>
     <ftpserver-core.version>1.0.6</ftpserver-core.version>
@@ -77,18 +76,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>test-jetty-servlet</artifactId>
-      <version>${test-jetty-servlet.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>net.sourceforge.nekohtml</groupId>
       <artifactId>nekohtml</artifactId>


### PR DESCRIPTION
…CVE-2017-7657 CVE-2015-2080

[PPP-4183] Use of Vulnerable Component: Multiple Jetty Components [Listed in Description] (CVE-2017-7656 | CVE-2017-7657 | CVE-2017-7658 | CVE-2015-2080 | CVE-2017-9735 )
[PDI-11851] Improve the jetty server version of Carte Server
[PPP-4402] Use of Vulnerable Component: jetty-server & jetty-util (CVE-2019-10246 | CVE-2019-10247)


To better cope with the synchronization with the Karaf upgrade, it was decided that the Jetty upgrade was to be split into two phases: the first would basically consist on centralizing the Jetty version on the parent POM (leaving the version as it is); the second phase (to be integrated into the Karaf upgrade development) would include the upgrade itself and any other changes required.

This PR belongs to phase 1 (check [maven-parent-poms#161](https://github.com/pentaho/maven-parent-poms/pull/161) for the complete list of PRs for phase 1).

**For this specific PR:**
Centralized Jetty components: use dependency management.


