### PR TITLE
[SP-5935] Backport of PDI-19132 - JSON Input step behavior changes wh…

### DIFF
--- a/plugins/json/core/src/main/java/org/pentaho/di/trans/steps/jsoninput/reader/FastJsonReader.java
+++ b/plugins/json/core/src/main/java/org/pentaho/di/trans/steps/jsoninput/reader/FastJsonReader.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2016 - 2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2016 - 2021 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -164,7 +164,7 @@ public class FastJsonReader implements IJsonReader {
   public RowSet parse( InputStream in ) throws KettleException {
     readInput( in );
     List<List<?>> results = evalCombinedResult();
-    int len = results.isEmpty() ? 0 : results.get( 0 ).size();
+    int len = results.isEmpty() ? 0 : getMaxRowSize( results );
     if ( log.isDetailed() ) {
       log.logDetailed( BaseMessages.getString( PKG, "JsonInput.Log.NrRecords", len ) );
     }
@@ -172,6 +172,15 @@ public class FastJsonReader implements IJsonReader {
       return getEmptyResponse();
     }
     return new TransposedRowSet( results );
+  }
+
+  /**
+   * Gets the max size of the result rows.
+   * @param results A list of lists representing the result rows
+   * @return the size of the largest row in the results
+   */
+  protected static int getMaxRowSize( List<List<?>> results ) {
+    return results.stream().mapToInt( List::size ).max().getAsInt();
   }
 
   private RowSet getEmptyResponse() {
@@ -193,7 +202,7 @@ public class FastJsonReader implements IJsonReader {
     public TransposedRowSet( List<List<?>> results ) {
       super();
       this.results = results;
-      this.rowCount = results.isEmpty() ? 0 : results.get( 0 ).size();
+      this.rowCount = results.isEmpty() ? 0 : FastJsonReader.getMaxRowSize( results );
     }
 
     @Override

--- a/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsoninput/JsonInputTest.java
+++ b/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsoninput/JsonInputTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1398,4 +1398,35 @@ public class JsonInputTest {
     assertEquals( "Meta input fields paths should be the same after processRows", PATH, inputMeta.getInputFields()[0].getPath() );
   }
 
+  /*
+   * see PDI-19132. When parsing, if the first field returned null, the second field would also return null, when in
+   * reality the path existed. This test makes sure that regardless of the order of the fields being searched the result
+   * is the same (the field with a path that exists returns the correct value).
+   */
+  @Test
+  public void testParsingWithNullFinding() throws Exception {
+    JsonInputField a = new JsonInputField( "A" );
+    a.setPath( "$..A.F1" );
+    a.setType( ValueMetaInterface.TYPE_STRING );
+    JsonInputField b = new JsonInputField( "B" );
+    b.setPath( "$..B.F2" );
+    b.setType( ValueMetaInterface.TYPE_STRING );
+    //Create two meta inputs with two different orders a,b and b,a
+    List results = new ArrayList<>();
+    List<JsonInputMeta> metas = Arrays.asList( createSimpleMeta( "json", a, b ), createSimpleMeta( "json", b, a ) );
+    for ( JsonInputMeta meta : metas ) {
+      JsonInputMeta metaAB = createSimpleMeta( "json", a, b );
+      JsonInput jsonInput = createJsonInput( "json", meta, new Object[] { "{'B':{'F2': one}, 'C':{'B': {'F2': three}}}" } );
+      jsonInput.addRowListener( new RowAdapter() {
+        @Override public void rowWrittenEvent( RowMetaInterface rowMeta, Object[] row ) {
+          results.addAll( Arrays.asList( row ) );
+        }
+      } );
+      processRows( jsonInput, 3 );
+      Assert.assertEquals( "error", 0, jsonInput.getErrors() );
+      //Regardless of the order the result should contain the findings "one" and "three".
+      Assert.assertTrue( results.contains( "one" ) );
+      Assert.assertTrue( results.contains( "three" ) );
+    }
+  }
 }

--- a/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsoninput/reader/FastJsonReaderTest.java
+++ b/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsoninput/reader/FastJsonReaderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2016 - 2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2016 - 2021 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,8 +22,6 @@
 
 package org.pentaho.di.trans.steps.jsoninput.reader;
 
-import static org.junit.Assert.*;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,9 +32,14 @@ import org.pentaho.di.trans.steps.jsoninput.JsonInputField;
 import com.jayway.jsonpath.Option;
 
 import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 
 public class FastJsonReaderTest {
   private static final Option[] DEFAULT_OPTIONS = { Option.SUPPRESS_EXCEPTIONS, Option.ALWAYS_RETURN_LIST, Option.DEFAULT_PATH_LEAF_TO_NULL };
@@ -94,5 +97,23 @@ public class FastJsonReaderTest {
     assertEquals( false, fJsonReader.isIgnoreMissingPath() );
     assertEquals( true, fJsonReader.isDefaultPathLeafToNull() );
     assertEquals( expectedOptions, fJsonReader.getJsonConfiguration().getOptions() );
+  }
+
+  @Test
+  public void testFastJsonReaderGetMaxRowSize() throws KettleException {
+    List<List<Integer>> mainList = new ArrayList<>();
+    List<Integer> l1 = new ArrayList<>();
+    List<Integer> l2 = new ArrayList<>();
+    List<Integer> l3 = new ArrayList<>();
+    l1.add( 1 );
+    l2.add( 1 );
+    l2.add( 2 );
+    l3.add( 1 );
+    l3.add( 2 );
+    l3.add( 3 );
+    mainList.add( l1 );
+    mainList.add( l2 );
+    mainList.add( l3 );
+    assertEquals( 3, FastJsonReader.getMaxRowSize( Collections.singletonList( mainList ) ) );
   }
 }


### PR DESCRIPTION
…en the order of the fields is changed (8.3 Suite)

cherry-pick of 7cf543b47b3c10356b60bc75af754c73946a87ba and 096157df1fc11bf2a36a4d0f772a1c322c74e5bc
from https://github.com/pentaho/pentaho-kettle/pull/7943

@smmribeiro @bcostahitachivantara @moraesvc 