### PR TITLE
[SP-5575] Backport of PDI-18369 - Converting Integer to Timestamp type using Select values step results in incorrect date (9.0 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1392,34 +1392,59 @@ public class Const {
   public static final String KETTLE_BIGDECIMAL_DIVISION_ROUNDING_MODE_DEFAULT = "HALF_EVEN";
 
   /**
-   * <p>This environment variable is used to define if a Timestamp should be converted to nanoseconds or
-   * milliseconds.</p>
-   * <p>By default, a Timestamp is in {@value #KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT}.</p>
+   * <p>This environment variable is used to define how Timestamp should be converted to a number and vice-versa.</p>
+   * <p>Three options exist:</p>
+   * <ul>
+   *   <li>{@link #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY}: converting a Timestamp to a number uses
+   *   milliseconds but converting a number to Timestamp assumes the value is in nanoseconds</li>
+   *   <li>{@link #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS}: both Timestamp to number and number to
+   *   Timestamp use milliseconds</li>
+   *   <li>{@link #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS}: both Timestamp to number and number to
+   *   Timestamp use nanoseconds</li>
+   * </ul>
+   * <p>The default is {@value #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_DEFAULT}.</p>
    *
-   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT
-   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS
-   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_DEFAULT
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS
    */
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT = "KETTLE_TIMESTAMP_OUTPUT_FORMAT";
+  public static final String KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE = "KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE";
 
   /**
-   * <p>The value to use for setting the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT} as nanoseconds.</p>
+   * <p>The value to use for setting the {@link #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE} as it behaved on former
+   * versions.</p>
    *
-   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS
    */
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS = "NANOSECONDS";
+  public static final String KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY = "LEGACY";
 
   /**
-   * <p>The value to use for setting the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT} as milliseconds.</p>
+   * <p>The value to use for setting the {@link #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE} to use milliseconds.</p>
    *
-   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS
    */
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS = "MILLISECONDS";
+  public static final String KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS = "MILLISECONDS";
 
   /**
-   * <p>The default value for the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT}.</p>
+   * <p>The value to use for setting the {@link #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE} to use nanoseconds.</p>
+   *
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS
    */
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS;
+  public static final String KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS = "NANOSECONDS";
+
+  /**
+   * <p>The default value for the {@link #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE}.</p>
+   *
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS
+   * @see #KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS
+   */
+  public static final String KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_DEFAULT =
+    KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY;
 
   /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer

--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1392,11 +1392,34 @@ public class Const {
   public static final String KETTLE_BIGDECIMAL_DIVISION_ROUNDING_MODE_DEFAULT = "HALF_EVEN";
 
   /**
-   * <p>This environment variable is used to define if a Timestamp should be converted to nanoseconds or milliseconds.</p>
-   * <p>By default, a Timestamp is in nanoseconds.</p>
+   * <p>This environment variable is used to define if a Timestamp should be converted to nanoseconds or
+   * milliseconds.</p>
+   * <p>By default, a Timestamp is in {@value #KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT}.</p>
+   *
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS
    */
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT = "KETTLE_TIMESTAMP_NUMERIC_FORMAT";
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = "NANOSECONDS";
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT = "KETTLE_TIMESTAMP_OUTPUT_FORMAT";
+
+  /**
+   * <p>The value to use for setting the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT} as nanoseconds.</p>
+   *
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS
+   */
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS = "NANOSECONDS";
+
+  /**
+   * <p>The value to use for setting the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT} as milliseconds.</p>
+   *
+   * @see #KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS
+   */
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS = "MILLISECONDS";
+
+  /**
+   * <p>The default value for the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT}.</p>
+   */
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS;
 
   /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer

--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1419,7 +1419,7 @@ public class Const {
   /**
    * <p>The default value for the {@link #KETTLE_TIMESTAMP_OUTPUT_FORMAT}.</p>
    */
-  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS;
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS;
 
   /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer

--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1392,6 +1392,13 @@ public class Const {
   public static final String KETTLE_BIGDECIMAL_DIVISION_ROUNDING_MODE_DEFAULT = "HALF_EVEN";
 
   /**
+   * <p>This environment variable is used to define if a Timestamp should be converted to nanoseconds or milliseconds.</p>
+   * <p>By default, a Timestamp is in nanoseconds.</p>
+   */
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT = "KETTLE_TIMESTAMP_NUMERIC_FORMAT";
+  public static final String KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT = "NANOSECONDS";
+
+  /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer
    * overflow while rounding
    *

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -37,8 +37,10 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.util.EnvUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
@@ -50,6 +52,9 @@ import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.timestamp.SimpleTimestampFormat;
 
 public class ValueMetaTimestamp extends ValueMetaDate {
+  private final String format =
+    Const.NVL( EnvUtil.getSystemProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT ), "NANOSECONDS" );
+  private static final String MILLISECONDS = "MILLISECONDS";
 
   public ValueMetaTimestamp() {
     this( null );
@@ -80,8 +85,13 @@ public class ValueMetaTimestamp extends ValueMetaDate {
       return null;
     }
 
-    long ms = timestamp.getTime();
-    return ms;
+    long milliseconds = timestamp.getTime();
+    if ( format.equalsIgnoreCase( MILLISECONDS )  ) {
+      return Long.valueOf( milliseconds );
+    } else {
+      long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
+      return seconds * 1000000000 + timestamp.getNanos();
+    }
   }
 
   @Override
@@ -90,8 +100,14 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     if ( timestamp == null ) {
       return null;
     }
-    long ms = timestamp.getTime();
-    return Long.valueOf( ms ).doubleValue();
+
+    long milliseconds = timestamp.getTime();
+    if ( format.equalsIgnoreCase( MILLISECONDS )  ) {
+      return Double.valueOf( milliseconds );
+    } else {
+      long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
+      return (double) seconds * 1000000000 + timestamp.getNanos();
+    }
   }
 
   @Override
@@ -100,10 +116,15 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     if ( timestamp == null ) {
       return null;
     }
-    BigDecimal nanos =
-        BigDecimal.valueOf( timestamp.getTime() ).multiply( BigDecimal.valueOf( 1000000000L ) ).add(
-            BigDecimal.valueOf( timestamp.getNanos() ) );
-    return nanos;
+
+    long milliseconds = timestamp.getTime();
+    if ( format.equalsIgnoreCase( MILLISECONDS )  ) {
+      return BigDecimal.valueOf( milliseconds );
+    } else {
+      long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
+      return BigDecimal.valueOf( seconds ).multiply( BigDecimal.valueOf( 1000000000L ) ).add(
+          BigDecimal.valueOf( timestamp.getNanos() ) );
+    }
   }
 
   @Override
@@ -232,11 +253,13 @@ public class ValueMetaTimestamp extends ValueMetaDate {
       return null;
     }
 
-    long msSinceEpoch = nanos / 1000000;
-    int leftNanos = (int) ( nanos - ( msSinceEpoch * 1000000 ) );
-    Timestamp timestamp = new Timestamp( msSinceEpoch );
-    timestamp.setNanos( leftNanos );
+    long ss = TimeUnit.SECONDS.convert( nanos, TimeUnit.NANOSECONDS );
+    long ms = TimeUnit.MILLISECONDS.convert( nanos, TimeUnit.NANOSECONDS );
+    long ns = TimeUnit.NANOSECONDS.convert( ss, TimeUnit.SECONDS );
+    int leftNs = (int) ( nanos - ns );
 
+    Timestamp timestamp = new Timestamp( ms );
+    timestamp.setNanos( leftNs );
     return timestamp;
   }
 

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
@@ -53,8 +53,8 @@ import org.pentaho.di.core.row.value.timestamp.SimpleTimestampFormat;
 
 public class ValueMetaTimestamp extends ValueMetaDate {
   private final String format =
-    Const.NVL( EnvUtil.getSystemProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT ), "NANOSECONDS" );
-  private static final String MILLISECONDS = "MILLISECONDS";
+    Const.NVL( EnvUtil.getSystemProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT ),
+      Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS );
 
   public ValueMetaTimestamp() {
     this( null );
@@ -86,11 +86,11 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( format.equalsIgnoreCase( MILLISECONDS )  ) {
-      return Long.valueOf( milliseconds );
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
+      return  milliseconds;
     } else {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
-      return seconds * 1000000000 + timestamp.getNanos();
+      return seconds * 1000000000L + timestamp.getNanos();
     }
   }
 
@@ -102,11 +102,11 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( format.equalsIgnoreCase( MILLISECONDS )  ) {
-      return Double.valueOf( milliseconds );
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
+      return (double) milliseconds;
     } else {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
-      return (double) seconds * 1000000000 + timestamp.getNanos();
+      return (double) seconds * 1000000000L + timestamp.getNanos();
     }
   }
 
