### PR TITLE
[BISERVER-3497] Introduce pentaho-support-encyption project

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@
     <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>
     <xmlunit.version>1.5</xmlunit.version>
     <joda.version>2.10.2</joda.version>
-    <pentaho-encryption-support-version>9.1.0.0-SNAPSHOT</pentaho-encryption-support-version>
+    <encryption-support.version>9.1.0.0-SNAPSHOT</encryption-support.version>
   </properties>
 
   <dependencies>
@@ -500,7 +500,7 @@
     <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-encryption-support</artifactId>
-      <version>${pentaho-encryption-support-version}</version>
+      <version>${encryption-support.version}</version>
     </dependency>
 
   </dependencies>

--- a/core/src/main/resources/kettle-password-encoder-plugins.xml
+++ b/core/src/main/resources/kettle-password-encoder-plugins.xml
@@ -2,7 +2,7 @@
 
   <password-encoder-plugin id="Kettle">
     <description>Kettle Password Encoder</description>
-    <classname>org.pentaho.di.core.encryption.KettleTwoWayPasswordEncoder</classname>
+    <classname>org.pentaho.support.encryption.KettleTwoWayPasswordEncoder</classname>
   </password-encoder-plugin>
  
 </password-encoder-plugins>


### PR DESCRIPTION
Fix encryption-support version property to use property used by jenkins
move kettle-password-encoder-plugins.xml out of kettle-core so it will use the on in classes