### PR TITLE
[PPP-4283] Use of Vulnerable Components: commons-httpclient-3.0.1.jar…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/http/HTTP.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/http/HTTP.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -262,14 +262,13 @@ public class HTTP extends BaseStep implements StepInterface {
       }
 
       uriBuilder = new URIBuilder( baseUrl ); // the base URL with variable substitution
-      List<NameValuePair> queryParams = uriBuilder.getQueryParams();
 
       for ( int i = 0; i < data.argnrs.length; i++ ) {
         String key = meta.getArgumentParameter()[ i ];
         String value = outputRowMeta.getString( row, data.argnrs[ i ] );
-        BasicNameValuePair basicNameValuePair = new BasicNameValuePair( key, value );
-        queryParams.add( basicNameValuePair );
+        uriBuilder.addParameter( key, value );
       }
+      List<NameValuePair> queryParams = uriBuilder.getQueryParams();
       if ( !queryParams.isEmpty() ) {
         uriBuilder.setParameters( queryParams );
       }


### PR DESCRIPTION
… and httpclient-4.0.1.jar (sonatype-2007-0004 | CVE-2011-1498 | CVE-2012-6153 | CVE-2012-5783)

URIBuilder class has changed from 4.5.3 to 4.5.9, so we have to change our code accordingly:

httpclient-4.5.9.jar
\org\apache\http\client\utils\URIBuilder.class
    public List getQueryParams()
    {
        return ((List) (queryParams == null ? Collections.emptyList() : new ArrayList(queryParams)));
    }

@smmribeiro 