@@ -118,7 +118,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( format.equalsIgnoreCase( MILLISECONDS )  ) {
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
       return BigDecimal.valueOf( milliseconds );
     } else {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
@@ -54,7 +54,7 @@ import org.pentaho.di.core.row.value.timestamp.SimpleTimestampFormat;
 public class ValueMetaTimestamp extends ValueMetaDate {
   private final String format =
     Const.NVL( EnvUtil.getSystemProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT ),
-      Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS );
+      Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_DEFAULT );
 
   public ValueMetaTimestamp() {
     this( null );
@@ -86,11 +86,11 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
-      return  milliseconds;
-    } else {
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS.equalsIgnoreCase( format ) ) {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
       return seconds * 1000000000L + timestamp.getNanos();
+    } else {
+      return  milliseconds;
     }
   }
 
@@ -102,11 +102,11 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
-      return (double) milliseconds;
-    } else {
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS.equalsIgnoreCase( format ) ) {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
       return (double) seconds * 1000000000L + timestamp.getNanos();
+    } else {
+      return (double) milliseconds;
     }
   }
 
@@ -118,12 +118,12 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     }
 
     long milliseconds = timestamp.getTime();
-    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS.equalsIgnoreCase( format )  ) {
-      return BigDecimal.valueOf( milliseconds );
-    } else {
+    if ( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS.equalsIgnoreCase( format ) ) {
       long seconds = TimeUnit.SECONDS.convert( milliseconds, TimeUnit.MILLISECONDS );
       return BigDecimal.valueOf( seconds ).multiply( BigDecimal.valueOf( 1000000000L ) ).add(
           BigDecimal.valueOf( timestamp.getNanos() ) );
+    } else {
+      return BigDecimal.valueOf( milliseconds );
     }
   }
 

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
@@ -136,7 +136,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
           case STORAGE_TYPE_BINARY_STRING:
             return (Timestamp) convertBinaryStringToNativeType( (byte[]) object );
           case STORAGE_TYPE_INDEXED:
-            return (Timestamp) index[( (Integer) object ).intValue()];
+            return (Timestamp) index[ ( (Integer) object ).intValue() ];
           default:
             throw new KettleValueException( toString() + " : Unknown storage type " + storageType + " specified." );
         }
@@ -147,7 +147,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
           case STORAGE_TYPE_BINARY_STRING:
             return convertStringToTimestamp( (String) convertBinaryStringToNativeType( (byte[]) object ) );
           case STORAGE_TYPE_INDEXED:
