### PR TITLE
[PDI-18389] Transformation with ETL Metadata Injection step developed…

### DIFF
--- a/plugins/meta-inject/src/main/java/org/pentaho/di/ui/trans/steps/metainject/MetaInjectDialog.java
+++ b/plugins/meta-inject/src/main/java/org/pentaho/di/ui/trans/steps/metainject/MetaInjectDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -808,14 +808,17 @@ public class MetaInjectDialog extends BaseStepDialog implements StepDialogInterf
 
   private boolean loadTransformation() throws KettleException {
     String filename = wPath.getText();
+    boolean isEmptyFilename = Utils.isEmpty( filename );
     if ( repository != null ) {
-      specificationMethod = ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME;
+      specificationMethod = ( isEmptyFilename && referenceObjectId != null )
+        ? ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE
+        : ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME;
     } else {
       specificationMethod = ObjectLocationSpecificationMethod.FILENAME;
     }
     switch ( specificationMethod ) {
       case FILENAME:
-        if ( Utils.isEmpty( filename ) ) {
+        if ( isEmptyFilename ) {
           return false;
         }
         if ( !filename.endsWith( ".ktr" ) ) {
@@ -825,7 +828,7 @@ public class MetaInjectDialog extends BaseStepDialog implements StepDialogInterf
         loadFileTrans( filename );
         break;
       case REPOSITORY_BY_NAME:
-        if ( Utils.isEmpty( filename ) ) {
+        if ( isEmptyFilename ) {
           return false;
         }
         if ( filename.endsWith( ".ktr" ) ) {


### PR DESCRIPTION
… in 6.1 loses configuration when Imported and Opened in 8.3

Since this case uses a deprecated specification method, this PR ensures the correct method is used for "old" imported files with that same "old" and deprecated specification method (REPOSITORY_BY_REFERENCE)
In that way an error Dialog will now pop up informing users that an error occurred, as suggested by Jens Bleuel.