### PR TITLE
[PDI-18458] When the Database connection which is used in the Transfo…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -2770,7 +2770,7 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
   private synchronized boolean endProcessing() throws KettleException {
     LogStatus status;
 
-    if ( isFinished() ) {
+    if ( isFinishedOrStopped() ) {
       if ( isStopped() ) {
         status = LogStatus.STOP;
       } else {


### PR DESCRIPTION
…rmation step is invalid, the status in pentaho_dilogs .trans_logs table does shows as "running" when the Transformation has failed.

@pentaho-lmartins @ssamora @ppatricio 