-            return convertStringToTimestamp( (String) index[( (Integer) object ).intValue()] );
+            return convertStringToTimestamp( (String) index[ ( (Integer) object ).intValue() ] );
           default:
             throw new KettleValueException( toString() + " : Unknown storage type " + storageType + " specified." );
         }
@@ -158,7 +158,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
           case STORAGE_TYPE_BINARY_STRING:
             return convertNumberToTimestamp( (Double) convertBinaryStringToNativeType( (byte[]) object ) );
           case STORAGE_TYPE_INDEXED:
-            return convertNumberToTimestamp( (Double) index[( (Integer) object ).intValue()] );
+            return convertNumberToTimestamp( (Double) index[ ( (Integer) object ).intValue() ] );
           default:
             throw new KettleValueException( toString() + " : Unknown storage type " + storageType + " specified." );
         }
@@ -169,7 +169,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
           case STORAGE_TYPE_BINARY_STRING:
             return convertIntegerToTimestamp( (Long) convertBinaryStringToNativeType( (byte[]) object ) );
           case STORAGE_TYPE_INDEXED:
-            return convertIntegerToTimestamp( (Long) index[( (Integer) object ).intValue()] );
+            return convertIntegerToTimestamp( (Long) index[ ( (Integer) object ).intValue() ] );
           default:
             throw new KettleValueException( toString() + " : Unknown storage type " + storageType + " specified." );
         }
@@ -180,7 +180,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
           case STORAGE_TYPE_BINARY_STRING:
             return convertBigNumberToTimestamp( (BigDecimal) convertBinaryStringToNativeType( (byte[]) object ) );
           case STORAGE_TYPE_INDEXED:
-            return convertBigNumberToTimestamp( (BigDecimal) index[( (Integer) object ).intValue()] );
+            return convertBigNumberToTimestamp( (BigDecimal) index[ ( (Integer) object ).intValue() ] );
           default:
             throw new KettleValueException( toString() + " : Unknown storage type " + storageType + " specified." );
         }
@@ -190,7 +190,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
         throw new KettleValueException( toString() + " : I don't know how to convert a binary value to timestamp." );
       case TYPE_SERIALIZABLE:
         throw new KettleValueException( toString()
-            + " : I don't know how to convert a serializable value to timestamp." );
+          + " : I don't know how to convert a serializable value to timestamp." );
 
       default:
         throw new KettleValueException( toString() + " : Unknown type " + type + " specified." );
