### PR TITLE
[TAP-1868] Fix an NPE when logging a KettleException.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutput.java
@@ -840,9 +840,14 @@ public class TextFileOutput extends BaseStep implements StepInterface {
         try {
           initOutput();
         } catch ( Exception e ) {
-          logError( "Couldn't open file "
-              + KettleVFS.getFriendlyURI( getParentVariableSpace().environmentSubstitute( meta.getFileName() ) )
-              + "." + getParentVariableSpace().environmentSubstitute( meta.getExtension() ), e );
+          if ( getParentVariableSpace() == null ) {
+            logError( "Couldn't open file "
+                + KettleVFS.getFriendlyURI( meta.getFileName() ) + "." + meta.getExtension(), e );
+          } else {
+            logError( "Couldn't open file "
+                + KettleVFS.getFriendlyURI( getParentVariableSpace().environmentSubstitute( meta.getFileName() ) )
+                + "." + getParentVariableSpace().environmentSubstitute( meta.getExtension() ), e );
+          }
           setErrors( 1L );
           stopAll();
         }


### PR DESCRIPTION
This test was erroring prior to the change.
```
ERROR] Failures:
[ERROR]   RowKeyTest.testHashCodeCalculationsandEquals:69 expected:<-798137542> but was:<-227281350>
[INFO]
[ERROR] Tests run: 2469, Failures: 1, Errors: 0, Skipped: 6
```