### PR TITLE
[BACKLOG-34401] Fixed a bug with parameters appearing on the TAG

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/core/widget/MultipleSelectionCombo.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/widget/MultipleSelectionCombo.java
@@ -156,7 +156,10 @@ public class MultipleSelectionCombo extends Composite {
         super.mouseUp( e );
 
         String labelText = ((SelectionLabel) ((Label) e.widget).getParent()).getLabelText();
-        addRemovedTagBackToListUI( labelText );
+        // Put the label back on the list unless it's a parameter.
+        if ( !labelText.startsWith( "$" ) ) {
+          addRemovedTagBackToListUI( labelText );
+        }
 
         selectedItemLabels = removeItemFromSelectedList( labelText );
 


### PR DESCRIPTION
This fixes the issue of when a parameter tag is removed of being placed in the list of tags from the catalog.  This insures the tag list only contains tags from the catalog.