### PR TITLE
Fixed PDI-19431 : Removed unnecessary file length validation

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/ftp/JobEntryFTP.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/ftp/JobEntryFTP.java
@@ -1081,20 +1081,6 @@ public class JobEntryFTP extends JobEntryBase implements Cloneable, JobEntryInte
             logDetailed( BaseMessages.getString( PKG, "JobEntryFTP.SetAscii" ) );
           }
         }
-
-        // Some FTP servers return a message saying no files found as a string in the filenlist
-        // e.g. Solaris 8
-        // CHECK THIS !!!
-
-        if ( ftpFiles.length == 1 ) {
-          String translatedWildcard = environmentSubstitute( wildcard );
-          if ( !Utils.isEmpty( translatedWildcard ) ) {
-            if ( ftpFiles[0].getName().startsWith( translatedWildcard ) ) {
-              throw new FTPException( ftpFiles[0].getName() );
-            }
-          }
-        }
-
         Pattern pattern = null;
         if ( !Utils.isEmpty( wildcard ) ) {
           String realWildcard = environmentSubstitute( wildcard );

--- a/engine/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
@@ -717,19 +717,6 @@ public class JobEntryFTPDelete extends JobEntryBase implements Cloneable, JobEnt
           realproxyusername, realproxypassword, realproxyport, timeout );
 
         filelist = ftpclient.dir();
-
-        // Some FTP servers return a message saying no files found as a string in the filenlist
-        // e.g. Solaris 8
-        // CHECK THIS !!!
-        if ( filelist.length == 1 ) {
-          String translatedWildcard = environmentSubstitute( wildcard );
-          if ( !Utils.isEmpty( translatedWildcard ) ) {
-            if ( filelist[0].startsWith( translatedWildcard ) ) {
-              throw new FTPException( filelist[0] );
-            }
-
-          }
-        }
       } else if ( protocol.equals( PROTOCOL_FTPS ) ) {
         // establish the secure connection
         FTPSConnect( realservername, realUsername, realserverport, realPassword, realFtpDirectory, timeout );


### PR DESCRIPTION
PDI-19431: Unable to get file from destination folder with a specific file name if destination folder has only one file with specified name.

As part of the fix removed unnecessary file length validations