### PR TITLE
[SP-5441] Backport of PDI-18063 - Option 'Use https protocol' in Slave Server dialog is not remembered after disconnecting the Repository and then re-connecting to the Repository again (9.0 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
+++ b/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -223,6 +223,7 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
     this.nonProxyHosts = nonProxyHosts;
 
     this.master = master;
+    this.sslMode = ssl;
     initializeVariablesFrom( null );
     this.log = new LogChannel( this );
   }

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/SlaveDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/SlaveDelegate.java
@@ -70,8 +70,8 @@ public class SlaveDelegate extends AbstractDelegate implements ITransformer, Sha
     slaveServer.setProxyPort( getString( rootNode, PROP_PROXY_PORT ) );
     slaveServer.setWebAppName( getString( rootNode, PROP_WEBAPP_NAME ) );
     slaveServer.setNonProxyHosts( getString( rootNode, PROP_NON_PROXY_HOSTS ) );
-    slaveServer.setMaster( rootNode.getProperty( PROP_MASTER ).getBoolean() );
-    slaveServer.setSslMode( rootNode.getProperty( PROP_USE_HTTPS_PROTOCOL ).getBoolean() );
+    slaveServer.setMaster( getBoolean( rootNode, PROP_MASTER ) );
+    slaveServer.setSslMode( getBoolean( rootNode, PROP_USE_HTTPS_PROTOCOL ) );
   }
 
   public DataNode elementToDataNode( RepositoryElementInterface element ) throws KettleException {

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/SlaveDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/SlaveDelegate.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2020 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,27 +30,18 @@ import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFile
 public class SlaveDelegate extends AbstractDelegate implements ITransformer, SharedObjectAssembler<SlaveServer>,
     java.io.Serializable {
 
-  private static final long serialVersionUID = -8084266831877112729L; /* EESOURCE: UPDATE SERIALVERUID */
-
-  private static final String NODE_ROOT = "Slave"; //$NON-NLS-1$
-
-  private static final String PROP_PASSWORD = "PASSWORD"; //$NON-NLS-1$
-
-  private static final String PROP_USERNAME = "USERNAME"; //$NON-NLS-1$
-
-  private static final String PROP_PORT = "PORT"; //$NON-NLS-1$
-
-  private static final String PROP_HOST_NAME = "HOST_NAME"; //$NON-NLS-1$
-
-  private static final String PROP_PROXY_HOST_NAME = "PROXY_HOST_NAME"; //$NON-NLS-1$
-
-  private static final String PROP_PROXY_PORT = "PROXY_PORT"; //$NON-NLS-1$
-
-  private static final String PROP_WEBAPP_NAME = "WEBAPP_NAME"; //$NON-NLS-1$
-
-  private static final String PROP_NON_PROXY_HOSTS = "NON_PROXY_HOSTS"; //$NON-NLS-1$
-
-  private static final String PROP_MASTER = "MASTER"; //$NON-NLS-1$
+  static final long serialVersionUID = -8084266831877112729L; /* EESOURCE: UPDATE SERIALVERUID */
+  static final String NODE_ROOT = "Slave";
+  static final String PROP_PASSWORD = "PASSWORD";
+  static final String PROP_USERNAME = "USERNAME";
+  static final String PROP_PORT = "PORT";
+  static final String PROP_HOST_NAME = "HOST_NAME";
+  static final String PROP_PROXY_HOST_NAME = "PROXY_HOST_NAME";
+  static final String PROP_PROXY_PORT = "PROXY_PORT";
+  static final String PROP_WEBAPP_NAME = "WEBAPP_NAME";
+  static final String PROP_NON_PROXY_HOSTS = "NON_PROXY_HOSTS";
+  static final String PROP_MASTER = "MASTER";
+  static final String PROP_USE_HTTPS_PROTOCOL = "USE_HTTPS_PROTOCOL";
 
   // ~ Instance fields =================================================================================================
 
@@ -80,6 +71,7 @@ public class SlaveDelegate extends AbstractDelegate implements ITransformer, Sha
     slaveServer.setWebAppName( getString( rootNode, PROP_WEBAPP_NAME ) );
     slaveServer.setNonProxyHosts( getString( rootNode, PROP_NON_PROXY_HOSTS ) );
     slaveServer.setMaster( rootNode.getProperty( PROP_MASTER ).getBoolean() );
+    slaveServer.setSslMode( rootNode.getProperty( PROP_USE_HTTPS_PROTOCOL ).getBoolean() );
   }
 
   public DataNode elementToDataNode( RepositoryElementInterface element ) throws KettleException {
@@ -104,6 +96,7 @@ public class SlaveDelegate extends AbstractDelegate implements ITransformer, Sha
     rootNode.setProperty( PROP_PROXY_PORT, slaveServer.getProxyPort() );
     rootNode.setProperty( PROP_NON_PROXY_HOSTS, slaveServer.getNonProxyHosts() );
     rootNode.setProperty( PROP_MASTER, slaveServer.isMaster() );
+    rootNode.setProperty( PROP_USE_HTTPS_PROTOCOL, slaveServer.isSslMode() );
     return rootNode;
   }
 

--- a/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/SlaveDelegateTest.java
+++ b/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/SlaveDelegateTest.java
@@ -1,0 +1,129 @@
+/*!
+ * Copyright 2020 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.pentaho.di.repository.pur;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.encryption.Encr;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.junit.rules.RestorePDIEnvironment;
+import org.pentaho.platform.api.repository2.unified.data.node.DataNode;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SlaveDelegateTest {
+
+  @ClassRule
+  public static RestorePDIEnvironment env = new RestorePDIEnvironment();
+
+  private PurRepository mockPurRepository;
+  private SlaveDelegate slaveDelegate;
+  private DataNode mockDataNode;
+  private  SlaveServer mockSlaveServer;
+
+  private static String PROP_HOST_NAME_VALUE = "hostname";
+  private static String PROP_USERNAME_VALUE = "username";
+  private static String PROP_PASSWORD_VALUE = "password";
+  private static String PROP_PORT_VALUE = "1234";
+  private static String PROP_PROXY_HOST_NAME_VALUE = "proxyhostname";
+  private static String PROP_PROXY_PORT_VALUE = "4321";
+  private static String PROP_WEBAPP_NAME_VALUE = "webappname";
+  private static String PROP_NON_PROXY_HOSTS_VALUE = "nonproxyhosts";
+  private static Boolean PROP_MASTER_VALUE = true;
+  private static Boolean PROP_USE_HTTPS_PROTOCOL_VALUE = true;
+
+
+  @Before
+  public void setup() throws KettleException {
+    KettleClientEnvironment.init();
+    mockPurRepository = mock( PurRepository.class );
+    slaveDelegate = new SlaveDelegate( mockPurRepository );
+
+    mockSlaveServer = mock( SlaveServer.class );
+    when( mockSlaveServer.getHostname() ).thenReturn( PROP_HOST_NAME_VALUE );
+    when( mockSlaveServer.getUsername() ).thenReturn( PROP_USERNAME_VALUE );
+    when( mockSlaveServer.getPassword() ).thenReturn( PROP_PASSWORD_VALUE );
+    when( mockSlaveServer.getPort() ).thenReturn( PROP_PORT_VALUE );
+    when( mockSlaveServer.getProxyHostname() ).thenReturn( PROP_PROXY_HOST_NAME_VALUE );
+    when( mockSlaveServer.getProxyPort() ).thenReturn( PROP_PROXY_PORT_VALUE );
+    when( mockSlaveServer.getWebAppName() ).thenReturn( PROP_WEBAPP_NAME_VALUE );
+    when( mockSlaveServer.getNonProxyHosts() ).thenReturn( PROP_NON_PROXY_HOSTS_VALUE );
+    when( mockSlaveServer.isMaster() ).thenReturn( PROP_MASTER_VALUE );
+    when( mockSlaveServer.isSslMode() ).thenReturn( PROP_USE_HTTPS_PROTOCOL_VALUE );
+
+    mockDataNode = mock( DataNode.class, RETURNS_DEEP_STUBS );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_HOST_NAME ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_HOST_NAME ).getString() ).thenReturn( PROP_HOST_NAME_VALUE );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_USERNAME ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_USERNAME ).getString() ).thenReturn( PROP_USERNAME_VALUE );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_PASSWORD ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_PASSWORD ).getString() ).thenReturn( PROP_PASSWORD_VALUE );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_PORT ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_PORT ).getString() ).thenReturn( PROP_PORT_VALUE );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_PROXY_HOST_NAME ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_PROXY_HOST_NAME ).getString() ).thenReturn( PROP_PROXY_HOST_NAME_VALUE );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_PROXY_PORT ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_PROXY_PORT ).getString() ).thenReturn( PROP_PROXY_PORT_VALUE );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_WEBAPP_NAME ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_WEBAPP_NAME ).getString() ).thenReturn( PROP_WEBAPP_NAME_VALUE );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_NON_PROXY_HOSTS ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_NON_PROXY_HOSTS ).getString() ).thenReturn( PROP_NON_PROXY_HOSTS_VALUE );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_MASTER ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_MASTER ).getBoolean() ).thenReturn( PROP_MASTER_VALUE );
+    when( mockDataNode.hasProperty( SlaveDelegate.PROP_USE_HTTPS_PROTOCOL ) ).thenReturn( true );
+    when( mockDataNode.getProperty( SlaveDelegate.PROP_USE_HTTPS_PROTOCOL ).getBoolean() ).thenReturn( PROP_USE_HTTPS_PROTOCOL_VALUE );
+  }
+
+  @Test
+  public void testElementToDataNode() throws KettleException {
+    DataNode dataNode = slaveDelegate.elementToDataNode( mockSlaveServer );
+
+    Assert.assertEquals( PROP_HOST_NAME_VALUE, slaveDelegate.getString( dataNode, SlaveDelegate.PROP_HOST_NAME ) );
+    Assert.assertEquals( PROP_USERNAME_VALUE, slaveDelegate.getString( dataNode, SlaveDelegate.PROP_USERNAME ) );
+    Assert.assertEquals( Encr.encryptPasswordIfNotUsingVariables( PROP_PASSWORD_VALUE ), slaveDelegate.getString( dataNode, SlaveDelegate.PROP_PASSWORD ) );
+    Assert.assertEquals( PROP_PORT_VALUE, slaveDelegate.getString( dataNode, SlaveDelegate.PROP_PORT ) );
+    Assert.assertEquals( PROP_PROXY_HOST_NAME_VALUE, slaveDelegate.getString( dataNode, SlaveDelegate.PROP_PROXY_HOST_NAME ) );
+    Assert.assertEquals( PROP_PROXY_PORT_VALUE, slaveDelegate.getString( dataNode, SlaveDelegate.PROP_PROXY_PORT ) );
+    Assert.assertEquals( PROP_WEBAPP_NAME_VALUE, slaveDelegate.getString( dataNode, SlaveDelegate.PROP_WEBAPP_NAME ) );
+    Assert.assertEquals( PROP_NON_PROXY_HOSTS_VALUE, slaveDelegate.getString( dataNode, SlaveDelegate.PROP_NON_PROXY_HOSTS ) );
+    Assert.assertEquals( PROP_MASTER_VALUE, slaveDelegate.getBoolean( dataNode, SlaveDelegate.PROP_MASTER ) );
+    Assert.assertEquals( PROP_USE_HTTPS_PROTOCOL_VALUE, slaveDelegate.getBoolean( dataNode, SlaveDelegate.PROP_USE_HTTPS_PROTOCOL ) );
+  }
+
+  @Test
+  public void testDataNodeToElement() throws KettleException {
+    SlaveServer slaveServer = new SlaveServer();
+    slaveDelegate.dataNodeToElement( mockDataNode, slaveServer );
+    Assert.assertEquals( PROP_HOST_NAME_VALUE, slaveServer.getHostname() );
+    Assert.assertEquals( PROP_USERNAME_VALUE, slaveServer.getUsername() );
+    Assert.assertEquals( PROP_PASSWORD_VALUE, slaveServer.getPassword() );
+    Assert.assertEquals( PROP_PORT_VALUE, slaveServer.getPort() );
+    Assert.assertEquals( PROP_PROXY_HOST_NAME_VALUE, slaveServer.getProxyHostname() );
+    Assert.assertEquals( PROP_PROXY_PORT_VALUE, slaveServer.getProxyPort() );
+    Assert.assertEquals( PROP_WEBAPP_NAME_VALUE, slaveServer.getWebAppName() );
+    Assert.assertEquals( PROP_NON_PROXY_HOSTS_VALUE, slaveServer.getNonProxyHosts() );
+    Assert.assertEquals( PROP_MASTER_VALUE, slaveServer.isMaster() );
+    Assert.assertEquals( PROP_USE_HTTPS_PROTOCOL_VALUE, slaveServer.isSslMode() );
+  }
+}


### PR DESCRIPTION
**Attention: This is the outcome of an automated process!**
Merge Masters: @pentaho-lmartins and 
Cherry-picks:
* https://github.com/Pentaho/pentaho-kettle/commit/d021f1dfc769568e8634568992390be1c19cae76
* https://github.com/Pentaho/pentaho-kettle/commit/9718d5c13e9335a1d20784b06aea9ce1d6b24d5b
