### PR TITLE
[BACKLOG-34349] - Catalog step - Multiselect dropdown list loses line…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/core/widget/MultipleSelectionCombo.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/widget/MultipleSelectionCombo.java
@@ -93,7 +93,7 @@ public class MultipleSelectionCombo extends Composite {
 
   private Composite bottomRow;
   private MouseAdapter exitAction;
-  private static final int MARGIN_OFFSET = 1;
+  private static final int MARGIN_OFFSET = 2;
 
   public MultipleSelectionCombo( Composite parent, int style ) {
     super( parent, style );


### PR DESCRIPTION
…s on ubuntu

* Fixed the margin offset value to accomodate the selected item entries from multiselect combo.

@pentaho/bb-8 please review.