### PR TITLE
[SP-6046] Backport of BISERVER-14546 - ProAuditDatabasejob locks MySQ…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -3311,7 +3311,7 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
   }
 
   public void truncateTable( String schema, String tablename ) throws KettleDatabaseException {
-    if ( Utils.isEmpty( connectionGroup ) ) {
+    if ( Utils.isEmpty( connectionGroup ) && !databaseMeta.getPluginId().equalsIgnoreCase( "MySQL" ) ) { // this is a hack to fix a know issue on MySQL issue name on Pentaho side BISERVER-14546
       String truncateStatement = databaseMeta.getTruncateTableStatement( schema, tablename );
       if ( truncateStatement == null ) {
         throw new KettleDatabaseException( "Truncate table not supported by "


### PR DESCRIPTION
…L8's pentaho_operations_mart.pro_audit_staging and pro_audit_tracker tables (9.2 Suite)

@smmribeiro @bcostahitachivantara 

cherry-pick of https://github.com/pentaho/pentaho-kettle/pull/8065