### PR TITLE
[PPP-4486] Use of Vulnerable Component: commons-codec [Multiple Versi…

### DIFF
--- a/plugins/google-analytics/assemblies/plugin/pom.xml
+++ b/plugins/google-analytics/assemblies/plugin/pom.xml
@@ -28,12 +28,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.9</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <scope>runtime</scope>

--- a/plugins/google-analytics/core/pom.xml
+++ b/plugins/google-analytics/core/pom.xml
@@ -18,7 +18,6 @@
 
   <properties>
     <pdi.version>9.1.0.0-SNAPSHOT</pdi.version>
-    <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
     <encoder.version>1.2</encoder.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
@@ -119,11 +118,6 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/plugins/json/core/pom.xml
+++ b/plugins/json/core/pom.xml
@@ -19,7 +19,6 @@
     <pentaho-metaverse.version>9.1.0.0-SNAPSHOT</pentaho-metaverse.version>
     <platform.version>9.1.0.0-SNAPSHOT</platform.version>
     <commons.io.version>1.4</commons.io.version>
-    <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
     <encoder.version>1.2</encoder.version>
     <guava.version>17.0</guava.version>

--- a/plugins/version-checker/core/pom.xml
+++ b/plugins/version-checker/core/pom.xml
@@ -39,11 +39,6 @@
       <version>${pdi.version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.3</version>
-    </dependency>
-    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
     <!-- Third-party dependencies -->
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <js.version>1.7R3</js.version>
-    <commons-codec.version>1.10</commons-codec.version>
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
     <guava.version>17.0</guava.version>
     <encoder.version>1.2</encoder.version>
@@ -132,17 +131,6 @@
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
         <version>${commons-beanutils.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
         <exclusions>
           <exclusion>
             <groupId>*</groupId>


### PR DESCRIPTION
…ons] (sonatype-2012-0050)

Bumping `commons-codec` to version 1.14 to address multiple CVEs.
Moving dependency management to the parent POMs.
Removing unnecessary dependencies.

Please see https://github.com/pentaho/maven-parent-poms/pull/214 for details.