### PR TITLE
[PDI-18369] Converting Integer to Timestamp type using Select values …

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1386,7 +1386,7 @@ public class Const {
   /**
    * <p>The default value for the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT}.</p>
    */
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS;
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS;
 
   /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
@@ -54,7 +54,7 @@ import org.pentaho.di.core.row.value.timestamp.SimpleTimestampFormat;
 public class ValueMetaTimestamp extends ValueMetaDate {
   private final String format =
     Const.NVL( EnvUtil.getSystemProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT ),
-      Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS );
+      Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT );
 
   public ValueMetaTimestamp() {
     this( null );
@@ -86,11 +86,11 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
-      return  milliseconds;
-    } else {
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS.equalsIgnoreCase( format ) ) {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
       return seconds * 1000000000L + timestamp.getNanos();
+    } else {
+      return  milliseconds;
     }
   }
 
@@ -102,11 +102,11 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
-      return (double) milliseconds;
-    } else {
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS.equalsIgnoreCase( format ) ) {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
       return (double) seconds * 1000000000L + timestamp.getNanos();
+    } else {
+      return (double) milliseconds;
     }
   }
 
@@ -118,12 +118,12 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
-      return BigDecimal.valueOf( milliseconds );
-    } else {
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS.equalsIgnoreCase( format ) ) {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
       return BigDecimal.valueOf( seconds ).multiply( BigDecimal.valueOf( 1000000000L ) ).add(
           BigDecimal.valueOf( timestamp.getNanos() ) );
+    } else {
+      return BigDecimal.valueOf( milliseconds );
     }
   }
 

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
@@ -149,7 +149,7 @@ public class ValueMetaTimestampTest {
     Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     long result = valueMetaTimestamp.getInteger( date );
-    long expected = 1567308896123456789L;
+    long expected = 1567308896123L;
     assertEquals( expected, result );
   }
 
@@ -169,7 +169,7 @@ public class ValueMetaTimestampTest {
     Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456000" );
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     double result = valueMetaTimestamp.getNumber( date );
-    double expected = 1567308896123456000L;
+    double expected = 1567308896123L;
     assertEquals( expected, result, 0 );
   }
 
@@ -189,7 +189,7 @@ public class ValueMetaTimestampTest {
     Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     BigDecimal result = valueMetaTimestamp.getBigNumber( date );
-    BigDecimal expected = BigDecimal.valueOf( 1567308896123456789L );
+    BigDecimal expected = BigDecimal.valueOf( 1567308896123L );
     assertEquals( expected, result );
   }
 
@@ -208,6 +208,6 @@ public class ValueMetaTimestampTest {
     System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "Something invalid!" );
     valueMetaTimestamp = new ValueMetaTimestamp();
     result = valueMetaTimestamp.getInteger( date );
-    assertEquals( 1567308896123456789L, result );
+    assertEquals( 1567308896123L, result );
   }
 }


### PR DESCRIPTION
…step results in incorrect date

Reverting the change in the default behaviour.
By default, Timestamp-to-Integer returns milliseconds once again.

@pentaho/tatooine @pentaho-lmartins