### PR TITLE
[PDI-18397] Refreshing database connection tree on jobs and transform…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/job/entry/JobEntryDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/entry/JobEntryDialog.java
@@ -48,8 +48,12 @@ import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.ui.core.PropsUI;
 import org.pentaho.di.ui.core.database.dialog.DatabaseDialog;
 import org.pentaho.di.ui.core.database.wizard.CreateDatabaseWizard;
+import org.pentaho.di.ui.spoon.Spoon;
+import org.pentaho.di.ui.spoon.tree.provider.DBConnectionFolderProvider;
 import org.pentaho.di.ui.util.DialogUtils;
 import org.pentaho.metastore.api.IMetaStore;
+
+import java.util.function.Supplier;
 
 /**
  * The JobEntryDialog class is responsible for constructing and opening the settings dialog for the job entry. Whenever
@@ -110,6 +114,8 @@ public class JobEntryDialog extends Dialog {
    * A reference to the parent shell
    */
   protected Shell parent;
+
+  private Supplier<Spoon> spoonSupplier = Spoon::getInstance;
 
   /**
    * A reference to a database dialog
@@ -355,6 +361,7 @@ public class JobEntryDialog extends Dialog {
       if ( connectionName != null ) {
         jobMeta.addDatabase( databaseMeta );
         reinitConnectionDropDown( wConnection, databaseMeta.getName() );
+        spoonSupplier.get().refreshTree( DBConnectionFolderProvider.STRING_CONNECTIONS );
       }
     }
   }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/DBConnectionFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/DBConnectionFolderProvider.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,11 +32,12 @@ import org.pentaho.di.ui.core.gui.GUIResource;
 import org.pentaho.di.ui.core.widget.tree.TreeNode;
 import org.pentaho.di.ui.spoon.DatabasesCollector;
 import org.pentaho.di.ui.spoon.Spoon;
+import org.pentaho.di.ui.spoon.tree.TreeFolderProvider;
 
 /**
  * Created by bmorrise on 6/28/18.
  */
-public class DBConnectionFolderProvider extends AutomaticTreeFolderProvider {
+public class DBConnectionFolderProvider extends TreeFolderProvider {
 
   private static Class<?> PKG = Spoon.class;
   public static final String STRING_CONNECTIONS = BaseMessages.getString( PKG, "Spoon.STRING_CONNECTIONS" );

--- a/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -85,12 +85,15 @@ import org.pentaho.di.ui.core.gui.GUIResource;
 import org.pentaho.di.ui.core.gui.WindowProperty;
 import org.pentaho.di.ui.core.widget.ComboVar;
 import org.pentaho.di.ui.core.widget.TableView;
+import org.pentaho.di.ui.spoon.Spoon;
+import org.pentaho.di.ui.spoon.tree.provider.DBConnectionFolderProvider;
 import org.pentaho.di.ui.util.DialogUtils;
 import org.pentaho.di.ui.util.HelpUtils;
 import org.pentaho.metastore.api.IMetaStore;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * This class provides functionality common to Step Dialogs.
@@ -227,6 +230,8 @@ public class BaseStepDialog extends Dialog {
    * A reference to a database dialog.
    */
   protected DatabaseDialog databaseDialog;
+
+  private Supplier<Spoon> spoonSupplier = Spoon::getInstance;
 
   static {
     // Get the button alignment
@@ -1488,6 +1493,7 @@ public class BaseStepDialog extends Dialog {
       if ( connectionName != null ) {
         transMeta.addDatabase( databaseMeta );
         reinitConnectionDropDown( wConnection, databaseMeta.getName() );
+        spoonSupplier.get().refreshTree( DBConnectionFolderProvider.STRING_CONNECTIONS );
       }
     }
   }

--- a/ui/src/test/java/org/pentaho/di/ui/job/entry/JobEntryDialog_ConnectionLine_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/job/entry/JobEntryDialog_ConnectionLine_Test.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -33,10 +33,18 @@ import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.ui.core.database.dialog.DatabaseDialog;
+import org.pentaho.di.ui.spoon.Spoon;
+import org.powermock.reflect.Whitebox;
 
-import static org.junit.Assert.*;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 
 /**
  * @author Andrey Khayrutdinov
@@ -80,8 +88,15 @@ public class JobEntryDialog_ConnectionLine_Test {
     when( dialog.showDbDialogUnlessCancelledOrValid( anyDbMeta(), anyDbMeta() ) )
       .thenAnswer( new PropsSettingAnswer( answeredName, INPUT_HOST ) );
 
+    Supplier<Spoon> mockSupplier = mock( Supplier.class );
+    Spoon mockSpoon = mock( Spoon.class );
+    Whitebox.setInternalState( dialog, "spoonSupplier", mockSupplier );
+    when( mockSupplier.get() ).thenReturn( mockSpoon );
     dialog.jobMeta = jobMeta;
     dialog.new AddConnectionListener( mock( CCombo.class ) ).widgetSelected( null );
+    if ( answeredName != null ) {
+      verify( mockSpoon, times( 1 ) ).refreshTree( anyString() );
+    }
   }
 
 

--- a/ui/src/test/java/org/pentaho/di/ui/trans/step/BaseStepDialog_ConnectionLine_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/trans/step/BaseStepDialog_ConnectionLine_Test.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -34,12 +34,18 @@ import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.ui.core.database.dialog.DatabaseDialog;
+import org.pentaho.di.ui.spoon.Spoon;
+import org.powermock.reflect.Whitebox;
 
-import static org.junit.Assert.*;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.times;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 
 /**
  * @author Andrey Khayrutdinov
@@ -83,8 +89,15 @@ public class BaseStepDialog_ConnectionLine_Test {
     when( dialog.showDbDialogUnlessCancelledOrValid( anyDbMeta(), anyDbMeta() ) )
       .thenAnswer( new PropsSettingAnswer( answeredName, INPUT_HOST ) );
 
+    Supplier<Spoon> mockSupplier = mock( Supplier.class );
+    Spoon mockSpoon = mock( Spoon.class );
+    Whitebox.setInternalState( dialog, "spoonSupplier", mockSupplier );
+    when( mockSupplier.get() ).thenReturn( mockSpoon );
     dialog.transMeta = transMeta;
     dialog.new AddConnectionListener( mock( CCombo.class ) ).widgetSelected( null );
+    if ( answeredName != null ) {
+      verify( mockSpoon, times( 1 ) ).refreshTree( anyString() );
+    }
   }
 
 


### PR DESCRIPTION
…ations causes performance issues in Spoon

This reported problem was a regression introduced by PDI-17799. This solution reverts the correction of PDI-17799 and implements it in another way. We do not refresh the Connections Tree all the time, but only when a new connection is created within a Transformation or Job Step.

@pentaho-lmartins @bmorrise 