### PR TITLE
[SP-5524] Backport of PDI-18621 - Using 'Open Referenced Object' removes

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -2333,6 +2333,14 @@ public class JobMeta extends AbstractMeta
       }
     }
     return null;
+  }
+
+  @Override
+  public void initializeVariablesFrom( VariableSpace parent ) {
+    super.initializeVariablesFrom( parent );
+    variables.setVariable( Const.INTERNAL_VARIABLE_JOB_REPOSITORY_DIRECTORY, null );
+    variables.setVariable( Const.INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY, null );
+    variables.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, null );
   }
 
   /**


### PR DESCRIPTION
Internal.Entry.Current.Directory from Sub Job in Spoon (9.0 Suite)