### PR TITLE
[PDI-18608] When AWS token has expires using VFS Browser no indication

### DIFF
--- a/plugins/file-open-save-new/core/src/main/javascript/app/services/folder.service.js
+++ b/plugins/file-open-save-new/core/src/main/javascript/app/services/folder.service.js
@@ -111,8 +111,7 @@ define(
                 self.selectFolder(folderFile.folder).then(reject());
               }
               else {
-                let message = folderFile;
-                reject(message);
+                reject(folderFile);
               }
             });
           });


### PR DESCRIPTION
Fix for javascript error on ubuntu that does not support 'let'