### PR TITLE
[BACKLOG-32300] S3 VFS can fail due to class not found error.

### DIFF
--- a/plugins/file-open-save-new/core/pom.xml
+++ b/plugins/file-open-save-new/core/pom.xml
@@ -174,7 +174,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
-            <Import-Package>org.pentaho.di.osgi, *</Import-Package>
+            <Import-Package>org.apache.xerces.parsers, org.pentaho.di.osgi, *</Import-Package>
             <Provide-Capability>
               org.pentaho.webpackage;root=/app
             </Provide-Capability>


### PR DESCRIPTION
AWS libraries use XMLReaderFactory.  xerces parser needed in the event
that XMLReaderFactory was initialized elsewhere, since parser classname
is statically ref'd in the factory.

https://jira.pentaho.com/browse/BACKLOG-32300