### PR TITLE
[PDI-18091] Preview data for Transformation Executor step shows conve…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransPreviewDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransPreviewDelegate.java
@@ -332,6 +332,7 @@ public class TransPreviewDelegate extends SpoonDelegate implements XulEventHandl
       }
       for ( int colNr = 0; colNr < rowMeta.size(); colNr++ ) {
         int dataIndex = dataRowMeta.indexOfValue( rowMeta.getValueMeta( colNr ).getName() );
+        dataIndex = dataIndex < 0 ? colNr : dataIndex;
         String string;
         ValueMetaInterface valueMetaInterface;
         try {


### PR DESCRIPTION
…rsion error when using parameters

Analyzing this case there is in fact a previous behavior (bug?) related with the TransExecutor stepMeta, since the rowMeta provided is related with the previous step, but the rowData shows values after execution.

In this particular case the preview step we will have one Column with only one  header "example1" (provided by the DataGrid step - previous step) but our data will have 3 Columns with different headers (as result of the TransExecutor execution itself). With BACKLOG-22742 we started to use indexing to find those Columns, that now fails validating them. They don't match.

Since this was working this way before this PR ensures the old behavior again, keeping the BACKLOG-22742 logic.

No unit tests provided due to SWT items to mock.

@pentaho-lmartins 