### PR TITLE
[PDI-18224] Step Metrics for Database Lookup step showing incorrect v…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -555,6 +555,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
 
   private ExecutorService heartbeat = null; // this transformations's heartbeat scheduled executor
 
+  private boolean executingClustered;
+
   /**
    * Instantiates a new transformation.
    */
@@ -5686,6 +5688,14 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
 
   public boolean isResultRowsSet() {
     return resultRowsSet;
+  }
+
+  public boolean isExecutingClustered() {
+    return executingClustered;
+  }
+
+  public void setExecutingClustered( boolean executingClustered ) {
+    this.executingClustered = executingClustered;
   }
 
   @Override

--- a/engine/src/main/java/org/pentaho/di/trans/cluster/TransSplitter.java
+++ b/engine/src/main/java/org/pentaho/di/trans/cluster/TransSplitter.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1474,11 +1474,6 @@ public class TransSplitter {
       //
       copy.setCopies( 1 );
     }
-
-    // Remove the clustering information on the slave transformation step
-    // We don't need it anymore, it only confuses.
-    //
-    copy.setClusterSchema( null );
 
     transMeta.addStep( copy );
     return copy;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/databaselookup/DatabaseLookup.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/databaselookup/DatabaseLookup.java
@@ -174,8 +174,7 @@ public class DatabaseLookup extends BaseStep implements StepInterface {
       // Only verify the data types if the data comes from the DB, NOT when we have a cache hit
       // In that case, we already know the data type is OK.
       if ( !cacheHit ) {
-        incrementLinesInput();
-
+        incrementLines();
         int[] types = meta.getReturnValueDefaultType();
 
         // The assumption here is that the types are in the same order
@@ -206,6 +205,13 @@ public class DatabaseLookup extends BaseStep implements StepInterface {
     }
 
     return outputRow;
+  }
+
+  @VisibleForTesting
+  void incrementLines() {
+    if ( !getStepMeta().isClustered() || ( getStepMeta().isClustered() && !getTrans().isExecutingClustered() ) ) {
+      incrementLinesInput();
+    }
   }
 
   // visible for testing purposes

--- a/engine/src/main/java/org/pentaho/di/www/PrepareExecutionTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/PrepareExecutionTransServlet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -213,6 +213,7 @@ public class PrepareExecutionTransServlet extends BaseHttpServlet implements Car
         trans.setGatheringMetrics( executionConfiguration.isGatheringMetrics() );
         trans.injectVariables( executionConfiguration.getVariables() );
         trans.setPreviousResult( executionConfiguration.getPreviousResult() );
+        trans.setExecutingClustered( executionConfiguration.isExecutingClustered() );
 
         try {
           trans.prepareExecution( null );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/databaselookup/DatabaseLookupUTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/databaselookup/DatabaseLookupUTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -35,11 +35,13 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -439,6 +441,75 @@ public class DatabaseLookupUTest {
 
     assertNotNull( data.cache.getRowFromCache( data.lookupMeta, new Object[] { 1L } ) );
     assertNotNull( data.cache.getRowFromCache( data.lookupMeta, new Object[] { 2L } ) );
+  }
+
+  @Test
+  public void testIncrementLinesNotClustered() {
+
+    DatabaseLookup dbLookup = mock( DatabaseLookup.class );
+    StepMeta stepMeta = mock( StepMeta.class );
+
+    doCallRealMethod().when( dbLookup ).incrementLines();
+    doReturn( stepMeta ).when( dbLookup ).getStepMeta();
+    doReturn( false ).when( stepMeta ).isClustered();
+
+    dbLookup.incrementLines();
+
+    verify( dbLookup, times( 1 ) ).incrementLinesInput();
+  }
+
+  @Test
+  public void testIncrementLinesClusteredNotRunningClustered() {
+
+    DatabaseLookup dbLookup = mock( DatabaseLookup.class );
+    StepMeta stepMeta = mock( StepMeta.class );
+    Trans trans = mock( Trans.class );
+
+    doCallRealMethod().when( dbLookup ).incrementLines();
+    doReturn( stepMeta ).when( dbLookup ).getStepMeta();
+    doReturn( trans ).when( dbLookup ).getTrans();
+    doReturn( true ).when( stepMeta ).isClustered();
+    doReturn( false ).when( trans ).isExecutingClustered();
+
+    dbLookup.incrementLines();
+
+    verify( dbLookup, times( 1 ) ).incrementLinesInput();
+  }
+
+  @Test
+  public void testIncrementLinesNotClusteredRunningClustered() {
+
+    DatabaseLookup dbLookup = mock( DatabaseLookup.class );
+    StepMeta stepMeta = mock( StepMeta.class );
+    Trans trans = mock( Trans.class );
+
+    doCallRealMethod().when( dbLookup ).incrementLines();
+    doReturn( stepMeta ).when( dbLookup ).getStepMeta();
+    doReturn( trans ).when( dbLookup ).getTrans();
+    doReturn( false ).when( stepMeta ).isClustered();
+    doReturn( true ).when( trans ).isExecutingClustered();
+
+    dbLookup.incrementLines();
+
+    verify( dbLookup, times( 1 ) ).incrementLinesInput();
+  }
+
+  @Test
+  public void testIncrementLinesClusteredRunningClustered() {
+
+    DatabaseLookup dbLookup = mock( DatabaseLookup.class );
+    StepMeta stepMeta = mock( StepMeta.class );
+    Trans trans = mock( Trans.class );
+
+    doCallRealMethod().when( dbLookup ).incrementLines();
+    doReturn( stepMeta ).when( dbLookup ).getStepMeta();
+    doReturn( trans ).when( dbLookup ).getTrans();
+    doReturn( true ).when( stepMeta ).isClustered();
+    doReturn( true ).when( trans ).isExecutingClustered();
+
+    dbLookup.incrementLines();
+
+    verify( dbLookup, times( 0 ) ).incrementLinesInput();
   }
 
   public class MockDatabaseLookup extends DatabaseLookup {


### PR DESCRIPTION
…alue when run in Clustered mode.

Reason behind the error relies on: 
- Increment of rows is done (correctly by `RemoteStep`).
- `DatabaseLoopup` also increments the rows (its ok for running without clustering, but doubles the results when executing in clustered mode - since the increment was already done by `RemoteStep`)

@pentaho-lmartins @pentaho/tatooine 