@@ -289,35 +289,35 @@ public class ValueMetaTimestamp extends ValueMetaDate {
 
   @Override
   public Object convertDataFromString( String pol, ValueMetaInterface convertMeta, String nullIf, String ifNull,
-      int trim_type ) throws KettleValueException {
+                                       int trimType ) throws KettleValueException {
     // null handling and conversion of value to null
     //
-    String null_value = nullIf;
-    if ( null_value == null ) {
+    String nullValue = nullIf;
+    if ( nullValue == null ) {
       switch ( convertMeta.getType() ) {
         case ValueMetaInterface.TYPE_BOOLEAN:
-          null_value = Const.NULL_BOOLEAN;
+          nullValue = Const.NULL_BOOLEAN;
           break;
         case ValueMetaInterface.TYPE_STRING:
-          null_value = Const.NULL_STRING;
+          nullValue = Const.NULL_STRING;
           break;
         case ValueMetaInterface.TYPE_BIGNUMBER:
-          null_value = Const.NULL_BIGNUMBER;
+          nullValue = Const.NULL_BIGNUMBER;
           break;
         case ValueMetaInterface.TYPE_NUMBER:
-          null_value = Const.NULL_NUMBER;
+          nullValue = Const.NULL_NUMBER;
           break;
         case ValueMetaInterface.TYPE_INTEGER:
-          null_value = Const.NULL_INTEGER;
+          nullValue = Const.NULL_INTEGER;
           break;
         case ValueMetaInterface.TYPE_DATE:
-          null_value = Const.NULL_DATE;
+          nullValue = Const.NULL_DATE;
           break;
         case ValueMetaInterface.TYPE_BINARY:
-          null_value = Const.NULL_BINARY;
+          nullValue = Const.NULL_BINARY;
           break;
         default:
-          null_value = Const.NULL_NONE;
+          nullValue = Const.NULL_NONE;
           break;
       }
     }
@@ -330,7 +330,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
       // because you could get an NPE since you haven't checked isEmpty(pol)
       // yet!
       if ( Utils.isEmpty( pol )
-          || pol.equalsIgnoreCase( Const.rightPad( new StringBuilder( null_value ), pol.length() ) ) ) {
+        || pol.equalsIgnoreCase( Const.rightPad( new StringBuilder( nullValue ), pol.length() ) ) ) {
         pol = ifNull;
       }
     }
@@ -341,14 +341,14 @@ public class ValueMetaTimestamp extends ValueMetaDate {
     if ( Utils.isEmpty( pol ) ) {
       return null;
     } else {
-      // if the null_value is specified, we try to match with that.
+      // if the nullValue is specified, we try to match with that.
       //
-      if ( !Utils.isEmpty( null_value ) ) {
-        if ( null_value.length() <= pol.length() ) {
-          // If the polled value is equal to the spaces right-padded null_value,
+      if ( !Utils.isEmpty( nullValue ) ) {
+        if ( nullValue.length() <= pol.length() ) {
+          // If the polled value is equal to the spaces right-padded nullValue,
           // we have a match
           //
-          if ( pol.equalsIgnoreCase( Const.rightPad( new StringBuilder( null_value ), pol.length() ) ) ) {
+          if ( pol.equalsIgnoreCase( Const.rightPad( new StringBuilder( nullValue ), pol.length() ) ) ) {
             return null;
           }
         }
@@ -364,7 +364,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
 
     // Trimming
     StringBuilder strpol;
-    switch ( trim_type ) {
+    switch ( trimType ) {
       case ValueMetaInterface.TRIM_TYPE_LEFT:
         strpol = new StringBuilder( pol );
         while ( strpol.length() > 0 && strpol.charAt( 0 ) == ' ' ) {
@@ -417,13 +417,10 @@ public class ValueMetaTimestamp extends ValueMetaDate {
   /**
    * Convert the specified data to the data type specified in this object.
    *
-   * @param meta2
-   *          the metadata of the object to be converted
-   * @param data2
-   *          the data of the object to be converted
+   * @param meta2 the metadata of the object to be converted
+   * @param data2 the data of the object to be converted
    * @return the object in the data type of this value metadata object
-   * @throws KettleValueException
-   *           in case there is a data conversion error
+   * @throws KettleValueException in case there is a data conversion error
    */
   @Override
   public Object convertData( ValueMetaInterface meta2, Object data2 ) throws KettleValueException {
@@ -487,7 +484,8 @@ public class ValueMetaTimestamp extends ValueMetaDate {
 
   @Override
   public ValueMetaInterface getValueFromSQLType( DatabaseMeta databaseMeta, String name, ResultSetMetaData rm,
-      int index, boolean ignoreLength, boolean lazyConversion ) throws KettleDatabaseException {
+                                                 int index, boolean ignoreLength, boolean lazyConversion )
+    throws KettleDatabaseException {
 
     try {
       int type = rm.getColumnType( index );
@@ -524,14 +522,13 @@ public class ValueMetaTimestamp extends ValueMetaDate {
 
     } catch ( Exception e ) {
       throw new KettleDatabaseException(
-          toStringMeta() + " : Unable to get timestamp from resultset at index " + index, e );
+        toStringMeta() + " : Unable to get timestamp from resultset at index " + index, e );
     }
-
   }
 
   @Override
   public void setPreparedStatementValue( DatabaseMeta databaseMeta, PreparedStatement preparedStatement, int index,
-      Object data ) throws KettleDatabaseException {
+                                         Object data ) throws KettleDatabaseException {
 
     try {
       if ( data != null ) {
@@ -541,16 +538,15 @@ public class ValueMetaTimestamp extends ValueMetaDate {
       }
     } catch ( Exception e ) {
       throw new KettleDatabaseException( toStringMeta() + " : Unable to set value on prepared statement on index "
-          + index, e );
+        + index, e );
     }
-
   }
 
   @Override
   public Object convertDataUsingConversionMetaData( Object data2 ) throws KettleValueException {
     if ( conversionMetadata == null ) {
       throw new KettleValueException(
-          "API coding error: please specify the conversion metadata before attempting to convert value " + name );
+        "API coding error: please specify the conversion metadata before attempting to convert value " + name );
     }
 
     return super.convertDataUsingConversionMetaData( data2 );
@@ -573,11 +569,10 @@ public class ValueMetaTimestamp extends ValueMetaDate {
       case STORAGE_TYPE_BINARY_STRING:
         return convertStringToBinaryString( (String) convertBinaryStringToNativeType( (byte[]) object ) );
       case STORAGE_TYPE_INDEXED:
-        return convertStringToBinaryString( getString( index[( (Integer) object ).intValue()] ) );
+        return convertStringToBinaryString( getString( index[ ( (Integer) object ).intValue() ] ) );
       default:
         throw new KettleValueException( toString() + " : Unknown storage type " + storageType + " specified." );
     }
-
   }
 
   @Override
@@ -616,14 +611,14 @@ public class ValueMetaTimestamp extends ValueMetaDate {
       }
     } catch ( ClassCastException e ) {
       throw new RuntimeException( toString() + " : There was a data type error: the data type of "
-          + object.getClass().getName() + " object [" + object + "] does not correspond to value meta ["
-          + toStringMeta() + "]" );
+        + object.getClass().getName() + " object [" + object + "] does not correspond to value meta ["
+        + toStringMeta() + "]" );
     } catch ( IOException e ) {
       throw new KettleFileException( toString() + " : Unable to write value timestamp data to output stream", e );
     } catch ( KettleValueException e ) {
       throw new RuntimeException( toString() + " : There was a data type error: the data type of "
-          + object.getClass().getName() + " object [" + object + "] does not correspond to value meta ["
-          + toStringMeta() + "]" );
+        + object.getClass().getName() + " object [" + object + "] does not correspond to value meta ["
+        + toStringMeta() + "]" );
     }
   }
 

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaTimestamp.java
@@ -344,13 +344,12 @@ public class ValueMetaTimestamp extends ValueMetaDate {
       // if the nullValue is specified, we try to match with that.
       //
       if ( !Utils.isEmpty( nullValue ) ) {
-        if ( nullValue.length() <= pol.length() ) {
-          // If the polled value is equal to the spaces right-padded nullValue,
-          // we have a match
-          //
-          if ( pol.equalsIgnoreCase( Const.rightPad( new StringBuilder( nullValue ), pol.length() ) ) ) {
-            return null;
-          }
+        // If the polled value is equal to the spaces right-padded nullValue,
+        // we have a match
+        //
+        if ( ( nullValue.length() <= pol.length() ) && pol
+          .equalsIgnoreCase( Const.rightPad( new StringBuilder( nullValue ), pol.length() ) ) ) {
+          return null;
         }
       } else {
         // Verify if there are only spaces in the polled value...

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
@@ -21,21 +21,6 @@
  ******************************************************************************/
 package org.pentaho.di.core.row.value;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-
-import java.math.BigDecimal;
-import java.sql.PreparedStatement;
-import java.sql.Timestamp;
-import java.util.Date;
-import java.util.TimeZone;
-
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -46,11 +31,44 @@ import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.junit.rules.RestorePDIEnvironment;
 
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
 /**
  * User: Dzmitry Stsiapanau Date: 3/20/2014 Time: 11:51 AM
  */
 public class ValueMetaTimestampTest {
+  private static final Timestamp TIMESTAMP_WITH_NANOSECONDS = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
+  private static final Timestamp TIMESTAMP_WITH_MILLISECONDS = Timestamp.valueOf( "2019-09-01 04:34:56.12300000" );
+  private static final long TIMESTAMP_AS_NANOSECONDS = 1567308896123456789L;
+  private static final long TIMESTAMP_AS_MILLISECONDS = 1567308896123L;
+
+  /**
+   * <p>For the Number to Timestamp conversion (nanoseconds) we use the above values but slightly truncated to avoid
+   * different results depending on the used JVM.</p>
+   * <p>This is because Number uses {@code double} which only guarantees 15 significant digits</p>
+   *
+   * @see #testConvertNumberToTimestamp_DefaultMode()
+   * @see #testConvertNumberToTimestamp_Nanoseconds()
+   */
+  private static final Timestamp TIMESTAMP_WITH_NANOSECONDS_DOUBLE = Timestamp.valueOf( "2019-09-01 04:34:56.123456" );
+  private static final double TIMESTAMP_AS_NANOSECONDS_DOUBLE = 1567308896123456000.0;
+
   @ClassRule public static RestorePDIEnvironment env = new RestorePDIEnvironment();
+
   @Test
   public void testSetPreparedStatementValue() throws Exception {
     ValueMetaTimestamp vm = new ValueMetaTimestamp();
@@ -58,17 +76,16 @@ public class ValueMetaTimestampTest {
     doAnswer( new Answer<Object>() {
       @Override
       public Object answer( InvocationOnMock invocationOnMock ) throws Throwable {
-        Object ts = invocationOnMock.getArguments()[1];
+        Object ts = invocationOnMock.getArguments()[ 1 ];
         return ts.toString();
       }
-    } ).when( ps ).setTimestamp( anyInt(), (Timestamp) anyObject() );
+    } ).when( ps ).setTimestamp( anyInt(), any( Timestamp.class ) );
 
     try {
       vm.setPreparedStatementValue( mock( DatabaseMeta.class ), ps, 0, null );
     } catch ( KettleDatabaseException ex ) {
       fail( "Check PDI-11547" );
     }
-
   }
 
   @Test
@@ -101,22 +118,28 @@ public class ValueMetaTimestampTest {
   public void testConvertStringToTimestamp() throws Exception {
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     assertEquals( Timestamp.valueOf( "2012-04-05 04:03:02.123456" ), valueMetaTimestamp
-        .convertStringToTimestamp( "2012/4/5 04:03:02.123456" ) );
+      .convertStringToTimestamp( "2012/4/5 04:03:02.123456" ) );
     assertEquals( Timestamp.valueOf( "2012-04-05 04:03:02.123" ), valueMetaTimestamp
-        .convertStringToTimestamp( "2012/4/5 04:03:02.123" ) );
+      .convertStringToTimestamp( "2012/4/5 04:03:02.123" ) );
     assertEquals( Timestamp.valueOf( "2012-04-05 04:03:02.123456789" ), valueMetaTimestamp
-        .convertStringToTimestamp( "2012/4/5 04:03:02.123456789" ) );
+      .convertStringToTimestamp( "2012/4/5 04:03:02.123456789" ) );
   }
 
   @Test
   public void testConvertTimestampToString() throws Exception {
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     assertEquals( "2012/04/05 04:03:02.123456000", valueMetaTimestamp.convertTimestampToString( Timestamp
-        .valueOf( "2012-04-05 04:03:02.123456" ) ) );
+      .valueOf( "2012-04-05 04:03:02.123456" ) ) );
     assertEquals( "2012/04/05 04:03:02.123000000", valueMetaTimestamp.convertTimestampToString( Timestamp
-        .valueOf( "2012-04-05 04:03:02.123" ) ) );
+      .valueOf( "2012-04-05 04:03:02.123" ) ) );
     assertEquals( "2012/04/05 04:03:02.123456789", valueMetaTimestamp.convertTimestampToString( Timestamp
-        .valueOf( "2012-04-05 04:03:02.123456789" ) ) );
+      .valueOf( "2012-04-05 04:03:02.123456789" ) ) );
+  }
+
+  @Test
+  public void testConvertDateToTimestamp_Null() throws KettleValueException {
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    assertNull( valueMetaTimestamp.convertDateToTimestamp( null ) );
   }
 
   @Test
@@ -134,80 +157,271 @@ public class ValueMetaTimestampTest {
   }
 
   @Test
-  public void testConvertIntegerToTimestamp() {
-    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
-    long nanoseconds = 1567308896123456789L;
+  public void testConvertTimestampToDate_Null() throws KettleValueException {
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
-    Timestamp result = valueMetaTimestamp.convertIntegerToTimestamp( nanoseconds );
-    Timestamp expected = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
-    assertEquals( expected, result );
+    assertNull( valueMetaTimestamp.getDate( null ) );
+  }
+
+  @Test( expected = KettleValueException.class )
+  public void testConvertTimestampToBoolean_Null() throws KettleValueException {
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    valueMetaTimestamp.getBoolean( TIMESTAMP_WITH_MILLISECONDS );
   }
 
   @Test
-  public void testConvertTimestampToInteger() throws KettleValueException {
-    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
-    Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
+  public void testConvertIntegerToTimestamp_Null() throws KettleValueException {
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
-    long result = valueMetaTimestamp.getInteger( date );
-    long expected = 1567308896123L;
-    assertEquals( expected, result );
+    assertNull( valueMetaTimestamp.convertIntegerToTimestamp( null ) );
   }
 
   @Test
-  public void testConvertNumberToTimestamp() {
+  public void testConvertIntegerToTimestamp_DefaultMode() throws KettleValueException {
     TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
-    double nanoseconds = 1567308896123456000L;
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY );
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
-    Timestamp result = valueMetaTimestamp.convertNumberToTimestamp( nanoseconds );
-    Timestamp expected = Timestamp.valueOf( "2019-09-01 04:34:56.123456000" );
-    assertEquals( expected, result );
-  }
-
-  @Test
-  public void testConvertTimestampToNumber() throws KettleValueException {
-    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
-    Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456000" );
-    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
-    double result = valueMetaTimestamp.getNumber( date );
-    double expected = 1567308896123L;
-    assertEquals( expected, result, 0 );
-  }
-
-  @Test
-  public void testConvertBigNumberToTimestamp() {
-    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
-    BigDecimal nanoseconds = BigDecimal.valueOf( 1567308896123456789L );
-    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
-    Timestamp result = valueMetaTimestamp.convertBigNumberToTimestamp( nanoseconds );
-    Timestamp expected = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
-    assertEquals( expected, result );
-  }
-
-  @Test
-  public void testConvertTimestampToBigNumber() throws KettleValueException {
-    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
-    Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
-    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
-    BigDecimal result = valueMetaTimestamp.getBigNumber( date );
-    BigDecimal expected = BigDecimal.valueOf( 1567308896123L );
-    assertEquals( expected, result );
-  }
-
-  @Test
-  public void testConvertTimestampToIntegerInMilliseconds() throws KettleValueException {
-    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
-    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS );
-    Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
-    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
-    long result = valueMetaTimestamp.getInteger( date );
-    assertEquals( 1567308896123L, result );
-    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS );
+    Timestamp result = valueMetaTimestamp.convertIntegerToTimestamp( TIMESTAMP_AS_NANOSECONDS );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS, result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE, "Something invalid!" );
     valueMetaTimestamp = new ValueMetaTimestamp();
-    result = valueMetaTimestamp.getInteger( date );
-    assertEquals( 1567308896123456789L, result );
-    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "Something invalid!" );
-    valueMetaTimestamp = new ValueMetaTimestamp();
-    result = valueMetaTimestamp.getInteger( date );
+    result = valueMetaTimestamp.convertIntegerToTimestamp( TIMESTAMP_AS_NANOSECONDS );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS, result );
+  }
+
+  @Test
+  public void testConvertIntegerToTimestamp_Milliseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result = valueMetaTimestamp.convertIntegerToTimestamp( TIMESTAMP_AS_MILLISECONDS );
+    assertEquals( TIMESTAMP_WITH_MILLISECONDS, result );
+  }
+
+  @Test
+  public void testConvertIntegerToTimestamp_Nanoseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result = valueMetaTimestamp.convertIntegerToTimestamp( TIMESTAMP_AS_NANOSECONDS );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS, result );
+  }
+
+  @Test
+  public void testConvertTimestampToInteger_Null() throws KettleValueException {
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    assertNull( valueMetaTimestamp.getInteger( null ) );
+  }
+
+  @Test
+  public void testConvertTimestampToInteger_DefaultMode() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    long result = valueMetaTimestamp.getInteger( TIMESTAMP_WITH_NANOSECONDS );
     assertEquals( 1567308896123L, result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE, "Something invalid!" );
