### PR TITLE
Prevent Argument List too long error during shell script execution [PDI-18803] and increase logs related to environment variables [PDI-12885]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ routes.yml
 
 rebel.xml
 rebel-remote.xml
+.metadata

--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1428,6 +1428,47 @@ public class Const {
     KETTLE_TIMESTAMP_NUMBER_CONVERSION_MODE_LEGACY;
 
   /**
+   * <p>
+   * A variable to configure the maximum number of characters of text that are allowed for a environment variable value to be added as argument to a system process executed by
+   * Kettle (i.e. by JobEntryShell)
+   * </p>
+   * <p>
+   * If not set or if the configured value is invalid, it defaults to {@value #KETTLE_MAX_ARG_STRLEN_DEFAULT}
+   * </p>
+   * <p>
+   * Check PDI-18803 for more details.
+   * </p>
+   *
+   * @see #KETTLE_MAX_ARG_STRLEN_DEFAULT
+   */
+  public static final String KETTLE_MAX_ARG_STRLEN = "KETTLE_MAX_ARG_STRLEN";
+
+  /**
+   * <p>
+   * The default value for the {@link #KETTLE_MAX_ARG_STRLEN} as a Integer.
+   * </p>
+   * <p>
+   * Check PDI-18803 for more details.
+   * </p>
+   *
+   * @see #KETTLE_MAX_ARG_STRLEN
+   */
+  public static final Integer KETTLE_MAX_ARG_STRLEN_DEFAULT = 2048;
+
+  /**
+   * <p>
+   * The default value for the {@link #KETTLE_MAX_ARG_STRLEN} as a String.
+   * </p>
+   * <p>
+   * Check PDI-18803 for more details.
+   * </p>
+   *
+   * @see #KETTLE_MAX_ARG_STRLEN
+   * @see #KETTLE_MAX_ARG_STRLEN_DEFAULT
+   */
+  public static final String KETTLE_MAX_ARG_STRLEN_DEFAULT_STRING = String.valueOf( KETTLE_MAX_ARG_STRLEN_DEFAULT );
+
+  /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer
    * overflow while rounding
    *

--- a/engine/src/main/resources/org/pentaho/di/job/entries/shell/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/job/entries/shell/messages/messages_en_US.properties
@@ -38,3 +38,5 @@ JobEntryShell.Error.UnableopenAppenderFile=Unable to open file appender for file
 JobShell.Fileformat.Scripts=Shell scripts
 JobShell.Filename.Label=Script file name\: 
 JobShell.Logfile.IncludeTime.Label=Include time in logfile? 
+JobEntryShell.VariableSizeExceeded=The {0} variable exceeds the maximum allowed size of {1} characters for a single process argument thus it has been ignored. 
+JobEntryShell.VariableAddedToProcessBuilderEnvironment= The {0} variable has been added to the process builder environment. Size\: {1}, Value\: {2}

--- a/engine/src/main/resources/org/pentaho/di/job/entries/shell/messages/messages_it_IT.properties
+++ b/engine/src/main/resources/org/pentaho/di/job/entries/shell/messages/messages_it_IT.properties
@@ -37,3 +37,5 @@ JobShell.Filename.Label=Nome del file script\:
 JobShell.NameOfLogfile.Label=Nome del file di log\: 
 JobShell.Append.Logfile.Tooltip=Seleziona qua per accodare il file di log
 JobShell.Previous.Tooltip=Seleziona qua per passare i risultati della precedente entry agli argomenti di questa entry.
+JobEntryShell.VariableSizeExceeded=La variabile {0} supera la dimensione massima consentita di {1} caratteri per un singolo argomento di processo e di conseguenza verr\u00E0 ignorata. 
+JobEntryShell.VariableAddedToProcessBuilderEnvironment= La variabile {0} \u00E8 stata aggiunta all''environment del process builder. Dimensione\: {1}, Valore\: {2}


### PR DESCRIPTION
This PR aims to solve #PDI-18803 and fullfill the request of increased logs present in #PDI-12885.
The implemented solution introduces a new environment variable (KETTLE_MAX_ARG_STRLEN) which defaults to 2048 in order to avoid hitting the Linux system length limit for both a single and total command line arguments ([more info here](https://www.in-ulm.de/~mascheck/various/argmax/#maximum_number)).
Logs have been added for both _add_ and _discard_ variable operations, the former at Debug level the latter at Detailed one.

This code has been tested with Kettle version 8.3.0.0-371

