### PR TITLE
[PDI-18304] Saving an imported job (exported to XML), the Internal.En…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -62,7 +62,9 @@ public class JobFileListener implements FileListener, ConnectionListener {
           return true;
         }
       }
-      jobMeta.setRepositoryDirectory( spoon.getDefaultSaveLocation( jobMeta ) );
+      if ( jobMeta.getRepositoryDirectory() == null || !importfile ) {
+        jobMeta.setRepositoryDirectory( spoon.getDefaultSaveLocation( jobMeta ) );
+      }
       jobMeta.setRepository( spoon.getRepository() );
       jobMeta.setMetaStore( spoon.getMetaStore() );
       if ( connection != null ) {


### PR DESCRIPTION
…try.Current.Directory is replaced with a hard coded path.

New approach. 
Ensuring that when importing a file from an XML (from filesystem) in a repository context will now not overwrite for the default (fake & hardcoded) directory if a directory is already imported/declared from the XML file itself.

No unit tests were broken.