+    valueMetaTimestamp = new ValueMetaTimestamp();
+    result = valueMetaTimestamp.getInteger( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( 1567308896123L, result );
+  }
+
+  @Test
+  public void testConvertTimestampToInteger_Milliseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    long result = valueMetaTimestamp.getInteger( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( 1567308896123L, result );
+  }
+
+  @Test
+  public void testConvertTimestampToInteger_Nanoseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    long result = valueMetaTimestamp.getInteger( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( TIMESTAMP_AS_NANOSECONDS, result );
+  }
+
+  @Test
+  public void testConvertNumberToTimestamp_Null() throws KettleValueException {
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    assertNull( valueMetaTimestamp.convertNumberToTimestamp( null ) );
+  }
+
+  @Test
+  public void testConvertNumberToTimestamp_DefaultMode() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result = valueMetaTimestamp.convertNumberToTimestamp( TIMESTAMP_AS_NANOSECONDS_DOUBLE );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS_DOUBLE, result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE, "Something invalid!" );
+    valueMetaTimestamp = new ValueMetaTimestamp();
+    result = valueMetaTimestamp.convertNumberToTimestamp( TIMESTAMP_AS_NANOSECONDS_DOUBLE );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS_DOUBLE, result );
+  }
+
+  @Test
+  public void testConvertNumberToTimestamp_Milliseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result = valueMetaTimestamp.convertNumberToTimestamp( (double) TIMESTAMP_AS_MILLISECONDS );
+    assertEquals( TIMESTAMP_WITH_MILLISECONDS, result );
+  }
+
+  @Test
+  public void testConvertNumberToTimestamp_Nanoseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    // Limiting the significant digits because we're using double
+    // Using the values used on other tests could originate different results depending on the JVM
+    Timestamp result = valueMetaTimestamp.convertNumberToTimestamp( TIMESTAMP_AS_NANOSECONDS_DOUBLE );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS_DOUBLE, result );
+  }
+
+  @Test
+  public void testConvertTimestampToNumber_Null() throws KettleValueException {
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    assertNull( valueMetaTimestamp.getNumber( null ) );
+  }
+
+  @Test
+  public void testConvertTimestampToNumber_DefaultMode() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    double result = valueMetaTimestamp.getNumber( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( 1567308896123.0, result, 0 );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE, "Something invalid!" );
+    valueMetaTimestamp = new ValueMetaTimestamp();
+    result = valueMetaTimestamp.getNumber( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( 1567308896123.0, result, 0 );
+  }
+
+  @Test
+  public void testConvertTimestampToNumber_Milliseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    double result = valueMetaTimestamp.getNumber( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( 1567308896123.0, result, 0 );
+  }
+
+  @Test
+  public void testConvertTimestampToNumber_Nanoseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    double result = valueMetaTimestamp.getNumber( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( (double) TIMESTAMP_AS_NANOSECONDS, result, 0 );
+  }
+
+  @Test
+  public void testConvertBigNumberToTimestamp_Null() throws KettleValueException {
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    assertNull( valueMetaTimestamp.convertBigNumberToTimestamp( null ) );
+  }
+
+  @Test
+  public void testConvertBigNumberToTimestamp_DefaultMode() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result =
+      valueMetaTimestamp.convertBigNumberToTimestamp( BigDecimal.valueOf( TIMESTAMP_AS_NANOSECONDS ) );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS, result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE, "Something invalid!" );
+    valueMetaTimestamp = new ValueMetaTimestamp();
+    result = valueMetaTimestamp.convertBigNumberToTimestamp( BigDecimal.valueOf( TIMESTAMP_AS_NANOSECONDS ) );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS, result );
+  }
+
+  @Test
+  public void testConvertBigNumberToTimestamp_Milliseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result =
+      valueMetaTimestamp.convertBigNumberToTimestamp( BigDecimal.valueOf( TIMESTAMP_AS_MILLISECONDS ) );
+    assertEquals( TIMESTAMP_WITH_MILLISECONDS, result );
+  }
+
+  @Test
+  public void testConvertBigNumberToTimestamp_Nanoseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result = valueMetaTimestamp.convertBigNumberToTimestamp( BigDecimal.valueOf( TIMESTAMP_AS_NANOSECONDS ) );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS, result );
+  }
+
+  @Test
+  public void testConvertTimestampToBigNumber_Null() throws KettleValueException {
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    assertNull( valueMetaTimestamp.getBigNumber( null ) );
+  }
+
+  @Test
+  public void testConvertTimestampToBigNumber_DefaultMode() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    BigDecimal result = valueMetaTimestamp.getBigNumber( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( BigDecimal.valueOf( 1567308896123L ), result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE, "Something invalid!" );
+    valueMetaTimestamp = new ValueMetaTimestamp();
+    result = valueMetaTimestamp.getBigNumber( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( BigDecimal.valueOf( 1567308896123L ), result );
+  }
+
+  @Test
+  public void testConvertTimestampToBigNumber_Milliseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_MILLISECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    BigDecimal result = valueMetaTimestamp.getBigNumber( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( BigDecimal.valueOf( 1567308896123L ), result );
+  }
+
+  @Test
+  public void testConvertTimestampToBigNumber_Nanoseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE,
+      Const.KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_NANOSECONDS );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    BigDecimal result = valueMetaTimestamp.getBigNumber( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( BigDecimal.valueOf( TIMESTAMP_AS_NANOSECONDS ), result );
+  }
+
+  @Test
+  public void testCloneValueData_Null() throws KettleValueException {
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    assertNull( valueMetaTimestamp.cloneValueData( null ) );
+  }
+
+  @Test
+  public void testCloneValueData() throws KettleValueException {
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Object clonedTimestamp = valueMetaTimestamp.cloneValueData( TIMESTAMP_WITH_NANOSECONDS );
+    assertEquals( TIMESTAMP_WITH_NANOSECONDS, clonedTimestamp );
   }
 }

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
@@ -149,7 +149,7 @@ public class ValueMetaTimestampTest {
     Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     long result = valueMetaTimestamp.getInteger( date );
-    long expected = 1567308896123456789L;
+    long expected = 1567308896123L;
     assertEquals( expected, result );
   }
 
