### PR TITLE
[BACKLOG-33339] Update ValueMetaConverter to convert timestamps to

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaConverter.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaConverter.java
@@ -344,6 +344,7 @@ public class ValueMetaConverter implements Serializable, IValueMetaConverter {
           + value + "'." );
     }
 
+    ValueMetaTimestamp pentahoTimeStamp = new ValueMetaTimestamp();
     Date dateValue;
     try {
       switch ( targetValueMetaType ) {
@@ -351,7 +352,7 @@ public class ValueMetaConverter implements Serializable, IValueMetaConverter {
           dateValue = new Date( ( (Timestamp) value ).getTime() );
           return datePattern.format( dateValue );
         case ValueMetaInterface.TYPE_INTEGER:
-          return ( (Timestamp) value ).getTime();
+          return pentahoTimeStamp.getInteger( value );
         case ValueMetaInterface.TYPE_TIMESTAMP:
           return new Timestamp( ( (Timestamp) value ).getTime() );
         case ValueMetaInterface.TYPE_DATE:

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaConverterTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaConverterTest.java
@@ -117,7 +117,7 @@ public class ValueMetaConverterTest {
 
       { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_NONE, timeStamp1, null },
       { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_STRING, timeStamp1, "2001/11/01 20:30:15.123" },
-      { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_INTEGER, timeStamp1, timeStamp1.getTime() },
+      { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_INTEGER, timeStamp1, timeStamp1.getTime() * 1000000 },
       { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_TIMESTAMP, timeStamp1, timeStamp1 },
       { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_DATE, timeStamp1, new Date( timeStamp1.getTime() ) },
 


### PR DESCRIPTION
integers in nanoseconds; follows implementation in PDI-18369.