### PR TITLE
[SP-5293] - Backport of PDI-18330 - Character corruption in the [ESRI Shapefile Reader] step (8.3 Suite)

### DIFF
--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/di/shapefilereader/ShapeFileReader.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/di/shapefilereader/ShapeFileReader.java
@@ -352,7 +352,7 @@ public class ShapeFileReader extends BaseStep implements StepInterface {
         return false;
       }
 
-      data.shapeFile = new ShapeFile( log, meta.getShapeFilename(), meta.getDbfFilename() );
+      data.shapeFile = new ShapeFile( log, meta.getShapeFilename(), meta.getDbfFilename(), meta.getEncoding() );
       try {
         data.shapeFile.readFile();
       } catch ( Exception e ) {

--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/di/shapefilereader/ShapeFileReader.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/di/shapefilereader/ShapeFileReader.java
@@ -27,6 +27,7 @@
 
 package org.pentaho.di.shapefilereader;
 
+import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowDataUtil;
@@ -350,6 +351,10 @@ public class ShapeFileReader extends BaseStep implements StepInterface {
       ) {
         logError( "We need both a shapefile and a DBF file." );
         return false;
+      }
+
+      if ( StringUtils.isBlank( meta.getEncoding() ) ) {
+        meta.setEncoding( getTransMeta().getVariable( "ESRI.encoding" ) );
       }
 
       data.shapeFile = new ShapeFile( log, meta.getShapeFilename(), meta.getDbfFilename(), meta.getEncoding() );

--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/di/shapefilereader/ShapeFileReaderMeta.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/di/shapefilereader/ShapeFileReaderMeta.java
@@ -152,7 +152,7 @@ public class ShapeFileReaderMeta extends BaseStepMeta implements StepMetaInterfa
   public void setDefault() {
     shapeFilename = "";
     dbfFilename = "";
-    encoding = "ISO8859-1";
+    encoding = "";
   }
 
   public void getFields( RowMetaInterface row, String name, RowMetaInterface[] info, StepMeta nextStep,

--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/di/shapefilereader/ShapeFileReaderMeta.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/di/shapefilereader/ShapeFileReaderMeta.java
@@ -77,7 +77,7 @@ public class ShapeFileReaderMeta extends BaseStepMeta implements StepMetaInterfa
   public String dbfFilename;
 
   /**
-   * The encoding to use for reading: null or empty string means system default encoding
+   * File encoding
    */
   private String encoding;
 
@@ -152,7 +152,7 @@ public class ShapeFileReaderMeta extends BaseStepMeta implements StepMetaInterfa
   public void setDefault() {
     shapeFilename = "";
     dbfFilename = "";
-    encoding = "";
+    encoding = "ISO8859-1";
   }
 
   public void getFields( RowMetaInterface row, String name, RowMetaInterface[] info, StepMeta nextStep,

--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
@@ -97,9 +97,10 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
     Shell parent = getParent();
     Display display = parent.getDisplay();
     //set encoding based on environment variable or empty otherwise
-    input.setEncoding( StringUtils.isNotBlank( transMeta.getVariable( "ESRI.encoding" ) )
-      ? transMeta.getVariable( "ESRI.encoding" ) : "" );
-
+    if ( StringUtils.isBlank( input.getEncoding() ) ) {
+      input.setEncoding( StringUtils.isNotBlank( transMeta.getVariable( "ESRI.encoding" ) )
+        ? transMeta.getVariable( "ESRI.encoding" ) : "" );
+    }
 
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.RESIZE | SWT.MAX | SWT.MIN );
     props.setLook( shell );

--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,12 +27,15 @@
 package org.pentaho.di.ui.shapefilereader;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CCombo;
+import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.ShellAdapter;
 import org.eclipse.swt.events.ShellEvent;
+import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
@@ -56,7 +59,10 @@ import org.pentaho.di.ui.core.dialog.EnterSelectionDialog;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 import org.pentaho.di.ui.util.SwtSvgImageUtil;
 
+import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Properties;
 
 public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogInterface {
@@ -73,6 +79,10 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
   private Button wbcDbf;
   private Text wDbf;
   private FormData fdlDbf, fdbDbf, fdbcDbf, fdDbf;
+
+  private Label wlEncoding;
+  private CCombo wEncoding;
+  private FormData fdlEncoding, fdEncoding;
 
   private ShapeFileReaderMeta input;
   private boolean backup_changed;
@@ -195,6 +205,39 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
     fdDbf.right = new FormAttachment( wbcDbf, -margin );
     fdDbf.top = new FormAttachment( wShape, margin );
     wDbf.setLayoutData( fdDbf );
+
+    //Encoding
+    wlEncoding = new Label( shell, SWT.RIGHT );
+    wlEncoding.setText( BaseMessages.getString( PKG, "ShapeFileReader.Encoding.Label" ) );
+    props.setLook( wlEncoding );
+    fdlEncoding = new FormData();
+    fdlEncoding.left = new FormAttachment( 0, 0 );
+    fdlEncoding.top = new FormAttachment( wDbf, margin );
+    fdlEncoding.right = new FormAttachment( middle, -margin );
+    wlEncoding.setLayoutData( fdlEncoding );
+    wEncoding = new CCombo( shell, SWT.BORDER | SWT.READ_ONLY );
+    wEncoding.setEditable( false );
+    props.setLook( wEncoding );
+    wEncoding.addModifyListener( lsMod );
+    fdEncoding = new FormData();
+    fdEncoding.left = new FormAttachment( middle, 0 );
+    fdEncoding.top = new FormAttachment( wDbf, margin );
+    fdEncoding.right = new FormAttachment( 100, 0 );
+    wEncoding.setLayoutData( fdEncoding );
+    wEncoding.addFocusListener( new FocusListener() {
+      public void focusLost( org.eclipse.swt.events.FocusEvent e ) {
+      }
+
+      public void focusGained( org.eclipse.swt.events.FocusEvent e ) {
+        if ( wEncoding.getItemCount() == 0 ) {
+          Cursor busy = new Cursor( shell.getDisplay(), SWT.CURSOR_WAIT );
+          shell.setCursor( busy );
+          setEncodings();
+          shell.setCursor( null );
+          busy.dispose();
+        }
+      }
+    } );
 
     // Some buttons
     wOK = new Button( shell, SWT.PUSH );
@@ -366,7 +409,25 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
       wDbf.setText( input.getDbfFilename() );
     }
 
+    if ( input.getEncoding() != null ) {
+      wEncoding.setText( input.getEncoding() );
+    }
+
     wStepname.selectAll();
+  }
+
+  private void setEncodings() {
+    List<Charset> values = new ArrayList<>( Charset.availableCharsets().values() );
+    for ( Charset charSet : values ) {
+      wEncoding.add( charSet.displayName() );
+    }
+
+    // Now select the default!
+    String defEncoding = transMeta.getVariable( "ESRI.encoding", "UTF-8" );
+    int idx = Const.indexOfString( defEncoding, wEncoding.getItems() );
+    if ( idx >= 0 ) {
+      wEncoding.select( idx );
+    }
   }
 
   private void cancel() {
@@ -380,6 +441,7 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
 
     input.setShapeFilename( wShape.getText() );
     input.setDbfFilename( wDbf.getText() );
+    input.setEncoding( wEncoding.getText() );
 
     dispose();
   }

--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
@@ -28,15 +28,12 @@ package org.pentaho.di.ui.shapefilereader;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.CCombo;
-import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.ShellAdapter;
 import org.eclipse.swt.events.ShellEvent;
-import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
@@ -60,10 +57,7 @@ import org.pentaho.di.ui.core.dialog.EnterSelectionDialog;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 import org.pentaho.di.ui.util.SwtSvgImageUtil;
 
-import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.List;
 import java.util.Properties;
 
 public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogInterface {

--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
@@ -26,6 +26,7 @@
  */
 package org.pentaho.di.ui.shapefilereader;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.events.FocusListener;
@@ -95,6 +96,10 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
   public String open() {
     Shell parent = getParent();
     Display display = parent.getDisplay();
+    //set encoding based on environment variable or empty otherwise
+    input.setEncoding( StringUtils.isNotBlank( transMeta.getVariable( "ESRI.encoding" ) )
+      ? transMeta.getVariable( "ESRI.encoding" ) : "" );
+
 
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.RESIZE | SWT.MAX | SWT.MIN );
     props.setLook( shell );
@@ -408,8 +413,7 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
     if ( input.getDbfFilename() != null ) {
       wDbf.setText( input.getDbfFilename() );
     }
-
-    if ( input.getEncoding() != null ) {
+    if ( StringUtils.isNotBlank( input.getEncoding() ) ) {
       wEncoding.setText( input.getEncoding() );
     }
 
@@ -422,9 +426,7 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
       wEncoding.add( charSet.displayName() );
     }
 
-    // Now select the default!
-    String defEncoding = transMeta.getVariable( "ESRI.encoding", "UTF-8" );
-    int idx = Const.indexOfString( defEncoding, wEncoding.getItems() );
+    int idx = Const.indexOfString( input.getEncoding(), wEncoding.getItems() );
     if ( idx >= 0 ) {
       wEncoding.select( idx );
     }
@@ -441,7 +443,8 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
 
     input.setShapeFilename( wShape.getText() );
     input.setDbfFilename( wDbf.getText() );
-    input.setEncoding( wEncoding.getText() );
+    input.setEncoding( StringUtils.isNotBlank( wEncoding.getText() )
+      ? wEncoding.getText() : input.getEncoding() );
 
     dispose();
   }

--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/di/ui/shapefilereader/ShapeFileReaderDialog.java
@@ -81,10 +81,6 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
   private Text wDbf;
   private FormData fdlDbf, fdbDbf, fdbcDbf, fdDbf;
 
-  private Label wlEncoding;
-  private CCombo wEncoding;
-  private FormData fdlEncoding, fdEncoding;
-
   private ShapeFileReaderMeta input;
   private boolean backup_changed;
 
@@ -211,39 +207,6 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
     fdDbf.right = new FormAttachment( wbcDbf, -margin );
     fdDbf.top = new FormAttachment( wShape, margin );
     wDbf.setLayoutData( fdDbf );
-
-    //Encoding
-    wlEncoding = new Label( shell, SWT.RIGHT );
-    wlEncoding.setText( BaseMessages.getString( PKG, "ShapeFileReader.Encoding.Label" ) );
-    props.setLook( wlEncoding );
-    fdlEncoding = new FormData();
-    fdlEncoding.left = new FormAttachment( 0, 0 );
-    fdlEncoding.top = new FormAttachment( wDbf, margin );
-    fdlEncoding.right = new FormAttachment( middle, -margin );
-    wlEncoding.setLayoutData( fdlEncoding );
-    wEncoding = new CCombo( shell, SWT.BORDER | SWT.READ_ONLY );
-    wEncoding.setEditable( false );
-    props.setLook( wEncoding );
-    wEncoding.addModifyListener( lsMod );
-    fdEncoding = new FormData();
-    fdEncoding.left = new FormAttachment( middle, 0 );
-    fdEncoding.top = new FormAttachment( wDbf, margin );
-    fdEncoding.right = new FormAttachment( 100, 0 );
-    wEncoding.setLayoutData( fdEncoding );
-    wEncoding.addFocusListener( new FocusListener() {
-      public void focusLost( org.eclipse.swt.events.FocusEvent e ) {
-      }
-
-      public void focusGained( org.eclipse.swt.events.FocusEvent e ) {
-        if ( wEncoding.getItemCount() == 0 ) {
-          Cursor busy = new Cursor( shell.getDisplay(), SWT.CURSOR_WAIT );
-          shell.setCursor( busy );
-          setEncodings();
-          shell.setCursor( null );
-          busy.dispose();
-        }
-      }
-    } );
 
     // Some buttons
     wOK = new Button( shell, SWT.PUSH );
@@ -414,23 +377,8 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
     if ( input.getDbfFilename() != null ) {
       wDbf.setText( input.getDbfFilename() );
     }
-    if ( StringUtils.isNotBlank( input.getEncoding() ) ) {
-      wEncoding.setText( input.getEncoding() );
-    }
 
     wStepname.selectAll();
-  }
-
-  private void setEncodings() {
-    List<Charset> values = new ArrayList<>( Charset.availableCharsets().values() );
-    for ( Charset charSet : values ) {
-      wEncoding.add( charSet.displayName() );
-    }
-
-    int idx = Const.indexOfString( input.getEncoding(), wEncoding.getItems() );
-    if ( idx >= 0 ) {
-      wEncoding.select( idx );
-    }
   }
 
   private void cancel() {
@@ -444,8 +392,6 @@ public class ShapeFileReaderDialog extends BaseStepDialog implements StepDialogI
 
     input.setShapeFilename( wShape.getText() );
     input.setDbfFilename( wDbf.getText() );
-    input.setEncoding( StringUtils.isNotBlank( wEncoding.getText() )
-      ? wEncoding.getText() : input.getEncoding() );
 
     dispose();
   }

