### PR TITLE
[PDI-18543] Duplicate logging issues when using Single Threader step.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/SingleThreadedTransExecutor.java
+++ b/engine/src/main/java/org/pentaho/di/trans/SingleThreadedTransExecutor.java
@@ -268,6 +268,7 @@ public class SingleThreadedTransExecutor {
 
     // See if the steps support the SingleThreaded transformation type...
     //
+    log.logBasic( "Single Threaded Executor initializing Trans: [" + trans.getName( ) + "]" );
     for ( StepMetaDataCombi combi : steps ) {
       TransformationType[] types = combi.stepMeta.getStepMetaInterface().getSupportedTransformationTypes();
       boolean ok = false;
@@ -402,6 +403,7 @@ public class SingleThreadedTransExecutor {
 
   public void dispose() throws KettleException {
 
+    log.logBasic( "Single Threaded Executor Disposing Trans: [" + trans.getName( ) + "]" );
     // Call output done.
     //
     for ( StepMetaDataCombi combi : trans.getSteps() ) {


### PR DESCRIPTION
Added logging to clearly indicate the transformation being executed from the Single Threaded executer. 