### PR TITLE
[PDI-18209] Kitchen it is not using the Parameters defined on the Job Pro…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -974,6 +974,9 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
               //
               if ( isPassingAllParameters() ) {
                 String parentValue = parentJob.getParameterValue( parameterNames[idx] );
+                if ( Utils.isEmpty( parentValue ) ) {
+                  parentValue = parentJob.getParameterDefault( parameterNames[idx] );
+                }
                 if ( !Utils.isEmpty( parentValue ) ) {
                   job.setParameterValue( parameterNames[idx], parentValue );
                 }


### PR DESCRIPTION
…perties

Kitchen & Pan do not initialize variables the same way as Spoon.

Spoon resolves them when you just click the Run Options option. Kitchen & Pan do not have that behavior, so we should use the param definition itself from our job and use the default param value created at job properties. (that is the same the Run Options logic uses to initialize)

No unit tests were broken with this fix. But QA Team should run all jobEntryJob (jobs that call another jobs) jobs to ensure no regressions on this one.

@pentaho-lmartins 