### PR TITLE
[SP-5682] Backport of PDI-18304 - Saving an imported job (exported to XML), the ${Internal.Entry.Current.Directory} is replaced with a hard coded path. (8.3 Suite)

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.ui.spoon;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.core.EngineMetaInterface;
 import org.pentaho.di.core.LastUsedFile;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
@@ -62,9 +63,9 @@ public class JobFileListener implements FileListener, ConnectionListener {
           return true;
         }
       }
-      if ( jobMeta.getRepositoryDirectory() == null || !importfile ) {
-        jobMeta.setRepositoryDirectory( spoon.getDefaultSaveLocation( jobMeta ) );
-      }
+      //same fix as in PDI-18786 where the clearCurrentDirectoryChangedListeners method was added
+      clearCurrentDirectoryChangedListenersWhenImporting( importfile, jobMeta );
+      jobMeta.setRepositoryDirectory( spoon.getDefaultSaveLocation( jobMeta ) );
       jobMeta.setRepository( spoon.getRepository() );
       jobMeta.setMetaStore( spoon.getMetaStore() );
       if ( connection != null ) {
@@ -102,6 +103,13 @@ public class JobFileListener implements FileListener, ConnectionListener {
         + fname, e );
     }
     return false;
+  }
+
+  @VisibleForTesting
+  void clearCurrentDirectoryChangedListenersWhenImporting( boolean importfile, JobMeta jobMeta ) {
+    if ( importfile ) {
+      jobMeta.clearCurrentDirectoryChangedListeners();
+    }
   }
 
   private JobMeta fixLinks( JobMeta jobMeta ) {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -62,7 +62,9 @@ public class JobFileListener implements FileListener, ConnectionListener {
           return true;
         }
       }
-      jobMeta.setRepositoryDirectory( spoon.getDefaultSaveLocation( jobMeta ) );
+      if ( jobMeta.getRepositoryDirectory() == null || !importfile ) {
+        jobMeta.setRepositoryDirectory( spoon.getDefaultSaveLocation( jobMeta ) );
+      }
       jobMeta.setRepository( spoon.getRepository() );
       jobMeta.setMetaStore( spoon.getMetaStore() );
       if ( connection != null ) {

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/JobFileListenerTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/JobFileListenerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -36,6 +36,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
@@ -196,4 +198,19 @@ public class JobFileListenerTest {
     assertEquals( resultExecMeta.getDirectory(), "/path/to" );
     assertEquals( resultExecMeta.getJobName(), "Job1" );
   }
+
+  @Test
+  public void testClearCurrentDirectoryChangedListenersWhenImporting() {
+    JobMeta jm = mock( JobMeta.class );
+    jobFileListener.clearCurrentDirectoryChangedListenersWhenImporting( true, jm );
+    verify( jm, times( 1 ) ).clearCurrentDirectoryChangedListeners();
+  }
+
+  @Test
+  public void testClearCurrentDirectoryChangedListenersWhenNotImporting() {
+    JobMeta jm = mock( JobMeta.class );
+    jobFileListener.clearCurrentDirectoryChangedListenersWhenImporting( false, jm );
+    verify( jm, times( 0 ) ).clearCurrentDirectoryChangedListeners();
+  }
+
 }


### PR DESCRIPTION
Cherry-pick of:
1st PR: https://github.com/pentaho/pentaho-kettle/pull/7489/commits/ac697338b65f1af8cbb689878405811c0fdc266f
2nd PR: https://github.com/pentaho/pentaho-kettle/pull/7504/commits/5e6461a35d2094964becb986f50eb39cd3f9463c

@pentaho-lmartins @ssamora @bcostahitachivantara