### PR TITLE
[PDI-18905] Removing a parameter or variable doesn't remove it unless…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/reflection/StringSearcher.java
+++ b/engine/src/main/java/org/pentaho/di/core/reflection/StringSearcher.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,6 +27,7 @@ import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.plugins.JobEntryPluginType;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.StepPluginType;
+import org.pentaho.di.trans.steps.textfileoutput.TextFileOutputMeta;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -67,6 +68,16 @@ public class StringSearcher {
 
     Class<? extends Object> baseClass = object.getClass();
     Field[] fields = baseClass.getDeclaredFields();
+    validateFields( object, level, stringList, parentObject, grandParentObject, baseClass, fields );
+    if ( object instanceof TextFileOutputMeta ) {
+      Field[] parentFields = baseClass.getSuperclass().getDeclaredFields();
+      validateFields( object, level, stringList, parentObject, grandParentObject, baseClass, parentFields );
+    }
+  }
+
+  static void validateFields( Object object, int level, List<StringSearchResult> stringList,
+                                      Object parentObject, Object grandParentObject, Class<?> baseClass,
+                                      Field[] fields ) {
     for ( int i = 0; i < fields.length; i++ ) {
       Field field = fields[i];
 


### PR DESCRIPTION
… you restart Spoon

After the rework made on https://jira.pentaho.com/browse/BACKLOG-24281, some metadata was moved from TextFileOutputMeta to the new superClass BaseFileOutputMeta. Having calls using reflection on TextFileOutputMeta will not provide the superClass fields/methods/etc that existed in TextFileOutputMeta before. This miss was causing the param/variable resolution issue, since the filename field was one of the "lost" metadata in the process.

Having in mind, this is a plenty core class to change, i provided a specific fix for this one class only, forcing StringSearcher to consider also the superClass for this case.

@pentaho-lmartins 