### PR TITLE
[BACKLOG-30731] Adding getProperties method to ConnectionDetails

### DIFF
--- a/core/src/main/java/org/pentaho/di/connections/ConnectionDetails.java
+++ b/core/src/main/java/org/pentaho/di/connections/ConnectionDetails.java
@@ -22,6 +22,9 @@
 
 package org.pentaho.di.connections;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * Created by bmorrise on 2/13/19.
  */
@@ -33,4 +36,13 @@ public interface ConnectionDetails {
   String getType();
 
   String getDescription();
+
+  /**
+   * Gets props associated with this ConnectionDetails.
+   * Allows implementors to expose connection properties without
+   * requiring clients to have the implementation as a dependency.
+   */
+  default Map<String, String> getProperties() {
+    return Collections.emptyMap();
+  }
 }


### PR DESCRIPTION
https://jira.pentaho.com/browse/BACKLOG-30731