### PR TITLE
[PDI-19578] Introduce property KETTLE_USE_META_FILE_CACHE (default N) to

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1609,6 +1609,14 @@ public class Const {
   public static final String KETTLE_AUTO_UPDATE_SITE_FILE = "KETTLE_AUTO_UPDATE_SITE_FILE";
 
   /**
+   * If true, use a cache when loading Trans/Job/Step metas vs reading from file system/repository for each load.
+   * Note: cache is currently broken; variable spaces do not get replaced upon loads of the same meta, so parameters
+   * that have changed do not get updated.  This should be off by default.
+   */
+  public static final String KETTLE_USE_META_FILE_CACHE = "KETTLE_USE_META_FILE_CACHE";
+  public static final String KETTLE_USE_META_FILE_CACHE_DEFAULT = "N";
+
+  /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer
    * overflow while rounding
    *

--- a/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
+++ b/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
@@ -326,7 +326,7 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
   }
 
   private T attemptCacheRead( String realFilename ) {
-    if ( metaFileCache == null ) {
+    if ( "N".equalsIgnoreCase( System.getProperty( Const.KETTLE_USE_META_FILE_CACHE, Const.KETTLE_USE_META_FILE_CACHE_DEFAULT ) ) || metaFileCache == null ) {
       return null;
     }
     return isTransMeta()

--- a/engine/src/test/java/org/pentaho/di/base/MetaFileLoaderImplTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/MetaFileLoaderImplTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,10 +21,12 @@
  ******************************************************************************/
 package org.pentaho.di.base;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.util.CurrentDirectoryResolver;
@@ -46,7 +48,7 @@ import org.pentaho.metastore.api.IMetaStore;
 
 import java.io.File;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -69,10 +71,17 @@ public class MetaFileLoaderImplTest {
   private BaseStepMeta baseStepMeta;
   private ObjectLocationSpecificationMethod specificationMethod;
   private String keyPath; //The absolute path used as part of the cachekey
+  private String oldSystemParam;
 
   @Before
   public void setUp() throws Exception {
+    oldSystemParam = System.getProperty( Const.KETTLE_USE_META_FILE_CACHE );
+    System.setProperty( Const.KETTLE_USE_META_FILE_CACHE, "Y" );
+  }
 
+  @After
+  public void tearDown() {
+    System.setProperty( Const.KETTLE_USE_META_FILE_CACHE, null == oldSystemParam ? "" : oldSystemParam );
   }
 
   @Test


### PR DESCRIPTION
control whether trans/job/step metas are cached when being loaded
multiple times over the life of a parent trans/job.  Cache is currently
broken; variable space is not updated even if a parent parameter value
has changed, resulting in undesired behavior.