### PR TITLE
[PDI-18719] Global LogChannels do not pick up DefaultLogLevel changes

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/logging/DefaultLogLevel.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/DefaultLogLevel.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -57,6 +57,7 @@ public class DefaultLogLevel {
    */
   public static void setLogLevel( LogLevel logLevel ) {
     DefaultLogLevel instance = getInstance();
+    LogChannel.updateGlobalLogChannels( logLevel );
     instance.logLevel = logLevel;
   }
 


### PR DESCRIPTION
The global log channels in PDI are initialized on startup with the
default log level of BASIC.

The default log level (loaded from .spoonrc|LogLevel) is read after these
fields are initialized, so those logchannels are not updated.  When the
default log level is changed we should update the global log channels.

https://jira.pentaho.com/browse/PDI-18719