### PR TITLE
[PDI-18089] - MDI cannot inject Report Definition File to Pentaho Reporting Output

### DIFF
--- a/engine/src/main/resources/org/pentaho/di/trans/steps/pentahoreporting/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/trans/steps/pentahoreporting/messages/messages_en_US.properties
@@ -61,6 +61,11 @@ PentahoReportingOutputMeta.Injection.PARAMETERS=All the parameters for the repor
 PentahoReportingOutputMeta.Injection.PARAMETER_NAME=The name of the report parameter
 PentahoReportingOutputMeta.Injection.FIELDNAME=The field name providing the source data
 
+PentahoReportingOutputMeta.Injection.INPUT_FILE=The name of report file path (.prpt)
+PentahoReportingOutputMeta.Injection.OUTPUT_FILE=The name of output file name
+PentahoReportingOutputMeta.Injection.USE_VALUES_FROM_FIELDS=Accept values from fields? (Y/N)
+PentahoReportingOutputMeta.Injection.CREATE_PARENT_FOLDER=Create Parent Folder? (Y/N)
+
 #################### ReportExportTask #####################
 ReportExportTask.ERROR_0001_TARGET_EXISTS=Target-File exists, but cannot be removed.
 ReportExportTask.USER_EXPORT_COMPLETE=Export complete


### PR DESCRIPTION
This is an additional PR due to an incomplete fix already merged ( master ) before 9.1 code freeze.
Could you please review and merge?

@rmansoor 
@pentaho-svigneri 