### PR TITLE
[BACKLOG-36063] Plugins migrated from kettle engine should be lowdeps,

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -31,6 +31,16 @@
         </property>
       </activation>
       <modules>
+        <module>monet-db-bulk-loader</module>
+        <module>postgresql-db-bulk-loader</module>
+        <module>oracle-bulk-loader</module>
+        <module>terafast-bulk-loader</module>
+        <module>infobright-bulk-loader</module>
+        <module>excel</module>
+        <module>ivw-bulk-loader</module>
+        <module>edi2xml</module>
+        <module>mysql-bulk-loader</module>
+        <module>yaml-input</module>
         <module>metastore-locator</module>
         <module>repository-locator</module>
       </modules>
@@ -73,21 +83,11 @@
         <module>lucid-db-streaming-loader</module>
         <module>salesforce</module>
         <module>pur</module>
-        <module>monet-db-bulk-loader</module>
         <module>ms-access</module>
-        <module>postgresql-db-bulk-loader</module>
-        <module>oracle-bulk-loader</module>
-        <module>terafast-bulk-loader</module>
-        <module>infobright-bulk-loader</module>
-        <module>excel</module>
-        <module>ivw-bulk-loader</module>
-        <module>edi2xml</module>
         <module>xml</module>
         <module>streaming</module>
         <module>metastore-locator</module>
         <module>repository-locator</module>
-        <module>mysql-bulk-loader</module>
-        <module>yaml-input</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
not highdeps, in order to preserve the original build order.