### PR TITLE
[PDI-18498] Transformation executor error passing transformation name…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -160,6 +160,13 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
           // This is a parent transformation and parent variable should work here. A child file name can be resolved via parent space.
           realTransname = space.environmentSubstitute( realTransname );
           realDirectory = space.environmentSubstitute( realDirectory );
+        }
+
+        if ( realDirectory.isEmpty() && !Utils.isEmpty( realTransname ) && realTransname.startsWith( "/" ) ) {
+          int index = realTransname.lastIndexOf( '/' );
+          String transPath =  realTransname;
+          realTransname = realTransname.substring( index + 1 );
+          realDirectory = transPath.substring( 0, index );
         }
 
         if ( rep != null ) {

--- a/ui/src/main/java/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/steps/transexecutor/TransExecutorDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -489,8 +489,11 @@ public class TransExecutorDialog extends BaseStepDialog implements StepDialogInt
         wPath.setText( Const.NVL( transExecutorMeta.getFileName(), "" ) );
         break;
       case REPOSITORY_BY_NAME:
-        String fullPath = Const.NVL( transExecutorMeta.getDirectoryPath(), "" ) + "/" + Const
-          .NVL( transExecutorMeta.getTransName(), "" );
+        String transname = transMeta.environmentSubstitute( transExecutorMeta.getTransName() );
+        String directoryPath = transMeta.environmentSubstitute( transExecutorMeta.getDirectoryPath() );
+        String fullPath = directoryPath.isEmpty() && !transname.isEmpty() && transname.startsWith( "/" )
+          ? Const.NVL( transExecutorMeta.getTransName(), "" )
+          : Const.NVL( transExecutorMeta.getDirectoryPath(), "" ) + "/" + Const.NVL( transExecutorMeta.getTransName(), "" );
         wPath.setText( fullPath );
         break;
       case REPOSITORY_BY_REFERENCE:


### PR DESCRIPTION
… with path in parameter
TransformationExecutor requires a "/" on the subTransformation path to distinguish which part is a directory path or a filename. In this case we have our path defined by 2 variables, so there's no "/" to make this logic work. 

For example:

1st Scenario
Sub path value: /public/test

Will produce:
Directory=/public/
Filename=test

2nd Scenario
Sub path value: ${variable1}${variable2}

Will produce:
Directory=""
Filename=/${variable1}${variable2}

So, since we can't resolve variables at this point - that will changed usability, from having a variable to a hard-coded path - this means we have to deal with the empty directory saved on transExecutorMeta on the second scenario.

Having that in mind we have to over check for this kind of cases:
- In StepWithMappingMeta.java after variable resolution a new check was added to correctly fill both directory and filename, for this cases.

- And when we opening or clicking the ok button at the transExecutor Dialog, it was adding an extra "/" since directory was empty. That logic was also changed, for these cases.


@pentaho-lmartins 
@pentaho/tatooine 