### PR TITLE
PDI-19201: Fix creation of SFTP connections/sessions to an SFTP Windows server

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/vfs/SftpFileSystemWindows.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/SftpFileSystemWindows.java
@@ -222,9 +222,9 @@ class SftpFileSystemWindows extends SftpFileSystem {
    * {@link  org.apache.commons.vfs2.provider.sftp.SftpFileSystem#getChannel() }
    */
   private void ensureSession() throws FileSystemException {
-    if ( !this.subclassSession.isConnected() ) {
+    if ( this.subclassSession == null || !this.subclassSession.isConnected() ) {
       synchronized ( this ) {
-        if ( !this.subclassSession.isConnected() ) {
+        if ( this.subclassSession == null || !this.subclassSession.isConnected() ) {
           closeSubclassSession();
           this.subclassSession = SftpFileSystemWindowsProvider.createSession( (GenericFileName) getRootName(),
             getFileSystemOptions() );


### PR DESCRIPTION
A nullcheck was missing

This fixes PDI-19201:
https://jira.pentaho.com/browse/PDI-19201