### PR TITLE
[SP-5344] Backport of PDI-18175 - Hadoop file input step cannot read RFC-4180 CSV files if there are fields containing line breaks (8.3 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -889,7 +889,7 @@ public class TextFileInputUtils {
 
     int matches = 0;
 
-    if ( StringUtils.isBlank( text ) ) {
+    if ( StringUtils.isBlank( text ) || StringUtils.isBlank( regex ) ) {
       return matches;
     }
 

--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -289,6 +289,48 @@ public class TextFileInputUtils {
   }
 
   public static final String getLine( LogChannelInterface log, InputStreamReader reader, EncodingType encodingType,
+                                      int fileFormatType, StringBuilder line, String regex )
+    throws KettleFileException {
+
+    return getLine( log, reader, encodingType, fileFormatType, line, regex, 0 ).line;
+
+  }
+
+  /**
+   *
+   * Returns in the first position a line; ;
+   * on the second position how many lines from file were read to get a full line
+   *
+   */
+  public static final TextFileLine getLine( LogChannelInterface log, InputStreamReader reader, EncodingType encodingType,
+                                      int fileFormatType, StringBuilder line, String regex, long lineNumberInFile )
+    throws KettleFileException {
+
+    String sline = getLine( log, reader, encodingType, fileFormatType, line );
+
+    while ( sline != null ) {
+    /*
+    Check that the number of enclosures in a line is even.
+    If not even it means that there was an enclosed line break.
+    We need to read the next line(s) to get the remaining data in this row.
+    */
+      if ( checkPattern( sline, regex ) % 2 == 0 ) {
+        return new TextFileLine( sline, lineNumberInFile, null );
+      }
+
+      String nextLine = getLine( log, reader, encodingType, fileFormatType, line );
+
+      if ( nextLine == null ) {
+        break;
+      }
+
+      sline = sline + nextLine;
+      lineNumberInFile++;
+    }
+    return new TextFileLine( sline, lineNumberInFile, null );
+  }
+
+  public static final String getLine( LogChannelInterface log, InputStreamReader reader, EncodingType encodingType,
       int formatNr, StringBuilder line ) throws KettleFileException {
     int c = 0;
     line.setLength( 0 );
@@ -901,5 +943,26 @@ public class TextFileInputUtils {
     }
 
     return matches;
+  }
+
+  /**
+   *
+   * Returns the line number in file
+   *
+   */
+
+  public static long skipLines( LogChannelInterface log, InputStreamReader reader, EncodingType encodingType,
+                                int fileFormatType, StringBuilder line, int nrLinesToSkip,
+                                String regex, long lineNumberInFile ) throws KettleFileException {
+
+    TextFileLine textFileLine = getLine( log, reader, encodingType, fileFormatType, line, regex, lineNumberInFile );
+    int skipped = 1;
+
+    while ( textFileLine.line != null && skipped < nrLinesToSkip ) {
+      textFileLine = getLine( log, reader, encodingType, fileFormatType, line, regex, textFileLine.lineNumber );
+      skipped++;
+    }
+
+    return textFileLine.lineNumber;
   }
 }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileLine.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileLine.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -35,6 +35,26 @@ public class TextFileLine {
     super();
     this.line = line;
     this.lineNumber = lineNumber;
+    this.file = file;
+  }
+
+  public String getLine() {
+    return line;
+  }
+
+  public void setLine( String line ) {
+    this.line = line;
+  }
+
+  public long getLineNumber() {
+    return lineNumber;
+  }
+
+  public FileObject getFile() {
+    return file;
+  }
+
+  public void setFile( FileObject file ) {
     this.file = file;
   }
 }

--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
@@ -66,7 +66,7 @@ import org.pentaho.di.trans.step.errorhandling.CompositeFileErrorHandler;
 import org.pentaho.di.trans.step.errorhandling.FileErrorHandler;
 import org.pentaho.di.trans.step.errorhandling.FileErrorHandlerContentLineNumber;
 import org.pentaho.di.trans.step.errorhandling.FileErrorHandlerMissingFiles;
-
+import org.pentaho.di.trans.steps.fileinput.text.TextFileLine;
 
 /**
  * Read all sorts of text files, convert them to rows and writes these to one or more output streams.
@@ -651,7 +651,7 @@ public class TextFileInput extends BaseStep implements StepInterface {
       boolean addPath, boolean addSize, boolean addIsHidden, boolean addLastModificationDate, boolean addUri,
       boolean addRootUri, String shortFilename, String path, boolean hidden, Date modificationDateTime, String uri,
       String rooturi, String extension, long size, final boolean failOnParseError ) throws KettleException {
-    if ( textFileLine == null || textFileLine.line == null ) {
+    if ( textFileLine == null || textFileLine.getLine() == null ) {
       return null;
     }
 
@@ -676,7 +676,7 @@ public class TextFileInput extends BaseStep implements StepInterface {
 
     try {
       // System.out.println("Convertings line to string ["+line+"]");
-      String[] strings = convertLineToStrings( log, textFileLine.line, info, delimiter, enclosure, escapeCharacter );
+      String[] strings = convertLineToStrings( log, textFileLine.getLine(), info, delimiter, enclosure, escapeCharacter );
       int shiftFields = ( passThruFields == null ? 0 : nrPassThruFields );
       for ( fieldnr = 0; fieldnr < nrfields; fieldnr++ ) {
         TextFileInputField f = info.getInputFields()[fieldnr];
@@ -732,7 +732,7 @@ public class TextFileInput extends BaseStep implements StepInterface {
                   errorText = sb.toString();
                 }
                 if ( errorHandler != null ) {
-                  errorHandler.handleLineError( textFileLine.lineNumber, AbstractFileErrorHandler.NO_PARTS );
+                  errorHandler.handleLineError( textFileLine.getLineNumber(), AbstractFileErrorHandler.NO_PARTS );
                 }
 
                 if ( info.isErrorLineSkipped() ) {
@@ -990,7 +990,7 @@ public class TextFileInput extends BaseStep implements StepInterface {
       if ( !data.doneWithHeader && data.pageLinesRead == 0 ) {
         // We are reading header lines
         if ( log.isRowLevel() ) {
-          logRowlevel( "P-HEADER (" + data.headerLinesRead + ") : " + textLine.line );
+          logRowlevel( "P-HEADER (" + data.headerLinesRead + ") : " + textLine.getLine() );
         }
         data.headerLinesRead++;
         if ( data.headerLinesRead >= meta.getNrHeaderLines() ) {
@@ -1005,15 +1005,15 @@ public class TextFileInput extends BaseStep implements StepInterface {
             for ( int i = 0; i < meta.getNrWraps(); i++ ) {
               String extra = "";
               if ( data.lineBuffer.size() > 0 ) {
-                extra = data.lineBuffer.get( 0 ).line;
+                extra = data.lineBuffer.get( 0 ).getLine();
                 data.lineBuffer.remove( 0 );
               }
-              textLine.line += extra;
+              textLine.setLine( textLine.getLine() + extra );
             }
           }
 
           if ( log.isRowLevel() ) {
-            logRowlevel( "P-DATA: " + textLine.line );
+            logRowlevel( "P-DATA: " + textLine.getLine() );
           }
           // Read a normal line on a page of data.
           data.pageLinesRead++;
@@ -1051,7 +1051,7 @@ public class TextFileInput extends BaseStep implements StepInterface {
 
           if ( meta.hasFooter() && data.footerLinesRead < meta.getNrFooterLines() ) {
             if ( log.isRowLevel() ) {
-              logRowlevel( "P-FOOTER: " + textLine.line );
+              logRowlevel( "P-FOOTER: " + textLine.getLine() );
             }
             data.footerLinesRead++;
           }
@@ -1094,18 +1094,18 @@ public class TextFileInput extends BaseStep implements StepInterface {
             for ( int i = 0; i < meta.getNrWraps(); i++ ) {
               String extra = "";
               if ( data.lineBuffer.size() > 0 ) {
-                extra = data.lineBuffer.get( 0 ).line;
+                extra = data.lineBuffer.get( 0 ).getLine();
                 data.lineBuffer.remove( 0 );
               } else {
                 tryToReadLine( true );
                 if ( !data.lineBuffer.isEmpty() ) {
-                  extra = data.lineBuffer.remove( 0 ).line;
+                  extra = data.lineBuffer.remove( 0 ).getLine();
                 }
               }
-              textLine.line += extra;
+              textLine.setLine( textLine.getLine() + extra );
             }
           }
-          if ( data.filePlayList.isProcessingNeeded( textLine.file, textLine.lineNumber,
+          if ( data.filePlayList.isProcessingNeeded( textLine.getFile(), textLine.getLineNumber(),
               AbstractFileErrorHandler.NO_PARTS ) ) {
             data.lineInFile++;
             long useNumber = meta.isRowNumberByFile() ? data.lineInFile : getLinesWritten() + 1;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/TextFileInputData.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/TextFileInputData.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -38,6 +38,7 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.errorhandling.FileErrorHandler;
+import org.pentaho.di.trans.steps.fileinput.text.TextFileLine;
 
 /**
  * @author Matt

--- a/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputContentParsingTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputContentParsingTest.java
@@ -206,6 +206,21 @@ public class CsvInputContentParsingTest extends BaseCsvParsingTest {
     );
   }
 
+  @Test
+  public void testEnclosures() throws Exception {
+    meta.setDelimiter( ";" );
+    meta.setEnclosure( "'" );
+    init( "enclosures.csv" );
+
+    setFields( new TextFileInputField( "Field 1", -1, -1 ), new TextFileInputField( "Field 2", -1, -1 ),
+      new TextFileInputField( "Field 3", -1, -1 ) );
+
+    process();
+
+    check( new Object[][] { { "1", "This line is un-even enclosure-wise because I'm using an escaped enclosure", "a" },
+      { "2", "Test isn't even\nhere", "b" } } );
+  }
+
   @Test( expected = KettleStepException.class )
   public void testNoHeaderOptions() throws Exception {
     meta.setHeaderPresent( false );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
@@ -51,6 +51,7 @@ import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.TransTestingUtil;
 import org.pentaho.di.trans.step.errorhandling.FileErrorHandler;
+import org.pentaho.di.trans.steps.fileinput.text.TextFileLine;
 import org.pentaho.di.trans.steps.StepMockUtil;
 import org.pentaho.di.utils.TestUtils;
 
@@ -277,7 +278,7 @@ public class TextFileInputTest {
   public void convertLineToRowTest() throws Exception {
     LogChannelInterface log = Mockito.mock( LogChannelInterface.class );
     TextFileLine textFileLine = Mockito.mock( TextFileLine.class );
-    textFileLine.line = "testData1;testData2;testData3";
+    textFileLine.setLine( "testData1;testData2;testData3" );
     InputFileMetaInterface info = Mockito.mock( InputFileMetaInterface.class );
     TextFileInputField[] textFileInputFields = { new TextFileInputField(), new TextFileInputField(), new TextFileInputField() };
     Mockito.doReturn( textFileInputFields ).when( info ).getInputFields();

--- a/engine/src/test/resources/org/pentaho/di/trans/steps/csvinput/files/enclosures.csv
+++ b/engine/src/test/resources/org/pentaho/di/trans/steps/csvinput/files/enclosures.csv
@@ -1,0 +1,4 @@
+Field 1;Field 2;Field 3
+1;'This line is un-even enclosure-wise because I''m using an escaped enclosure';a
+2;'Test isn''t even
+here';b

--- a/ui/src/main/java/org/pentaho/di/ui/trans/step/common/CsvInputAwareStepDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/step/common/CsvInputAwareStepDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2018-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -81,7 +81,7 @@ public interface CsvInputAwareStepDialog {
 
     // Read a line of data to determine the number of rows...
     final String line = TextFileInputUtils.getLine( getLogChannel(), reader, encodingType, meta.getFileFormatTypeNr(),
-      new StringBuilder( 1000 ) );
+      new StringBuilder( 1000 ), enclosure );
     if ( !StringUtils.isBlank( line ) ) {
       fieldNames = CsvInput.guessStringsFromLine( getLogChannel(), line, delimiter, enclosure,
         meta.getEscapeCharacter() );

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/fileinput/text/TextFileCSVImportProgressDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/fileinput/text/TextFileCSVImportProgressDialog.java
@@ -269,26 +269,11 @@ public class TextFileCSVImportProgressDialog implements CsvInputAwareImportProgr
     int fileFormatType = meta.getFileFormatTypeNr();
 
     if ( meta.content.header ) {
-      line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
-      fileLineNumber++;
-      int skipped = 0;
-      while ( line != null && skipped < meta.content.nrHeaderLines ) {
-        /*
-        Check that the number of enclosures in a line is even.
-        If not even it means that there was an enclosed line break.
-        We need to read the next line(s) to get the remaining data in this row.
-        */
-        if ( TextFileInputUtils.checkPattern( line, meta.getEnclosure() ) % 2 != 0 ) {
-          line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
-        } else {
-          //Increment when a full line header was read
-          skipped++;
-        }
-        fileLineNumber++;
-      }
+      fileLineNumber = TextFileInputUtils.skipLines( log, reader, encodingType, fileFormatType, lineBuffer,
+        meta.content.nrHeaderLines, meta.getEnclosure(), fileLineNumber );
     }
     //Reading the first line of data
