### PR TITLE
[PDI-18456] Update the SQLite JDBC Driver to the latest (3.27.2.1).

### DIFF
--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -35,7 +35,7 @@
         <jt400.version>6.1</jt400.version>
         <LucidDbClient-minimal.version>0.9.4</LucidDbClient-minimal.version>
         <sapdbc.version>7.4.4</sapdbc.version>
-        <sqlite-jdbc.version>3.7.2</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.27.2.1</sqlite-jdbc.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <webservices-api.version>2.3.1</webservices-api.version>
         <webservices-rt.version>2.3.1</webservices-rt.version>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -35,7 +35,7 @@
     <jt400.version>6.1</jt400.version>
     <LucidDbClient-minimal.version>0.9.4</LucidDbClient-minimal.version>
     <sapdbc.version>7.4.4</sapdbc.version>
-    <sqlite-jdbc.version>3.7.2</sqlite-jdbc.version>
+    <sqlite-jdbc.version>3.27.2.1</sqlite-jdbc.version>
     <webservices-api.version>2.3.1</webservices-api.version>
     <webservices-rt.version>2.3.1</webservices-rt.version>
     <asm.version>3.2</asm.version>

--- a/core/src/main/java/org/pentaho/di/core/database/SQLiteDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/SQLiteDatabaseMeta.java
@@ -214,7 +214,7 @@ public class SQLiteDatabaseMeta extends BaseDatabaseMeta implements DatabaseInte
 
   @Override
   public String[] getUsedLibraries() {
-    return new String[] { "sqlite-jdbc-3.7.2.jar" };
+    return new String[] { "sqlite-jdbc-3.27.2.1.jar" };
   }
 
   /**

--- a/core/src/test/java/org/pentaho/di/core/database/SQLiteDatabaseMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/SQLiteDatabaseMetaTest.java
@@ -66,7 +66,7 @@ public class SQLiteDatabaseMetaTest {
     assertFalse( nativeMeta.supportsBitmapIndex() );
     assertFalse( nativeMeta.supportsSynonyms() );
     assertFalse( nativeMeta.supportsErrorHandling() );
-    assertArrayEquals( new String[] { "sqlite-jdbc-3.7.2.jar" }, nativeMeta.getUsedLibraries() );
+    assertArrayEquals( new String[] { "sqlite-jdbc-3.27.2.1.jar" }, nativeMeta.getUsedLibraries() );
 
     assertEquals( "\"FOO\".\"BAR\"", nativeMeta.getSchemaTableCombination( "FOO", "BAR" ) );
 


### PR DESCRIPTION
This change is needed for PDI-18453 changes. 