### PR TITLE
[PDI-18283] pdi.log: Excuting Jobs/Transformation using Slave Server results to Jobs/Transformation name as null along with duplicate entries.

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/logging/Slf4jLoggingEventListener.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/Slf4jLoggingEventListener.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,10 +28,12 @@ import java.util.function.Function;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
+import org.pentaho.di.repository.RepositoryObjectType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.pentaho.di.core.logging.LoggingObjectType.DATABASE;
 import static org.pentaho.di.core.logging.LoggingObjectType.TRANS;
 import static org.pentaho.di.core.logging.LoggingObjectType.STEP;
@@ -111,18 +113,26 @@ public class Slf4jLoggingEventListener implements KettleLoggingEventListener {
     while ( loggingObject != null ) {
       if ( loggingObject.getObjectType() == TRANS || loggingObject.getObjectType() == JOB ) {
         RepositoryDirectoryInterface rd = loggingObject.getRepositoryDirectory();
-        String filename = loggingObject.getFilename();
+        String name;
+        if ( isNotBlank( loggingObject.getFilename() ) ) {
+          name = loggingObject.getFilename();
+        } else {
+          name = loggingObject.getObjectType() == TRANS
+            ? ( loggingObject.getObjectName() + RepositoryObjectType.TRANSFORMATION.getExtension() )
+            : ( loggingObject.getObjectName() + RepositoryObjectType.JOB.getExtension() );
+        }
+
         if ( rd != null ) {
           String path = rd.getPath();
           if ( path.equals( SEPARATOR ) ) {
-            if ( filename != null && filename.length() > 0 ) {
-              subjects.add( filename );
+            if ( name != null && name.length() > 0 ) {
+              subjects.add( name );
             }
           } else {
-            subjects.add( path + SEPARATOR + filename );
+            subjects.add( path + SEPARATOR + name );
           }
-        } else if ( filename != null && filename.length() > 0 ) {
-          subjects.add( filename );
+        } else if ( name != null && name.length() > 0 ) {
+          subjects.add( name );
         }
       }
       loggingObject = loggingObject.getParent();

--- a/core/src/test/java/org/pentaho/di/core/logging/Slf4jLoggingEventListenerTest.java
+++ b/core/src/test/java/org/pentaho/di/core/logging/Slf4jLoggingEventListenerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,6 +28,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.pentaho.di.repository.RepositoryDirectory;
+import org.pentaho.di.repository.RepositoryObjectType;
 import org.slf4j.Logger;
 
 import java.util.function.Function;
@@ -47,10 +49,12 @@ public class Slf4jLoggingEventListenerTest {
   @Mock private LoggingObjectInterface loggingObject;
   @Mock private LogMessage message;
   @Mock private Function<String, LoggingObjectInterface> logObjProvider;
+  @Mock private RepositoryDirectory repositoryDirectory;
 
   private String logChannelId = "logChannelId";
   private String msgText = "message";
   private String messageSub = "subject";
+  private String testPath = "/test/path";
   private LogLevel logLevel = BASIC;
 
 
@@ -118,4 +122,41 @@ public class Slf4jLoggingEventListenerTest {
     verifyZeroInteractions( transLogger );
   }
 
+  @Test
+  public void testJobWithAndWithoutFilename() {
+    when( logObjProvider.apply( logChannelId ) ).thenReturn( loggingObject );
+    when( loggingObject.getLogChannelId() ).thenReturn( logChannelId );
+    when( loggingObject.getObjectType() ).thenReturn( LoggingObjectType.JOB );
+    when( loggingObject.getObjectName() ).thenReturn( "TestJob" );
+    when( loggingObject.getFilename() ).thenReturn( "filename" );
+    when( loggingObject.getRepositoryDirectory() ).thenReturn( repositoryDirectory );
+    when( repositoryDirectory.getPath() ).thenReturn( testPath );
+    when( message.getLevel() ).thenReturn( LogLevel.BASIC );
+    listener.eventAdded( logEvent );
+    verify( jobLogger ).info( "[" + testPath + "/filename]  " + msgText );
+
+    when( loggingObject.getFilename() ).thenReturn( null );
+    listener.eventAdded( logEvent );
+    verify( jobLogger ).info( "[" + testPath + "/TestJob"
+      + RepositoryObjectType.JOB.getExtension() + "]  " + msgText );
+  }
+
+  @Test
+  public void testTransWithAndWithoutFilename() {
+    when( logObjProvider.apply( logChannelId ) ).thenReturn( loggingObject );
+    when( loggingObject.getLogChannelId() ).thenReturn( logChannelId );
+    when( loggingObject.getObjectType() ).thenReturn( LoggingObjectType.TRANS );
+    when( loggingObject.getObjectName() ).thenReturn( "TestTrans" );
+    when( loggingObject.getFilename() ).thenReturn( "filename" );
+    when( loggingObject.getRepositoryDirectory() ).thenReturn( repositoryDirectory );
+    when( repositoryDirectory.getPath() ).thenReturn( testPath );
+    when( message.getLevel() ).thenReturn( LogLevel.BASIC );
+    listener.eventAdded( logEvent );
+    verify( transLogger ).info( "[" + testPath + "/filename]  " + msgText );
+
+    when( loggingObject.getFilename() ).thenReturn( null );
+    listener.eventAdded( logEvent );
+    verify( transLogger ).info( "[" + testPath + "/TestTrans"
+      + RepositoryObjectType.TRANSFORMATION.getExtension() + "]  " + msgText );
+  }
 }


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins 

* [PDI-18283] Ensuring that the name of the job/transformation is printed. Either pull from the filename string if it exists, or to pull from the object name and append the appropriate extension to replicate the filename.
* [PDI-18283] Adding test code
* [PDI-18283] Updating license year