### PR TITLE
Update client assemblies to package newer Eclipse libraries that work…

### DIFF
--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -23,11 +23,9 @@
     <oss-licenses.version>9.2.0.0-SNAPSHOT</oss-licenses.version>
 
     <!-- swt -->
-    <org.eclipse.swt.gtk.linux.x86.version>3.108.0</org.eclipse.swt.gtk.linux.x86.version>
-    <org.eclipse.swt.gtk.linux.x86_64.version>3.108.0</org.eclipse.swt.gtk.linux.x86_64.version>
-    <org.eclipse.swt.win32.win32.x86.version>4.6</org.eclipse.swt.win32.win32.x86.version>
-    <org.eclipse.swt.win32.win32.x86_64.version>4.6</org.eclipse.swt.win32.win32.x86_64.version>
-    <org.eclipse.swt.cocoa.macosx.x86_64.version>4.6</org.eclipse.swt.cocoa.macosx.x86_64.version>
+    <org.eclipse.swt.gtk.linux.x86_64.version>3.115.100</org.eclipse.swt.gtk.linux.x86_64.version>
+    <org.eclipse.swt.win32.win32.x86_64.version>3.115.100</org.eclipse.swt.win32.win32.x86_64.version>
+    <org.eclipse.swt.cocoa.macosx.x86_64.version>3.115.100</org.eclipse.swt.cocoa.macosx.x86_64.version>
 
     <!-- Pentaho drivers kar file dependencies versions -->
     <pentaho-hadoop-shims-cdh61.version>9.2.0.0-SNAPSHOT</pentaho-hadoop-shims-cdh61.version>
@@ -179,17 +177,6 @@
     <!-- swt -->
     <dependency>
       <groupId>org.eclipse.platform</groupId>
-      <artifactId>org.eclipse.swt.gtk.linux.x86</artifactId>
-      <version>${org.eclipse.swt.gtk.linux.x86.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
       <version>${org.eclipse.swt.gtk.linux.x86_64.version}</version>
       <exclusions>
@@ -200,19 +187,26 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.swt</groupId>
-      <artifactId>org.eclipse.swt.win32.win32.x86</artifactId>
-      <version>${org.eclipse.swt.win32.win32.x86.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.swt</groupId>
+      <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
       <version>${org.eclipse.swt.win32.win32.x86_64.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.swt</groupId>
+      <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.swt.cocoa.macosx.x86_64</artifactId>
       <version>${org.eclipse.swt.cocoa.macosx.x86_64.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/assemblies/client/src/assembly/assembly.xml
+++ b/assemblies/client/src/assembly/assembly.xml
@@ -48,15 +48,6 @@
     <!-- swt -->
     <dependencySet>
       <includes>
-        <include>org.eclipse.platform:*.linux.x86</include>
-      </includes>
-      <outputDirectory>libswt/linux/x86</outputDirectory>
-      <outputFileNameMapping>swt.jar</outputFileNameMapping>
-      <useTransitiveDependencies>false</useTransitiveDependencies>
-      <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
-    <dependencySet>
-      <includes>
         <include>org.eclipse.platform:*.linux.x86_64</include>
       </includes>
       <outputDirectory>libswt/linux/x86_64</outputDirectory>
@@ -66,16 +57,7 @@
     </dependencySet>
     <dependencySet>
       <includes>
-        <include>org.eclipse.swt:*.win32.x86</include>
-      </includes>
-      <outputDirectory>libswt/win32</outputDirectory>
-      <outputFileNameMapping>swt.jar</outputFileNameMapping>
-      <useTransitiveDependencies>false</useTransitiveDependencies>
-      <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
-    <dependencySet>
-      <includes>
-        <include>org.eclipse.swt:*.win32.x86_64</include>
+        <include>org.eclipse.platform:*.win32.x86_64</include>
       </includes>
       <outputDirectory>libswt/win64</outputDirectory>
       <outputFileNameMapping>swt.jar</outputFileNameMapping>
@@ -84,7 +66,7 @@
     </dependencySet>
     <dependencySet>
       <includes>
-        <include>org.eclipse.swt:*.macosx.x86_64</include>
+        <include>org.eclipse.platform:*.macosx.x86_64</include>
       </includes>
       <outputDirectory>libswt/osx64</outputDirectory>
       <outputFileNameMapping>swt.jar</outputFileNameMapping>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -56,6 +56,7 @@
     <bahir.version>2.3.2</bahir.version>
     <snowflake-jdbc.version>3.6.28</snowflake-jdbc.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
+    <jface.version>3.22.0</jface.version>
   </properties>
 
   <dependencies>
@@ -85,6 +86,10 @@
           <groupId>org.eclipse.swt</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+        	<groupId>org.eclipse</groupId>
+        	<artifactId>jface</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -95,6 +100,18 @@
         <exclusion>
           <groupId>org.eclipse.swt</groupId>
           <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>        	
+          <groupId>org.eclipse.core</groupId>
+		  <artifactId>*</artifactId>        
+        </exclusion>
+        <exclusion>
+		  <groupId>org.eclipse.equinox</groupId>
+  		  <artifactId>common</artifactId>
+        </exclusion>
+        <exclusion>
+        	<groupId>org.eclipse</groupId>
+        	<artifactId>jface</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -110,6 +127,13 @@
       </exclusions>
     </dependency>
 
+	<!-- Updated Eclipse Dependencies -->
+    <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.jface</artifactId>
+        <version>${jface.version}</version>
+    </dependency>
+	
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>


### PR DESCRIPTION
Update client assemblies to package newer Eclipse libraries that work better on current Mac OS versions.  This includes updates to SWT, JFace, Eclipse common and command runtimes.

There are still some issues relative to theming on Mac OS such that it is not always easy to read some text, but at least it avoid the exceptions that occur when updating the SWT version without updating JFace and the core runtime libraries along with it.

It should be noticed that this does not update the dependencies for the various libraries since they appear to be the same from a compilation perspective.  It merely overrides the versions that are captured via the assembly into the community edition zip file.

Finally, it should be noted that these changes also remove the old 32 bit versions of the SWT libraries as they appear to be unsupported at this point and generally speaking, most people should be on a 64 bit OS.
