### PR TITLE
[PDI-18440][PDI-18442] Fixes issues with null v.s. empty values

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -741,6 +741,24 @@ public class Const {
   public static final String KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL";
 
   /**
+   * This flag will prevent Kettle from converting {@code null} strings to empty strings in {@link org.pentaho.di.core.row.value.ValueMetaBase}
+   * The default value is {@code false}.
+   */
+  public static final String KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY = "KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY";
+
+  /**
+   * This flag will prevent Kettle from yielding {@code null} as the value of an empty XML tag in {@link org.pentaho.di.core.xml.XMLHandler}
+   * The default value is {@code false} and an empty XML tag will produce a {@code null} value.
+   */
+  public static final String KETTLE_XML_EMPTY_TAG_YIELDS_EMPTY_VALUE = "KETTLE_XML_EMPTY_TAG_YIELDS_EMPTY_VALUE";
+
+  /**
+   * This flag will cause the "Get XML data" step to yield null values on missing elements and empty values on empty elements when set to "Y".
+   * By default, both empty elements and missing elements will yield empty values.
+   */
+  public static final String KETTLE_XML_MISSING_TAG_YIELDS_NULL_VALUE = "KETTLE_XML_MISSING_TAG_YIELDS_NULL_VALUE";
+
+  /**
    * System wide flag to allow non-strict string to number conversion for backward compatibility. If this setting is set
    * to "Y", an string starting with digits will be converted successfully into a number. (example: 192.168.1.1 will be
    * converted into 192 or 192.168 depending on the decimal symbol). The default (N) will be to throw an error if

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -4033,8 +4033,13 @@ public class ValueMetaBase implements ValueMetaInterface {
     Boolean isEmptyAndNullDiffer = convertStringToBoolean(
         Const.NVL( System.getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
 
-    if ( pol == null && isStringValue && isEmptyAndNullDiffer ) {
-      pol = Const.NULL_STRING;
+    Boolean normalizeNullStringToEmpty = !convertStringToBoolean(
+      Const.NVL( System.getProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" ), "N" ) );
+
+    if ( normalizeNullStringToEmpty ) {
+      if ( pol == null && isStringValue && isEmptyAndNullDiffer ) {
+        pol = Const.NULL_STRING;
+      }
     }
 
     if ( pol == null ) {

--- a/core/src/main/java/org/pentaho/di/core/xml/XMLHandler.java
+++ b/core/src/main/java/org/pentaho/di/core/xml/XMLHandler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -70,6 +70,8 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import static org.pentaho.di.core.row.value.ValueMetaBase.convertStringToBoolean;
+
 
 /**
  * This class contains a number of (static) methods to facilitate the retrieval of information from XML Node(s).
@@ -131,12 +133,19 @@ public class XMLHandler {
       return null;
     }
 
+    Boolean xmlEmptyTagYieldsEmptyValue = convertStringToBoolean(
+      Const.NVL( System.getProperty( Const.KETTLE_XML_EMPTY_TAG_YIELDS_EMPTY_VALUE, "N" ), "N" ) );
+
     children = n.getChildNodes();
     for ( int i = 0; i < children.getLength(); i++ ) {
       childnode = children.item( i );
       if ( childnode.getNodeName().equalsIgnoreCase( tag ) ) {
-        if ( childnode.getFirstChild() != null ) {
-          return childnode.getFirstChild().getNodeValue();
+        if ( xmlEmptyTagYieldsEmptyValue ) {
+          return childnode.getTextContent();
+        } else {
+          if ( childnode.getFirstChild() != null ) {
+            return childnode.getFirstChild().getNodeValue();
+          }
         }
       }
     }

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest_NullEmpty.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest_NullEmpty.java
@@ -1,0 +1,79 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2020 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.row.value;
+
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ValueMetaBaseTest_NullEmpty {
+
+  /**
+   * By default, converting null value to a string value will yield a null value.
+   * This is the expected behavior in current and past versions.
+   */
+  @Test
+  public void convertDataFromStringWithDefaults() throws Exception {
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
+    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" );
+
+    ValueMetaBase out = new ValueMetaString();
+    ValueMetaBase value = new ValueMetaString();
+
+    Object data = out.convertDataFromString( null, value, null, null, 0 );
+    assertNull( data );
+  }
+
+  /**
+   * When KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL is set to "Y" whe start getting unexpected results, see PDI-18440.
+   * This flag should have no effect in data conversions, only when comparing values.
+   */
+  @Test
+  public void convertDataFromStringWithEmptyDiffersFromNull() throws Exception {
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
+    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" );
+
+    ValueMetaBase out = new ValueMetaString();
+    ValueMetaBase value = new ValueMetaString();
+
+    Object data = out.convertDataFromString( null, value, null, null, 0 );
+    assertEquals( "", data );
+  }
+
+  /**
+   * The new KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY flag fixes PDI-18440 resetting the behavior to what is expected.
+   */
+  @Test
+  public void convertDataFromStringWithEmptyDiffersFromNullAndDoNotNormalize() throws Exception {
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
+    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
+
+    ValueMetaBase out = new ValueMetaString();
+    ValueMetaBase value = new ValueMetaString();
+
+    Object data = out.convertDataFromString( null, value, null, null, 0 );
+    assertNull( data );
+  }
+}

