### PR TITLE
[PDI-17878] Wrong path is resolved when using {Internal.Entry.Current…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/csvinput/CsvInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/csvinput/CsvInput.java
@@ -877,7 +877,8 @@ public class CsvInput extends BaseStep implements StepInterface {
       // Otherwise, we'll grab the list of file names later...
       //
       if ( getTransMeta().findNrPrevSteps( getStepMeta() ) == 0 ) {
-        String filename = environmentSubstitute( meta.getFilename() );
+
+        String filename = filenameValidatorForInputFiles( meta.getFilename() );
 
         if ( Utils.isEmpty( filename ) ) {
           logError( BaseMessages.getString( PKG, "CsvInput.MissingFilename.Message" ) );
@@ -1161,4 +1162,15 @@ public class CsvInput extends BaseStep implements StepInterface {
 
     return strings.toArray( new String[ strings.size() ] );
   }
+
+  String filenameValidatorForInputFiles( String filename ) {
+    if ( getTransMeta().getRepository() != null && getTransMeta().getRepository().isConnected() && filename
+      .contains( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) ) {
+      return environmentSubstitute( filename.replace( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY,
+        Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY ) );
+    } else {
+      return environmentSubstitute( filename );
+    }
+  }
+
 }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputTest.java
@@ -25,9 +25,12 @@ package org.pentaho.di.trans.steps.csvinput;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.QueueRowSet;
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.steps.StepMockUtil;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
@@ -35,10 +38,13 @@ import org.pentaho.di.trans.steps.textfileinput.TextFileInputField;
 
 import java.io.File;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class CsvInputTest extends CsvInputUnitTestBase {
 
@@ -96,4 +102,65 @@ public class CsvInputTest extends CsvInputUnitTestBase {
     assertTrue( tmpFile.delete() );
     assertFalse( tmpFile.exists() );
   }
+
+  @Test
+  public void testFilenameValidatorForInputFilesConnectedToRep() {
+    CsvInput csvInput = mock( CsvInput.class );
+
+    String internalEntryVariable = "internalEntryVariable";
+    String internalTransformationVariable = "internalTransformationVariable";
+
+    String filename = Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ;
+    csvInput.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, internalEntryVariable );
+    csvInput.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, internalTransformationVariable );
+
+    TransMeta transmeta = mock( TransMeta.class );
+
+    Repository rep = mock( Repository.class );
+
+    when( csvInput.getTransMeta() ).thenReturn( transmeta );
+    when( transmeta.getRepository() ).thenReturn( rep );
+    when( rep.isConnected() ).thenReturn( true );
+
+    when( csvInput.filenameValidatorForInputFiles( any() ) ).thenCallRealMethod();
+    when( csvInput.environmentSubstitute( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY  ) ).thenReturn( internalEntryVariable );
+    when( csvInput.environmentSubstitute( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY  ) ).thenReturn( internalTransformationVariable );
+
+
+    String finalFilename = csvInput.filenameValidatorForInputFiles(filename);
+
+    assertEquals( internalTransformationVariable, finalFilename );
+
+  }
+
+  @Test
+  public void testFilenameValidatorForInputFilesNotConnectedToRep() {
+    CsvInput csvInput = mock( CsvInput.class );
+
+    String internalEntryVariable = "internalEntryVariable";
+    String internalTransformationVariable = "internalTransformationVariable";
+
+    String filename = Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ;
+    csvInput.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, internalEntryVariable );
+    csvInput.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, internalTransformationVariable );
+
+    TransMeta transmeta = mock( TransMeta.class );
+
+    Repository rep = mock( Repository.class );
+
+    when( csvInput.getTransMeta() ).thenReturn( transmeta );
+    when( transmeta.getRepository() ).thenReturn( rep );
+    when( rep.isConnected() ).thenReturn( false );
+
+    when( csvInput.filenameValidatorForInputFiles( any() ) ).thenCallRealMethod();
+    when( csvInput.environmentSubstitute( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY  ) ).thenReturn( internalEntryVariable );
+    when( csvInput.environmentSubstitute( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY  ) ).thenReturn( internalTransformationVariable );
+
+
+    String finalFilename = csvInput.filenameValidatorForInputFiles(filename);
+
+    assertEquals( internalEntryVariable, finalFilename );
+
+  }
+
 }


### PR DESCRIPTION
….Directory} in KTR called by CDA

This case is indeed a side effect of PDI-16441.

The PDI-16441 is correct, since it gives the expected behavior to how should the  variable ${Internal.Entry.Current.Directory} be working.

If we are connected to a repo - it should resolve into rep paths.
If we are not connected to a repo - it should resolve into user File-system paths.
Having that in mind, it conflicts with the CSVInput logic of allowing only CSVinputFiles from fileSystem paths, even if we are connected to a repository.

So, the described behavior was a result of a bug that PDI-16441 fixed.

Since we have some artifacts that used this behavior, previous to the PDI-16441 fix, a PR was sent: https://github.com/pentaho/pentaho-kettle/pull/7134

Please note that this is a CSVInput fix ensuring the old behavior, only when connected to a repo, since the variable itself is working as expected.

@pentaho-lmartins 