### PR TITLE
[BACKLOG-32808] Internal variables are not used when selecting a file…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/core/events/dialog/SelectionAdapterFileDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/events/dialog/SelectionAdapterFileDialog.java
@@ -392,6 +392,12 @@ public abstract class SelectionAdapterFileDialog<T> extends SelectionAdapter {
   private static String replaceCurrentDir( String path, String parentPath ) {
     if ( !Utils.isEmpty( path ) && !Utils.isEmpty( parentPath ) && path.startsWith( parentPath ) ) {
       path = path.replace( parentPath, "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}" );
+
+      // Ensure the path is uniform for windows. Path's using the internal variable need to use forward slash
+      if ( Const.isWindows() ) {
+        path = path.replace( '\\', '/' );
+      }
+
     }
     return path;
   }


### PR DESCRIPTION
… or folder in the same directory when using updated VFS browser