### PR TITLE
[PDI-18228] Pan bad read of Data Grid Step

### DIFF
--- a/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
@@ -25,6 +25,7 @@ package org.pentaho.di.kitchen;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -52,6 +53,7 @@ import org.pentaho.di.core.plugins.RepositoryPluginType;
 import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.util.ExecutorUtil;
 import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.i18n.LanguageChoice;
 import org.pentaho.di.metastore.MetaStoreConst;
 import org.pentaho.di.pan.CommandLineOption;
 import org.pentaho.metastore.stores.delegate.DelegatingMetaStore;
@@ -69,7 +71,7 @@ public class Kitchen {
   public static void main( String[] a ) throws Exception {
     final ExecutorService executor = ExecutorUtil.getExecutor();
     final RepositoryPluginType repositoryPluginType = RepositoryPluginType.getInstance();
-
+    Locale.setDefault( LanguageChoice.getInstance().getDefaultLocale() );
     final Future<Map.Entry<KettlePluginException, Future<KettleException>>> repositoryRegisterFuture =
       executor.submit( new Callable<Map.Entry<KettlePluginException, Future<KettleException>>>() {
 

--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -24,6 +24,7 @@ package org.pentaho.di.pan;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.pentaho.di.base.CommandExecutorCodes;
 import org.pentaho.di.base.Params;
@@ -41,6 +42,7 @@ import org.pentaho.di.core.parameters.NamedParams;
 import org.pentaho.di.core.parameters.NamedParamsDefault;
 import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.i18n.LanguageChoice;
 import org.pentaho.di.kitchen.Kitchen;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
@@ -58,6 +60,7 @@ public class Pan {
   public static void main( String[] a ) throws Exception {
     KettleClientEnvironment.getInstance().setClient( KettleClientEnvironment.ClientType.PAN );
     KettleEnvironment.init();
+    Locale.setDefault( LanguageChoice.getInstance().getDefaultLocale() );
 
     List<String> args = new ArrayList<String>();
     for ( int i = 0; i < a.length; i++ ) {


### PR DESCRIPTION
The default Locale was not being set when we run transformations with PAN.
That caused differences between spoon and Pan executions, since spoon was initializing it accordingly to the LanguageChoice value.

In this case, the NumberFormat was different due to Locale, causing the described behavior.

Kitchen had also the same problem. It was also fixed in this PR.
