### PR TITLE
[PDI-19514] Spoon fires queries on opening or editing Table Input poi…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -2393,17 +2393,6 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
 
     // No cache entry found
 
-    // The new method of retrieving the query fields fails on Oracle because
-    // they failed to implement the getMetaData method on a prepared statement.
-    // (!!!)
-    // Even recent drivers like 10.2 fail because of it.
-    //
-    // There might be other databases that don't support it (we have no
-    // knowledge of this at the time of writing).
-    // If we discover other RDBMSs, we will create an interface for it.
-    // For now, we just try to get the field layout on the re-bound in the
-    // exception block below.
-    //
     try {
       if ( databaseMeta.supportsPreparedStatementMetadataRetrieval() ) {
         // On with the regular program.

--- a/core/src/main/java/org/pentaho/di/core/database/OracleDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/OracleDatabaseMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -555,17 +555,6 @@ public class OracleDatabaseMeta extends BaseDatabaseMeta implements DatabaseInte
   @Override
   public boolean requiresCreateTablePrimaryKeyAppend() {
     return true;
-  }
-
-  /**
-   * Most databases allow you to retrieve result metadata by preparing a SELECT statement.
-   *
-   * @return true if the database supports retrieval of query metadata from a prepared statement. False if the query
-   *         needs to be executed first.
-   */
-  @Override
-  public boolean supportsPreparedStatementMetadataRetrieval() {
-    return false;
   }
 
   /**


### PR DESCRIPTION
…nting to Oracle Database

Since version 11.2 (released in 2005), Oracle has support for obtaining the metadata of a SELECT statement without executing the PreparedStatement.

@bcostahitachivantara @renato-s @andreramos89 
@rmansoor @pminutillo 