### PR TITLE
[BACKLOG-33388 BACKLOG-33449 BACKLOG-33454 BACKLOG-33450 BACKLOG-33451] Upgrade Angular JS library from 1.5.8 version to 1.7.8 for pentaho-kettle

### DIFF
--- a/plugins/connections/assemblies/feature/src/main/feature/feature.xml
+++ b/plugins/connections/assemblies/feature/src/main/feature/feature.xml
@@ -11,9 +11,10 @@
 
     <!-- START client side dependencies -->
     <bundle>pentaho-webjars:mvn:org.webjars.bower/angular/${angular.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-i18n/${angular-i18n.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-ui-router/${angular-ui-router.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-animate/${angular-animate.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/angular-i18n/${angular.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__core/${uirouter-core.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__angularjs/${uirouter-angularjs.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-animate/${angular.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/require-css/${require-css.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/requirejs-text/${requirejs-text.version}</bundle>
     <!-- END -->

--- a/plugins/connections/pom.xml
+++ b/plugins/connections/pom.xml
@@ -25,15 +25,11 @@
     <dependency.karaf.version>3.0.3</dependency.karaf.version>
     <dependency.osgi.version>4.3.1</dependency.osgi.version>
     <version.for.license>${project.version}</version.for.license>
-    <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
-    <angular.version>1.5.8</angular.version>
-    <angular-animate.version>${angular.version}</angular-animate.version>
+    <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n,uirouter__core,uirouter__angularjs</js.project.list>
     <pentaho-osgi-bundles.version>9.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <angular-ui-router.version>0.4.2</angular-ui-router.version>
     <cxf.karaf.version>3.0.13</cxf.karaf.version>
     <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>
-    <angular-i18n.version>1.5.6</angular-i18n.version>
     <swt.version>4.6</swt.version>
     <dependency.javax.servlet-api.version>3.0.1</dependency.javax.servlet-api.version>
     <dependency.javax.ws.rs-api.version>2.0</dependency.javax.ws.rs-api.version>
@@ -114,16 +110,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>angular</artifactId>
-        <version>${angular.version}</version>
-        <scope>provided</scope>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>uirouter__core</artifactId>
       </dependency>
       <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>angular-i18n</artifactId>
-        <version>${angular-i18n.version}</version>
-        <scope>provided</scope>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>uirouter__angularjs</artifactId>
       </dependency>
       <dependency>
         <groupId>org.webjars.bower</groupId>

--- a/plugins/connections/ui/pom.xml
+++ b/plugins/connections/ui/pom.xml
@@ -82,7 +82,7 @@
       <artifactId>angular</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars.bower</groupId>
+      <groupId>org.webjars.npm</groupId>
       <artifactId>angular-i18n</artifactId>
     </dependency>
     <dependency>

--- a/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/dialog/ConnectionDialog.java
+++ b/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/dialog/ConnectionDialog.java
@@ -62,10 +62,10 @@ public class ConnectionDialog extends ThinDialog {
     StringBuilder clientPath = new StringBuilder();
     clientPath.append( getClientPath() );
     if ( connectionName != null ) {
-      clientPath.append( "#/summary" );
+      clientPath.append( "#!/summary" );
       clientPath.append( "?connection=" ).append( connectionName );
     } else {
-      clientPath.append( "#/intro" );
+      clientPath.append( "#!/intro" );
     }
     super.createDialog( title, getRepoURL( clientPath.toString() ),
       OPTIONS, LOGO );

--- a/plugins/connections/ui/src/main/javascript/app/app.animation.js
+++ b/plugins/connections/ui/src/main/javascript/app/app.animation.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 Hitachi Vantara. All rights reserved.
+ * Copyright 2019-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ define(
     function () {
       'use strict';
 
-      var factoryArray = ["$rootScope", "$state", factory];
+      var factoryArray = ["$rootScope", "$state", "$transitions", factory];
       var module = {
         class: ".transition",
         factory: factoryArray
@@ -36,11 +36,12 @@ define(
        * @param {Object} $rootScope
        * @returns {Object} The callbacks for animation
        */
-      function factory($rootScope, $state) {
+      function factory($rootScope, $state, $transitions) {
         var transition = $state.params.transition;
-        $rootScope.$on('$stateChangeStart', function (evt, toState, toParams, fromState, fromParams) {
-          if (toParams.transition) {
-            transition = toParams.transition;
+
+        $transitions.onStart({ }, function(trans) {
+          if (trans.targetState().params().transition) {
+            transition = trans.targetState().params().transition;
           }
         });
 

--- a/plugins/connections/ui/src/main/javascript/app/app.module.js
+++ b/plugins/connections/ui/src/main/javascript/app/app.module.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 Hitachi Vantara. All rights reserved.
+ * Copyright 2019-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ define([
   "./directives/showpassword.directive",
   "./service/helper.service",
   "./service/data.service",
-  "angular-ui-router",
+  "@uirouter/angularjs",
   "angular-animate"
 ], function (angular, plugins, appConfig, appAnimation, introComponent, summaryComponent, creatingComponent,
              successComponent, failureComponent, selectboxComponent, controlsComponent, messageComponent, helpComponent,

--- a/plugins/connections/ui/src/main/resources-filtered/app/package.json
+++ b/plugins/connections/ui/src/main/resources-filtered/app/package.json
@@ -14,8 +14,9 @@
   "dependencies": {
     "angular": "${angular.version}",
     "angular-animate": "${angular.version}",
-    "angular-i18n": "${angular-i18n.version}",
-    "angular-ui-router": "${angular-ui-router.version}",
+    "angular-i18n": "${angular.version}",
+    "@uirouter/core": "${uirouter-core.version}",
+    "@uirouter/angularjs": "${uirouter-angularjs.version}",
     "require-css": "${require-css.version}",
     "requirejs-text": "${requirejs-text.version}",
     "dojo": "${dojo.version}",

--- a/plugins/file-open-save-new/assemblies/feature/src/main/feature/feature.xml
+++ b/plugins/file-open-save-new/assemblies/feature/src/main/feature/feature.xml
@@ -12,8 +12,9 @@
 
     <!-- START client side dependencies -->
     <bundle>pentaho-webjars:mvn:org.webjars.bower/angular/${angular.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-i18n/${angular-i18n.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-ui-router/${angular-ui-router.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/angular-i18n/${angular.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__core/${uirouter-core.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__angularjs/${uirouter-angularjs.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/require-css/${require-css.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/requirejs-text/${requirejs-text.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/dojo/${dojo.version}</bundle>

--- a/plugins/file-open-save-new/core/pom.xml
+++ b/plugins/file-open-save-new/core/pom.xml
@@ -86,7 +86,7 @@
       <artifactId>angular</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars.bower</groupId>
+      <groupId>org.webjars.npm</groupId>
       <artifactId>angular-i18n</artifactId>
     </dependency>
     <dependency>

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
@@ -124,7 +124,7 @@ public class FileOpenSaveDialog extends ThinDialog implements FileDetails {
     String cmd = fileDialogOperation.getCommand();
 
     clientPath.append( getClientPath() );
-    clientPath.append( !Utils.isEmpty( cmd ) ? "#/" + cmd : "" );
+    clientPath.append( !Utils.isEmpty( cmd ) ? "#!/" + cmd : "" );
 
     List<NameValuePair> parameters = new ArrayList<>();
     addParameter( parameters, PATH_PARAM, dialogPath );

--- a/plugins/file-open-save-new/core/src/main/javascript/app/app.module.js
+++ b/plugins/file-open-save-new/core/src/main/javascript/app/app.module.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 Hitachi Vantara. All rights reserved.
+ * Copyright 2019-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ define([
   "./services/message.service",
   "./services/modal.service",
   "./shared/shared.module",
-  "angular-ui-router"
+  "@uirouter/angularjs"
 ], function (angular, fileServices, appConfig, appComponent, cardComponent, folderComponent, errorComponent,
              loadingComponent, addressbarComponent, filesComponent, searchComponent, modalsComponent, selectBoxComponent,
              filebarComponent, fileControls, helperService, dataService, repositoryService, vfsService, localService,

--- a/plugins/file-open-save-new/core/src/main/resources-filtered/app/package.json
+++ b/plugins/file-open-save-new/core/src/main/resources-filtered/app/package.json
@@ -13,8 +13,9 @@
   ],
   "dependencies": {
     "angular": "${angular.version}",
-    "angular-ui-router": "${angular-ui-router.version}",
-    "angular-i18n": "${angular-i18n.version}",
+    "@uirouter/core": "${uirouter-core.version}",
+    "@uirouter/angularjs": "${uirouter-angularjs.version}",
+    "angular-i18n": "${angular.version}",
     "require-css": "${require-css.version}",
     "requirejs-text": "${requirejs-text.version}",
     "dojo": "${dojo.version}",

--- a/plugins/file-open-save-new/pom.xml
+++ b/plugins/file-open-save-new/pom.xml
@@ -25,12 +25,9 @@
     <pdi.version>9.1.0.0-SNAPSHOT</pdi.version>
     <version.for.license>${project.version}</version.for.license>
     <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
-    <angular.version>1.5.8</angular.version>
     <pentaho-osgi-bundles.version>9.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <angular-ui-router.version>0.4.2</angular-ui-router.version>
     <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>
-    <angular-i18n.version>1.5.6</angular-i18n.version>
     <swt.version>4.6</swt.version>
     <dojo.version>1.9.2</dojo.version>
     <dependency.javax.servlet-api.version>3.0.1</dependency.javax.servlet-api.version>
@@ -127,18 +124,6 @@
             <groupId>*</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>angular</artifactId>
-        <version>${angular.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>angular-i18n</artifactId>
-        <version>${angular-i18n.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.webjars.bower</groupId>

--- a/plugins/file-open-save/assemblies/feature/src/main/feature/feature.xml
+++ b/plugins/file-open-save/assemblies/feature/src/main/feature/feature.xml
@@ -12,8 +12,9 @@
 
     <!-- START client side dependencies -->
     <bundle>pentaho-webjars:mvn:org.webjars.bower/angular/${angular.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-i18n/${angular-i18n.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-ui-router/${angular-ui-router.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/angular-i18n/${angular.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__core/${uirouter-core.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__angularjs/${uirouter-angularjs.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/require-css/${require-css.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/requirejs-text/${requirejs-text.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/dojo/${dojo.version}</bundle>

--- a/plugins/file-open-save/core/pom.xml
+++ b/plugins/file-open-save/core/pom.xml
@@ -75,7 +75,7 @@
       <artifactId>angular</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars.bower</groupId>
+      <groupId>org.webjars.npm</groupId>
       <artifactId>angular-i18n</artifactId>
     </dependency>
     <dependency>
@@ -94,7 +94,7 @@
       <groupId>org.webjars.npm</groupId>
       <artifactId>jquery</artifactId>
       <scope>runtime</scope>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>

--- a/plugins/file-open-save/core/src/main/java/org/pentaho/repo/dialog/RepositoryOpenSaveDialog.java
+++ b/plugins/file-open-save/core/src/main/java/org/pentaho/repo/dialog/RepositoryOpenSaveDialog.java
@@ -73,7 +73,7 @@ public class RepositoryOpenSaveDialog extends ThinDialog {
     RepositoryBrowserController.repository = repository;
     StringBuilder clientPath = new StringBuilder();
     clientPath.append( getClientPath() );
-    clientPath.append( !Utils.isEmpty( state ) ? "#/" + state : "" );
+    clientPath.append( !Utils.isEmpty( state ) ? "#!/" + state : "" );
     clientPath.append( !Utils.isEmpty( directory ) ? "?path=" + directory : "?" );
     clientPath.append( !Utils.isEmpty( directory ) ? "&" : "" );
     clientPath.append( !Utils.isEmpty( filter ) ? "filter=" + filter : "" );

--- a/plugins/file-open-save/core/src/main/javascript/app/app.module.js
+++ b/plugins/file-open-save/core/src/main/javascript/app/app.module.js
@@ -1,7 +1,7 @@
 /*!
  * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2017 Hitachi Vantara. All rights reserved.
+ * Copyright 2017-2020 Hitachi Vantara. All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Hitachi Vantara and its licensors. The intellectual
@@ -43,7 +43,7 @@ define([
   "./components/breadcrumb/breadcrumb.directive",
   "./services/data.service",
   "./shared/directives/resize/resize.module",
-  "angular-ui-router"
+  "@uirouter/angularjs"
 ], function(angular, appConfig, appComponent, cardComponent, folderComponent, errorComponent,
             loadingComponent, breadcrumbComponent, filesComponent, searchComponent, editDirective, keyDirective,
             focusDirective, scrollToFolderDirective, breadcrumbDirective, dataService, resizeModule) {

--- a/plugins/file-open-save/core/src/main/resources-filtered/app/package.json
+++ b/plugins/file-open-save/core/src/main/resources-filtered/app/package.json
@@ -13,8 +13,9 @@
   ],
   "dependencies": {
     "angular": "${angular.version}",
-    "angular-ui-router": "${angular-ui-router.version}",
-    "angular-i18n": "${angular-i18n.version}",
+    "@uirouter/core": "${uirouter-core.version}",
+    "@uirouter/angularjs": "${uirouter-angularjs.version}",
+    "angular-i18n": "${angular.version}",
     "require-css": "${require-css.version}",
     "requirejs-text": "${requirejs-text.version}",
     "dojo": "${dojo.version}",

--- a/plugins/file-open-save/pom.xml
+++ b/plugins/file-open-save/pom.xml
@@ -23,13 +23,10 @@
   <properties>
     <pdi.version>9.1.0.0-SNAPSHOT</pdi.version>
     <version.for.license>${project.version}</version.for.license>
-    <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
-    <angular.version>1.5.8</angular.version>
+    <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n,uirouter__core,uirouter__angularjs</js.project.list>
     <pentaho-osgi-bundles.version>9.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <angular-ui-router.version>0.4.2</angular-ui-router.version>
     <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>
-    <angular-i18n.version>1.5.6</angular-i18n.version>
     <swt.version>4.6</swt.version>
     <dojo.version>1.9.2</dojo.version>
     <dependency.javax.servlet-api.version>3.0.1</dependency.javax.servlet-api.version>
@@ -126,18 +123,6 @@
             <groupId>*</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>angular</artifactId>
-        <version>${angular.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>angular-i18n</artifactId>
-        <version>${angular-i18n.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.webjars.bower</groupId>

--- a/plugins/get-fields/assemblies/feature/src/main/feature/feature.xml
+++ b/plugins/get-fields/assemblies/feature/src/main/feature/feature.xml
@@ -12,8 +12,7 @@
 
     <!-- START client side dependencies -->
     <bundle>pentaho-webjars:mvn:org.webjars.bower/angular/${angular.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-i18n/${angular-i18n.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-ui-router/${angular-ui-router.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/angular-i18n/${angular.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/require-css/${require-css.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/requirejs-text/${requirejs-text.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/dojo/${dojo.version}</bundle>

--- a/plugins/get-fields/core/pom.xml
+++ b/plugins/get-fields/core/pom.xml
@@ -75,7 +75,7 @@
       <artifactId>angular</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars.bower</groupId>
+      <groupId>org.webjars.npm</groupId>
       <artifactId>angular-i18n</artifactId>
     </dependency>
     <dependency>

--- a/plugins/get-fields/core/src/main/java/org/pentaho/getfields/dialog/GetFieldsDialog.java
+++ b/plugins/get-fields/core/src/main/java/org/pentaho/getfields/dialog/GetFieldsDialog.java
@@ -64,7 +64,7 @@ public class GetFieldsDialog extends ThinDialog {
   public void open() {
     StringBuilder clientPath = new StringBuilder();
     clientPath.append( getClientPath() );
-    clientPath.append( "#?path=" );
+    clientPath.append( "#!?path=" );
     clientPath.append( file );
     clientPath.append( "&type=" );
     clientPath.append( type );

--- a/plugins/get-fields/core/src/main/resources-filtered/app/package.json
+++ b/plugins/get-fields/core/src/main/resources-filtered/app/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@pentaho/di-core-ui": "${project.version}",
     "angular": "${angular.version}",
-    "angular-ui-router": "${angular-ui-router.version}",
     "angular-i18n": "${angular-i18n.version}",
     "require-css": "${require-css.version}",
     "requirejs-text": "${requirejs-text.version}",

--- a/plugins/get-fields/pom.xml
+++ b/plugins/get-fields/pom.xml
@@ -24,12 +24,9 @@
     <pdi.version>9.1.0.0-SNAPSHOT</pdi.version>
     <version.for.license>${project.version}</version.for.license>
     <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
-    <angular.version>1.5.8</angular.version>
     <pentaho-osgi-bundles.version>9.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <angular-ui-router.version>0.4.2</angular-ui-router.version>
     <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>
-    <angular-i18n.version>1.5.6</angular-i18n.version>
     <swt.version>4.6</swt.version>
     <dojo.version>1.9.2</dojo.version>
     <dependency.javax.servlet-api.version>3.0.1</dependency.javax.servlet-api.version>
@@ -119,12 +116,6 @@
         <groupId>org.webjars.bower</groupId>
         <artifactId>angular</artifactId>
         <version>${angular.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>angular-i18n</artifactId>
-        <version>${angular-i18n.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/plugins/repositories/assemblies/feature/src/main/feature/feature.xml
+++ b/plugins/repositories/assemblies/feature/src/main/feature/feature.xml
@@ -6,12 +6,12 @@
     <details>${project.description}</details>
     <!-- START client side dependencies -->
     <bundle>pentaho-webjars:mvn:org.webjars.bower/angular/${angular.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-route/${angular-route.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-sanitize/${angular-sanitize.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-sanitize/${angular.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-translate/${angular-translate.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-animate/${angular-animate.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-ui-router/${angular-ui-router.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-i18n/${angular-i18n.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-animate/${angular.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__core/${uirouter-core.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__angularjs/${uirouter-angularjs.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.npm/angular-i18n/${angular.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/require-css/${require-css.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/requirejs-text/${requirejs-text.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/dojo/${dojo.version}</bundle>

--- a/plugins/repositories/core/pom.xml
+++ b/plugins/repositories/core/pom.xml
@@ -41,31 +41,21 @@
     <dependency>
       <groupId>org.webjars.bower</groupId>
       <artifactId>angular</artifactId>
-      <version>${angular.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.webjars.bower</groupId>
-      <artifactId>angular-route</artifactId>
-      <version>${angular-route.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.webjars.bower</groupId>
       <artifactId>angular-sanitize</artifactId>
-      <version>${angular-sanitize.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.webjars.bower</groupId>
       <artifactId>angular-translate</artifactId>
-      <version>${angular-translate.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.webjars.bower</groupId>
       <artifactId>angular-animate</artifactId>
-      <version>${angular-animate.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -163,9 +153,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.webjars.bower</groupId>
+      <groupId>org.webjars.npm</groupId>
       <artifactId>angular-i18n</artifactId>
-      <version>${angular-i18n.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/dialog/RepositoryDialog.java
+++ b/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/dialog/RepositoryDialog.java
@@ -52,10 +52,10 @@ public class RepositoryDialog extends ThinDialog {
   private static final int HEIGHT = 630;
   private static final int OPTIONS = SWT.APPLICATION_MODAL | SWT.DIALOG_TRIM;
   private static final String CREATION_TITLE = BaseMessages.getString( PKG, "RepositoryDialog.Dialog.NewRepo.Title" );
-  private static final String CREATION_WEB_CLIENT_PATH = "#/add";
+  private static final String CREATION_WEB_CLIENT_PATH = "#!/add";
   private static final String MANAGER_TITLE = BaseMessages.getString( PKG, "RepositoryDialog.Dialog.Manager.Title" );
   private static final String LOGIN_TITLE = BaseMessages.getString( PKG, "RepositoryDialog.Dialog.Login.Title" );
-  private static final String LOGIN_WEB_CLIENT_PATH = "#/connect";
+  private static final String LOGIN_WEB_CLIENT_PATH = "#!/connect";
   private static final String OSGI_SERVICE_PORT = "OSGI_SERVICE_PORT";
   private static final String THIN_CLIENT_HOST = "THIN_CLIENT_HOST";
   private static final String THIN_CLIENT_PORT = "THIN_CLIENT_PORT";

--- a/plugins/repositories/core/src/main/javascript/app/app.animation.js
+++ b/plugins/repositories/core/src/main/javascript/app/app.animation.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Hitachi Vantara. All rights reserved.
+ * Copyright 2018-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ define(
     function () {
       'use strict';
 
-      var factoryArray = ["$rootScope", "$state", factory];
+      var factoryArray = ["$rootScope", "$state", "$transitions", factory];
       var module = {
         class: ".transition",
         factory: factoryArray
@@ -37,7 +37,7 @@ define(
        * @param {Object} $rootScope
        * @returns {Object} The callbacks for animation
        */
-      function factory($rootScope, $state) {
+      function factory($rootScope, $state, $transitions) {
         var transition = $state.current.name === "connecting" ? "fade" : "slideLeft";
         var transitions = {
           "add->other": "fade",
@@ -61,8 +61,9 @@ define(
           "connect->connecting": "fade",
           "connecting->connect": "fade"
         };
-        $rootScope.$on('$stateChangeStart', function(evt, toState, toParams, fromState, fromParams) {
-          var next = transitions[fromState.name + "->" + toState.name];
+
+        $transitions.onStart({ }, function(trans) {
+          var next = transitions[trans.from().name + "->" + trans.to().name];
           if (next) {
             transition = next;
           } else {
@@ -72,7 +73,7 @@ define(
 
         return {
           enter: enter,
-          leave: leave,
+          leave: leave
         };
 
         function enter(element, done) {

--- a/plugins/repositories/core/src/main/javascript/app/app.config.js
+++ b/plugins/repositories/core/src/main/javascript/app/app.config.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Hitachi Vantara. All rights reserved.
+ * Copyright 2018-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,8 @@ define([], function() {
           params: {
             credentials: null,
             connection: null,
-            error: null
+            error: null,
+            repo: null
           }
         })
         .state('connecting', {

--- a/plugins/repositories/core/src/main/javascript/app/app.module.js
+++ b/plugins/repositories/core/src/main/javascript/app/app.module.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Hitachi Vantara. All rights reserved.
+ * Copyright 2018-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@
    "./components/shared/focus/focus.directive",
    "./components/shared/help/help.component",
    "./components/shared/service/helper.service",
-   "angular-ui-router",
+   "@uirouter/angularjs",
    "angular-animate"
  ], function(angular, appConfig, appAnimation, pentahoModule, databaseModule, fileModule, managerComponent, managerService, addComponent, connectComponent, connectService, connectingComponent, otherComponent, otherService, loadingComponent, failureComponent, successComponent, errorComponent, focusDirective, helpComponent, helperService) {
    'use strict';

--- a/plugins/repositories/core/src/main/javascript/app/components/database/database.module.js
+++ b/plugins/repositories/core/src/main/javascript/app/components/database/database.module.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Hitachi Vantara. All rights reserved.
+ * Copyright 2018-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ define([
   "./loading/loading.service",
   "./failure/failure.component",
   "./success/success.component",
-  "angular-ui-router"
+  "@uirouter/angularjs"
 ], function(angular, appConfig, databaseComponent, detailsComponent, detailsService, selectComponent, selectService, loadingComponent, loadingService, failureComponent, successComponent) {
   'use strict';
 

--- a/plugins/repositories/core/src/main/javascript/app/components/file/file.module.js
+++ b/plugins/repositories/core/src/main/javascript/app/components/file/file.module.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Hitachi Vantara. All rights reserved.
+ * Copyright 2018-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ define([
   "./loading/loading.service",
   "./failure/failure.component",
   "./success/success.component",
-  "angular-ui-router"
+  "@uirouter/angularjs"
 ], function(angular, appConfig, fileComponent, detailsComponent, detailsService, loadingComponent, loadingService, failureComponent, successComponent) {
   'use strict';
 

--- a/plugins/repositories/core/src/main/javascript/app/components/pentaho/pentaho.component.js
+++ b/plugins/repositories/core/src/main/javascript/app/components/pentaho/pentaho.component.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Hitachi Vantara. All rights reserved.
+ * Copyright 2018-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,7 @@ define([
   'use strict';
 
   var options = {
-    bindings: {
-      connection: "<"
-    },
+    bindings: {},
     controllerAs: "vm",
     template: template,
     controller: pentahoController

--- a/plugins/repositories/core/src/main/javascript/app/components/pentaho/pentaho.module.js
+++ b/plugins/repositories/core/src/main/javascript/app/components/pentaho/pentaho.module.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Hitachi Vantara. All rights reserved.
+ * Copyright 2018-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ define([
   "./loading/loading.service",
   "./failure/failure.component",
   "./success/success.component",
-  "angular-ui-router"
+  "@uirouter/angularjs"
 ], function(angular, appConfig, pentahoComponent, detailsComponent, detailsService, loadingComponent, loadingService, failureComponent, successComponent) {
   'use strict';
 

--- a/plugins/repositories/core/src/main/resources-filtered/app/package.json
+++ b/plugins/repositories/core/src/main/resources-filtered/app/package.json
@@ -14,8 +14,9 @@
   "dependencies": {
     "angular": "${angular.version}",
     "angular-animate": "${angular.version}",
-    "angular-i18n": "${angular-i18n.version}",
-    "angular-ui-router": "${angular-ui-router.version}",
+    "angular-i18n": "${angular.version}",
+    "@uirouter/core": "${uirouter-core.version}",
+    "@uirouter/angularjs": "${uirouter-angularjs.version}",
     "require-css": "${require-css.version}",
     "requirejs-text": "${requirejs-text.version}",
     "dojo": "${dojo.version}",

--- a/plugins/repositories/pom.xml
+++ b/plugins/repositories/pom.xml
@@ -17,16 +17,9 @@
 
   <properties>
     <pdi.version>9.1.0.0-SNAPSHOT</pdi.version>
-    <angular.version>1.5.8</angular.version>
-    <angular-route.version>${angular.version}</angular-route.version>
-    <angular-sanitize.version>${angular.version}</angular-sanitize.version>
-    <angular-animate.version>${angular.version}</angular-animate.version>
-    <angular-translate.version>2.12.1</angular-translate.version>
-    <angular-ui-router.version>0.4.2</angular-ui-router.version>
     <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>
     <dojo.version>1.9.2</dojo.version>
-    <angular-i18n.version>${angular.version}</angular-i18n.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
BACKLOG-33388
BACKLOG-33449
BACKLOG-33454
BACKLOG-33450
BACKLOG-33451

Related PRs
https://github.com/pentaho/pdi-plugins-ee/pull/169
https://github.com/pentaho/big-data-plugin/pull/2033