### PR TITLE
[PDI-19160] - Set variables(job entry): When "Variable substitution" …

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
@@ -255,9 +255,12 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
 
       if ( variableName != null ) {
         for ( int i = 0; i < variableName.length; i++ ) {
-          variables.add( variableName[ i ] );
-          variableValues.add( variableValue[ i ] );
-          variableTypes.add( variableType[ i ] );
+          if ( ( variables.contains( variableName[ i ] ) && replaceVars ) || !variables.contains(
+            variableName[ i ] ) ) {
+            variables.add( variableName[ i ] );
+            variableValues.add( variableValue[ i ] );
+            variableTypes.add( variableType[ i ] );
+          }
         }
       }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
@@ -65,7 +65,7 @@ import org.w3c.dom.Node;
  * This defines a 'Set variables' job entry.
  *
  * @author Samatar Hassan
- * @since 06-05-2007
+ * @since 25-08-2022
  */
 public class JobEntrySetVariables extends JobEntryBase implements Cloneable, JobEntryInterface {
   private static Class<?> PKG = JobEntrySetVariables.class; // for i18n purposes, needed by Translator2!!


### PR DESCRIPTION
Code is added to respect Variable Substitution flag so that variables declared in the Set Variables step operated as below
1. Variable will be overridden if the same variable is available in the property file and Variable Substitution flag is true
2. Variable will not be overridden if the Variable Substitution flag is false
3. Variable will be added if the variable is not available in the property file and  Variable Substitution flag is true/false.
