### PR TITLE
[SP-5843] - Backport of PDI-18387 - Fields defined in "Key(s) to lookup the values" goes missing in the Delete Step (8.3 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/delete/DeleteMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/delete/DeleteMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/engine/src/main/java/org/pentaho/di/trans/steps/delete/DeleteMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/delete/DeleteMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -342,7 +342,7 @@ public class DeleteMeta extends BaseStepMeta implements StepMetaInterface {
       schemaName = rep.getStepAttributeString( id_step, "schema" );
       tableName = rep.getStepAttributeString( id_step, "table" );
 
-      int nrkeys = rep.countNrStepAttributes( id_step, "key_name" );
+      int nrkeys = rep.countNrStepAttributes( id_step, "key_field" );
 
       allocate( nrkeys );
 

--- a/engine/src/test/java/org/pentaho/di/trans/steps/delete/DeleteMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/delete/DeleteMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *


### PR DESCRIPTION
@pentaho-lmartins 
@ssamora 
@smmribeiro 

It only was backported the changes needed to fix the issue, it was not backported changes related with sonnar.