### PR TITLE
[PDI-18677] Command line arguments are not picked by Kitchen and sent…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
@@ -287,7 +287,7 @@ public class Kitchen {
               .customNamedParams( customOptions )
               .build();
 
-      result = getCommandExecutor().execute( jobParams );
+      result = getCommandExecutor().execute( jobParams, args.toArray( new String[ args.size() ] ) );
 
     } catch ( Throwable t ) {
       t.printStackTrace();

--- a/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
@@ -25,7 +25,6 @@ package org.pentaho.di.kitchen;
 import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.base.AbstractBaseCommandExecutor;
 import org.pentaho.di.base.CommandExecutorCodes;
-import org.pentaho.di.base.KettleConstants;
 import org.pentaho.di.base.Params;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.Result;
@@ -70,6 +69,10 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     setPkgClazz( pkgClazz );
     setLog( log );
     setKettleInit( kettleInit );
+  }
+
+  public Result execute( final Params params ) throws Throwable {
+    return execute( params, null );
   }
 
   public Result execute( Params params, String[] arguments ) throws Throwable {

--- a/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
@@ -179,7 +179,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     try {
 
       // Set the command line arguments on the job ...
-      job.setArguments( ( arguments!= null && arguments.length > 0 )  ? arguments : convert( KettleConstants.toJobMap( params ) ) );
+      job.setArguments( arguments );
       job.initializeVariablesFrom( null );
       job.setLogLevel( getLog().getLogLevel() );
       job.getJobMeta().setInternalKettleVariables( job );

--- a/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/KitchenCommandExecutor.java
@@ -72,7 +72,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     setKettleInit( kettleInit );
   }
 
-  public Result execute( Params params ) throws Throwable {
+  public Result execute( Params params, String[] arguments ) throws Throwable {
 
     getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Kitchen.Log.Starting" ) );
 
@@ -179,7 +179,7 @@ public class KitchenCommandExecutor extends AbstractBaseCommandExecutor {
     try {
 
       // Set the command line arguments on the job ...
-      job.setArguments( convert( KettleConstants.toJobMap( params ) ) );
+      job.setArguments( ( arguments!= null && arguments.length > 0 )  ? arguments : convert( KettleConstants.toJobMap( params ) ) );
       job.initializeVariablesFrom( null );
       job.setLogLevel( getLog().getLogLevel() );
       job.getJobMeta().setInternalKettleVariables( job );

--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -274,7 +274,7 @@ public class Pan {
               .namedParams( optionParams )
               .build();
 
-      Result result = getCommandExecutor().execute( transParams );
+      Result result = getCommandExecutor().execute( transParams, args.toArray( new String[ args.size() ] )  );
 
       exitJVM( result.getExitStatus() );
 

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -26,7 +26,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.pentaho.di.base.AbstractBaseCommandExecutor;
 import org.pentaho.di.base.CommandExecutorCodes;
-import org.pentaho.di.base.KettleConstants;
 import org.pentaho.di.base.Params;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.Result;

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -73,7 +73,7 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
     setLog( log );
   }
 
-  public Result execute( final Params params ) throws Throwable {
+  public Result execute( final Params params, String[] arguments  ) throws Throwable {
 
     getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Pan.Log.StartingToRun" ) );
 
@@ -189,7 +189,7 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
 
       // allocate & run the required sub-threads
       try {
-        trans.prepareExecution( convert(  KettleConstants.toTransMap( params ) ) );
+        trans.prepareExecution( ( arguments!= null && arguments.length > 0 )  ? arguments : convert(  KettleConstants.toTransMap( params ) ) );
 
         if ( !StringUtils.isEmpty( params.getResultSetStepName() ) ) {
 

--- a/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/pan/PanCommandExecutor.java
@@ -73,6 +73,10 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
     setLog( log );
   }
 
+  public Result execute( final Params params ) throws Throwable {
+    return execute( params, null );
+  }
+
   public Result execute( final Params params, String[] arguments  ) throws Throwable {
 
     getLog().logMinimal( BaseMessages.getString( getPkgClazz(), "Pan.Log.StartingToRun" ) );
@@ -189,7 +193,7 @@ public class PanCommandExecutor extends AbstractBaseCommandExecutor {
 
       // allocate & run the required sub-threads
       try {
-        trans.prepareExecution( ( arguments!= null && arguments.length > 0 )  ? arguments : convert(  KettleConstants.toTransMap( params ) ) );
+        trans.prepareExecution( arguments );
 
         if ( !StringUtils.isEmpty( params.getResultSetStepName() ) ) {
 

--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenCommandExecutorTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenCommandExecutorTest.java
@@ -127,7 +127,7 @@ public class KitchenCommandExecutorTest {
     when( BaseMessages.getString( any( Class.class ), anyString(), anyVararg() ) ).thenReturn( "" );
 
     try {
-      Result result = kitchenCommandExecutor.execute( params );
+      Result result = kitchenCommandExecutor.execute( params, null );
       Assert.assertEquals( CommandExecutorCodes.Kitchen.COULD_NOT_LOAD_JOB.getCode(), result.getExitStatus() );
     } catch ( Throwable throwable ) {
       Assert.fail();

--- a/engine/src/test/java/org/pentaho/di/pan/PanCommandExecutorTest.java
+++ b/engine/src/test/java/org/pentaho/di/pan/PanCommandExecutorTest.java
@@ -184,7 +184,7 @@ public class PanCommandExecutorTest {
     when( BaseMessages.getString( any( Class.class ), anyString(), anyVararg() ) ).thenReturn( "" );
 
     try {
-      Result result = panCommandExecutor.execute( params );
+      Result result = panCommandExecutor.execute( params, null );
       Assert.assertEquals( CommandExecutorCodes.Pan.COULD_NOT_LOAD_TRANS.getCode(), result.getExitStatus() );
     } catch ( Throwable throwable ) {
       Assert.fail();


### PR DESCRIPTION
… to job/transformation

This is a sample PR for fixing the PDI-18677 case.
Needs some confirmation regarding supporting "unsupported" arguments.
Help page (https://help.pentaho.com/Documentation/9.0/Products/Use_Command_Line_Tools_to_Run_Transformations_and_Jobs) describes a list of valid arguments to be passed, but PDI-18677 uses a simple "var1" argument and some behavior is expected. Not sure which behavior we should/should not implement. Looks like some legacy old behavior.
This was a side-effect of #6337 that removed all "unsupported" arguments with params refactor.
This PR returns the old behavior, but at the same time keeps the same code introduced by #6337.
More details provided in Jira.

After confirmation, https://github.com/pentaho/pentaho-ee/pull/1929/files needs to be changed accordingly --> UPDATE: just adapted the execute function to received both params & params and arguments calls.
