### PR TITLE
[PDI-19163] Upgraded mongo java driver version from 3.10.2 to 3.12.10

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
-      <version>3.10.2</version>
+      <version>3.12.10</version>
     </dependency>
     <!-- Updated Eclipse Dependencies -->
     <dependency>


### PR DESCRIPTION
Upgrading java mongo driver to the latest possible version without many changes in the code.