### PR TITLE
PDI-19160-Set_variables(job_entry)_When_Variable_substitution_is_N,_the_value_of_the_externally_set_variable_is_replaced

### DIFF
--- a/assemblies/plugins/pom.xml
+++ b/assemblies/plugins/pom.xml
@@ -67,6 +67,7 @@
     <pdi-avro-format-plugin.version>${project.version}</pdi-avro-format-plugin.version>
     <pentaho-metaverse.version>9.4.0.0-SNAPSHOT</pentaho-metaverse.version>
     <pdi-xml-plugin.version>9.4.0.0-SNAPSHOT</pdi-xml-plugin.version>
+    <pdi-json-plugin.version>9.4.0.0-SNAPSHOT</pdi-json-plugin.version>
   </properties>
 
   <dependencies>
@@ -694,6 +695,18 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho.di.plugins</groupId>
+      <artifactId>kettle-json-plugin</artifactId>
+      <version>${pdi-json-plugin.version}</version>
+      <type>zip</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>
@@ -703,26 +716,11 @@
           <name>!no-osgi</name>
         </property>
       </activation>
-      <properties>
-        <pdi-json-plugin.version>9.4.0.0-SNAPSHOT</pdi-json-plugin.version>
-      </properties>
       <dependencies>
         <dependency>
           <groupId>pentaho</groupId>
           <artifactId>pentaho-big-data-plugin</artifactId>
           <version>${big-data-plugin.version}</version>
-          <type>zip</type>
-          <exclusions>
-            <exclusion>
-              <groupId>*</groupId>
-              <artifactId>*</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>org.pentaho.di.plugins</groupId>
-          <artifactId>kettle-json-plugin</artifactId>
-          <version>${pdi-json-plugin.version}</version>
           <type>zip</type>
           <exclusions>
             <exclusion>

--- a/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -255,9 +255,12 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
 
       if ( variableName != null ) {
         for ( int i = 0; i < variableName.length; i++ ) {
-          variables.add( variableName[ i ] );
-          variableValues.add( variableValue[ i ] );
-          variableTypes.add( variableType[ i ] );
+          if ( ( variables.contains( variableName[ i ] ) && replaceVars ) || !variables.contains(
+            variableName[ i ] ) ) {
+            variables.add( variableName[ i ] );
+            variableValues.add( variableValue[ i ] );
+            variableTypes.add( variableType[ i ] );
+          }
         }
       }
 


### PR DESCRIPTION
Code is added to respect Variable Substitution flag so that variables declared in the Set Variables step operated as below

Variable will be overridden if the same variable is available in the property file and Variable Substitution flag is true
Variable will not be overridden if the Variable Substitution flag is false
Variable will be added if the variable is not available in the property file and Variable Substitution flag is true/false.