### PR TITLE
[BACKLOG-31173] - Spark Tuning - UI JoinTunable Support

### DIFF
--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/spark/SparkTunableProperties.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/spark/SparkTunableProperties.java
@@ -61,7 +61,7 @@ public class SparkTunableProperties {
     .put( "MemoryGroupBy", datasetTunable() )
     //    .put( "Unique", datasetTunable()
     //    .put( "UniqueRowsByHashSet", datasetTunable()
-    .put( "MergeJoin", datasetTunable() )
+    .put( "MergeJoin", multiTunable( datasetTunable(), joinTunable() ) )
     .put( "RecordsFromStream", datasetTunable() )
     .put( "Abort", datasetTunable() )
     .put( "TransExecutor", datasetTunable() )
@@ -75,8 +75,8 @@ public class SparkTunableProperties {
     .put( "Mapping", datasetTunable() )
     .put( "TableOutput", datasetTunable() )
     .put( "SwitchCase", datasetTunable() )
-    .put( "MergeRows", datasetTunable() )
-    .put( "JoinRows", datasetTunable() )
+    .put( "MergeRows", multiTunable( datasetTunable(), joinTunable() ) )
+    .put( "JoinRows", multiTunable( datasetTunable(), joinTunable() ) )
     .put( "JavaFilter", datasetTunable() )
 
     // Step List Pulled from pdi-spark-hbase-ee beans.xml
@@ -109,6 +109,12 @@ public class SparkTunableProperties {
       "num.repartition.before",
       "columns.repartition.before",
       "persist.type.before"
+    );
+  }
+
+  private static List<String> joinTunable() {
+    return Arrays.asList(
+      "join.broadcast.stepName"
     );
   }
 

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/spark/SparkTunablePropertiesTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/spark/SparkTunablePropertiesTest.java
@@ -40,6 +40,15 @@ public class SparkTunablePropertiesTest {
   }
 
   @Test
+  public void testJoinTunable() {
+    assertTrue( SparkTunableProperties.getProperties( "MergeJoin" ).contains( "join.broadcast.stepName" ) );
+    assertTrue( SparkTunableProperties.getProperties( "JoinRows" ).contains( "join.broadcast.stepName" ) );
+    assertTrue( SparkTunableProperties.getProperties( "MergeRows" ).contains( "join.broadcast.stepName" ) );
+    assertFalse( SparkTunableProperties.getProperties( "badID" ).contains( "join.broadcast.stepName" ) );
+
+  }
+
+  @Test
   public void testJdbcTunable() {
     List<String> properties = SparkTunableProperties.getProperties( "TableInput" );
     assertTrue( properties.contains( "jdbc.columnName" ) );


### PR DESCRIPTION
Add support on "Spark Tuning Parameters" for join-specific tuning params (steps MergeRows, MergeJoin and JoinRows) 