### PR TITLE
[BACKLOG-33104] - Copyright needs to be updated to 2020 on 'Info.plis…

### DIFF
--- a/assemblies/static/src/main/resources-filtered/Data Integration.app/Contents/Info.plist
+++ b/assemblies/static/src/main/resources-filtered/Data Integration.app/Contents/Info.plist
@@ -7,7 +7,7 @@
 		<key>CFBundleDevelopmentRegion</key>
 		<string>English</string>
 		<key>CFBundleGetInfoString</key>
-		<string>Pentaho Data Integration ${project.version} (c) 2007 - 2019 Hitachi Vantara</string>
+		<string>Pentaho Data Integration ${project.version} (c) 2007 - 2020 Hitachi Vantara</string>
 		<key>CFBundleExecutable</key>
 		<string>JavaApplicationStub</string>
 		<key>CFBundleIconFile</key>


### PR DESCRIPTION
…t' for each client tool

@pentaho/millenniumfalcon 