### PR TITLE
[PDI-18466] MongoDB output - Update all the array values in MongoDB b…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/util/StringUtil.java
+++ b/core/src/main/java/org/pentaho/di/core/util/StringUtil.java
@@ -196,6 +196,7 @@ public class StringUtil {
     int i = rest.indexOf( HEX_OPEN );
     while ( i > -1 ) {
       int j = rest.indexOf( HEX_CLOSE, i + HEX_OPEN.length() );
+      if ( i + HEX_OPEN.length() == j ) break; // invalid Hex Expression empty array
       // search for closing string
       if ( j > -1 ) {
         buffer.append( rest.substring( 0, i ) );

--- a/core/src/test/java/org/pentaho/di/core/util/StringUtilTest.java
+++ b/core/src/test/java/org/pentaho/di/core/util/StringUtilTest.java
@@ -227,6 +227,12 @@ public class StringUtilTest extends TestCase {
   }
 
   @Test
+  public void testSubstituteHex_ignoreEmptyArrayDefinition() throws Exception {
+    String text = "holdings.$[].as_of_dt";
+    assertEquals( text, StringUtil.substituteHex( text ) );
+  }
+
+  @Test
   public void environmentSubstituteHexTest() {
     String result = StringUtil.environmentSubstitute( "$[31,32,33,34,35,36]", createVariables1( "${", "}" ) );
     assertEquals( "123456", result );


### PR DESCRIPTION
…ased on a matching key

invalid Hex Expression - empty array - is now ignored
Please also check this PR (related): pentaho/pentaho-mongodb-plugin#197
@ssamora 