### PR TITLE
[SP-5681] Backport of PDI-18458 - When the Database connection which ...

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -20,6 +20,7 @@
   <properties>
     <!-- Test running configuration -->
     <maven-surefire-plugin.reuseForks>true</maven-surefire-plugin.reuseForks>
+    <maven-surefire-plugin.argLine>-noverify</maven-surefire-plugin.argLine>
     <maven-failsafe-plugin.reuseForks>false</maven-failsafe-plugin.reuseForks>
 
     <!-- Pentaho dependencies -->

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -1238,10 +1238,12 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     }
 
     if ( !ok ) {
-      // Halt the other threads as well, signal end-of-the line to the outside
-      // world...
-      // Also explicitly call dispose() to clean up resources opened during
-      // init();
+      // Some Steps fail on initialization but don't set the status.
+      // Let's guarantee that Transformation has the proper status.
+      setStopped( true );
+
+      // Halt the other threads as well, signal end-of-the line to the outside world...
+      // Also explicitly call dispose() to clean up resources opened during init();
       //
       for ( int i = 0; i < initThreads.length; i++ ) {
         StepMetaDataCombi combi = initThreads[ i ].getCombi();
@@ -1263,7 +1265,7 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
       } catch ( KettleException e ) {
         // listeners produces errors
         log.logError( BaseMessages.getString( PKG, "Trans.FinishListeners.Exception" ) );
-        // we will not pass this exception up to prepareExecuton() entry point.
+        // we will not pass this exception up to prepareExecution() entry point.
       } finally {
         // Flag the transformation as finished even if exception was thrown
         setFinished( true );

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -2770,7 +2770,7 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
   private synchronized boolean endProcessing() throws KettleException {
     LogStatus status;
 
-    if ( isFinished() ) {
+    if ( isFinishedOrStopped() ) {
       if ( isStopped() ) {
         status = LogStatus.STOP;
       } else {

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -1238,8 +1238,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     }
 
     if ( !ok ) {
-      // Some Steps fail on initialization but don't set the status.
-      // Let's guarantee that Transformation has the proper status.
+      // One or more steps failed on initialization.
+      // Transformation is now stopped.
       setStopped( true );
 
       // Halt the other threads as well, signal end-of-the line to the outside world...

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -2770,12 +2770,10 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
   private synchronized boolean endProcessing() throws KettleException {
     LogStatus status;
 
-    if ( isFinishedOrStopped() ) {
-      if ( isStopped() ) {
-        status = LogStatus.STOP;
-      } else {
-        status = LogStatus.END;
-      }
+    if ( isStopped() ) {
+      status = LogStatus.STOP;
+    } else if ( isFinished() ) {
+      status = LogStatus.END;
     } else if ( isPaused() ) {
       status = LogStatus.PAUSED;
     } else {

--- a/engine/src/test/java/org/pentaho/di/trans/TransTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/TransTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,9 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.ProgressMonitorListener;
@@ -41,7 +39,9 @@ import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.logging.LogStatus;
 import org.pentaho.di.core.logging.StepLogTable;
+import org.pentaho.di.core.logging.TransLogTable;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
@@ -52,14 +52,14 @@ import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaDataCombi;
 import org.pentaho.di.trans.step.StepMetaInterface;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -74,8 +74,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -84,32 +83,26 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith ( MockitoJUnitRunner.class )
+@RunWith ( PowerMockRunner.class )
+@PrepareForTest( { Database.class, Trans.class } )
 public class TransTest {
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
-  @Mock private StepInterface stepMock, stepMock2;
-  @Mock private StepDataInterface data, data2;
-  @Mock private StepMeta stepMeta, stepMeta2;
-  @Mock private TransMeta transMeta;
 
-
-  int count = 10000;
-  Trans trans;
-  TransMeta meta;
+  private int count = 10000;
+  private Trans trans;
+  private TransMeta meta;
 
 
   @BeforeClass
-  public static void beforeClass() throws KettleException {
+  public static void beforeClass() throws Exception {
     KettleEnvironment.init();
   }
 
   @Before
-  public void beforeTest() throws KettleException {
-    meta = new TransMeta();
-    trans = new Trans( meta );
+  public void beforeTest() throws Exception {
+    meta = spy( new TransMeta() );
+    trans = spy( new Trans( meta ) );
     trans.setLog( Mockito.mock( LogChannelInterface.class ) );
-    trans.prepareExecution( null );
-    trans.startThreads();
   }
 
   /**
@@ -117,16 +110,16 @@ public class TransTest {
    */
   @Test ( timeout = 1000 )
   public void transWithNoStepsIsNotEndless() throws Exception {
-    Trans transWithNoSteps = new Trans( new TransMeta() );
-    transWithNoSteps = spy( transWithNoSteps );
+    trans.prepareExecution( new String[] {} );
+    trans.startThreads();
 
-    transWithNoSteps.prepareExecution( new String[] {} );
-
-    transWithNoSteps.startThreads();
+    while ( trans.isRunning() ) {
+      Thread.sleep( 1 );
+    }
 
     // check trans lifecycle is not corrupted
-    verify( transWithNoSteps ).fireTransStartedListeners();
-    verify( transWithNoSteps ).fireTransFinishedListeners();
+    verify( trans ).fireTransStartedListeners();
+    verify( trans ).fireTransFinishedListeners();
   }
 
   @Test
@@ -154,16 +147,16 @@ public class TransTest {
   public void testLoggingObjectIsNotLeakInMeta() {
     String expected = meta.log.getLogChannelId();
     meta.clear();
-    String actual = meta.log.getLogChannelId();
+
     assertEquals( "Use same logChannel for empty constructors, or assign General level for clear() calls",
-      expected, actual );
+      expected, meta.log.getLogChannelId() );
   }
 
   /**
    * PDI-10762 - Trans and TransMeta leak
    */
   @Test
-  public void testLoggingObjectIsNotLeakInTrans() throws KettleException {
+  public void testLoggingObjectIsNotLeakInTrans() throws Exception {
     Repository rep = Mockito.mock( Repository.class );
     RepositoryDirectoryInterface repInt = Mockito.mock( RepositoryDirectoryInterface.class );
     Mockito.when(
@@ -172,6 +165,7 @@ public class TransTest {
     Mockito.when( rep.findDirectory( Mockito.anyString() ) ).thenReturn( repInt );
 
     Trans trans = new Trans( meta, rep, "junit", "junitDir", "fileName" );
+
     assertEquals( "Log channel General assigned", LogChannel.GENERAL.getLogChannelId(), trans.log
       .getLogChannelId() );
   }
@@ -179,84 +173,75 @@ public class TransTest {
   /**
    * PDI-5229 - ConcurrentModificationException when restarting transformation Test that listeners can be accessed
    * concurrently during transformation finish
-   *
-   * @throws KettleException
-   * @throws InterruptedException
    */
   @Test
-  public void testTransFinishListenersConcurrentModification() throws KettleException, InterruptedException {
+  public void testTransFinishListenersConcurrentModification() throws Exception {
     CountDownLatch start = new CountDownLatch( 1 );
     TransFinishListenerAdder add = new TransFinishListenerAdder( trans, start );
     TransFinishListenerFirer firer = new TransFinishListenerFirer( trans, start );
     startThreads( add, firer, start );
+
     assertEquals( "All listeners are added: no ConcurrentModificationException", count, add.c );
     assertEquals( "All Finish listeners are iterated over: no ConcurrentModificationException", count, firer.c );
   }
 
   /**
    * Test that listeners can be accessed concurrently during transformation start
-   *
-   * @throws InterruptedException
    */
   @Test
-  public void testTransStartListenersConcurrentModification() throws InterruptedException {
+  public void testTransStartListenersConcurrentModification() throws Exception {
     CountDownLatch start = new CountDownLatch( 1 );
     TransFinishListenerAdder add = new TransFinishListenerAdder( trans, start );
     TransStartListenerFirer starter = new TransStartListenerFirer( trans, start );
     startThreads( add, starter, start );
+
     assertEquals( "All listeners are added: no ConcurrentModificationException", count, add.c );
     assertEquals( "All Start listeners are iterated over: no ConcurrentModificationException", count, starter.c );
   }
 
   /**
    * Test that transformation stop listeners can be accessed concurrently
-   *
-   * @throws InterruptedException
    */
   @Test
-  public void testTransStoppedListenersConcurrentModification() throws InterruptedException {
+  public void testTransStoppedListenersConcurrentModification() throws Exception {
     CountDownLatch start = new CountDownLatch( 1 );
     TransStoppedCaller stopper = new TransStoppedCaller( trans, start );
     TransStopListenerAdder adder = new TransStopListenerAdder( trans, start );
     startThreads( stopper, adder, start );
+
     assertEquals( "All transformation stop listeners is added", count, adder.c );
     assertEquals( "All stop call success", count, stopper.c );
   }
 
   @Test
-  public void testPDI12424ParametersFromMetaAreCopiedToTrans() throws KettleException, URISyntaxException, IOException {
+  public void testPDI12424ParametersFromMetaAreCopiedToTrans() throws Exception {
     String testParam = "testParam";
     String testParamValue = "testParamValue";
-    TransMeta mockTransMeta = mock( TransMeta.class );
-    when( mockTransMeta.listVariables() ).thenReturn( new String[] {} );
-    when( mockTransMeta.listParameters() ).thenReturn( new String[] { testParam } );
-    when( mockTransMeta.getParameterValue( testParam ) ).thenReturn( testParamValue );
+    when( meta.listVariables() ).thenReturn( new String[] {} );
+    when( meta.listParameters() ).thenReturn( new String[] { testParam } );
+    when( meta.getParameterValue( testParam ) ).thenReturn( testParamValue );
     FileObject ktr = KettleVFS.createTempFile( "parameters", ".ktr", "ram://" );
     try ( OutputStream outputStream = ktr.getContent().getOutputStream( true ) ) {
       InputStream inputStream = new ByteArrayInputStream( "<transformation></transformation>".getBytes() );
       IOUtils.copy( inputStream, outputStream );
     }
-    Trans trans = new Trans( mockTransMeta, null, null, null, ktr.getURL().toURI().toString() );
+
+    Trans trans = new Trans( meta, null, null, null, ktr.getURL().toURI().toString() );
+
     assertEquals( testParamValue, trans.getParameterValue( testParam ) );
   }
 
   @Test
   public void testRecordsCleanUpMethodIsCalled() throws Exception {
     Database mockedDataBase = mock( Database.class );
-    Trans trans = mock( Trans.class );
-
     StepLogTable stepLogTable =
       StepLogTable.getDefault( mock( VariableSpace.class ), mock( HasDatabasesInterface.class ) );
     stepLogTable.setConnectionName( "connection" );
 
-    TransMeta transMeta = new TransMeta();
-    transMeta.setStepLogTable( stepLogTable );
+    meta.setStepLogTable( stepLogTable );
+    doReturn( mockedDataBase ).when( trans ).createDataBase( any( DatabaseMeta.class ) );
+    trans.setSteps( new ArrayList<>() );
 
-    when( trans.getTransMeta() ).thenReturn( transMeta );
-    when( trans.createDataBase( any( DatabaseMeta.class ) ) ).thenReturn( mockedDataBase );
-    when( trans.getSteps() ).thenReturn( new ArrayList<>() );
-
-    doCallRealMethod().when( trans ).writeStepLogInformation();
     trans.writeStepLogInformation();
 
     verify( mockedDataBase ).cleanupLogRecords( stepLogTable );
@@ -264,7 +249,6 @@ public class TransTest {
 
   @Test
   public void testFireTransFinishedListeners() throws Exception {
-    Trans trans = new Trans();
     TransListener mockListener = mock( TransListener.class );
     trans.setTransListeners( Collections.singletonList( mockListener ) );
 
@@ -275,7 +259,6 @@ public class TransTest {
 
   @Test ( expected = KettleException.class )
   public void testFireTransFinishedListenersExceptionOnTransFinished() throws Exception {
-    Trans trans = new Trans();
     TransListener mockListener = mock( TransListener.class );
     doThrow( KettleException.class ).when( mockListener ).transFinished( trans );
     trans.setTransListeners( Collections.singletonList( mockListener ) );
@@ -283,55 +266,76 @@ public class TransTest {
     trans.fireTransFinishedListeners();
   }
 
-  @Test
+  @Test ( timeout = 1000 )
   public void testFinishStatus() throws Exception {
+    trans.prepareExecution( null );
+    trans.startThreads();
+
     while ( trans.isRunning() ) {
       Thread.sleep( 1 );
     }
+
     assertEquals( Trans.STRING_FINISHED, trans.getStatus() );
   }
 
   @Test
   public void testSafeStop() {
-    when( stepMock.isSafeStopped() ).thenReturn( false );
-    when( stepMock.getStepname() ).thenReturn( "stepName" );
+    StepInterface stepMock1 = mock( StepInterface.class );
+    StepDataInterface stepDataMock1 = mock( StepDataInterface.class );
+    StepMeta stepMetaMock1 = mock( StepMeta.class );
 
-    trans.setSteps( of( combi( stepMock, data, stepMeta ) ) );
+    when( stepMock1.getStepname() ).thenReturn( "stepName" );
+    trans.setSteps( of( combi( stepMock1, stepDataMock1, stepMetaMock1 ) ) );
+
+    // Scenario: step not stopped
+    when( stepMock1.isSafeStopped() ).thenReturn( false );
     Result result = trans.getResult();
     assertFalse( result.isSafeStop() );
 
-    when( stepMock.isSafeStopped() ).thenReturn( true );
+    // Scenario: step stopped
+    when( stepMock1.isSafeStopped() ).thenReturn( true );
     result = trans.getResult();
     assertTrue( result.isSafeStop() );
   }
 
   @Test
-  public void safeStopStopsInputStepsRightAway() throws KettleException {
-    trans.setSteps( of( combi( stepMock, data, stepMeta ) ) );
-    when( transMeta.findPreviousSteps( stepMeta, true ) ).thenReturn( emptyList() );
-    trans.transMeta = transMeta;
+  public void safeStopStopsInputStepsRightAway() throws Exception {
+    StepInterface stepMock1 = mock( StepInterface.class );
+    StepDataInterface stepDataMock1 = mock( StepDataInterface.class );
+    StepMeta stepMetaMock1 = mock( StepMeta.class );
+
+    trans.setSteps( of( combi( stepMock1, stepDataMock1, stepMetaMock1 ) ) );
+
     trans.safeStop();
-    verifyStopped( stepMock, 1 );
+
+    verifyStopped( stepMock1, 1 );
   }
 
   @Test
-  public void safeLetsNonInputStepsKeepRunning() throws KettleException {
-    trans.setSteps( of(
-      combi( stepMock, data, stepMeta ),
-      combi( stepMock2, data2, stepMeta2 ) ) );
+  public void safeLetsNonInputStepsKeepRunning() throws Exception {
+    StepInterface stepMock1 = mock( StepInterface.class );
+    StepInterface stepMock2 = mock( StepInterface.class );
+    StepDataInterface stepDataMock1 = mock( StepDataInterface.class );
+    StepDataInterface stepDataMock2 = mock( StepDataInterface.class );
+    StepMeta stepMetaMock1 = mock( StepMeta.class );
+    StepMeta stepMetaMock2 = mock( StepMeta.class );
 
-    when( transMeta.findPreviousSteps( stepMeta, true ) ).thenReturn( emptyList() );
+    trans.setSteps( of(
+      combi( stepMock1, stepDataMock1, stepMetaMock1 ),
+      combi( stepMock2, stepDataMock2, stepMetaMock2 ) ) );
+
+    doReturn( emptyList() ).when( meta ).findPreviousSteps( stepMetaMock1, true );
     // stepMeta2 will have stepMeta as previous, so is not an input step
-    when( transMeta.findPreviousSteps( stepMeta2, true ) ).thenReturn( of( stepMeta ) );
-    trans.transMeta = transMeta;
+    doReturn( of( stepMetaMock1 ) ).when( meta ).findPreviousSteps( stepMetaMock2, true );
 
     trans.safeStop();
-    verifyStopped( stepMock, 1 );
+
+    verifyStopped( stepMock1, 1 );
     // non input step shouldn't have stop called
     verifyStopped( stepMock2, 0 );
   }
 
-  private void verifyStopped( StepInterface step, int numberTimesCalled ) throws KettleException {
+  private void verifyStopped( StepInterface step, int numberTimesCalled ) throws Exception {
     verify( step, times( numberTimesCalled ) ).setStopped( true );
     verify( step, times( numberTimesCalled ) ).setSafeStopped( true );
     verify( step, times( numberTimesCalled ) ).resumeRunning();
@@ -494,21 +498,12 @@ public class TransTest {
     @Override
     public void transStopped( Trans trans ) {
     }
-
   };
 
   @Test
   public void testNewTransformationsWithContainerObjectId() throws Exception {
-    TransMeta meta = mock( TransMeta.class );
-    doReturn( new String[] { "X", "Y", "Z" } ).when( meta ).listVariables();
-    doReturn( new String[] { "A", "B", "C" } ).when( meta ).listParameters();
-    doReturn( "XYZ" ).when( meta ).getVariable( anyString() );
-    doReturn( "" ).when( meta ).getParameterDescription( anyString() );
-    doReturn( "" ).when( meta ).getParameterDefault( anyString() );
-    doReturn( "ABC" ).when( meta ).getParameterValue( anyString() );
-
     String carteId = UUID.randomUUID().toString();
-    doReturn( carteId ).when( meta ).getContainerObjectId();
+    meta.setCarteObjectId( carteId );
 
     Trans trans = new Trans( meta );
 
@@ -521,14 +516,6 @@ public class TransTest {
    */
   @Test
   public void testTwoTransformationsGetSameLogChannelId() throws Exception {
-    TransMeta meta = mock( TransMeta.class );
-    doReturn( new String[] { "X", "Y", "Z" } ).when( meta ).listVariables();
-    doReturn( new String[] { "A", "B", "C" } ).when( meta ).listParameters();
-    doReturn( "XYZ" ).when( meta ).getVariable( anyString() );
-    doReturn( "" ).when( meta ).getParameterDescription( anyString() );
-    doReturn( "" ).when( meta ).getParameterDefault( anyString() );
-    doReturn( "ABC" ).when( meta ).getParameterValue( anyString() );
-
     Trans trans1 = new Trans( meta );
     Trans trans2 = new Trans( meta );
 
@@ -541,28 +528,14 @@ public class TransTest {
    */
   @Test
   public void testTwoTransformationsGetDifferentLogChannelIdWithDifferentCarteId() throws Exception {
-    TransMeta meta1 = mock( TransMeta.class );
-    doReturn( new String[] { "X", "Y", "Z" } ).when( meta1 ).listVariables();
-    doReturn( new String[] { "A", "B", "C" } ).when( meta1 ).listParameters();
-    doReturn( "XYZ" ).when( meta1 ).getVariable( anyString() );
-    doReturn( "" ).when( meta1 ).getParameterDescription( anyString() );
-    doReturn( "" ).when( meta1 ).getParameterDefault( anyString() );
-    doReturn( "ABC" ).when( meta1 ).getParameterValue( anyString() );
-
-    TransMeta meta2 = mock( TransMeta.class );
-    doReturn( new String[] { "X", "Y", "Z" } ).when( meta2 ).listVariables();
-    doReturn( new String[] { "A", "B", "C" } ).when( meta2 ).listParameters();
-    doReturn( "XYZ" ).when( meta2 ).getVariable( anyString() );
-    doReturn( "" ).when( meta2 ).getParameterDescription( anyString() );
-    doReturn( "" ).when( meta2 ).getParameterDefault( anyString() );
-    doReturn( "ABC" ).when( meta2 ).getParameterValue( anyString() );
-
+    TransMeta meta1 = new TransMeta();
+    TransMeta meta2 = new TransMeta();
 
     String carteId1 = UUID.randomUUID().toString();
     String carteId2 = UUID.randomUUID().toString();
 
-    doReturn( carteId1 ).when( meta1 ).getContainerObjectId();
-    doReturn( carteId2 ).when( meta2 ).getContainerObjectId();
+    meta1.setCarteObjectId( carteId1 );
+    meta2.setCarteObjectId( carteId2 );
 
     Trans trans1 = new Trans( meta1 );
     Trans trans2 = new Trans( meta2 );
@@ -573,100 +546,284 @@ public class TransTest {
 
   @Test
   public void testSetInternalEntryCurrentDirectoryWithFilename( ) {
-    Trans transTest = new Trans(  );
-    boolean hasFilename = true;
-    boolean hasRepoDir = false;
-    transTest.copyVariablesFrom( null );
-    transTest.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "Original value defined at run execution" );
-    transTest.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, "file:///C:/SomeFilenameDirectory" );
-    transTest.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_REPOSITORY_DIRECTORY, "/SomeRepDirectory" );
-    transTest.setInternalEntryCurrentDirectory( hasFilename, hasRepoDir );
+    setInternalEntryCurrentDirectory();
 
-    assertEquals( "file:///C:/SomeFilenameDirectory", transTest.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
+    trans.setInternalEntryCurrentDirectory( true, false );
 
+    assertEquals( "file:///C:/SomeFilenameDirectory", trans.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
   }
 
   @Test
   public void testSetInternalEntryCurrentDirectoryWithRepository( ) {
-    Trans transTest = new Trans(  );
-    boolean hasFilename = false;
-    boolean hasRepoDir = true;
-    transTest.copyVariablesFrom( null );
-    transTest.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "Original value defined at run execution" );
-    transTest.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, "file:///C:/SomeFilenameDirectory" );
-    transTest.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_REPOSITORY_DIRECTORY, "/SomeRepDirectory" );
-    transTest.setInternalEntryCurrentDirectory( hasFilename, hasRepoDir );
+    setInternalEntryCurrentDirectory();
 
-    assertEquals( "/SomeRepDirectory", transTest.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
+    trans.setInternalEntryCurrentDirectory( false, true );
+
+    assertEquals( "/SomeRepDirectory", trans.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
   }
 
   @Test
   public void testSetInternalEntryCurrentDirectoryWithoutFilenameOrRepository( ) {
-    Trans transTest = new Trans(  );
-    transTest.copyVariablesFrom( null );
-    boolean hasFilename = false;
-    boolean hasRepoDir = false;
-    transTest.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "Original value defined at run execution" );
-    transTest.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, "file:///C:/SomeFilenameDirectory" );
-    transTest.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_REPOSITORY_DIRECTORY, "/SomeRepDirectory" );
-    transTest.setInternalEntryCurrentDirectory( hasFilename, hasRepoDir );
+    setInternalEntryCurrentDirectory();
 
-    assertEquals( "Original value defined at run execution", transTest.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY )  );
+    trans.setInternalEntryCurrentDirectory( false, false );
+
+    assertEquals( "Original value defined at run execution", trans.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY )  );
+  }
+
+  /**
+   * Common base for testSetInternalEntryCurrentDirectory's' tests.
+   */
+  private void setInternalEntryCurrentDirectory() {
+    trans.copyVariablesFrom( null );
+    trans.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "Original value defined at run execution" );
+    trans.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, "file:///C:/SomeFilenameDirectory" );
+    trans.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_REPOSITORY_DIRECTORY, "/SomeRepDirectory" );
   }
 
   @Test
-  public void testCleanup_WithoutSteps() throws Exception {
-    Trans trans = new Trans();
-
-    // First try steps being 'null'
+  public void testCleanup_WithoutSteps_null() throws Exception {
     trans.setSteps( null );
     assertNull( trans.getSteps() );
+
     // this should work (no exception thrown)
     trans.cleanup();
+  }
 
-    // Now steps being an empty list
+  @Test
+  public void testCleanup_WithoutSteps_emptyList() throws Exception {
     trans.setSteps( new ArrayList<>() );
     assertNotNull( trans.getSteps() );
+
     // this should also work (no exception thrown)
     trans.cleanup();
   }
 
   @Test
   public void testCleanup_WithSteps() throws Exception {
-    Trans trans = new Trans();
-    // A step that is already disposed
-    StepInterface step1 = mock( StepInterface.class );
-    StepMetaInterface meta1 = mock( StepMetaInterface.class );
-    StepDataInterface data1 = mock( StepDataInterface.class );
-    when( data1.isDisposed() ).thenReturn( true );
-    StepMetaDataCombi stepMetaDataCombi1 = new StepMetaDataCombi();
-    stepMetaDataCombi1.step = step1;
-    stepMetaDataCombi1.meta = meta1;
-    stepMetaDataCombi1.data = data1;
-    // A step not yet disposed
-    StepInterface step2 = mock( StepInterface.class );
-    StepMetaInterface meta2 = mock( StepMetaInterface.class );
-    StepDataInterface data2 = mock( StepDataInterface.class );
-    when( data2.isDisposed() ).thenReturn( false );
-    StepMetaDataCombi stepMetaDataCombi2 = new StepMetaDataCombi();
-    stepMetaDataCombi2.step = step2;
-    stepMetaDataCombi2.meta = meta2;
-    stepMetaDataCombi2.data = data2;
+    StepInterface stepMock1 = mock( StepInterface.class );
+    StepInterface stepMock2 = mock( StepInterface.class );
+    StepDataInterface stepDataMock1 = mock( StepDataInterface.class );
+    StepDataInterface stepDataMock2 = mock( StepDataInterface.class );
+    StepMeta stepMetaMock1 = mock( StepMeta.class );
+    StepMeta stepMetaMock2 = mock( StepMeta.class );
 
-    List<StepMetaDataCombi> steps = Arrays.asList( stepMetaDataCombi1, stepMetaDataCombi2 );
-    trans.setSteps( steps );
+    // A step that is already disposed
+    when( stepDataMock1.isDisposed() ).thenReturn( true );
+
+    // A step not yet disposed
+    when( stepDataMock2.isDisposed() ).thenReturn( false );
+
+    trans.setSteps( of(
+      combi( stepMock1, stepDataMock1, stepMetaMock1 ),
+      combi( stepMock2, stepDataMock2, stepMetaMock2 ) ) );
+
     // this should work (no exception thrown)
     trans.cleanup();
 
     // The isDisposed method is always invoked  
-    verify( data1 ).isDisposed();
-    verify( data2 ).isDisposed();
-    // Only 'data2' is to be disposed
-    verify( step1, times( 0 ) ).dispose( any( StepMetaInterface.class ), any( StepDataInterface.class ) );
-    verify( step2, times( 1 ) ).dispose( any( StepMetaInterface.class ), any( StepDataInterface.class ) );
+    verify( stepDataMock1 ).isDisposed();
+    verify( stepDataMock2 ).isDisposed();
+    // Only 'stepDataMock2' is to be disposed
+    verify( stepMock1, times( 0 ) ).dispose( any( StepMetaInterface.class ), any( StepDataInterface.class ) );
+    verify( stepMock2, times( 1 ) ).dispose( any( StepMetaInterface.class ), any( StepDataInterface.class ) );
     // The cleanup method is always invoked
-    verify( step1 ).cleanup();
-    verify( step2 ).cleanup();
+    verify( stepMock1 ).cleanup();
+    verify( stepMock2 ).cleanup();
   }
 
+
+  /**
+   * <p>PDI-18458: A Stopped transformation would be logged as 'Running'.</p>
+   *
+   * @see #testEndProcessing_StatusCalculation_Base()
+   * @see #testEndProcessing_StatusCalculation_Finished()
+   * @see #testEndProcessing_StatusCalculation_Paused()
+   * @see #testEndProcessing_StatusCalculation_Running()
+   */
+  @Test
+  public void testEndProcessing_StatusCalculation_Stopped() throws Exception {
+    Database database = testEndProcessing_StatusCalculation_Base();
+
+    // Set 'Stopped'
+    trans.setStopped( true );
+
+    int allCount = 0;
+
+    for( boolean finished : new boolean[] { false, true } ) {
+      for( boolean initializing : new boolean[] { false, true } ) {
+        for( boolean paused : new boolean[] { false, true } ) {
+          for( boolean preparing : new boolean[] { false, true } ) {
+            for( boolean running : new boolean[] { false, true } ) {
+              trans.setFinished( finished );
+              trans.setInitializing( initializing );
+              trans.setPaused( paused );
+              trans.setPreparing( preparing );
+              trans.setRunning( running );
+
+              trans.fireTransFinishedListeners();
+
+              ++allCount;
+            }
+          }
+        }
+      }
+    }
+
+    // All cases should result in status being 'Stopped'.
+    verify( database, times( allCount ) ).writeLogRecord( meta.getTransLogTable(), LogStatus.STOP, trans, null );
+  }
+
+  /**
+   * <p>PDI-18458: A Stopped transformation would be logged as 'Running'.</p>
+   *
+   * @see #testEndProcessing_StatusCalculation_Base()
+   * @see #testEndProcessing_StatusCalculation_Paused()
+   * @see #testEndProcessing_StatusCalculation_Running()
+   * @see #testEndProcessing_StatusCalculation_Stopped()
+   */
+  @Test
+  public void testEndProcessing_StatusCalculation_Finished() throws Exception {
+    Database database = testEndProcessing_StatusCalculation_Base();
+
+    // Set 'Finished'
+    trans.setFinished( true );
+
+    int stopCount = 0;
+    int allCount = 0;
+
+    for( boolean initializing : new boolean[] { false, true } ) {
+      for( boolean paused : new boolean[] { false, true } ) {
+        for( boolean preparing : new boolean[] { false, true } ) {
+          for( boolean running : new boolean[] { false, true } ) {
+            for( boolean stopped : new boolean[] { false, true } ) {
+              trans.setInitializing( initializing );
+              trans.setPaused( paused );
+              trans.setPreparing( preparing );
+              trans.setRunning( running );
+              trans.setStopped( stopped );
+
+              trans.fireTransFinishedListeners();
+
+              ++allCount;
+              if( stopped ) {
+                ++stopCount;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // All cases, except where stopped is set, should result in status being 'End'.
+    verify( database, times( allCount - stopCount ) ).writeLogRecord( meta.getTransLogTable(), LogStatus.END, trans, null );
+    verify( database, times( stopCount ) ).writeLogRecord( meta.getTransLogTable(), LogStatus.STOP, trans, null );
+  }
+
+  /**
+   * <p>PDI-18458: A Stopped transformation would be logged as 'Running'.</p>
+   *
+   * @see #testEndProcessing_StatusCalculation_Base()
+   * @see #testEndProcessing_StatusCalculation_Finished()
+   * @see #testEndProcessing_StatusCalculation_Running()
+   * @see #testEndProcessing_StatusCalculation_Stopped()
+   */
+  @Test
+  public void testEndProcessing_StatusCalculation_Paused() throws Exception {
+    Database database = testEndProcessing_StatusCalculation_Base();
+
+    // Set 'Paused'
+    trans.setPaused( true );
+
+    // It can't be 'Finished' nor 'Stopped'
+    trans.setFinished( false );
+    trans.setStopped( false );
+
+    int allCount = 0;
+
+    for( boolean initializing : new boolean[] { false, true } ) {
+      for( boolean preparing : new boolean[] { false, true } ) {
+        for( boolean running : new boolean[] { false, true } ) {
+          trans.setInitializing( initializing );
+          trans.setPreparing( preparing );
+          trans.setRunning( running );
+
+          trans.fireTransFinishedListeners();
+
+          ++allCount;
+        }
+      }
+    }
+
+    // All cases should result in status being 'End'.
+    verify( database, times( allCount ) ).writeLogRecord( meta.getTransLogTable(), LogStatus.PAUSED, trans, null );
+  }
+
+  /**
+   * <p>PDI-18458: A Stopped transformation would be logged as 'Running'.</p>
+   *
+   * @see #testEndProcessing_StatusCalculation_Base()
+   * @see #testEndProcessing_StatusCalculation_Finished()
+   * @see #testEndProcessing_StatusCalculation_Paused()
+   * @see #testEndProcessing_StatusCalculation_Stopped()
+   */
+  @Test
+  public void testEndProcessing_StatusCalculation_Running() throws Exception {
+    Database database = testEndProcessing_StatusCalculation_Base();
+
+    // It can't be 'Finished', 'Paused' nor 'Stopped'
+    trans.setFinished( false );
+    trans.setPaused( false );
+    trans.setStopped( false );
+
+    int allCount = 0;
+
+    for( boolean initializing : new boolean[] { false, true } ) {
+      for( boolean preparing : new boolean[] { false, true } ) {
+        for( boolean running : new boolean[] { false, true } ) {
+          trans.setInitializing( initializing );
+          trans.setPreparing( preparing );
+          trans.setRunning( running );
+
+          trans.fireTransFinishedListeners();
+
+          ++allCount;
+        }
+      }
+    }
+
+    // All cases should result in status being 'Running'.
+    verify( database, times( allCount ) ).writeLogRecord( meta.getTransLogTable(), LogStatus.RUNNING, trans, null );
+  }
+
+  /**
+   * <p>PDI-18458: A Stopped transformation would be logged as 'Running'.</p>
+   * <p>Base for the testEndProcessing_StatusCalculation's tests.</p>
+   *
+   * @return the mocked {@link Database} object used on the test
+   *
+   * @see #testEndProcessing_StatusCalculation_Finished()
+   * @see #testEndProcessing_StatusCalculation_Paused()
+   * @see #testEndProcessing_StatusCalculation_Running()
+   * @see #testEndProcessing_StatusCalculation_Stopped()
+   */
+  private Database testEndProcessing_StatusCalculation_Base() throws Exception {
+    TransLogTable transLogTable = spy( new TransLogTable(null, null, null) );
+    doReturn("AnActualTableNametransLogTable").when(transLogTable).getActualTableName();
+    doReturn("AnActualConnectionName").when(transLogTable).getActualConnectionName();
+    doReturn("AnActualSchemaName").when(transLogTable).getActualSchemaName();
+    DatabaseMeta databaseMeta = mock( DatabaseMeta.class );
+    doReturn( databaseMeta).when( transLogTable ).getDatabaseMeta();
+    doReturn( transLogTable).when( meta ).getTransLogTable();
+    doReturn( false ).when( transLogTable ).isBatchIdUsed();
+    doReturn( "MetaName" ).when( meta ).getName();
+    Database database = mock( Database.class );
+    PowerMockito.whenNew( Database.class ).withAnyArguments().thenReturn(database);
+    doNothing().when( database ).connect();
+
+    trans.calculateBatchIdAndDateRange();
+    trans.beginProcessing();
+
+    return database;
+  }
 }


### PR DESCRIPTION
...is used in the Transformation step is invalid, the status in pentaho_dilogs .trans_logs table does shows as "running" when the Transformation has failed. (9.0 Suite)
[SP-5677] Backport of PDI-18459 - When the Database connection which is used in the Transformation step is valid,status in pentaho_dilogs .trans_logs table does shows as "running" even though the Transformation has failed. (9.0 Suite)

This Pull Request refers to two issues because the original PRs were done along some time and have some dependencies between the two PR'issues.

Cherry picked PRs:

- [pentaho-kettle#7441](https://github.com/pentaho/pentaho-kettle/pull/7441) (PDI-18458)
- [pentaho-kettle#7523](https://github.com/pentaho/pentaho-kettle/pull/7523) (PDI-18458)
- [pentaho-kettle#7442](https://github.com/pentaho/pentaho-kettle/pull/7442) (PDI-18459)
- [pentaho-kettle#7528](https://github.com/pentaho/pentaho-kettle/pull/7528) (PDI-18459)

@pentaho-lmartins @ssamora @ppatricio @bcostahitachivantara 
