### PR TITLE
[PDI-18369] Converting Integer to Timestamp type using Select values …

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1359,11 +1359,34 @@ public class Const {
   public static final String KETTLE_BIGDECIMAL_DIVISION_ROUNDING_MODE_DEFAULT = "HALF_EVEN";
 
   /**
-   * <p>This environment variable is used to define if a Timestamp should be converted to nanoseconds or milliseconds.</p>
-   * <p>By default, a Timestamp is in nanoseconds.</p>
+   * <p>This environment variable is used to define if a Timestamp should be converted to nanoseconds or
+   * milliseconds.</p>
+   * <p>By default, a Timestamp is in {@value #KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT}.</p>
+   *
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS
    */
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT = "KETTLE_TIMESTAMP_NUMERIC_FORMAT";
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = "NANOSECONDS";
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT = "KETTLE_TIMESTAMP_OUTPUT_FORMAT";
+
+  /**
+   * <p>The value to use for setting the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT} as nanoseconds.</p>
+   *
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS
+   */
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS = "NANOSECONDS";
+
+  /**
+   * <p>The value to use for setting the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT} as milliseconds.</p>
+   *
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS
+   */
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS = "MILLISECONDS";
+
+  /**
+   * <p>The default value for the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT}.</p>
+   */
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS;
 
   /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
@@ -53,8 +53,8 @@ import org.pentaho.di.core.row.value.timestamp.SimpleTimestampFormat;
 
 public class ValueMetaTimestamp extends ValueMetaDate {
   private final String format =
-    Const.NVL( EnvUtil.getSystemProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT ), "NANOSECONDS" );
-  private static final String MILLISECONDS = "MILLISECONDS";
+    Const.NVL( EnvUtil.getSystemProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT ),
+      Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS );
 
   public ValueMetaTimestamp() {
     this( null );
@@ -86,11 +86,11 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( format.equalsIgnoreCase( MILLISECONDS )  ) {
-      return Long.valueOf( milliseconds );
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
+      return  milliseconds;
     } else {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
-      return seconds * 1000000000 + timestamp.getNanos();
+      return seconds * 1000000000L + timestamp.getNanos();
     }
   }
 
@@ -102,11 +102,11 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( format.equalsIgnoreCase( MILLISECONDS )  ) {
-      return Double.valueOf( milliseconds );
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
+      return (double) milliseconds;
     } else {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
-      return (double) seconds * 1000000000 + timestamp.getNanos();
+      return (double) seconds * 1000000000L + timestamp.getNanos();
     }
   }
 
@@ -118,7 +118,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( format.equalsIgnoreCase( MILLISECONDS )  ) {
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
       return BigDecimal.valueOf( milliseconds );
     } else {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
@@ -196,12 +196,18 @@ public class ValueMetaTimestampTest {
   @Test
   public void testConvertTimestampToIntegerInMilliseconds() throws KettleValueException {
     TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
-    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "MILLISECONDS" );
+    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS );
     Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     long result = valueMetaTimestamp.getInteger( date );
-    long expected = 1567308896123L;
-    assertEquals( expected, result );
-    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "NANOSECONDS" );
+    assertEquals( 1567308896123L, result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS );
+    valueMetaTimestamp = new ValueMetaTimestamp();
+    result = valueMetaTimestamp.getInteger( date );
+    assertEquals( 1567308896123456789L, result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "Something invalid!" );
+    valueMetaTimestamp = new ValueMetaTimestamp();
+    result = valueMetaTimestamp.getInteger( date );
+    assertEquals( 1567308896123456789L, result );
   }
 }


### PR DESCRIPTION
…step results in incorrect date

There was a mismatch between the Kettle property and the constant representing it (KETTLE_TIMESTAMP_OUTPUT_FORMAT != KETTLE_TIMESTAMP_NUMERIC_FORMAT).
Created constants for the possible values and made use of them in the code to reduce the probability of an error.
I've also augmented the unit test.

@pentaho/tatooine @pentaho-lmartins @ssamora @ppatricio @LeonardoCoelho71950 