### PR TITLE
[PDI-16613] Fix Run configurations drop down list is editable and giv…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/core/dialog/ConfigurationDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/dialog/ConfigurationDialog.java
@@ -446,7 +446,7 @@ public abstract class ConfigurationDialog extends Dialog {
     fdlRunConfiguration.left = new FormAttachment( 0 );
     wlRunConfiguration.setLayoutData( fdlRunConfiguration );
 
-    wRunConfiguration = new CCombo( cRunConfiguration, SWT.BORDER );
+    wRunConfiguration = new CCombo( cRunConfiguration, SWT.BORDER | SWT.READ_ONLY );
     props.setLook( wRunConfiguration );
     FormData fdRunConfiguration = new FormData();
     fdRunConfiguration.width = 200;


### PR DESCRIPTION
## description
Run configurations is set to read-only mode, the code is as follows:
old: `wRunConfiguration = new CCombo( cRunConfiguration, SWT.BORDER);`
new: `wRunConfiguration = new CCombo( cRunConfiguration, SWT.BORDER | SWT.READ_ONLY );`

Verification is as follows:
![check](http://www.zhangrenhua.com/back_images/[PDI-16613]-check.png)

## Changed files
org.pentaho.di.ui.core.dialog.ConfigurationDialog.java