### PR TITLE
[SP-5729] Backport of BISERVER-14442 - Database connections using connection pooling will not adhere to changes in the connection details (9.1 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/ConnectionPoolUtil.java
+++ b/core/src/main/java/org/pentaho/di/core/database/ConnectionPoolUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -104,9 +104,14 @@ public class ConnectionPoolUtil {
   }
 
   // BACKLOG-674
-  private static String getDataSourceName( DatabaseMeta dbMeta, String partitionId ) {
-    return dbMeta.getName() + Const.NVL( dbMeta.getDatabaseName(), "" ) + Const.NVL( dbMeta.getHostname(), "" )
-        + Const.NVL( dbMeta.getDatabasePortNumberString(), "" ) + Const.NVL( partitionId, "" );
+  public static String getDataSourceName( DatabaseMeta dbMeta, String partitionId ) {
+
+    String name = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getName(), "" ) );
+    String database = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getDatabaseName(), "" ) );
+    String hostname = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getHostname(), "" ) );
+    String port = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getDatabasePortNumberString(), "" ) );
+
+    return name + database + hostname + port + Const.NVL( partitionId, "" );
   }
 
   /**

--- a/core/src/main/java/org/pentaho/di/core/database/ConnectionPoolUtil.java
+++ b/core/src/main/java/org/pentaho/di/core/database/ConnectionPoolUtil.java
@@ -107,11 +107,16 @@ public class ConnectionPoolUtil {
   public static String getDataSourceName( DatabaseMeta dbMeta, String partitionId ) {
 
     String name = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getName(), "" ) );
+    String username = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getUsername(), "" ) );
+    String password = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getPassword(), "" ) );
+    String preferredSchema = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getPreferredSchemaName(), "" ) );
     String database = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getDatabaseName(), "" ) );
     String hostname = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getHostname(), "" ) );
     String port = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getDatabasePortNumberString(), "" ) );
+    String initialPoolSize = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getInitialPoolSizeString(), "" ) );
+    String maximumPoolSize = dbMeta.environmentSubstitute( Const.NVL( dbMeta.getMaximumPoolSizeString(), "" ) );
 
-    return name + database + hostname + port + Const.NVL( partitionId, "" );
+    return name + username + password + preferredSchema + database + hostname + port + initialPoolSize + maximumPoolSize + Const.NVL( partitionId, "" );
   }
 
   /**

--- a/core/src/main/java/org/pentaho/di/core/database/DataSourceProviderInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DataSourceProviderInterface.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -49,6 +49,19 @@ public interface DataSourceProviderInterface {
    * @throws DataSourceNamingException
    */
   DataSource getNamedDataSource( String datasourceName, DatasourceType type ) throws DataSourceNamingException;
