### PR TITLE
[BACKLOG-36233] Moved the metaverse analyzer and lifecycle listener

### DIFF
--- a/plugins/meta-inject/impl/pom.xml
+++ b/plugins/meta-inject/impl/pom.xml
@@ -18,37 +18,44 @@
     <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.3</powermock.version>
+    <platform.version>9.4.0.0-SNAPSHOT</platform.version>
   </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>pentaho-kettle</groupId>
-            <artifactId>kettle-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>pentaho-kettle</groupId>
-            <artifactId>kettle-engine</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.healthmarketscience.jackcess</groupId>
-            <artifactId>jackcess</artifactId>
-            <scope>compile</scope>
-        </dependency>
+      <dependency>
+          <groupId>pentaho-kettle</groupId>
+          <artifactId>kettle-core</artifactId>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>pentaho-kettle</groupId>
+          <artifactId>kettle-engine</artifactId>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>com.healthmarketscience.jackcess</groupId>
+          <artifactId>jackcess</artifactId>
+          <scope>compile</scope>
+      </dependency>
 
-        <dependency>
-            <groupId>pentaho-kettle</groupId>
-            <artifactId>kettle-ui-swt</artifactId>
-            <version>${pdi.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>pentaho</groupId>
-            <artifactId>pentaho-metaverse-api</artifactId>
-            <version>${pentaho-metaverse.version}</version>
-            <scope>provided</scope>
-        </dependency>
+      <dependency>
+          <groupId>pentaho-kettle</groupId>
+          <artifactId>kettle-ui-swt</artifactId>
+          <version>${pdi.version}</version>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>pentaho</groupId>
+          <artifactId>pentaho-metaverse-api</artifactId>
+          <version>${pentaho-metaverse.version}</version>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>pentaho</groupId>
+        <artifactId>pentaho-platform-core</artifactId>
+        <version>${platform.version}</version>
+        <scope>provided</scope>
+      </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>pentaho-kettle</groupId>

--- a/plugins/meta-inject/impl/src/main/java/org/pentaho/di/trans/steps/metainject/analyzer/MetaInjectAnalyzer.java
+++ b/plugins/meta-inject/impl/src/main/java/org/pentaho/di/trans/steps/metainject/analyzer/MetaInjectAnalyzer.java
@@ -20,7 +20,7 @@
  *
  ******************************************************************************/
 
-package org.pentaho.di.ui.trans.steps.metainject.analyzer;
+package org.pentaho.di.trans.steps.metainject.analyzer;
 
 import com.tinkerpop.blueprints.Vertex;
 import org.apache.commons.lang.StringUtils;

--- a/plugins/meta-inject/impl/src/main/java/org/pentaho/di/trans/steps/metainject/lifecycle/KettleMetaInjectPluginLifecycleListener.java
+++ b/plugins/meta-inject/impl/src/main/java/org/pentaho/di/trans/steps/metainject/lifecycle/KettleMetaInjectPluginLifecycleListener.java
@@ -18,13 +18,13 @@
  * limitations under the License.
  */
 
-package org.pentaho.di.ui.trans.steps.metainject.lifecycle;
+package org.pentaho.di.trans.steps.metainject.lifecycle;
 
 import org.pentaho.di.core.annotations.LifecyclePlugin;
 import org.pentaho.di.core.lifecycle.LifeEventHandler;
 import org.pentaho.di.core.lifecycle.LifecycleException;
 import org.pentaho.di.core.lifecycle.LifecycleListener;
-import org.pentaho.di.ui.trans.steps.metainject.analyzer.MetaInjectAnalyzer;
+import org.pentaho.di.trans.steps.metainject.analyzer.MetaInjectAnalyzer;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 
 /**

--- a/plugins/meta-inject/ui/pom.xml
+++ b/plugins/meta-inject/ui/pom.xml
@@ -14,7 +14,6 @@
 
   <properties>
     <jface.version>3.3.0-I20070606-0010</jface.version>
-    <blueprints-core.version>2.6.0</blueprints-core.version>
   </properties>
 
   <dependencies>
@@ -35,15 +34,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-metaverse-api</artifactId>
-      <version>${pentaho-metaverse.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>meta-inject-plugins-impl</artifactId>
-      <version>9.4.0.0-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
plugins to the same jar as the step meta class; keeping them separate
was causing classloading issues during metaverse execution.