### PR TITLE
[SP-5594] - Backport of PDI-18489 - When using the Excel Input Step r…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1316,6 +1316,22 @@ public class Const {
     String.valueOf( KETTLE_ZIP_MAX_TEXT_SIZE_DEFAULT );
 
   /**
+   * <p>The default value for the {@link #KETTLE_ZIP_NEGATIVE_MIN_INFLATE} as a Double.</p>
+   * <p>Check PDI-18489 for more details.</p>
+   */
+  public static final Double KETTLE_ZIP_NEGATIVE_MIN_INFLATE = -1.0d;
+
+  /**
+   * <p>This environment variable is used to define whether the check of xlsx zip bomb is performed. This is set to false by default.</p>
+   */
+  public static final String KETTLE_XLSX_ZIP_BOMB_CHECK = "KETTLE_XLSX_ZIP_BOMB_CHECK";
+  private static final String KETTLE_XLSX_ZIP_BOMB_CHECK_DEFAULT = "false";
+  public static boolean checkXlsxZipBomb() {
+    String checkZipBomb = System.getProperty( KETTLE_XLSX_ZIP_BOMB_CHECK, KETTLE_XLSX_ZIP_BOMB_CHECK_DEFAULT );
+    return Boolean.valueOf( checkZipBomb );
+  }
+
+  /**
    * <p>A variable to configure if the S3 input / output steps should use the Amazon Default Credentials Provider Chain
    * even if access credentials are specified within the transformation.</p>
    */

--- a/engine/src/main/java/org/pentaho/di/trans/steps/excelinput/ExcelInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/excelinput/ExcelInput.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -740,7 +740,8 @@ public class ExcelInput extends BaseStep implements StepInterface {
         .getSystemProperty( Const.KETTLE_ZIP_MIN_INFLATE_RATIO, Const.KETTLE_ZIP_MIN_INFLATE_RATIO_DEFAULT_STRING );
     double minInflateRatio;
     try {
-      minInflateRatio = Double.parseDouble( minInflateRatioVariable );
+      minInflateRatio = Const.checkXlsxZipBomb() ? Double.parseDouble( minInflateRatioVariable )
+              : Const.KETTLE_ZIP_NEGATIVE_MIN_INFLATE;
     } catch ( NullPointerException | NumberFormatException e ) {
       minInflateRatio = Const.KETTLE_ZIP_MIN_INFLATE_RATIO_DEFAULT;
     }

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -548,5 +548,11 @@
     <variable>KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE</variable>
     <default-value>LEGACY</default-value>
   </kettle-variable>
+
+  <kettle-variable>
+    <description>This environment variable is used to enable the checking of zip bomb. This is set to false by default.</description>
+    <variable>KETTLE_XLSX_ZIP_BOMB_CHECK</variable>
+    <default-value>false</default-value>
+  </kettle-variable>
 </kettle-variables>
 

--- a/engine/src/test/java/org/pentaho/di/trans/steps/excelinput/ExcelInputContentParsingTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/excelinput/ExcelInputContentParsingTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class ExcelInputContentParsingTest extends BaseExcelParsingTest {
@@ -130,12 +129,31 @@ public class ExcelInputContentParsingTest extends BaseExcelParsingTest {
 
     // Initializing the ExcelInput step should make the new values to be set
     meta.setSpreadSheetType( SpreadSheetType.SAX_POI );
+    System.setProperty( Const.KETTLE_XLSX_ZIP_BOMB_CHECK, Boolean.TRUE.toString() );
     init( "Balance_Type_Codes.xlsx" );
 
     // Verify that the default values were used
     assertEquals( Const.KETTLE_ZIP_MAX_ENTRY_SIZE_DEFAULT, (Long) ZipSecureFile.getMaxEntrySize() );
     assertEquals( Const.KETTLE_ZIP_MAX_TEXT_SIZE_DEFAULT, (Long) ZipSecureFile.getMaxTextSize() );
     assertEquals( Const.KETTLE_ZIP_MIN_INFLATE_RATIO_DEFAULT, (Double) ZipSecureFile.getMinInflateRatio() );
+  }
+
+  @Test
+  public void testZipBombConfiguration_CheckDisabled() throws Exception {
+
+    Double bogusMinInflateRatio = 0.5d;
+    ZipSecureFile.setMinInflateRatio( bogusMinInflateRatio );
+
+    // Verify the Min Inflate Ratio was set
+    assertEquals( bogusMinInflateRatio, (Double) ZipSecureFile.getMinInflateRatio() );
+
+    // Initializing the ExcelInput step should make the new values to be set
+    meta.setSpreadSheetType( SpreadSheetType.SAX_POI );
+    // Disabling the zip bomb checking property
+    System.setProperty( Const.KETTLE_XLSX_ZIP_BOMB_CHECK, Boolean.FALSE.toString() );
+    init( "Balance_Type_Codes.xlsx" );
+
+    assertEquals( Const.KETTLE_ZIP_NEGATIVE_MIN_INFLATE, (Double) ZipSecureFile.getMinInflateRatio() );
   }
 
   @Test
@@ -148,6 +166,7 @@ public class ExcelInputContentParsingTest extends BaseExcelParsingTest {
     System.setProperty( Const.KETTLE_ZIP_MAX_ENTRY_SIZE, maxEntrySizeVal.toString() );
     System.setProperty( Const.KETTLE_ZIP_MAX_TEXT_SIZE, maxTextSizeVal.toString() );
     System.setProperty( Const.KETTLE_ZIP_MIN_INFLATE_RATIO, minInflateRatioVal.toString() );
+    System.setProperty( Const.KETTLE_XLSX_ZIP_BOMB_CHECK, Boolean.TRUE.toString() );
     //ExcelInput excelInput = new ExcelInput( null, null, 0, null, null );
 
     // Initializing the ExcelInput step should make the new values to be set
@@ -167,6 +186,7 @@ public class ExcelInputContentParsingTest extends BaseExcelParsingTest {
     // For this zip to be correctly handed, we need to allow a lower inflate ratio
     Double minInflateRatio = 0.007d;
     System.setProperty( Const.KETTLE_ZIP_MIN_INFLATE_RATIO, minInflateRatio.toString() );
+    System.setProperty( Const.KETTLE_XLSX_ZIP_BOMB_CHECK, Boolean.TRUE.toString() );
 
     meta.setSpreadSheetType( SpreadSheetType.SAX_POI );
     init( "Balance_Type_Codes.xlsx" );


### PR DESCRIPTION
…esults in an exception when the compression ratio is too high for an xlsx file (8.3 Suite)

* Backport of PDI-18489 - When using the Excel Input Step results in an exception when the compression ratio is too high for an xlsx file (8.3 Suite)

@pentaho/bb-8 please review.