### PR TITLE
[BACKLOG-36073] Cleanup mongo dependencies; metaverse no longer has a

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -125,11 +125,6 @@
 
     <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pentaho-mongodb-plugin</artifactId>
-      <version>${pentaho-mongodb-plugin.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
       <artifactId>pentaho-mongo-utils</artifactId>
       <version>${pentaho-mongodb-plugin.version}</version>
     </dependency>


### PR DESCRIPTION
dependency on mongo plugin so the jar does not need to be in /lib