-    line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
+    line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineBuffer, meta.getEnclosure() );
     int linenr = 1;
 
     List<StringEvaluator> evaluators = new ArrayList<StringEvaluator>();
@@ -302,19 +287,7 @@ public class TextFileCSVImportProgressDialog implements CsvInputAwareImportProgr
     while ( !errorFound && line != null && ( linenr <= samples || samples == 0 ) && !monitor.isCanceled() ) {
       monitor.subTask( BaseMessages.getString( PKG, "TextFileCSVImportProgressDialog.Task.ScanningLine", ""
           + linenr ) );
-      while ( line != null ) {
-        /*
-        Check that the number of enclosures in a line is even.
-        If not even it means that there was an enclosed line break.
-        We need to read the next line(s) to get the remaining data in this row.
-        */
-        if ( TextFileInputUtils.checkPattern( line, meta.getEnclosure() ) % 2 != 0 ) {
-          line = line + TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
-          fileLineNumber++;
-        } else {
-          break;
-        }
-      }
+
       if ( samples > 0 ) {
         monitor.worked( 1 );
       }
@@ -362,14 +335,15 @@ public class TextFileCSVImportProgressDialog implements CsvInputAwareImportProgr
         evaluator.evaluateString( string );
       }
 
-      fileLineNumber++;
       if ( r != null ) {
         linenr++;
       }
 
       // Grab another line...
