### PR TITLE
9.1 Fix failing tests on Windows

### DIFF
--- a/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputContentParsingTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputContentParsingTest.java
@@ -215,7 +215,7 @@ public class CsvInputContentParsingTest extends BaseCsvParsingTest {
     process();
 
     check( new Object[][] { { "1", "This line is un-even enclosure-wise because I'm using an escaped enclosure", "a" },
-      { "2", "Test isn't even\nhere", "b" } } );
+      { "2", "Test isn't even\r\nhere", "b" } } );
   }
 
   @Test( expected = KettleStepException.class )

--- a/engine/src/test/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -40,7 +41,6 @@ import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
@@ -140,15 +140,9 @@ public class IngresVectorwiseTest {
     stepMockHelper.cleanUp();
   }
 
-  /**
-   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
-   * Systems:
-   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
-   * operating system besides Windows."
-   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
-   */
   @Test
   public void testGuiErrors() {
+    assumeFalse(isWindows());
     try {
       int r = wrongRows.size();
       BaseStep step = doOutput( wrongRows, "0" );
@@ -165,15 +159,9 @@ public class IngresVectorwiseTest {
     }
   }
 
-  /**
-   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
-   * Systems:
-   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
-   * operating system besides Windows."
-   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
-   */
   @Test
   public void testGuiErrorsWithErrorsAllowed() {
+    assumeFalse(isWindows());
     try {
       int r = wrongRows.size();
       BaseStep step = doOutput( wrongRows, "2" );
@@ -190,15 +178,9 @@ public class IngresVectorwiseTest {
     }
   }
 
-  /**
-   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
-   * Systems:
-   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
-   * operating system besides Windows."
-   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
-   */
   @Test
   public void testGuiSuccess() {
+    assumeFalse(isWindows());
     try {
       int r = rows.size();
       BaseStep step = doOutput( rows, "0" );
@@ -215,15 +197,9 @@ public class IngresVectorwiseTest {
     }
   }
 
-  /**
-   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
-   * Systems:
-   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
-   * operating system besides Windows."
-   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
-   */
   @Test
   public void testWaitForFinish() {
+    assumeFalse(isWindows());
     try {
       int r = rows.size();
       BaseStep step = doOutput( wrongRows, "2" );
@@ -238,16 +214,9 @@ public class IngresVectorwiseTest {
     }
   }
 
-  /**
-   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
-   * Systems:
-   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
-   * operating system besides Windows."
-   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
-   */
   @Test
-  @Ignore
   public void testVWLoadMocker() {
+    assumeFalse(isWindows());
     String cmd =
       "java -cp . -Duser.dir=" + VWLoadMocker.class.getProtectionDomain().getCodeSource().getLocation().getPath()
         + " org.pentaho.di.trans.steps.ivwloader.VWLoadMocker 5000 0 /tmp/error.txt";
@@ -357,4 +326,15 @@ public class IngresVectorwiseTest {
     return ivwLoader;
   }
 
+  /**
+   * Test will fail if you're on a Windows system. IngresVectorwise Bulk Loading is only available for POSIX Operating
+   * Systems:
+   * "The VW bulk loader only runs under POSIX operating systems that support named pipes. This includes every modern
+   * operating system besides Windows."
+   * @see <a href="https://wiki.pentaho.com/display/EAI/Ingres+VectorWise+Bulk+Loader">Ingres Vectorwise Bulk Loader</a>
+   */
+  private static boolean isWindows() {
+    final String os = System.getProperty("os.name");
+    return os != null && os.toLowerCase().startsWith("win");
+  }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/uniquerowsbyhashset/RowKeyTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/uniquerowsbyhashset/RowKeyTest.java
@@ -66,7 +66,7 @@ public class RowKeyTest {
     uniqueRowsObj.fieldnrs = new int[0];
     uniqueRowsObj.storeValues = false;
     RowKey rowKey1 = new RowKey( arr1, uniqueRowsObj );
-    assertEquals( rowKey1.hashCode(),  -227281350 );
+    assertEquals( 1780192570, rowKey1.hashCode() );
     assertTrue( rowKey1.equals( new Object() ) );
 
     uniqueRowsObj.storeValues = true;


### PR DESCRIPTION
Backport to 9.1 of https://github.com/pentaho/pentaho-kettle/pull/8007