### PR TITLE
[PDI-18578]

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -137,6 +137,8 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
 
   public boolean setAppendLogfile;
 
+  public boolean suppressResultData;
+
   public String logfile, logext;
 
   public boolean addDate, addTime;
@@ -334,6 +336,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
     retval.append( "      " ).append( XMLHandler.addTagValue( "create_parent_folder", createParentFolder ) );
     retval.append( "      " ).append( XMLHandler.addTagValue( "logging_remote_work", loggingRemoteWork ) );
     retval.append( "      " ).append( XMLHandler.addTagValue( "run_configuration", runConfiguration ) );
+    retval.append( "      " ).append( XMLHandler.addTagValue( "suppress_result_data", isSuppressResultData() ) );
 
     if ( arguments != null ) {
       for ( int i = 0; i < arguments.length; i++ ) {
@@ -420,6 +423,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       createParentFolder = "Y".equalsIgnoreCase( XMLHandler.getTagValue( entrynode, "create_parent_folder" ) );
       loggingRemoteWork = "Y".equalsIgnoreCase( XMLHandler.getTagValue( entrynode, "logging_remote_work" ) );
       runConfiguration = XMLHandler.getTagValue( entrynode, "run_configuration" );
+      setSuppressResultData( "Y".equalsIgnoreCase( XMLHandler.getTagValue( entrynode, "suppress_result_data" ) ) );
 
       remoteSlaveServerName = XMLHandler.getTagValue( entrynode, "slave_server_name" );
 
@@ -503,6 +507,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       followingAbortRemotely = rep.getJobEntryAttributeBoolean( id_jobentry, "follow_abort_remote" );
       loggingRemoteWork = rep.getJobEntryAttributeBoolean( id_jobentry, "logging_remote_work" );
       runConfiguration = rep.getJobEntryAttributeString( id_jobentry, "run_configuration" );
+      setSuppressResultData( rep.getJobEntryAttributeBoolean( id_jobentry, "suppress_result_data", false ) );
 
       // How many arguments?
       int argnr = rep.countNrJobEntryAttributes( id_jobentry, "argument" );
@@ -564,6 +569,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       rep.saveJobEntryAttribute( id_job, getObjectId(), "create_parent_folder", createParentFolder );
       rep.saveJobEntryAttribute( id_job, getObjectId(), "logging_remote_work", loggingRemoteWork );
       rep.saveJobEntryAttribute( id_job, getObjectId(), "run_configuration", runConfiguration );
+      rep.saveJobEntryAttribute( id_job, getObjectId(), "suppress_result_data", isSuppressResultData() );
 
       // Save the arguments...
       if ( arguments != null ) {
@@ -614,6 +620,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
     waitingToFinish = true;
     followingAbortRemotely = false; // backward compatibility reasons
     createParentFolder = false;
+    setSuppressResultData( false );
     logFileLevel = LogLevel.BASIC;
   }
 
@@ -1730,8 +1737,8 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
    * the result row data of the transformation when it finishes running.  Only applies to remote slave servers.
    */
   public boolean isSuppressResultData() {
-    boolean returnVal = false;
-    if ( parentJobMeta != null ) {
+    boolean returnVal = suppressResultData;
+    if ( !suppressResultData && parentJobMeta != null ) {
       String[] params = parentJobMeta.listParameters();
       for ( String param : params ) {
         if ( param.startsWith( "SUPPRESS_TRANS_RESULT_DATA_" ) ) {
@@ -1747,5 +1754,9 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       }
     }
     return returnVal;
+  }
+
+  public void setSuppressResultData( boolean suppressResultData ) {
+    this.suppressResultData = suppressResultData;
   }
 }

--- a/engine/src/main/resources/org/pentaho/di/job/entries/trans/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/job/entries/trans/messages/messages_en_US.properties
@@ -45,6 +45,7 @@ JobTrans.Specification.Group.Label=Transformation specification
 JobTrans.TransformationFile.Label=Transformation filename\:
 JobTrans.Loglevel.Label=Log level\:
 JobTrans.AbortRemote.Label=Follow local abort to remote transformation
+JobTrans.SuppressResults.Label=Suppress result data from remote transformation
 JobTrans.Previous.Tooltip=Check this to pass the results of the previous entry to the arguments of this entry.
 JobTrans.Header=Transformation
 JobTrans.Fileformat.XML=XML files

--- a/engine/src/main/resources/org/pentaho/di/job/entries/trans/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/job/entries/trans/messages/messages_en_US.properties
@@ -82,6 +82,7 @@ JobEntryTransDialog.Exception.UnableToReferenceObjectId.Message=Unable to get in
 JobTrans.Log.OpeningTransByReference=Opening a transformation by reference with id={0}
 JobTrans.Exception.LogFilenameMissing=Log filename is empty or not specified!
 JobTrans.Exception.UnableToRunJob=Unable to run job {0}. The {1} has an error. {2}
+JobTrans.Exception.SuppressResultParam=Error checking for suppress trans result params
 JobTrans.Browse.Label=Browse...
 
 JobTrans.Fileformat.TXT=Text files

--- a/ui/src/main/java/org/pentaho/di/ui/job/entries/trans/JobEntryTransDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/entries/trans/JobEntryTransDialog.java
@@ -88,6 +88,8 @@ import java.util.List;
 public class JobEntryTransDialog extends JobEntryBaseDialog implements JobEntryDialogInterface {
   private static Class<?> PKG = JobEntryTrans.class; // for i18n purposes, needed by Translator2!!
 
+  protected Button wSuppressResultData;
+
   protected JobEntryTrans jobEntry;
 
   private static final String[] FILE_FILTERLOGNAMES = new String[] {
@@ -175,6 +177,14 @@ public class JobEntryTransDialog extends JobEntryBaseDialog implements JobEntryD
     fdFollow.top = new FormAttachment( wWaitingToFinish, 10 );
     fdFollow.left = new FormAttachment( 0, 0 );
     wFollowingAbortRemotely.setLayoutData( fdFollow );
+
+    wSuppressResultData = new Button( gExecution, SWT.CHECK );
+    props.setLook( wSuppressResultData );
+    wSuppressResultData.setText( BaseMessages.getString( PKG, "JobTrans.SuppressResults.Label" ) );
+    FormData fdSuppress = new FormData();
+    fdSuppress.top = new FormAttachment( wFollowingAbortRemotely, 10 );
+    fdSuppress.left = new FormAttachment( 0, 0 );
+    wSuppressResultData.setLayoutData( fdSuppress );
 
     Composite cRunConfiguration = new Composite( wOptions, SWT.NONE );
     cRunConfiguration.setLayout( new FormLayout() );
@@ -416,6 +426,7 @@ public class JobEntryTransDialog extends JobEntryBaseDialog implements JobEntryD
     wClearFiles.setSelection( jobEntry.clearResultFiles );
     wWaitingToFinish.setSelection( jobEntry.isWaitingToFinish() );
     wFollowingAbortRemotely.setSelection( jobEntry.isFollowingAbortRemotely() );
+    wSuppressResultData.setSelection( jobEntry.isSuppressResultData() );
     wAppendLogfile.setSelection( jobEntry.setAppendLogfile );
 
     wbLogFilename.setSelection( jobEntry.setAppendLogfile );
@@ -582,6 +593,7 @@ public class JobEntryTransDialog extends JobEntryBaseDialog implements JobEntryD
     jet.setAppendLogfile = wAppendLogfile.getSelection();
     jet.setWaitingToFinish( wWaitingToFinish.getSelection() );
     jet.setFollowingAbortRemotely( wFollowingAbortRemotely.getSelection() );
+    jet.setSuppressResultData( wSuppressResultData.getSelection() );
 
     TransExecutionConfiguration executionConfiguration = new TransExecutionConfiguration();
     executionConfiguration.setRunConfiguration( jet.getRunConfiguration() );


### PR DESCRIPTION
Provide the capability to suppress result data from a transformation running on a remote slave.  First commit provides this ability via named parameters for back-porting, second commit adds a GUI checkbox.