### PR TITLE
[PDI-19104] - Getting "Illegal character in opaque part at index" error when using the "file:\" protocol in the HTTP Job Entry.

### DIFF
--- a/engine/src/test/java/org/pentaho/di/job/entries/http/JobEntryHTTP_PDI_19104_Test.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/http/JobEntryHTTP_PDI_19104_Test.java
@@ -61,7 +61,7 @@ public class JobEntryHTTP_PDI_19104_Test {
     localTargetFile.deleteOnExit();
 
     Object[] r = new Object[] {
-      "file://" + localSourceFile.getCanonicalPath(),
+      "file://" + localSourceFile.toURI().toURL().getFile(),
       null,
       localTargetFile.getCanonicalPath() };
 


### PR DESCRIPTION
@ssamora 
@smmribeiro 
@moraesvc 