--- a/core/src/test/java/org/pentaho/di/core/xml/XMLHandlerTest.java
+++ b/core/src/test/java/org/pentaho/di/core/xml/XMLHandlerTest.java
@@ -1,0 +1,81 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2020 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.xml;
+
+import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class XMLHandlerTest {
+
+  @Test
+  public void getTagValueWithNullNode() {
+    assertNull( XMLHandler.getTagValue( null, "text"  ) );
+  }
+
+  /**
+   * Default behavior, an empty XML tag in the "Filter rows" step meta will be considered {@code null}.
+   * This will prevent filtering rows with empty values.
+   */
+  @Test
+  public void getTagValueEmptyTagYieldsNullValue() {
+    System.setProperty( Const.KETTLE_XML_EMPTY_TAG_YIELDS_EMPTY_VALUE, "N" );
+    assertNull( XMLHandler.getTagValue( getNode(), "text"  ) );
+  }
+
+  /**
+   * An empty XML tag in the "Filter rows" step meta will be considered an empty string.
+   * This will allow filtering rows with empty values.
+   */
+  @Test
+  public void getTagValueEmptyTagYieldsEmptyValue() {
+    System.setProperty( Const.KETTLE_XML_EMPTY_TAG_YIELDS_EMPTY_VALUE, "Y" );
+    assertEquals( "", XMLHandler.getTagValue( getNode(), "text"  ) );
+  }
+
+  private Node getNode() {
+    Element first = mock( Element.class );
+    doReturn( null ).when( first ).getNodeValue();
+
+    Node child = mock( Node.class );
+    doReturn( "text" ).when( child ).getNodeName();
+    doReturn( first ).when( child ).getFirstChild();
+    doReturn( "" ).when( child ).getTextContent();
+
+    NodeList children = mock( NodeList.class );
+    doReturn( 1 ).when( children ).getLength();
+    doReturn( child ).when( children ).item( 0 );
+
+    Node node = mock( Node.class );
+    doReturn( children ).when( node ).getChildNodes();
+
+    return node;
+  }
+}

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -149,6 +149,24 @@
   </kettle-variable>
 
   <kettle-variable>
+    <description>Prevents Kettle from converting null strings to empty strings when KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL is set to "Y".</description>
+    <variable>KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY</variable>
+    <default-value>N</default-value>
+  </kettle-variable>
+
+  <kettle-variable>
+    <description>Prevent Kettle from yielding null as the value of an empty value.</description>
+    <variable>KETTLE_XML_EMPTY_TAG_YIELDS_EMPTY_VALUE</variable>
+    <default-value>N</default-value>
+  </kettle-variable>
+
+  <kettle-variable>
+    <description>Cause the "Get XML data" step to yield null values on missing elements and empty values on empty elements when set to "Y".</description>
+    <variable>KETTLE_XML_MISSING_TAG_YIELDS_NULL_VALUE</variable>
+    <default-value>N</default-value>
+  </kettle-variable>
+
+  <kettle-variable>
     <description>The maximum number of log lines that are kept internally by Kettle. Set to 0 to keep all rows
       (default)
     </description>


### PR DESCRIPTION
This is the proposed fix using three different Kettle properties to override the behavior of `KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL` which is producing different results from previous versions considering version **4.4.2** as the correct behavior.

When `KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL` is set to "Y", three other flags may need to be set to "Y" to accommodate changes in behavior between versions.

- `KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY` - prevents the **Data grid** step from producing empty values when the "Set empty value" option is not set for a given field
- `KETTLE_XML_EMPTY_TAG_YIELDS_EMPTY_VALUE` - allows the **Filter rows** step to filter rows on an empty values, if not set, the empty value will be converted to a `null` and the comparison between empty and null will yield false, thus not filtering the wanted rows;
- `KETTLE_XML_MISSING_TAG_YIELDS_NULL_VALUE` - causes the **Get XML data** step to yield null values on missing elements and empty values on empty elements, otherwise it will always produce empty values, even when nodes are missing.

Please review but **do not merge**.

@ssamora @ppatricio @pamval 