@@ -169,7 +169,7 @@ public class ValueMetaTimestampTest {
     Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456000" );
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     double result = valueMetaTimestamp.getNumber( date );
-    double expected = 1567308896123456000L;
+    double expected = 1567308896123L;
     assertEquals( expected, result, 0 );
   }
 
@@ -189,7 +189,7 @@ public class ValueMetaTimestampTest {
     Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     BigDecimal result = valueMetaTimestamp.getBigNumber( date );
-    BigDecimal expected = BigDecimal.valueOf( 1567308896123456789L );
+    BigDecimal expected = BigDecimal.valueOf( 1567308896123L );
     assertEquals( expected, result );
   }
 
@@ -208,6 +208,6 @@ public class ValueMetaTimestampTest {
     System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "Something invalid!" );
     valueMetaTimestamp = new ValueMetaTimestamp();
     result = valueMetaTimestamp.getInteger( date );
-    assertEquals( 1567308896123456789L, result );
+    assertEquals( 1567308896123L, result );
   }
 }

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
@@ -196,12 +196,18 @@ public class ValueMetaTimestampTest {
   @Test
   public void testConvertTimestampToIntegerInMilliseconds() throws KettleValueException {
     TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
-    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "MILLISECONDS" );
+    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_MILLISECONDS );
     Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
     ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
     long result = valueMetaTimestamp.getInteger( date );