--- a/plugins/shapefilereader/core/src/main/java/org/pentaho/gis/shapefiles/ShapeFile.java
+++ b/plugins/shapefilereader/core/src/main/java/org/pentaho/gis/shapefiles/ShapeFile.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -49,6 +50,7 @@ public class ShapeFile {
 
   private String dbfFilename;
   private String shapeFilename;
+  private String encoding;
 
   public ShapeFile( LogChannelInterface log, String name ) {
     this.log = log;
@@ -62,6 +64,15 @@ public class ShapeFile {
     this.log = log;
     this.shapeFilename = shapeFilename;
     this.dbfFilename = dbfFilename;
+
+    shapes = new ArrayList<ShapeInterface>();
+  }
+
+  public ShapeFile( LogChannelInterface log, String shapeFilename, String dbfFilename, String encoding ) {
+    this.log = log;
+    this.shapeFilename = shapeFilename;
+    this.dbfFilename = dbfFilename;
+    this.encoding = encoding;
 
     shapes = new ArrayList<ShapeInterface>();
   }
@@ -88,6 +99,11 @@ public class ShapeFile {
 
       XBase xbase = new XBase( log, dbfFilename );
       xbase.open(); // throws exception now
+
+      //Set encoding
+      if ( StringUtils.isNotBlank( encoding ) ) {
+        xbase.getReader().setCharactersetName( encoding );
+      }
 
       // First determine the meta-data for this dbf file...
       RowMetaInterface fields = xbase.getFields();

--- a/plugins/shapefilereader/core/src/main/resources/org/pentaho/di/shapefilereader/messages/messages_en_US.properties
+++ b/plugins/shapefilereader/core/src/main/resources/org/pentaho/di/shapefilereader/messages/messages_en_US.properties
@@ -1,3 +1,4 @@
 Input=Input
 ShapeFileReader.Step.Name=ESRI shapefile reader
 ShapeFileReader.Step.Description=Reads shape file data from an ESRI shape file and linked DBF file
+ShapeFileReader.Encoding.Label=Encoding


### PR DESCRIPTION
Cherry-pick of:

- 0a81e1b32b29391f6fc5a29641d1599a5306f242
- ee8b693e839fe28e86996c62b4dca6a6c2d19dc7
- 94deb145a4a4d1c7c217a5951cb17c94a5a36efe
-  5ab9eb502d860fcb19b247167fd67c2967ff6743
- Last commit is to remove UI Changes

@smmribeiro 