### PR TITLE
[PDI-18096] Missing alert message in Ubuntu 18.04

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/util/EnvironmentUtils.java
+++ b/ui/src/main/java/org/pentaho/di/ui/util/EnvironmentUtils.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2017 - 2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2017 - 2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/ui/src/main/java/org/pentaho/di/ui/util/EnvironmentUtils.java
+++ b/ui/src/main/java/org/pentaho/di/ui/util/EnvironmentUtils.java
@@ -89,18 +89,14 @@ public class EnvironmentUtils {
   }
 
   /**
-   * Checks the existence of the webkit library on ubuntu 16 or ubuntu 14 .
+   * Checks the existence of the webkit library on ubuntu.
    *
-   * @return 'true' if the webkit library is not present in ubuntu 16 or ubuntu 14 , 'false' otherwise.
+   * @return 'true' if the webkit library is not present in ubuntu, 'false' otherwise.
    */
   public synchronized boolean isWebkitUnavailable() {
     String path = getWebkitPath();
     String osName = getEnvironmentName();
-    return  ( ( path == null || path.length() < 1 || !path.contains( "webkit" ) )
-        &&
-        ( osName.contains( SUPPORTED_DISTRIBUTION_NAME + " " + getSupportedVersion( "max.ubuntu.os.distribution.supported" ) )
-            ||
-            osName.contains( SUPPORTED_DISTRIBUTION_NAME + " " + getSupportedVersion( "min.ubuntu.os.distribution.supported" ) ) ) );
+    return  ( path == null || path.length() < 1 || !path.contains( "webkit" ) ) && osName.contains( SUPPORTED_DISTRIBUTION_NAME );
   }
 
   /**

--- a/ui/src/main/resources/org/pentaho/di/ui/core/default.properties
+++ b/ui/src/main/resources/org/pentaho/di/ui/core/default.properties
@@ -451,5 +451,3 @@ lasttype8=N
 lasttype9=N
 min.mac.browser.supported=601
 min.windows.browser.supported=11
-min.ubuntu.os.distribution.supported=14
-max.ubuntu.os.distribution.supported=16

--- a/ui/src/test/java/org/pentaho/di/ui/util/EnvironmentUtilsTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/util/EnvironmentUtilsTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -35,7 +35,9 @@ public class EnvironmentUtilsTest {
 
   @Test
   public void isUnSupportedBrowserEnvironmentTest( ) {
-    EnvironmentUtilsMock mock = new EnvironmentUtilsMock( Case.UBUNTU_16 );
+    EnvironmentUtilsMock mock = new EnvironmentUtilsMock( Case.UBUNTU );
+    assertTrue( mock.getMockedInstance().isUnsupportedBrowserEnvironment() );
+    mock = new EnvironmentUtilsMock( Case.UBUNTU_WRONG );
     assertFalse( mock.getMockedInstance().isUnsupportedBrowserEnvironment() );
     mock = new EnvironmentUtilsMock( Case.MAC_OS_X );
     assertFalse( mock.getMockedInstance().isUnsupportedBrowserEnvironment() );
@@ -49,23 +51,19 @@ public class EnvironmentUtilsTest {
 
   @Test
   public void isWebkitUnavailableTest( ) {
-    EnvironmentUtilsMock mock = new EnvironmentUtilsMock( Case.UBUNTU_16 );
-    assertFalse( mock.getMockedInstance().isWebkitUnavailable() );
-    mock = new EnvironmentUtilsMock( Case.UBUNTU_14 );
+    EnvironmentUtilsMock mock = new EnvironmentUtilsMock( Case.UBUNTU );
     assertFalse( mock.getMockedInstance().isWebkitUnavailable() );
     mock = new EnvironmentUtilsMock( Case.MAC_OS_X );
     assertFalse( mock.getMockedInstance().isWebkitUnavailable() );
     mock = new EnvironmentUtilsMock( Case.WINDOWS );
     assertFalse( mock.getMockedInstance().isWebkitUnavailable() );
     mock = new EnvironmentUtilsMock( Case.UBUNTU_WRONG );
-    assertTrue( mock.getMockedInstance().isWebkitUnavailable() );
+    assertFalse( mock.getMockedInstance().isWebkitUnavailable() );
   }
 
   @Test
   public void getBrowserName( ) {
-    EnvironmentUtilsMock mock = new EnvironmentUtilsMock( Case.UBUNTU_16 );
-    assertEquals( mock.getMockedInstance().getBrowserName(), "Midori" );
-    mock = new EnvironmentUtilsMock( Case.UBUNTU_14 );
+    EnvironmentUtilsMock mock = new EnvironmentUtilsMock( Case.UBUNTU );
     assertEquals( mock.getMockedInstance().getBrowserName(), "Midori" );
     mock = new EnvironmentUtilsMock( Case.MAC_OS_X );
     assertEquals( mock.getMockedInstance().getBrowserName(), "Safari" );
@@ -82,9 +80,8 @@ public class EnvironmentUtilsTest {
     private Case option;
     private static final String WEBKIT_PATH = "/path/mock/webkit";
     private static final String MAC_OS_X_NAME = "mac os x";
-    private static final String LINUX_NAME = "linux";
-    private static final String UBUNTU_16_NAME = "ubuntu 16";
-    private static final String UBUNTU_14_NAME = "ubuntu 14";
+    private static final String UBUNTU_NAME = "ubuntu";
+    private static final String UBUNTU_WRONG_NAME = "linux";
     private static final String WINDOWS_NAME = "windows";
     private static final String IE_10_AGENT = "Mozilla/4.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/5.0)";
     private static final String MIDORI_AGENT = "Mozilla/5.0 (X11; Linux) AppleWebKit/538.15 ("
@@ -106,8 +103,7 @@ public class EnvironmentUtilsTest {
     @Override
     protected String getWebkitPath() {
       switch ( option ) {
-        case UBUNTU_16:
-        case UBUNTU_14:
+        case UBUNTU:
           return WEBKIT_PATH;
         case UBUNTU_WRONG:
           return "";
@@ -119,10 +115,10 @@ public class EnvironmentUtilsTest {
     @Override
     protected String getOsName() {
       switch ( option ) {
-        case UBUNTU_16:
         case UBUNTU_WRONG:
-        case UBUNTU_14:
-          return LINUX_NAME;
+          return UBUNTU_WRONG_NAME;
+        case UBUNTU:
+          return UBUNTU_NAME;
         case MAC_OS_X:
         case MACOS_X_WRONG:
           return MAC_OS_X_NAME;
@@ -137,8 +133,7 @@ public class EnvironmentUtilsTest {
     @Override
     protected String getUserAgent() {
       switch ( option ) {
-        case UBUNTU_16:
-        case UBUNTU_14:
+        case UBUNTU:
           return MIDORI_AGENT;
         case MAC_OS_X:
           return SAFARI_9_AGENT;
@@ -155,14 +150,10 @@ public class EnvironmentUtilsTest {
 
     @Override
     protected int getSupportedVersion( String property ) {
-      if ( property.contains("min.mac.browser.supported") ) {
+      if ( property.contains( "min.mac.browser.supported" ) ) {
         return 601;
-      } else if ( property.contains("min.windows.browser.supported") ) {
+      } else if ( property.contains( "min.windows.browser.supported" ) ) {
         return 11;
-      } else if ( property.contains("min.ubuntu.os.distribution.supported") ) {
-        return 15;
-      } else if ( property.contains("max.ubuntu.os.distribution.supported") ) {
-        return 16;
       }
       return 0;
     }
@@ -177,14 +168,11 @@ public class EnvironmentUtilsTest {
       BufferedReader bufferedReader = Mockito.mock( BufferedReader.class );
       try {
         switch ( option ) {
-          case UBUNTU_16:
-            when( bufferedReader.readLine() ).thenReturn( UBUNTU_16_NAME );
-            break;
-          case UBUNTU_14:
-            when( bufferedReader.readLine() ).thenReturn( UBUNTU_14_NAME );
+          case UBUNTU:
+            when( bufferedReader.readLine() ).thenReturn( UBUNTU_NAME );
             break;
           case UBUNTU_WRONG:
-            when( bufferedReader.readLine() ).thenReturn( UBUNTU_16_NAME );
+            when( bufferedReader.readLine() ).thenReturn( UBUNTU_WRONG_NAME );
             break;
           default:
             when( bufferedReader.readLine() ).thenReturn( "" );
@@ -198,7 +186,7 @@ public class EnvironmentUtilsTest {
   }
 
   enum Case {
-    UBUNTU_16, UBUNTU_14, UBUNTU_WRONG, MAC_OS_X, MACOS_X_WRONG, WINDOWS, WINDOWS_WRONG
+    UBUNTU, UBUNTU_WRONG, MAC_OS_X, MACOS_X_WRONG, WINDOWS, WINDOWS_WRONG
   }
 
 }


### PR DESCRIPTION
The particular message being show is about the absence of _libwebkitgtk_ in Ubuntu. It does not relate with any version in particular of Ubuntu. 
We were only verifying for the supported versions at the time (14 and 16). As soon as users start to use newer versions the message would not appear (although we would still face the problems of not having _libwebkitgtk_ installed). 
A possible correction could be to update the versions to the current supported ones (which now are 16 and 18) but, 
since the error occurs because of the absence of lib and the message it self only refers to the lib itself, we should not verify the version of the OS and warn the user. 
Also, we always show the error in the log messages regardless of the version (it also, like this correction, only checks if the lib is missing in Ubuntu, regardless of the version). 
Keeping the versions will only cause the error to occur again in the future when we support some higher version of Ubuntu. 

@ppatricio @pentaho-lmartins 