### PR TITLE
[PDI-18616] Fix CACHED_ROW_META target description not displayed in E…

### DIFF
--- a/engine/src/main/resources/org/pentaho/di/trans/steps/tableinput/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/tableinput/messages/messages_en_US.properties
@@ -24,6 +24,7 @@ TableInput.Exception.DatabaseConnectionsIsNeeded=You need to specify a database 
 TableInputMeta.InfoStream.Description=These rows are used as parameters.  
 TableInputMeta.Injection.SQL=The SQL statement used to read information from the database connection.
 TableInputMeta.Injection.LAZY_CONVERSION=Enable this option to optimize data type conversion performance.
+TableInputMeta.Injection.CACHED_ROW_META=Enable this option to cache row metadata.
 TableInputMeta.Injection.REPLACE_VARIABLES=Enable this option to replace variables in the script.
 TableInputMeta.Injection.EXECUTE_FOR_EACH_ROW=Enable this option to data insert for each individual row.
 TableInputMeta.Injection.LIMIT=The maximum number of lines to read.


### PR DESCRIPTION
## description
Add TableInputMeta.Injection.CACHED_ROW_META description:
TableInputMeta.Injection.CACHED_ROW_META = Enable this option to cache row metadata.

Verification is as follows:
![check](http://www.zhangrenhua.com/back_images/[PDI-18616]-check.png)

## Changed files
org/pentaho/di/trans/steps/tableinput/messages/messages_en_US.properties