-    long expected = 1567308896123L;
-    assertEquals( expected, result );
-    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "NANOSECONDS" );
+    assertEquals( 1567308896123L, result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT_NANOSECONDS );
+    valueMetaTimestamp = new ValueMetaTimestamp();
+    result = valueMetaTimestamp.getInteger( date );
+    assertEquals( 1567308896123456789L, result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "Something invalid!" );
+    valueMetaTimestamp = new ValueMetaTimestamp();
+    result = valueMetaTimestamp.getInteger( date );
+    assertEquals( 1567308896123456789L, result );
   }
 }

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaTimestampTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,16 +30,20 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.junit.rules.RestorePDIEnvironment;
 
 /**
@@ -127,6 +131,77 @@ public class ValueMetaTimestampTest {
     Timestamp convertedTimestamp = valueMetaTimestamp.convertDateToTimestamp( timestamp );
     assertEquals( convertedTimestamp.getTime(), timestamp.getTime() );
     assertEquals( convertedTimestamp.getNanos(), timestamp.getNanos() );
+  }
 
+  @Test
+  public void testConvertIntegerToTimestamp() {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    long nanoseconds = 1567308896123456789L;
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result = valueMetaTimestamp.convertIntegerToTimestamp( nanoseconds );
+    Timestamp expected = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
+    assertEquals( expected, result );
+  }
+
+  @Test
+  public void testConvertTimestampToInteger() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    long result = valueMetaTimestamp.getInteger( date );
+    long expected = 1567308896123456789L;
+    assertEquals( expected, result );
+  }
+
+  @Test
+  public void testConvertNumberToTimestamp() {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    double nanoseconds = 1567308896123456000L;
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result = valueMetaTimestamp.convertNumberToTimestamp( nanoseconds );
+    Timestamp expected = Timestamp.valueOf( "2019-09-01 04:34:56.123456000" );
+    assertEquals( expected, result );
+  }
+
+  @Test
+  public void testConvertTimestampToNumber() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456000" );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    double result = valueMetaTimestamp.getNumber( date );
+    double expected = 1567308896123456000L;
+    assertEquals( expected, result, 0 );
+  }
+
+  @Test
+  public void testConvertBigNumberToTimestamp() {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    BigDecimal nanoseconds = BigDecimal.valueOf( 1567308896123456789L );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    Timestamp result = valueMetaTimestamp.convertBigNumberToTimestamp( nanoseconds );
+    Timestamp expected = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
+    assertEquals( expected, result );
+  }
+
+  @Test
+  public void testConvertTimestampToBigNumber() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    BigDecimal result = valueMetaTimestamp.getBigNumber( date );
+    BigDecimal expected = BigDecimal.valueOf( 1567308896123456789L );
+    assertEquals( expected, result );
+  }
+
+  @Test
+  public void testConvertTimestampToIntegerInMilliseconds() throws KettleValueException {
+    TimeZone.setDefault( TimeZone.getTimeZone( "Europe/London" ) );
+    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "MILLISECONDS" );
+    Timestamp date = Timestamp.valueOf( "2019-09-01 04:34:56.123456789" );
+    ValueMetaTimestamp valueMetaTimestamp = new ValueMetaTimestamp();
+    long result = valueMetaTimestamp.getInteger( date );
+    long expected = 1567308896123L;
+    assertEquals( expected, result );
+    System.setProperty( Const.KETTLE_TIMESTAMP_OUTPUT_FORMAT, "NANOSECONDS" );
   }
 }

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -556,9 +556,10 @@
   </kettle-variable>
 
   <kettle-variable>
-    <description>This environment variable is used to define if a Timestamp should be converted to nanoseconds or milliseconds.</description>
-    <variable>KETTLE_TIMESTAMP_OUTPUT_FORMAT</variable>
-    <default-value>NANOSECONDS</default-value>
+    <description>This environment variable is used to define how Timestamp should be converted to a number and vice-versa.
+      Possible values: "LEGACY" (default), "MILLISECONDS", "NANOSECONDS".</description>
+    <variable>KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE</variable>
+    <default-value>LEGACY</default-value>
   </kettle-variable>
 </kettle-variables>
 

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -554,5 +554,11 @@
     <variable>KETTLE_XLSX_ZIP_BOMB_CHECK</variable>
     <default-value>false</default-value>
   </kettle-variable>
+
+  <kettle-variable>
+    <description>This environment variable is used to define if a Timestamp should be converted to nanoseconds or milliseconds.</description>
+    <variable>KETTLE_TIMESTAMP_OUTPUT_FORMAT</variable>
+    <default-value>NANOSECONDS</default-value>
+  </kettle-variable>
 </kettle-variables>
 


### PR DESCRIPTION
Original PRs:
- [#7251](https://github.com/pentaho/pentaho-kettle/pull/7251)
- [#7259](https://github.com/pentaho/pentaho-kettle/pull/7259)
- [#7271](https://github.com/pentaho/pentaho-kettle/pull/7271)
- [#7364](https://github.com/pentaho/pentaho-kettle/pull/7364): on this PR there's code that should have been done/merged under [BACKLOG-33399](https://jira.pentaho.com/browse/BACKLOG-33399) but was, for convenience, done here (to know: classes 'ValueMetaConverter' and 'ValueMetaConverterTest') - **This code is not supposed to be backported!**

It may be a good idea **not to squash** the commits for everyone to see these details.


@ppatricio @pentaho/tatooine 
