### PR TITLE
[PDI-18856] - PDI Kettle Status Page - Sapphire Theme - Transformation/Job Table Records & References to mantleRuby.css

### DIFF
--- a/engine/src/main/java/org/pentaho/di/www/StatusServletUtils.java
+++ b/engine/src/main/java/org/pentaho/di/www/StatusServletUtils.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2018-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2018-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -84,7 +84,7 @@ class StatusServletUtils {
       }
 
       // webapps folder will always be one directory closer to default directory, need to update relative path string
-      relativePathSeparator = relativePathSeparator.replaceFirst( "(\\.\\.\\\\)", "" );
+      relativePathSeparator = ".." + File.separator;
 
       // Get mantle theme CSS file
       String mantleThemeDirStr = relativePathSeparator + "webapps" + root + File.separator + "mantle" + File.separator


### PR DESCRIPTION
@pentaho-lmartins 
@ssamora 
@smmribeiro 

I did not add unit test because it is not easy to do and it was clearly a mistake using explicit file separator for windows instead of generic File.separator.

I refactored the code just for simplicity. (Take a look at line 56)
  