### PR TITLE
[BACKLOG-36110] org.osgi.core library still needs to be present in

### DIFF
--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -586,6 +586,23 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!--OSGi Dependency-->
+        <!--Because of:-->
+        <!--pentaho-platform-core (PentahoSystem) and pdi-osgi-bridge-core (KarafLifecycleListener and OSGIPluginRegistryExtension)-->
+        <!--Still needed even for a no-osgi build because of PentahoSystem dependency -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
     <profiles>
         <profile>
@@ -616,15 +633,6 @@
                             <artifactId>*</artifactId>
                         </exclusion>
                     </exclusions>
-                </dependency>
-
-                <!--OSGi Dependencies-->
-                <!--Because of:-->
-                <!--pentaho-platform-core (PentahoSystem) and pdi-osgi-bridge-core (KarafLifecycleListener and OSGIPluginRegistryExtension)-->
-                <dependency>
-                    <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.core</artifactId>
-                    <scope>compile</scope>
                 </dependency>
 
                 <!-- Karaf Dependencies -->

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -684,6 +684,21 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!--OSGi Dependencies-->
+    <!--Because of:-->
+    <!--pentaho-platform-core (PentahoSystem) and pdi-osgi-bridge-core (KarafLifecycleListener and OSGIPluginRegistryExtension)-->
+    <!--Still needed for a no-osgi build because of PentahoSystem dependency -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <profiles>
@@ -738,15 +753,6 @@
               <artifactId>*</artifactId>
             </exclusion>
           </exclusions>
-        </dependency>
-
-        <!--OSGi Dependencies-->
-        <!--Because of:-->
-        <!--pentaho-platform-core (PentahoSystem) and pdi-osgi-bridge-core (KarafLifecycleListener and OSGIPluginRegistryExtension)-->
-        <dependency>
-          <groupId>org.osgi</groupId>
-          <artifactId>org.osgi.core</artifactId>
-          <scope>compile</scope>
         </dependency>
 
         <!-- Karaf Dependencies -->


### PR DESCRIPTION
no-osgi artifacts because it is a dependency of PentahoSystem/OSGIRuntimeObjectFactory