### PR TITLE
[BACKLOG-33920] Create or Edit a Connection is broken in PME

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/core/database/dialog/XulDatabaseDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/database/dialog/XulDatabaseDialog.java
@@ -232,7 +232,8 @@ public class XulDatabaseDialog {
   }
 
   public void setDatabaseMeta( DatabaseMeta dbMeta ) {
-    if ( RepositorySecurityUI.verifyOperations( parentShell, Spoon.getInstance().getRepository(), RepositoryOperation.MODIFY_DATABASE ) ) {
+    if ( ( Spoon.getInstance() != null )
+      && RepositorySecurityUI.verifyOperations( parentShell, Spoon.getInstance().getRepository(), RepositoryOperation.MODIFY_DATABASE ) ) {
       return;
     }
 


### PR DESCRIPTION
* Adding in a null check for other design tools that do not spin up a Spoon instance (metadata-editor in this case). Check prevents non-Spoon related tools from throwing null exceptions and not generating the database connection dialog.