### PR TITLE
[PDI-17423] - PDI REST Client Not Sending Content-Length(setting chunked)

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -349,7 +349,7 @@
     </dependency>
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-apache-client4</artifactId>
+      <artifactId>jersey-apache-client</artifactId>
       <version>${jersey-apache-client.version}</version>
       <exclusions>
         <exclusion>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -351,12 +351,6 @@
       <groupId>com.sun.jersey.contribs</groupId>
       <artifactId>jersey-apache-client</artifactId>
       <version>${jersey-apache-client.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/engine/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
@@ -28,9 +28,9 @@ import com.sun.jersey.api.client.UniformInterfaceException;
 import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
 import com.sun.jersey.api.uri.UriComponent;
-import com.sun.jersey.client.apache4.ApacheHttpClient4;
-import com.sun.jersey.client.apache4.config.ApacheHttpClient4Config;
-import com.sun.jersey.client.apache4.config.DefaultApacheHttpClient4Config;
+import com.sun.jersey.client.apache.ApacheHttpClient;
+import com.sun.jersey.client.apache.config.ApacheHttpClientConfig;
+import com.sun.jersey.client.apache.config.DefaultApacheHttpClientConfig;
 import com.sun.jersey.client.urlconnection.HTTPSProperties;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
 import org.apache.http.auth.AuthScope;
@@ -115,7 +115,7 @@ public class Rest extends BaseStep implements StepInterface {
         logDetailed( BaseMessages.getString( PKG, "Rest.Log.ConnectingToURL", data.realUrl ) );
       }
       // create an instance of the com.sun.jersey.api.client.Client class
-      client = ApacheHttpClient4.create( data.config );
+      client = ApacheHttpClient.create( data.config );
       if ( data.basicAuthentication != null ) {
         client.addFilter( data.basicAuthentication );
       }
@@ -285,16 +285,16 @@ public class Rest extends BaseStep implements StepInterface {
   private void setConfig() throws KettleException {
     if ( data.config == null ) {
       // Use ApacheHttpClient for supporting proxy authentication.
-      data.config = new DefaultApacheHttpClient4Config();
+      data.config = new DefaultApacheHttpClientConfig();
       if ( !Utils.isEmpty( data.realProxyHost ) ) {
         // PROXY CONFIGURATION
-        data.config.getProperties().put( ApacheHttpClient4Config.PROPERTY_PROXY_URI, "http://" + data.realProxyHost + ":" + data.realProxyPort );
+        data.config.getProperties().put( ApacheHttpClientConfig.PROPERTY_PROXY_URI, "http://" + data.realProxyHost + ":" + data.realProxyPort );
         if ( !Utils.isEmpty( data.realHttpLogin ) && !Utils.isEmpty( data.realHttpPassword ) ) {
           AuthScope authScope = new AuthScope( data.realProxyHost, data.realProxyPort );
           UsernamePasswordCredentials credentials = new UsernamePasswordCredentials( data.realHttpLogin, data.realHttpPassword );
           CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
           credentialsProvider.setCredentials( authScope, credentials );
-          data.config.getProperties().put( ApacheHttpClient4Config.PROPERTY_CREDENTIALS_PROVIDER, credentialsProvider );
+          data.config.getProperties().put( ApacheHttpClientConfig.PROPERTY_CREDENTIALS_PROVIDER, credentialsProvider );
         }
       } else {
         if ( !Utils.isEmpty( data.realHttpLogin ) ) {
@@ -303,7 +303,7 @@ public class Rest extends BaseStep implements StepInterface {
         }
       }
       if ( meta.isPreemptive() ) {
-        data.config.getProperties().put( ApacheHttpClient4Config.PROPERTY_PREEMPTIVE_BASIC_AUTHENTICATION, true );
+        data.config.getProperties().put( ApacheHttpClientConfig.PROPERTY_PREEMPTIVE_AUTHENTICATION, true );
       }
       // SSL TRUST STORE CONFIGURATION
       if ( !Utils.isEmpty( data.trustStoreFile ) ) {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/rest/RestData.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/rest/RestData.java
@@ -24,13 +24,12 @@ package org.pentaho.di.trans.steps.rest;
 
 import javax.ws.rs.core.MediaType;
 
+import com.sun.jersey.client.apache.config.DefaultApacheHttpClientConfig;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
 
 import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
-import com.sun.jersey.client.apache4.config.DefaultApacheHttpClient4Config;
-
 /**
  * @author Samatar
  * @since 16-jan-2011
@@ -94,7 +93,7 @@ public class RestData extends BaseStepData implements StepDataInterface {
   public String trustStoreFile;
   public String trustStorePassword;
 
-  public DefaultApacheHttpClient4Config config;
+  public DefaultApacheHttpClientConfig config;
 
   public HTTPBasicAuthFilter basicAuthentication;
 

--- a/engine/src/test/java/org/pentaho/di/trans/steps/rest/RestTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/rest/RestTest.java
@@ -24,7 +24,7 @@ package org.pentaho.di.trans.steps.rest;
 
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.client.apache4.ApacheHttpClient4;
+import com.sun.jersey.client.apache.ApacheHttpClient;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,7 +54,7 @@ import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith( PowerMockRunner.class )
-@PrepareForTest( ApacheHttpClient4.class )
+@PrepareForTest( ApacheHttpClient.class )
 public class RestTest {
 
   @Test
@@ -87,11 +87,11 @@ public class RestTest {
     WebResource resource = mock( WebResource.class );
     doReturn( builder ).when( resource ).getRequestBuilder();
 
-    ApacheHttpClient4 client = mock( ApacheHttpClient4.class );
+    ApacheHttpClient client = mock( ApacheHttpClient.class );
     doReturn( resource ).when( client ).resource( anyString() );
 
-    mockStatic( ApacheHttpClient4.class );
-    when( ApacheHttpClient4.create( any() ) ).thenReturn( client );
+    mockStatic( ApacheHttpClient.class );
+    when( ApacheHttpClient.create( any() ) ).thenReturn( client );
 
     RestMeta meta = mock( RestMeta.class );
     doReturn( false ).when( meta ).isDetailed();


### PR DESCRIPTION

@pentaho-lmartins 
@pentaho/tatooine 

The problem reported is related with a bug in Jersey and Apache Client Implementation.

When a ClientRequest is converted to a HttpUriRequest a private method getHttpEntity() is called that returns a HttpEntity. Unfortunately, this returns a HttpEntity whose getContentLength() always returns a -1.

When the Apache http client creates the request it will consult the HttpEntity object for a length and since it returns -1 no Content-Length header will be set.

The solution was add an implementation of Apache Http Client 3.5 for Jersey instead of 4.x.

