### PR TITLE
Do not printStackTrace() when RunThread error

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/step/RunThread.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/RunThread.java
@@ -73,7 +73,6 @@ public class RunThread implements Runnable {
           // nor call the setErrors() and stopAll() below.
           log.logError( "UnexpectedError: ", t );
         } else {
-          t.printStackTrace();
           log.logError( BaseMessages.getString( "System.Log.UnexpectedError" ), t );
         }
 


### PR DESCRIPTION
Codes below should not call `t.printStackTrace()` to print stack to stderr, it should rely on `log.logError()` do the work.

https://github.com/pentaho/pentaho-kettle/blob/5bbca055f14dd7358619e27674256f7572e8338b/engine/src/main/java/org/pentaho/di/trans/step/RunThread.java#L75-L78