### PR TITLE
[SP-5410] Backport of PPP-4459 - Use of Vulnerable Component: org.ecl…

### DIFF
--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -53,7 +53,6 @@
         <spark.version>2.1.0</spark.version>
         <kafka.spark.version>2.3.2</kafka.spark.version>
         <databricks.version>4.0.0</databricks.version>
-        <paho.version>1.2.0</paho.version>
         <bahir.version>2.3.2</bahir.version>
    </properties>
 
@@ -128,13 +127,6 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>${paho.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.bahir</groupId>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -52,7 +52,6 @@
     <spark.version>2.1.0</spark.version>
     <kafka.spark.version>2.3.2</kafka.spark.version>
     <databricks.version>4.0.0</databricks.version>
-    <paho.version>1.2.0</paho.version>
     <bahir.version>2.3.2</bahir.version>
     <snowflake-jdbc.version>3.6.28</snowflake-jdbc.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
@@ -129,13 +128,6 @@
     <dependency>
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-      <version>${paho.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.bahir</groupId>

--- a/plugins/streaming/impls/mqtt/pom.xml
+++ b/plugins/streaming/impls/mqtt/pom.xml
@@ -58,7 +58,6 @@
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
     <junit.version>4.12</junit.version>
     <guava.version>17.0</guava.version>
-    <paho.version>1.2.0</paho.version>
     <powermock.version>1.6.6</powermock.version>
   </properties>
 
@@ -97,7 +96,6 @@
     <dependency>
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-      <version>${paho.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
…ipse.paho:org.eclipse.paho.client.mqttv3: CVE-2019-11777 (9.0 Suite)

Cherry-pick of #7248 into 9.0 branch.
Related with https://github.com/pentaho/maven-parent-poms/pull/215.