### PR TITLE
[PDI-18619] Memory leak due to failing to clean up EmbeddedMetastore …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/attributes/metastore/EmbeddedMetaStore.java
+++ b/engine/src/main/java/org/pentaho/di/core/attributes/metastore/EmbeddedMetaStore.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -45,6 +45,7 @@ import org.pentaho.metastore.stores.memory.MemoryMetaStoreElementOwner;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -66,6 +67,7 @@ public class EmbeddedMetaStore extends BaseMetaStore implements ReadWriteLock {
   public EmbeddedMetaStore( AttributesInterface attributesInterface ) {
     this.attributesInterface = attributesInterface;
     this.lock = new ReentrantReadWriteLock();
+    this.name = UUID.randomUUID().toString(); // default, unique name
   }
 
   @Override public void createNamespace( final String namespace ) throws MetaStoreException {

--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -630,12 +630,6 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
 
     JobExecutionExtension extension = new JobExecutionExtension( this, prevResult, jobEntryCopy, true );
     ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobBeforeJobEntryExecution.id, extension );
-
-    jobMeta.disposeEmbeddedMetastoreProvider();
-    if ( jobMeta.getMetastoreLocatorOsgi() != null ) {
-      jobMeta.setEmbeddedMetastoreProviderKey( jobMeta.getMetastoreLocatorOsgi().setEmbeddedMetastore( jobMeta
-          .getEmbeddedMetaStore() ) );
-    }
 
     if ( extension.result != null ) {
       prevResult = extension.result;

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -768,12 +768,6 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     log.snap( Metrics.METRIC_TRANSFORMATION_INIT_START );
 
     ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.TransformationPrepareExecution.id, this );
-
-    transMeta.disposeEmbeddedMetastoreProvider();
-    if ( transMeta.getMetastoreLocatorOsgi() != null ) {
-      transMeta.setEmbeddedMetastoreProviderKey(
-        transMeta.getMetastoreLocatorOsgi().setEmbeddedMetastore( transMeta.getEmbeddedMetaStore() ) );
-    }
 
     checkCompatibility();
 

--- a/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,6 +25,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.NotePadMeta;
 import org.pentaho.di.core.Props;
@@ -95,10 +98,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+@RunWith( MockitoJUnitRunner.class )
 public class AbstractMetaTest {
-  AbstractMeta meta;
-  ObjectId objectId;
-  Repository repo;
+  private AbstractMeta meta;
+  private ObjectId objectId;
+  private Repository repo;
+
+  @Mock private MetastoreLocatorOsgi mockMetastoreLocatorOsgi;
 
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
 
@@ -763,17 +769,21 @@ public class AbstractMetaTest {
   }
 
   @Test
-  public void testGetSetEmbeddedMetastoreProviderKey() throws Exception {
-    assertNull( meta.getEmbeddedMetastoreProviderKey() );
+  public void testEmbeddedMetastoreProviderKeyIsMemoized() {
     String keyValue = "keyValue";
-    meta.setEmbeddedMetastoreProviderKey( keyValue );
+    meta.setMetastoreLocatorOsgi( mockMetastoreLocatorOsgi );
+    when( mockMetastoreLocatorOsgi.setEmbeddedMetastore( meta.getEmbeddedMetaStore() ) ).thenReturn( keyValue );
+
     assertEquals( keyValue, meta.getEmbeddedMetastoreProviderKey() );
+    assertEquals( keyValue, meta.getEmbeddedMetastoreProviderKey() );
+    verify( mockMetastoreLocatorOsgi, times( 1 ) )
+      .setEmbeddedMetastore( meta.getEmbeddedMetaStore() );
   }
+
 
   @Test
   public void testGetSetMetastoreLocatorOsgi() throws Exception {
     assertNull( meta.getMetastoreLocatorOsgi() );
-    MetastoreLocatorOsgi mockMetastoreLocatorOsgi = mock( MetastoreLocatorOsgi.class );
     meta.setMetastoreLocatorOsgi( mockMetastoreLocatorOsgi );
     assertEquals( mockMetastoreLocatorOsgi, meta.getMetastoreLocatorOsgi() );
   }


### PR DESCRIPTION
…objects

Within a single job or trans, multiple other jobs/trans can be launched in
parallel.  It's also possible for more than one of those jobs/trans to share
a jobmeta or transmeta.  Because of this, the former logic for disposing
and creating the metastorelocator key could result in orphaned keys,
since multiple threads may create new ones without disposing the previous.

This change (combined with https://github.com/pentaho/pentaho-osgi-bundles/pull/364)
stores only a single embeddedmetastore for each meta, and associates a single
key.  Disposal verifies that the trans or job doing the disposing is the "top level"
job or trans holding that key, making sure it will be cleaned up when no other job
or trans needs it.

https://jira.pentaho.com/browse/PDI-18619