### PR TITLE
[SP-5827] Add a kettle property to control the size of the

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1144,6 +1144,11 @@ public class Const {
   public static final String KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT = "KETTLE_GLOBAL_LOG_VARIABLES_CLEAR_ON_EXPORT";
 
   /**
+   * Property controls the capacity of the transFinishedBlockingQueue in Trans.
+   */
+  public static final String KETTLE_TRANS_FINISHED_BLOCKING_QUEUE_SIZE = "KETTLE_TRANS_FINISHED_BLOCKING_QUEUE_SIZE";
+
+  /**
    * Compatibility settings for {@link org.pentaho.di.core.row.ValueDataUtil#hourOfDay(ValueMetaInterface, Object)}.
    *
    * Switches off the fix for calculation of timezone decomposition.

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -557,6 +557,9 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
 
   private boolean executingClustered;
 
+  private static final int TRANS_FINISHED_BLOCKING_QUEUE_SIZE =
+    Integer.parseInt( System.getProperty( Const.KETTLE_TRANS_FINISHED_BLOCKING_QUEUE_SIZE, "200" ) );
+
   /**
    * Instantiates a new transformation.
    */
@@ -1420,7 +1423,7 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     setPaused( false );
     setStopped( false );
 
-    transFinishedBlockingQueue = new ArrayBlockingQueue<>( 10 );
+    transFinishedBlockingQueue = new ArrayBlockingQueue<>( TRANS_FINISHED_BLOCKING_QUEUE_SIZE );
 
     TransListener transListener = new TransAdapter() {
       @Override


### PR DESCRIPTION
ArrayBlockingQueue used to signal when steps are finished.  Set new
default high enough to avoid it filling up in the future.

This commit is a cherry-pick from master 3b9592ef0d