### PR TITLE
[PDI-18659] After the execution of an ETL Metadata Injection step to …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/tableoutput/TableOutputMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/tableoutput/TableOutputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -158,13 +158,13 @@ public class TableOutputMeta extends BaseStepMeta implements StepMetaInterface, 
   }
 
   @Injection( name = "DATABASE_FIELD_NAME", group = "DATABASE_FIELDS" )
-  private String[] fieldStream;
+  private String[] fieldDatabase;
 
   /**
    * Fields in the table to insert
    */
   @Injection( name = "DATABASE_STREAM_NAME", group = "DATABASE_FIELDS" )
-  private String[] fieldDatabase;
+  private String[] fieldStream;
 
 
   /**


### PR DESCRIPTION
…configure the database fields in a Table Output step, the resulting fields in the "Table field" and "Stream field" columns on the "Database fields" tab are reversed.

@pentaho-lmartins @ppatricio @bcostahitachivantara @smmribeiro 