+
+
+  /**
+   * Invalidate the named data source of respecting its <code>type</code>
+   *
+   * @param datasourceName name of the desired data source
+   * @param type           data source's type
+   * @return named data source
+   * @throws DataSourceNamingException
+   */
+  default DataSource invalidateNamedDataSource( String datasourceName, DatasourceType type ) throws DataSourceNamingException {
+    throw new UnsupportedOperationException( "The invalidateNamedDataSource method was not implemented yet." );
+  }
 
   enum DatasourceType {
     JNDI, POOLED

--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -456,6 +456,10 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
       } else {
         if ( databaseMeta.isUsingConnectionPool() ) {
           String name = databaseMeta.getName();
+          if ( databaseMeta.isNeedUpdate() ) {
+            dsp.invalidateNamedDataSource( name, DatasourceType.POOLED );
+            databaseMeta.setNeedUpdate( false );
+          }
           try {
             try {
               this.connection = dsp.getNamedDataSource( name, DatasourceType.POOLED ).getConnection();

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -129,6 +129,8 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   private ObjectRevision objectRevision;
 
   private boolean readOnly = false;
+
+  private boolean needUpdate = false;
 
   /**
    * Indicates that the connections doesn't point to a type of database yet.
@@ -913,8 +915,17 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     databaseInterface.setIndexTablespace( index_tablespace );
   }
 
+  boolean isNeedUpdate() {
+    return needUpdate;
+  }
+
+  void setNeedUpdate( boolean needUpdate ) {
+    this.needUpdate = needUpdate;
+  }
+
   public void setChanged() {
     setChanged( true );
+    setNeedUpdate( true );
   }
 
   public void setChanged( boolean ch ) {

--- a/core/src/main/java/org/pentaho/di/core/database/util/DatabaseUtil.java
+++ b/core/src/main/java/org/pentaho/di/core/database/util/DatabaseUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -197,5 +197,10 @@ public class DatabaseUtil implements DataSourceProviderInterface {
       }
     }
     throw new IllegalArgumentException( "Unsupported data source type: " + type );
+  }
+
+  @Override public DataSource invalidateNamedDataSource( String datasourceName, DatasourceType type )
+    throws DataSourceNamingException {
+    return FoundDS.remove( datasourceName );
   }
 }

--- a/core/src/test/java/org/pentaho/di/core/database/ConnectionPoolUtilTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/ConnectionPoolUtilTest.java
@@ -156,22 +156,38 @@ public class ConnectionPoolUtilTest implements Driver {
     ConnectionPoolUtil connectionPoolUtil = new ConnectionPoolUtil();
     DatabaseMeta dbMetaMock = mock( DatabaseMeta.class );
     String dbMetaName = UUID.randomUUID().toString();
+    String dbMetaUsername = UUID.randomUUID().toString();
+    String dbMetaPassword = UUID.randomUUID().toString();
+    String dbMetaSchema = UUID.randomUUID().toString();
     String dbMetaDatabase = UUID.randomUUID().toString();
     String dbMetaHostname = UUID.randomUUID().toString();
     String dbMetaPort = UUID.randomUUID().toString();
+    String dbMetaInitialPoolSize = UUID.randomUUID().toString();
+    String dbMetaMaximumPoolSize = UUID.randomUUID().toString();
     String partitionId = UUID.randomUUID().toString();
 
     when( dbMetaMock.getName() ).thenReturn( dbMetaName );
+    when( dbMetaMock.getUsername() ).thenReturn( dbMetaUsername );
+    when( dbMetaMock.getPassword() ).thenReturn( dbMetaPassword );
+    when( dbMetaMock.getPreferredSchemaName() ).thenReturn( dbMetaSchema );
     when( dbMetaMock.getDatabaseName() ).thenReturn( dbMetaDatabase );
     when( dbMetaMock.getHostname() ).thenReturn( dbMetaHostname );
     when( dbMetaMock.getDatabasePortNumberString() ).thenReturn( dbMetaPort );
+    when( dbMetaMock.getInitialPoolSizeString() ).thenReturn( dbMetaInitialPoolSize );
+    when( dbMetaMock.getMaximumPoolSizeString() ).thenReturn( dbMetaMaximumPoolSize );
 
     when( dbMetaMock.environmentSubstitute( eq( dbMetaName ) ) ).thenReturn( dbMetaName );
+    when( dbMetaMock.environmentSubstitute( eq( dbMetaUsername ) ) ).thenReturn( dbMetaUsername );
+    when( dbMetaMock.environmentSubstitute( eq( dbMetaPassword ) ) ).thenReturn( dbMetaPassword );
+    when( dbMetaMock.environmentSubstitute( eq( dbMetaSchema ) ) ).thenReturn( dbMetaSchema );
     when( dbMetaMock.environmentSubstitute( eq( dbMetaDatabase ) ) ).thenReturn( dbMetaDatabase );
     when( dbMetaMock.environmentSubstitute( eq( dbMetaHostname ) ) ).thenReturn( dbMetaHostname );
     when( dbMetaMock.environmentSubstitute( eq( dbMetaPort ) ) ).thenReturn( dbMetaPort );
+    when( dbMetaMock.environmentSubstitute( eq( dbMetaInitialPoolSize ) ) ).thenReturn( dbMetaInitialPoolSize );
+    when( dbMetaMock.environmentSubstitute( eq( dbMetaMaximumPoolSize ) ) ).thenReturn( dbMetaMaximumPoolSize );
 
-    String dataSourceNameExpected = dbMetaName + dbMetaDatabase + dbMetaHostname + dbMetaPort + partitionId;
+    String dataSourceNameExpected = dbMetaName + dbMetaUsername + dbMetaPassword + dbMetaSchema + dbMetaDatabase +
+      dbMetaHostname + dbMetaPort + dbMetaInitialPoolSize + dbMetaMaximumPoolSize + partitionId;
     String dataSourceName = connectionPoolUtil.getDataSourceName( dbMetaMock, partitionId );
 
     assertEquals( dataSourceNameExpected, dataSourceName );

--- a/core/src/test/java/org/pentaho/di/core/database/ConnectionPoolUtilTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/ConnectionPoolUtilTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -43,11 +43,14 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.logging.Logger;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.any;
@@ -147,6 +150,33 @@ public class ConnectionPoolUtilTest implements Driver {
     connectionName = ConnectionPoolUtil.buildPoolName( dbMeta, "" );
     assertTrue( connectionName.equals( "CP2pentaholocal3306" ) );
   }
+
+  @Test
+  public void testGetDataSourceName() {
+    ConnectionPoolUtil connectionPoolUtil = new ConnectionPoolUtil();
+    DatabaseMeta dbMetaMock = mock( DatabaseMeta.class );
+    String dbMetaName = UUID.randomUUID().toString();
+    String dbMetaDatabase = UUID.randomUUID().toString();
+    String dbMetaHostname = UUID.randomUUID().toString();
+    String dbMetaPort = UUID.randomUUID().toString();
+    String partitionId = UUID.randomUUID().toString();
+
+    when( dbMetaMock.getName() ).thenReturn( dbMetaName );
+    when( dbMetaMock.getDatabaseName() ).thenReturn( dbMetaDatabase );
+    when( dbMetaMock.getHostname() ).thenReturn( dbMetaHostname );
+    when( dbMetaMock.getDatabasePortNumberString() ).thenReturn( dbMetaPort );
+
+    when( dbMetaMock.environmentSubstitute( eq( dbMetaName ) ) ).thenReturn( dbMetaName );
+    when( dbMetaMock.environmentSubstitute( eq( dbMetaDatabase ) ) ).thenReturn( dbMetaDatabase );
+    when( dbMetaMock.environmentSubstitute( eq( dbMetaHostname ) ) ).thenReturn( dbMetaHostname );
+    when( dbMetaMock.environmentSubstitute( eq( dbMetaPort ) ) ).thenReturn( dbMetaPort );
+
+    String dataSourceNameExpected = dbMetaName + dbMetaDatabase + dbMetaHostname + dbMetaPort + partitionId;
+    String dataSourceName = connectionPoolUtil.getDataSourceName( dbMetaMock, partitionId );
+
+    assertEquals( dataSourceNameExpected, dataSourceName );
+  }
+
 
   @Test
   public void testConfigureDataSource() throws KettleDatabaseException {

--- a/core/src/test/java/org/pentaho/di/core/database/DatabaseMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/DatabaseMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,6 +22,25 @@
 
 package org.pentaho.di.core.database;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.encryption.Encr;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettlePluginException;
+import org.pentaho.di.core.plugins.DatabasePluginType;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaNone;
+import org.pentaho.di.core.row.value.ValueMetaPluginType;
+import org.pentaho.di.junit.rules.RestorePDIEnvironment;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,25 +52,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.pentaho.di.core.RowMetaAndData;
-import org.pentaho.di.core.encryption.Encr;
-import org.pentaho.di.core.exception.KettleDatabaseException;
-import org.pentaho.di.core.exception.KettlePluginException;
-import org.pentaho.di.core.plugins.DatabasePluginType;
-import org.pentaho.di.core.row.RowMeta;
-import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaNone;
-import org.pentaho.di.core.row.value.ValueMetaPluginType;
-import org.pentaho.di.core.KettleClientEnvironment;
-import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.junit.rules.RestorePDIEnvironment;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -66,6 +66,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.powermock.reflect.Whitebox.getInternalState;
+import static org.powermock.reflect.Whitebox.setInternalState;
 
 public class DatabaseMetaTest {
   @ClassRule public static RestorePDIEnvironment env = new RestorePDIEnvironment();
@@ -434,5 +436,34 @@ public class DatabaseMetaTest {
     Assert.assertNotNull( DatabaseMeta.findDatabase( databases, " 1" ) );
     Assert.assertNotNull( DatabaseMeta.findDatabase( databases, " 1 " ) );
   }
+
+  @Test
+  public void testIsNeedUpdateTrue() {
+    DatabaseMeta meta = new DatabaseMeta();
+    setInternalState( meta, "needUpdate", true );
+    assertTrue( meta.isNeedUpdate() );
+  }
+
+  @Test
+  public void testIsNeedUpdateFalse() {
+    DatabaseMeta meta = new DatabaseMeta();
+    setInternalState( meta, "needUpdate", false );
+    assertFalse( meta.isNeedUpdate() );
+  }
+
+  @Test
+  public void testSetNeedUpdateTrue() {
+    DatabaseMeta meta = new DatabaseMeta();
+    meta.setNeedUpdate( true );
+    assertTrue( getInternalState( meta, "needUpdate" ) );
+  }
+
+  @Test
+  public void testSetNeedUpdateFalse() {
+    DatabaseMeta meta = new DatabaseMeta();
+    meta.setNeedUpdate( false );
+    assertFalse( getInternalState( meta, "needUpdate" ) );
+  }
+
 
 }


### PR DESCRIPTION
Cherry-pick of #7535 and #7631 into 9.1 branch.

Merge before https://github.com/pentaho/pentaho-platform/pull/4762 and https://github.com/pentaho/pdi-platform-plugin/pull/84

@ssamora @ppatricio 