### PR TITLE
PDI-19588 - Fix JAAS in Carte

### DIFF
--- a/engine/src/main/java/org/pentaho/di/www/WebServer.java
+++ b/engine/src/main/java/org/pentaho/di/www/WebServer.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.jaas.JAASLoginService;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.DefaultIdentityService;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.Connector;
@@ -72,7 +73,6 @@ import java.util.TimerTask;
 public class WebServer {
 
   private static final int DEFAULT_DETECTION_TIMER = 20000;
-  public static final String DEFAULT_ROLE = "default";
   public static final String SERVICE_NAME = "Kettle";
   private static Class<?> PKG = WebServer.class; // for i18n purposes, needed by Translator2!!
 
@@ -159,26 +159,28 @@ public class WebServer {
     server = new Server();
 
     List<String> roles = new ArrayList<>();
-    roles.add( Constraint.ANY_ROLE );
+    roles.add( Constraint.ANY_AUTH );
 
     // Set up the security handler, optionally with JAAS
     //
     ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
-
+    
     if ( System.getProperty( "loginmodulename" ) != null
         && System.getProperty( "java.security.auth.login.config" ) != null ) {
       JAASLoginService jaasLoginService = new JAASLoginService( SERVICE_NAME );
       jaasLoginService.setLoginModuleName( System.getProperty( "loginmodulename" ) );
+      if( jaasLoginService.getIdentityService() == null ) {
+        jaasLoginService.setIdentityService( new DefaultIdentityService() );
+      }
       securityHandler.setLoginService( jaasLoginService );
     } else {
-      roles.add( DEFAULT_ROLE );
       HashLoginService hashLoginService;
       SlaveServer slaveServer = transformationMap.getSlaveServerConfig().getSlaveServer();
       if ( !Utils.isEmpty( slaveServer.getPassword() ) ) {
         hashLoginService = new HashLoginService( SERVICE_NAME );
         UserStore userStore = new UserStore();
         userStore.addUser( slaveServer.getUsername(), new Password( slaveServer.getPassword() ),
-          new String[] { DEFAULT_ROLE } );
+          new String[] { } );
         hashLoginService.setUserStore( userStore );
       } else {
         // See if there is a kettle.pwd file in the KETTLE_HOME directory:
@@ -194,12 +196,11 @@ public class WebServer {
           @Override
           protected String[] loadRoleInfo( UserPrincipal user ) {
             List<String> newRoles = new ArrayList<>();
-            newRoles.add( DEFAULT_ROLE );
             String[] roles = super.loadRoleInfo( user );
             if ( null != roles ) {
               Collections.addAll( newRoles, roles );
             }
-            return newRoles.toArray( new String[ 0 ] );
+            return newRoles.toArray( new String[ newRoles.size() ] );
           }
         };
       }
@@ -208,7 +209,7 @@ public class WebServer {
 
     Constraint constraint = new Constraint();
     constraint.setName( Constraint.__BASIC_AUTH );
-    constraint.setRoles( roles.toArray( new String[ 0 ] ) );
+    constraint.setRoles( roles.toArray( new String[ roles.size() ] ) );
     constraint.setAuthenticate( true );
 
     ConstraintMapping constraintMapping = new ConstraintMapping();
@@ -217,6 +218,7 @@ public class WebServer {
 
     securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );
 
+    
     // Add all the servlets defined in kettle-servlets.xml ...
     //
     ContextHandlerCollection contexts = new ContextHandlerCollection();


### PR DESCRIPTION
This changed the basic carte constraint mapping to ANY_AUTH, which allows any authorized user to access any part of Carte (removing the default role and ANY_ROLE combination). Jetty processes ANY_ROLE before ANY_AUTH during init, and ignores ANY_AUTH. Also, had to assign a DefaultIdentityService, because without it, the authenticator of the IdentityService was not initialized and skipped, resulting in 403 forbidden responses whenever JAAS was used.