### PR TITLE
[PDI-18139] Copy tables Wizard is broken and errors out with "There is no repository connection available" when connected to repository.

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
@@ -578,7 +578,7 @@ public class SpoonJobDelegate extends SpoonDelegate {
 
           //PDI-18139 REST api of pentaho server gives 400 bad request if the resource has '[',']' symbols.
           //replace them with acceptable alternative
-          transname = transname.replaceAll("\\[", "'").replaceAll("\\]", "'");
+          transname = transname.replaceAll("[\\[,\\]]", "'");
           TransMeta transMeta = new TransMeta();
           //during the saving to repository name is not filled in, but it is required to get to the step of submitting to REST api
           //init it to make sure it is available on the next steps

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
@@ -576,7 +576,13 @@ public class SpoonJobDelegate extends SpoonDelegate {
               + sourceDbInfo + "].[" + tables[i]
               + BaseMessages.getString( PKG, "Spoon.RipDB.Monitor.Transname2" ) + targetDbInfo + "]";
 
+          //PDI-18139 REST api of pentaho server gives 400 bad request if the resource has '[',']' symbols.
+          //replace them with acceptable alternative
+          transname = transname.replaceAll("\\[", "'").replaceAll("\\]", "'");
           TransMeta transMeta = new TransMeta();
+          //during the saving to repository name is not filled in, but it is required to get to the step of submitting to REST api
+          //init it to make sure it is available on the next steps
+          transMeta.setName(transname);
           if ( repdir != null ) {
             transMeta.setRepositoryDirectory( repdir );
           } else {


### PR DESCRIPTION
Fix for the https://jira.pentaho.com/browse/PDI-18139

The error is happening due to empty name of the transformation and invalid format of the name when uploading to the repository.
Proposing to set the name to transformation in advance in format that is acceptable by the pentaho-server. 
Original transformation name contains '[',']' symbols that are not acceptable by pentaho-server REST API. Replacing it to alternative ' symbols that are maybe fine.

With the fix locally the transformation is getting created.

I am not so familiar with the code - if the the should have initialized somewhere else and reason is different - let's discuss.

Also not sure how to write the test for this component since it is a big component and I am not what is the design for the transformation name initialization.