### PR TITLE
[SP-5415]

### DIFF
--- a/engine/src/main/resources/org/pentaho/di/job/entries/trans/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/job/entries/trans/messages/messages_en_US.properties
@@ -82,6 +82,7 @@ JobEntryTransDialog.Exception.UnableToReferenceObjectId.Message=Unable to get in
 JobTrans.Log.OpeningTransByReference=Opening a transformation by reference with id={0}
 JobTrans.Exception.LogFilenameMissing=Log filename is empty or not specified!
 JobTrans.Exception.UnableToRunJob=Unable to run job {0}. The {1} has an error. {2}
+JobTrans.Exception.SuppressResultParam=Error checking for suppress trans result params
 JobTrans.Browse.Label=Browse...
 
 JobTrans.Fileformat.TXT=Text files


### PR DESCRIPTION
[PDI-18578] Provide users with the ability to specify a named parameter
in a job to selectively suppress the result row data from
transformations running on a remote slave server.