### PR TITLE
[SP-5590] Backport of PDI-18739 - Text File Input cannot process a cs…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1157,6 +1157,9 @@ public class Const {
   // See PDI-17980 for details
   public static final String KETTLE_COMPATIBILITY_USE_JDBC_METADATA = "KETTLE_COMPATIBILITY_USE_JDBC_METADATA";
 
+  // See PDI-PDI-18739 for details
+  public static final String KETTLE_COMPATIBILITY_TEXT_FILE_INPUT_USE_LENIENT_ENCLOSURE_HANDLING = "KETTLE_COMPATIBILITY_TEXT_FILE_INPUT_USE_LENIENT_ENCLOSURE_HANDLING";
+
   /**
    * The XML file that contains the list of native import rules
    */


### PR DESCRIPTION
…v file row with an unequal amount of enclosures(double quotes) in a column value (9.0 Suite)

cherry-pick of b04057c

@pentaho-lmartins 