### PR TITLE
[BACKLOG-34530] converts s3 to s3a before sending to AEL

### DIFF
--- a/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileObject.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileObject.java
@@ -244,4 +244,9 @@ public class ConnectionFileObject extends AbstractFileObject<ConnectionFileSyste
   public String getOriginalURIString() {
     return resolvedFileObject.getPublicURIString();
   }
+
+  @Override
+  public String getAELSafeURIString() {
+    return getOriginalURIString().replaceFirst( "s3://", "s3a://" );
+  }
 }

--- a/core/src/main/java/org/pentaho/di/core/vfs/AliasedFileObject.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/AliasedFileObject.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,6 +32,13 @@ public interface AliasedFileObject {
    * @return original URI string
    */
   String getOriginalURIString();
+
+  /**
+   * Returns the original file object URI but swaps s3:// for s3a://
+   * when needed
+   * @return
+   */
+  String getAELSafeURIString();
 
   public static boolean isAliasedFile( FileObject file) {
     return AliasedFileObject.class.isAssignableFrom( file.getClass() );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,10 +22,7 @@
 
 package org.pentaho.di.trans.steps.fileinput.text;
 
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileObject;
@@ -74,7 +71,9 @@ import org.pentaho.di.workarounds.ResolvableResource;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
 
-import com.google.common.annotations.VisibleForTesting;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 @SuppressWarnings( "deprecation" )
 @InjectionSupported( localizationPrefix = "TextFileInput.Injection.", groups = { "FILENAME_LINES", "FIELDS", "FILTERS" } )
@@ -1372,7 +1371,7 @@ public class TextFileInputMeta extends BaseFileInputMeta<BaseFileInputAdditional
         try {
           FileObject fileObject = KettleVFS.getFileObject( getParentStepMeta().getParentTransMeta().environmentSubstitute( inputFiles.fileName[i] ) );
           if ( AliasedFileObject.isAliasedFile( fileObject ) ) {
-            inputFiles.fileName[i] = ( (AliasedFileObject) fileObject ).getOriginalURIString();
+            inputFiles.fileName[i] = ( (AliasedFileObject) fileObject ).getAELSafeURIString();
           }
         } catch ( KettleFileException e ) {
           throw new RuntimeException( e );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,15 +22,10 @@
 
 package org.pentaho.di.trans.steps.textfileoutput;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.vfs2.FileObject;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleFileException;
@@ -42,6 +37,7 @@ import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.AliasedFileObject;
 import org.pentaho.di.core.vfs.KettleVFS;
@@ -62,6 +58,10 @@ import org.pentaho.di.trans.steps.file.BaseFileOutputMeta;
 import org.pentaho.di.workarounds.ResolvableResource;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /*
  * Created on 4-apr-2003
@@ -1141,7 +1141,7 @@ public class TextFileOutputMeta extends BaseFileOutputMeta implements StepMetaIn
       try {
         FileObject fileObject = KettleVFS.getFileObject( getParentStepMeta().getParentTransMeta().environmentSubstitute( fileName ) );
         if ( AliasedFileObject.isAliasedFile( fileObject ) ) {
-          fileName = ( (AliasedFileObject) fileObject ).getOriginalURIString();
+          fileName = ( (AliasedFileObject) fileObject ).getAELSafeURIString();
         }
       } catch ( KettleFileException e ) {
         throw new RuntimeException( e );

--- a/engine/src/test/java/org/pentaho/di/trans/ael/adapters/TransMetaConverterTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/ael/adapters/TransMetaConverterTest.java
@@ -458,7 +458,7 @@ public class TransMetaConverterTest {
 
     doReturn( transMeta ).when( transMeta ).realClone( false );
     when( KettleVFS.getFileObject( any() ) ).thenReturn( connectionFileObject );
-    when( connectionFileObject.getOriginalURIString() ).thenReturn( FINAL_NAME );
+    when( connectionFileObject.getAELSafeURIString() ).thenReturn( FINAL_NAME );
 
     StepMeta textFileStep = new StepMeta( "resolvableStep", spy( new TextFileInputMeta() ) );
     BaseFileInputFiles inputFiles = new BaseFileInputFiles();

--- a/engine/src/test/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,15 +22,6 @@
 
 package org.pentaho.di.trans.steps.textfileoutput;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.UUID;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -43,6 +34,15 @@ import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.steps.loadsave.LoadSaveTester;
 import org.pentaho.di.trans.steps.loadsave.validator.ArrayLoadSaveValidator;
 import org.pentaho.di.trans.steps.loadsave.validator.FieldLoadSaveValidator;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
 
 public class TextFileOutputMetaTest {
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();


### PR DESCRIPTION
[BACKLOG-34530] converts s3 to s3a for AEL pvfs files