### PR TITLE
[TEST] Some tests were periodically failing because the

### DIFF
--- a/engine/src/test/java/org/pentaho/di/trans/streaming/common/BaseStreamStepTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/streaming/common/BaseStreamStepTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -23,13 +23,13 @@
 package org.pentaho.di.trans.streaming.common;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.exception.KettleException;
@@ -37,6 +37,7 @@ import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
 import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
@@ -64,6 +65,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith ( MockitoJUnitRunner.class )
 public class BaseStreamStepTest {
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
   private BaseStreamStep baseStreamStep;
 
   @Mock BaseStreamStepMeta meta;
@@ -119,8 +121,6 @@ public class BaseStreamStepTest {
     // Necessary since the Current.Directory may change when running non-locally.
     // Variables should all be set in variableizedStepMeta after init, with the caveat that
     // the substrans location must be set using the parents Current.Directory.
-    KettleEnvironment.init();
-
     File testFile = File.createTempFile( "testInitFilenameSubstitution", ".ktr",
       folder.getRoot() );
     try ( PrintWriter pw = new PrintWriter( testFile ) ) {

--- a/plugins/meta-inject/src/test/java/org/pentaho/di/trans/steps/metainject/OpenMappingExtensionTest.java
+++ b/plugins/meta-inject/src/test/java/org/pentaho/di/trans/steps/metainject/OpenMappingExtensionTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2022 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,15 @@ package org.pentaho.di.trans.steps.metainject;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.ui.spoon.SpoonLifecycleListener;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 /**
  * Created by Vasilina_Terehova on 3/31/2017.
@@ -42,7 +42,6 @@ public class OpenMappingExtensionTest {
 
   @Before
   public void setup() {
-    setKettleLogFactoryWithMock();
     transMeta = spy( new TransMeta() );
     stepMeta = mock( StepMeta.class );
     metaData = new Object[] { stepMeta, transMeta };
@@ -59,10 +58,4 @@ public class OpenMappingExtensionTest {
     assert ( transMeta.getName().contains( afterInjectionMessageAdded ) );
   }
 
-  private void setKettleLogFactoryWithMock() {
-    LogChannelInterfaceFactory logChannelInterfaceFactory = mock( LogChannelInterfaceFactory.class );
-    logChannelInterface = mock( LogChannelInterface.class );
-    when( logChannelInterfaceFactory.create( any() ) ).thenReturn( logChannelInterface );
-    KettleLogStore.setLogChannelInterfaceFactory( logChannelInterfaceFactory );
-  }
 }

--- a/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/JmsProducerTest.java
+++ b/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/JmsProducerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2018-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,12 +25,12 @@ package org.pentaho.di.trans.step.jms;
 import org.apache.activemq.artemis.junit.EmbeddedJMSResource;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
@@ -38,6 +38,7 @@ import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
 import org.pentaho.di.core.plugins.StepPluginType;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.util.GenericStepData;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
@@ -73,6 +74,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith ( MockitoJUnitRunner.class )
 public class JmsProducerTest {
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
   @Mock LogChannelInterfaceFactory logChannelFactory;
   @Mock LogChannelInterface logChannel;
   @Mock JMSContext jmsContext;
@@ -94,7 +96,6 @@ public class JmsProducerTest {
       JmsProducerMeta.class,
       JmsProducerMeta.class.getAnnotation( org.pentaho.di.core.annotations.Step.class ),
       Collections.emptyList(), false, null );
-    KettleEnvironment.init();
   }
 
   @Before

--- a/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/context/ActiveMQProviderTest.java
+++ b/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/context/ActiveMQProviderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,18 +24,19 @@ package org.pentaho.di.trans.step.jms.context;
 import org.apache.activemq.artemis.junit.EmbeddedJMSResource;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
 import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.plugins.StepPluginType;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.jms.JmsConsumerMeta;
@@ -61,6 +62,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith( MockitoJUnitRunner.class )
 public class ActiveMQProviderTest {
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
   @Mock LogChannelInterfaceFactory logChannelFactory;
   @Mock LogChannelInterface logChannel;
 
@@ -91,7 +93,6 @@ public class ActiveMQProviderTest {
       JmsConsumerMeta.class,
       JmsConsumerMeta.class.getAnnotation( org.pentaho.di.core.annotations.Step.class ),
       Collections.emptyList(), false, null );
-    KettleEnvironment.init();
   }
 
   @Before

--- a/plugins/streaming/impls/mqtt/pom.xml
+++ b/plugins/streaming/impls/mqtt/pom.xml
@@ -157,6 +157,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>pentaho-kettle</groupId>
+      <artifactId>kettle-engine</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>1.3</version>

--- a/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerTest.java
+++ b/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerTest.java
@@ -23,41 +23,30 @@ package org.pentaho.di.trans.step.mqtt;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.logging.KettleLogStore;
-import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.StepPluginType;
-import org.pentaho.di.core.util.StringUtil;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
 
 @RunWith ( MockitoJUnitRunner.class )
 public class MQTTConsumerTest {
-  @Mock LogChannelInterfaceFactory logChannelFactory;
-  @Mock LogChannelInterface logChannel;
-
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
   private Trans trans;
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    KettleClientEnvironment.init();
     PluginRegistry.addPluginType( StepPluginType.getInstance() );
-    PluginRegistry.init();
     if ( !Props.isInitialized() ) {
       Props.init( 0 );
     }
@@ -69,13 +58,6 @@ public class MQTTConsumerTest {
 
   @Before
   public void setup() throws Exception {
-    MockitoAnnotations.initMocks( this );
-    KettleLogStore.setLogChannelInterfaceFactory( logChannelFactory );
-    when( logChannelFactory.create( any(), any() ) ).thenReturn( logChannel );
-    when( logChannelFactory.create( any() ) ).thenReturn( logChannel );
-    // Line below added to avoid `org.mockito.exceptions.misusing.UnnecessaryStubbingException` from being thrown
-    logChannelFactory.create( StringUtil.EMPTY_STRING );
-
     TransMeta transMeta = new TransMeta( getClass().getResource( "/ConsumeRows.ktr" ).getPath() );
     trans = new Trans( transMeta );
     trans.setVariable( "mqttServer", "127.0.0.1:1883" );

--- a/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTProducerTest.java
+++ b/plugins/streaming/impls/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTProducerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2018-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2018-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,21 +26,20 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
-import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
 import org.pentaho.di.core.plugins.StepPluginType;
+import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMetaDataCombi;
@@ -54,6 +53,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -62,6 +62,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith ( MockitoJUnitRunner.class )
 public class MQTTProducerTest {
+  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
   @Mock MqttClient mqttClient;
   @Mock LogChannelInterfaceFactory logChannelFactory;
   @Mock LogChannelInterface logChannel;
@@ -75,13 +76,13 @@ public class MQTTProducerTest {
       MQTTProducerMeta.class,
       MQTTProducerMeta.class.getAnnotation( Step.class ),
       Collections.emptyList(), false, null );
-    KettleEnvironment.init();
   }
 
   @Before
   public void setup() throws Exception {
     KettleLogStore.setLogChannelInterfaceFactory( logChannelFactory );
     when( logChannelFactory.create( any(), any() ) ).thenReturn( logChannel );
+    lenient().when( logChannelFactory.create( any() ) ).thenReturn( logChannel );
 
     TransMeta transMeta = new TransMeta( getClass().getResource( "/ProduceFourRows.ktr" ).getPath() );
     trans = new Trans( transMeta );


### PR DESCRIPTION
KettleLogStore.logChannelInterfaceFactory is a static variable that gets
replaced by a mock in many (but not all) unit tests, which, if not
cleaned up after the test, can lead to problems in other tests running
concurrently or on the same fork.  Additionally, BeanInjectionInfo has a
static variable to hold its LogChannelInterface object, which can cause
problems depending on whether it's initialized by a normal factory or a
mock.