-      //
-      line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
+      TextFileLine textFileLine = TextFileInputUtils
+        .getLine( log, reader, encodingType, fileFormatType, lineBuffer, enclosure, fileLineNumber );
+      line = textFileLine.getLine();
+      fileLineNumber = textFileLine.getLineNumber();
     }
 
     monitor.worked( 1 );

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/fileinput/text/TextFileInputDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/fileinput/text/TextFileInputDialog.java
@@ -2825,30 +2825,22 @@ public class TextFileInputDialog extends BaseStepDialog implements StepDialogInt
         if ( skipHeaders ) {
           // Skip the header lines first if more then one, it helps us position
           if ( meta.content.layoutPaged && meta.content.nrLinesDocHeader > 0 ) {
-            int skipped = 0;
-            String line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineStringBuilder );
-            while ( line != null && skipped < meta.content.nrLinesDocHeader - 1 ) {
-              skipped++;
-              line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineStringBuilder );
-            }
+            TextFileInputUtils.skipLines( log, reader, encodingType, fileFormatType,
+              lineStringBuilder,  meta.content.nrLinesDocHeader - 1, meta.getEnclosure(), 0 );
           }
 
           // Skip the header lines first if more then one, it helps us position
           if ( meta.content.header && meta.content.nrHeaderLines > 0 ) {
-            int skipped = 0;
-            String line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineStringBuilder );
-            while ( line != null && skipped < meta.content.nrHeaderLines - 1 ) {
-              skipped++;
-              line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineStringBuilder );
-            }
+            TextFileInputUtils.skipLines( log, reader, encodingType, fileFormatType,
+              lineStringBuilder,  meta.content.nrHeaderLines - 1, meta.getEnclosure(), 0 );
           }
         }
 
