### PR TITLE
[PDI-19457] : "PDI - Microsoft Excel Output Step Using Template Errors - Regression"

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/exceloutput/ExcelOutput.java
@@ -548,6 +548,7 @@ public class ExcelOutput extends BaseStep implements StepInterface {
           // Check if the sheet already exists
           data.sheet = data.workbook.getSheet( sheetName );
           if ( null == data.sheet ) {
+            logError( "WorkSheet Name is null or different from that of Template WorkSheet Name" );
             // Create the sheet at the end of the workbook using the first sheet as template
             data.workbook.copySheet( 0, sheetName, data.workbook.getNumberOfSheets() );
             data.sheet = data.workbook.getSheet( sheetName );


### PR DESCRIPTION
PDI-19457 "PDI - Microsoft Excel Output Step Using Template Errors - Regression": Correct Error message is displayed when different worksheet name is used in Template and output file.
This PR is only to log the right error message and not change functionality. 
The other sub-issues of the ticket have been dealt with by updating the documentation by raising another ticket for the same as mentioned in the comments section of the ticket.
Kindly review the PR.