### PR TITLE
[BACKLOG-31521] Allow UUIDs to be passed from Pan/Kitchen, add them to the log4j MDC on execution

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/KettleConstants.java
+++ b/engine/src/main/java/org/pentaho/di/base/KettleConstants.java
@@ -64,6 +64,7 @@ public class KettleConstants {
   public static final String RESULT_SET_STEP_NAME = "stepname";
   public static final String RESULT_SET_COPY_NUMBER = "copynum";
   public static final String BASE64_ZIP = "base64zip";
+  public static final String UUID = "uuid";
 
   public static Map<String, String> toJobMap( Params params ) {
 

--- a/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
@@ -114,7 +114,7 @@ public class Kitchen {
 
     StringBuilder optionRepname, optionUsername, optionTrustUser, optionPassword, optionJobname, optionDirname, initialDir;
     StringBuilder optionFilename, optionLoglevel, optionLogfile, optionLogfileOld, optionListdir;
-    StringBuilder optionListjobs, optionListrep, optionNorep, optionVersion, optionListParam, optionExport, optionBase64Zip;
+    StringBuilder optionListjobs, optionListrep, optionNorep, optionVersion, optionListParam, optionExport, optionBase64Zip, optionUuid;
     NamedParams optionParams = new NamedParamsDefault();
     NamedParams customOptions = new NamedParamsDefault();
 
@@ -181,6 +181,7 @@ public class Kitchen {
           "initialDir", null, initialDir =
           new StringBuilder(), false, true ),
         new CommandLineOption( "zip", "Base64Zip", optionBase64Zip = new StringBuilder(), false, true ),
+        new CommandLineOption( "uuid", "UUID", optionUuid = new StringBuilder(), false, true ),
         new CommandLineOption(
           "custom", BaseMessages.getString( PKG, "Kitchen.ComdLine.Custom" ), customOptions, false ),
         maxLogLinesOption, maxLogTimeoutOption, };
@@ -254,7 +255,8 @@ public class Kitchen {
         }
       }
 
-      Params jobParams = ( new Params.Builder() )
+      Params.Builder builder = optionUuid.length() > 0 ? new Params.Builder( optionUuid.toString() ) : new Params.Builder();
+      Params jobParams = ( builder )
               .blockRepoConns( optionNorep.toString() )
               .repoName( optionRepname.toString() )
               .repoUsername( optionUsername.toString() )

--- a/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
@@ -23,6 +23,7 @@
 package org.pentaho.di.kitchen;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.log4j.MDC;
 import org.pentaho.di.base.AbstractBaseCommandExecutor;
 import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.base.KettleConstants;
@@ -226,6 +227,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
         return exitWithStatus( CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode() ); // same as the other list options
       }
 
+      MDC.put( KettleConstants.UUID, params.getUuid() ); // Add the UUID to log4j MDC so it can be inserted in log lines
       job.start(); // Execute the selected job.
       job.waitUntilFinished();
       setResult( job.getResult() ); // get the execution result
@@ -247,6 +249,8 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     calculateAndPrintElapsedTime( start, stop, "Kitchen.Log.StartStop", "Kitchen.Log.ProcessEndAfter", "Kitchen.Log.ProcessEndAfterLong",
             "Kitchen.Log.ProcessEndAfterLonger", "Kitchen.Log.ProcessEndAfterLongest" );
     getResult().setElapsedTimeMillis( stop.getTime() - start.getTime() );
+
+    MDC.remove( KettleConstants.UUID ); // cleanup log4j MDC
 
     return exitWithStatus( returnCode );
   }

--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -72,7 +72,7 @@ public class Pan {
     StringBuilder optionListtrans, optionListrep, optionExprep, optionNorep, optionSafemode;
     StringBuilder optionVersion, optionJarFilename, optionListParam, optionMetrics, initialDir;
     StringBuilder optionResultSetStepName, optionResultSetCopyNumber;
-    StringBuilder optionBase64Zip;
+    StringBuilder optionBase64Zip, optionUuid;
 
     NamedParams optionParams = new NamedParamsDefault();
 
@@ -153,6 +153,9 @@ public class Pan {
         new CommandLineOption(
           "zip", "Base64Zip", optionBase64Zip =
           new StringBuilder(), false, true ),
+        new CommandLineOption(
+                "uuid", "UUID", optionUuid =
+                new StringBuilder(), false, true ),
         new CommandLineOption(
           "metrics", BaseMessages.getString( PKG, "Pan.ComdLine.Metrics" ), optionMetrics =
           new StringBuilder(), true, false ), maxLogLinesOption, maxLogTimeoutOption };
@@ -237,7 +240,8 @@ public class Pan {
         }
       }
 
-      Params transParams = ( new Params.Builder() )
+      Params.Builder builder = optionUuid.length() > 0 ? new Params.Builder( optionUuid.toString() ) : new Params.Builder();
+      Params transParams = ( builder )
               .blockRepoConns( optionNorep.toString() )
               .repoName( optionRepname.toString() )
               .repoUsername( optionUsername.toString() )

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -24,6 +24,7 @@ package org.pentaho.di.pan;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
+import org.apache.log4j.MDC;
 import org.pentaho.di.base.AbstractBaseCommandExecutor;
 import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.base.KettleConstants;
@@ -187,6 +188,8 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
 
       final List<RowMetaAndData> rows = new ArrayList<RowMetaAndData>(  );
 
+      MDC.put( KettleConstants.UUID, params.getUuid() );  // Add the UUID to log4j MDC so it can be inserted in log lines
+
       // allocate & run the required sub-threads
       try {
         trans.prepareExecution( convert(  KettleConstants.toTransMap( params ) ) );
@@ -274,6 +277,7 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
       if ( isEnabled( params.getTrustRepoUser() ) ) {
         System.clearProperty( "pentaho.repository.client.attemptTrust" ); // we set it, now we sanitize it
       }
+      MDC.remove( KettleConstants.UUID );  // cleanup log4j MDC
     }
   }
 


### PR DESCRIPTION
@pentaho/rogueone 

- Adds a new `uuid` parameter (this is hidden, like the `base64zip` parameter, so it won't need external documentation)
- Adds the UUID from params into the log4j MDC so it can be inserted into log lines
