### PR TITLE
[BACKLOG-31992] Remove MDC calls

### DIFF
--- a/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
@@ -23,7 +23,6 @@
 package org.pentaho.di.kitchen;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.log4j.MDC;
 import org.pentaho.di.base.AbstractBaseCommandExecutor;
 import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.base.KettleConstants;
@@ -227,7 +226,6 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
         return exitWithStatus( CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode() ); // same as the other list options
       }
 
-      MDC.put( KettleConstants.UUID, params.getUuid() ); // Add the UUID to log4j MDC so it can be inserted in log lines
       job.start(); // Execute the selected job.
       job.waitUntilFinished();
       setResult( job.getResult() ); // get the execution result
@@ -249,8 +247,6 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     calculateAndPrintElapsedTime( start, stop, "Kitchen.Log.StartStop", "Kitchen.Log.ProcessEndAfter", "Kitchen.Log.ProcessEndAfterLong",
             "Kitchen.Log.ProcessEndAfterLonger", "Kitchen.Log.ProcessEndAfterLongest" );
     getResult().setElapsedTimeMillis( stop.getTime() - start.getTime() );
-
-    MDC.remove( KettleConstants.UUID ); // cleanup log4j MDC
 
     return exitWithStatus( returnCode );
   }

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -24,7 +24,6 @@ package org.pentaho.di.pan;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import org.apache.log4j.MDC;
 import org.pentaho.di.base.AbstractBaseCommandExecutor;
 import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.base.KettleConstants;
@@ -188,8 +187,6 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
 
       final List<RowMetaAndData> rows = new ArrayList<RowMetaAndData>(  );
 
-      MDC.put( KettleConstants.UUID, params.getUuid() );  // Add the UUID to log4j MDC so it can be inserted in log lines
-
       // allocate & run the required sub-threads
       try {
         trans.prepareExecution( convert(  KettleConstants.toTransMap( params ) ) );
@@ -277,7 +274,6 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
       if ( isEnabled( params.getTrustRepoUser() ) ) {
         System.clearProperty( "pentaho.repository.client.attemptTrust" ); // we set it, now we sanitize it
       }
-      MDC.remove( KettleConstants.UUID );  // cleanup log4j MDC
     }
   }
 


### PR DESCRIPTION
These calls aren't needed with the new approach.

The `--uuid` option for Pan/Kitchen isn't really either, but it probably will be for future work, and those are very low impact, so we'll leave them in for now.