### PR TITLE
[SP-6073] PDI-19355 Saleforce Input step is replacing NULL values for…

### DIFF
--- a/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforce/SalesforceConnection.java
+++ b/plugins/salesforce/core/src/main/java/org/pentaho/di/trans/steps/salesforce/SalesforceConnection.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -610,7 +610,7 @@ public class SalesforceConnection {
     for ( int index = 0; index <= lastIndex; index++ ) {
       for ( XmlObject element : getChildren( currentSObject ) ) {
         if ( element.getName().getLocalPart().equals( fieldHierarchy[index] ) ) {
-          if ( index == lastIndex ) {
+          if ( index == lastIndex || ( element.getValue() == null && !element.hasChildren() ) ) {
             return element;
           } else {
             if ( element instanceof  SObject ) {

--- a/plugins/salesforce/core/src/test/java/org/pentaho/di/trans/steps/salesforce/SalesforceConnectionTest.java
+++ b/plugins/salesforce/core/src/test/java/org/pentaho/di/trans/steps/salesforce/SalesforceConnectionTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -333,6 +333,17 @@ public class SalesforceConnectionTest {
     SObject childObject = createObject( "subField", "subValue" );
     parentObject.addField( "subField", childObject );
     assertEquals( "Get value of record with hierarchy", "subValue", conn.getRecordValue( sObject, "parentField.subField" ) );
+
+    SObject parentObject2 = createObject( "parentField2", null );
+    sObject.addField( "parentField2", parentObject2 );
+    SObject childObject2 = createObject( "subField2", null );
+    parentObject2.addField( "subField2", childObject2 );
+    assertNull( "Get value of record with hierarchy", conn.getRecordValue( sObject, "parentField2.subField2" ) );
+
+    SObject parentObject3 = createObject( "parentField3", null );
+    sObject.addField( "parentField3", parentObject3 );
+    parentObject3.addField( "subField3", null );
+    assertNull( "Get value of record with hierarchy", conn.getRecordValue( sObject, "parentField3.subField3" ) );
 
     XmlObject nullObject = new XmlObject( new QName( "nullField" ) );
     sObject.addField( "nullField", nullObject );


### PR DESCRIPTION
… the Name of lookup references to custom objects with the Name of the record of the Standard Object which has the empty reference value (9.2.0.2 branch)