### PR TITLE
[PPP-4447] Use of vulnerable component - Tika Core 1.1x

### DIFF
--- a/plugins/pur/core/pom.xml
+++ b/plugins/pur/core/pom.xml
@@ -38,7 +38,6 @@
     <!-- Test dependencies -->
     <se-jcr.version>0.9</se-jcr.version>
     <jcr.version>2.0</jcr.version>
-    <jackrabbit-core.version>2.14.2</jackrabbit-core.version>
 
     <!-- Wadl2Java Settings -->
     <wadl2java.generated-class-name>Localhost_PentahoPlugin</wadl2java.generated-class-name>
@@ -328,8 +327,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-core</artifactId>
-      <version>${jackrabbit-core.version}</version>
+      <artifactId>jackrabbit-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Replaces #6947. We actually depend on `jackrabbit-api` and not `jackrabbit-core`.

**Do not merge before https://github.com/pentaho/maven-parent-poms/pull/178!**

@ssamora @RPAraujo 