### PR TITLE
[PPP-4496] Use of Vulnerable Component: Components/kafka

### DIFF
--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -48,7 +48,6 @@
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <enunciate-jersey-rt.version>1.27</enunciate-jersey-rt.version>
         <enunciate-core-annotations.version>1.27</enunciate-core-annotations.version>
-        <kafka-clients.version>0.10.2.1</kafka-clients.version>
         <tyrus-standalone-client.version>1.13.1</tyrus-standalone-client.version>
         <spark.version>2.1.0</spark.version>
         <kafka.spark.version>2.3.2</kafka.spark.version>
@@ -116,7 +115,6 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${kafka-clients.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -47,7 +47,6 @@
     <jsr311-api.version>1.1.1</jsr311-api.version>
     <enunciate-jersey-rt.version>1.27</enunciate-jersey-rt.version>
     <enunciate-core-annotations.version>1.27</enunciate-core-annotations.version>
-    <kafka-clients.version>0.10.2.1</kafka-clients.version>
     <tyrus-standalone-client.version>1.13.1</tyrus-standalone-client.version>
     <spark.version>2.1.0</spark.version>
     <kafka.spark.version>2.3.2</kafka.spark.version>
@@ -117,7 +116,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>${kafka-clients.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaConverterTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaConverterTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2017-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2017-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -117,7 +117,7 @@ public class ValueMetaConverterTest {
 
       { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_NONE, timeStamp1, null },
       { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_STRING, timeStamp1, "2001/11/01 20:30:15.123" },
-      { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_INTEGER, timeStamp1, timeStamp1.getTime() * 1000000 },
+      { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_INTEGER, timeStamp1, timeStamp1.getTime() },
       { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_TIMESTAMP, timeStamp1, timeStamp1 },
       { ValueMetaInterface.TYPE_TIMESTAMP, ValueMetaInterface.TYPE_DATE, timeStamp1, new Date( timeStamp1.getTime() ) },
 


### PR DESCRIPTION
* [PPP-4496] Upgrading to version 0.10.2.2
* [PPP-4496] Removing version reference, maven-parent-pom will control version info.
* [PPP-4496] Fixing unit test since nano default was set back to milli default in PDI-18369

This is from a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/218
- https://github.com/pentaho/big-data-plugin/pull/2032
- https://github.com/pentaho/pdi-plugins-ee/pull/168
- https://github.com/pentaho/pentaho-platform/pull/4649
- https://github.com/pentaho/pentaho-reporting/pull/1327
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/152
- https://github.com/pentaho/pentaho-metadata-editor/pull/190
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/85
- https://github.com/pentaho/pentaho-kettle/pull/7309
- https://github.com/pentaho/pentaho-big-data-ee/pull/441