### PR TITLE
[PDI-18990] Get a file with FTP: "Check Folder" option fails when the…

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/job/entries/ftp/JobEntryFTPDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/entries/ftp/JobEntryFTPDialog.java
@@ -1383,6 +1383,9 @@ public class JobEntryFTPDialog extends JobEntryDialog implements JobEntryDialogI
         ftpclient.setRemoteAddr( InetAddress.getByName( realServername ) );
         ftpclient.setRemotePort( realPort );
 
+        // Use the specified encoding
+        ftpclient.setControlEncoding( wControlEncoding.getText() );
+
         if ( !Utils.isEmpty( wProxyHost.getText() ) ) {
           String realProxy_host = jobMeta.environmentSubstitute( wProxyHost.getText() );
           ftpclient.setRemoteAddr( InetAddress.getByName( realProxy_host ) );


### PR DESCRIPTION
… folder has Japanese characters

It was missing the configuration of the encoding to use.

@pentaho-lmartins @ssamora @bcostahitachivantara 