-        String line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineStringBuilder );
+        String line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineStringBuilder, meta.getEnclosure() );
         while ( line != null && ( linenr < maxnr || nrlines == 0 ) ) {
           retval.add( line );
           linenr++;
-          line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineStringBuilder );
+          line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineStringBuilder, meta.getEnclosure() );
         }
       } catch ( Exception e ) {
         throw new KettleException( BaseMessages.getString( PKG, "TextFileInputDialog.Exception.ErrorGettingFirstLines",

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/textfileinput/TextFileCSVImportProgressDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/textfileinput/TextFileCSVImportProgressDialog.java
@@ -50,12 +50,12 @@ import org.pentaho.di.core.util.StringEvaluator;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.steps.fileinput.text.TextFileInputUtils;
-import org.pentaho.di.trans.steps.textfileinput.EncodingType;
+import org.pentaho.di.trans.steps.fileinput.text.EncodingType;
+import org.pentaho.di.trans.steps.fileinput.text.TextFileLine;
 import org.pentaho.di.trans.steps.textfileinput.InputFileMetaInterface;
 import org.pentaho.di.trans.steps.textfileinput.TextFileInput;
 import org.pentaho.di.trans.steps.textfileinput.TextFileInputField;
 import org.pentaho.di.trans.steps.textfileinput.TextFileInputMeta;
-import org.pentaho.di.trans.steps.textfileinput.TextFileLine;
 import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.trans.step.common.CsvInputAwareImportProgressDialog;
 
@@ -271,26 +271,11 @@ public class TextFileCSVImportProgressDialog implements CsvInputAwareImportProgr
     int fileFormatType = meta.getFileFormatTypeNr();
 
     if ( meta.hasHeader() ) {
-      line = TextFileInput.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
-      fileLineNumber++;
-      int skipped = 0;
-      while ( line != null && skipped < meta.getNrHeaderLines() ) {
-        /*
-        Check that the number of enclosures in a line is even.
-        If not even it means that there was an enclosed line break.
-        We need to read the next line(s) to get the remaining data in this row.
-        */
-        if ( TextFileInputUtils.checkPattern( line, meta.getEnclosure() ) % 2 != 0 ) {
-          line = line + TextFileInput.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
-        } else {
-          //Increment when a full line header was read
-          skipped++;
-        }
-        fileLineNumber++;
-      }
+      fileLineNumber = TextFileInputUtils.skipLines( log, reader, encodingType, fileFormatType, lineBuffer,
+        meta.getNrHeaderLines(), meta.getEnclosure(), fileLineNumber );
     }
     //Reading the first line of data
-    line = TextFileInput.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
+    line = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineBuffer, meta.getEnclosure() );
     int linenr = 1;
 
     List<StringEvaluator> evaluators = new ArrayList<StringEvaluator>();
@@ -304,19 +289,6 @@ public class TextFileCSVImportProgressDialog implements CsvInputAwareImportProgr
     while ( !errorFound && line != null && ( linenr <= samples || samples == 0 ) && !monitor.isCanceled() ) {
       monitor.subTask( BaseMessages.getString( PKG, "TextFileCSVImportProgressDialog.Task.ScanningLine", ""
         + linenr ) );
-      while ( line != null ) {
-        /*
-        Check that the number of enclosures in a line is even.
-        If not even it means that there was an enclosed line break.
-        We need to read the next line(s) to get the remaining data in this row.
-        */
-        if ( TextFileInputUtils.checkPattern( line, meta.getEnclosure() ) % 2 != 0 ) {
-          line = line + TextFileInput.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
-          fileLineNumber++;
-        } else {
-          break;
-        }
-      }
       if ( samples > 0 ) {
         monitor.worked( 1 );
       }
@@ -364,14 +336,15 @@ public class TextFileCSVImportProgressDialog implements CsvInputAwareImportProgr
         evaluator.evaluateString( string );
       }
 
-      fileLineNumber++;
       if ( r != null ) {
         linenr++;
       }
 
       // Grab another line...
-      //
-      line = TextFileInput.getLine( log, reader, encodingType, fileFormatType, lineBuffer );
+      TextFileLine
+        textFileLine = TextFileInputUtils.getLine( log, reader, encodingType, fileFormatType, lineBuffer, enclosure, fileLineNumber );
+      line = textFileLine.getLine();
+      fileLineNumber = textFileLine.getLineNumber();
     }
 
     monitor.worked( 1 );


### PR DESCRIPTION
**Attention: This is the outcome of an automated process!**
Merge Masters: @ppatricio and @bcostahitachivantara
Cherry-picks:
* https://github.com/Pentaho/pentaho-kettle/commit/c970269d66109f9f356a144d1a2c239d0d268ece
* https://github.com/Pentaho/pentaho-kettle/commit/d4a3cbb9aea2732d009925ac4742f61a568c88e8
