### PR TITLE
[PPP-4295] Use of Vulnerable Component: activemq-all, activemq-osgi, …

### DIFF
--- a/plugins/streaming/impls/mqtt/pom.xml
+++ b/plugins/streaming/impls/mqtt/pom.xml
@@ -58,7 +58,6 @@
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
     <junit.version>4.12</junit.version>
     <guava.version>17.0</guava.version>
-    <activemq.version>5.13.1</activemq.version>
     <paho.version>1.2.0</paho.version>
     <powermock.version>1.6.6</powermock.version>
   </properties>


### PR DESCRIPTION
…activeio-core, activemq-camel, activemq-karaf (CVE-2018-11775)

Merge after https://github.com/pentaho/maven-parent-poms/pull/186.

@ssamora 