### PR TITLE
[PDI-18786]

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -635,6 +635,16 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
     }
   }
 
+  /*
+   * Remove all listeners; to be used during imports and other times when the directory property is changed but
+   * we do not want to trigger the steps to update.
+   */
+  public void clearCurrentDirectoryChangedListeners() {
+    if ( currentDirectoryChangedListeners != null ) {
+      currentDirectoryChangedListeners.clear();
+    }
+  }
+
   /**
    * Notify listeners of a change in current directory.
    */

--- a/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
+++ b/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
@@ -800,6 +800,8 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
       updateDisplay();
     }
 
+    jobMeta.clearCurrentDirectoryChangedListeners();
+
     if ( existintId == null || overwrite ) {
       replaceSharedObjects( jobMeta );
       jobMeta.setRepositoryDirectory( targetDirectory );


### PR DESCRIPTION
[SP-5614]
CurrentDirectoryChangedListener was firing during import and
causing erroneous changes to the imported job when the directory to
contain the job did not exist prior to import.

This commit is a cherry-pick from master d74dc98ebe.