### PR TITLE
[PPP-4448] Use of Vulnerable Component - XStream 1.4.10

### DIFF
--- a/plugins/drools/core/pom.xml
+++ b/plugins/drools/core/pom.xml
@@ -20,7 +20,6 @@
 
     <pdi.version>9.0.0.0-SNAPSHOT</pdi.version>
     <drools.version>6.4.0.Final</drools.version>
-    <xstream.version>1.4.10</xstream.version>
     <mvel2.version>2.2.8.Final</mvel2.version>
     <org.eclipse.jdt>3.4.2.v_883_R34x</org.eclipse.jdt>
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
@@ -73,46 +72,6 @@
         <exclusion>
           <groupId>org.drools</groupId>
           <artifactId>drools-reteoo</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-core</artifactId>
-      <version>${drools.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-compiler</artifactId>
-      <version>${drools.version}</version>
-      <exclusions>
-        <!-- it requires 1.4.7 xstream version that  is vulnerable. See BACKLOG-11939 -->
-        <exclusion>
-          <groupId>com.thoughtworks.xstream</groupId>
-          <artifactId>xstream</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <!-- add xsteam manually-->
-    <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>${xstream.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
This is part of a series of PRs. See https://github.com/pentaho/maven-parent-poms/pull/170 for details.

**Don't merge before the PR above.**

Removing all the dependencies will keep the plugin assembly the same with the exception of the updated `XStream` component.