### PR TITLE
[BACKLOG-36213] Pom cleanup; properties for Pentaho dependencies cannot

### DIFF
--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -16,10 +16,10 @@
 
   <properties>
     <pdi-dataservice-driver-bundle.version>${project.version}</pdi-dataservice-driver-bundle.version>
-    <ael.version>9.4.0.0-SNAPSHOT</ael.version>
 
     <pentaho-launcher.version>9.4.0.0-SNAPSHOT</pentaho-launcher.version>
     <oss-licenses.version>9.4.0.0-SNAPSHOT</oss-licenses.version>
+    <pentaho-karaf.version>9.4.0.0-SNAPSHOT</pentaho-karaf.version>
 
     <!-- swt -->
     <org.eclipse.swt.gtk.linux.x86.version>3.108.0</org.eclipse.swt.gtk.linux.x86.version>
@@ -115,9 +115,6 @@
           <name>!no-osgi</name>
         </property>
       </activation>
-      <properties>
-        <pentaho-karaf.version>9.4.0.0-SNAPSHOT</pentaho-karaf.version>
-      </properties>
       <dependencies>
         <dependency>
           <groupId>org.pentaho.di</groupId>

--- a/assemblies/core/client/pom.xml
+++ b/assemblies/core/client/pom.xml
@@ -17,10 +17,10 @@
 
     <properties>
         <pdi-dataservice-driver-bundle.version>${project.version}</pdi-dataservice-driver-bundle.version>
-        <ael.version>9.4.0.0-SNAPSHOT</ael.version>
 
         <pentaho-launcher.version>9.4.0.0-SNAPSHOT</pentaho-launcher.version>
         <oss-licenses.version>9.4.0.0-SNAPSHOT</oss-licenses.version>
+        <pentaho-karaf.version>9.4.0.0-SNAPSHOT</pentaho-karaf.version>
 
         <!-- swt -->
         <org.eclipse.swt.gtk.linux.x86.version>3.108.0</org.eclipse.swt.gtk.linux.x86.version>
@@ -109,9 +109,6 @@
                     <name>!no-osgi</name>
                 </property>
             </activation>
-            <properties>
-                <pentaho-karaf.version>9.4.0.0-SNAPSHOT</pentaho-karaf.version>
-            </properties>
             <dependencies>
                 <!-- PDI Assemblies -->
                 <dependency>

--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -26,6 +26,8 @@
         <pentaho-metaverse.version>9.4.0.0-SNAPSHOT</pentaho-metaverse.version>
         <platform.version>9.4.0.0-SNAPSHOT</platform.version>
         <pentaho-reporting.version>9.4.0.0-SNAPSHOT</pentaho-reporting.version>
+        <pdi-osgi-bridge.version>9.4.0.0-SNAPSHOT</pdi-osgi-bridge.version>
+        <pentaho-hadoop-shims.version>9.4.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
 
         <!-- third party -->
         <derbyclient.version>10.2.1.6</derbyclient.version>
@@ -541,10 +543,6 @@
                     <name>!no-osgi</name>
                 </property>
             </activation>
-            <properties>
-                <pdi-osgi-bridge.version>9.4.0.0-SNAPSHOT</pdi-osgi-bridge.version>
-                <pentaho-hadoop-shims.version>9.4.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>pentaho</groupId>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -27,6 +27,8 @@
     <pentaho-metaverse.version>9.4.0.0-SNAPSHOT</pentaho-metaverse.version>
     <platform.version>9.4.0.0-SNAPSHOT</platform.version>
     <pentaho-reporting.version>9.4.0.0-SNAPSHOT</pentaho-reporting.version>
+    <pdi-osgi-bridge.version>9.4.0.0-SNAPSHOT</pdi-osgi-bridge.version>
+    <pentaho-hadoop-shims.version>9.4.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
 
     <!-- third party -->
     <derbyclient.version>10.2.1.6</derbyclient.version>
@@ -646,6 +648,7 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
+      <version>${osgi.core.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -664,10 +667,6 @@
           <name>!no-osgi</name>
         </property>
       </activation>
-      <properties>
-        <pdi-osgi-bridge.version>9.4.0.0-SNAPSHOT</pdi-osgi-bridge.version>
-        <pentaho-hadoop-shims.version>9.4.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
-      </properties>
       <dependencies>
         <dependency>
           <groupId>pentaho</groupId>


### PR DESCRIPTION
be declared inside profiles; they must be in the main pom file.