### PR TITLE
[PDI-19160]-Set variables(job entry): When "Variable substitution" is N, the value of the externally set variable is replaced.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -255,9 +255,12 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
 
       if ( variableName != null ) {
         for ( int i = 0; i < variableName.length; i++ ) {
-          variables.add( variableName[ i ] );
-          variableValues.add( variableValue[ i ] );
-          variableTypes.add( variableType[ i ] );
+          if ( ( variables.contains( variableName[ i ] ) && replaceVars ) || !variables.contains(
+            variableName[ i ] ) ) {
+            variables.add( variableName[ i ] );
+            variableValues.add( variableValue[ i ] );
+            variableTypes.add( variableType[ i ] );
+          }
         }
       }
 

--- a/engine/src/test/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariablesTest.java
@@ -230,6 +230,19 @@ public class JobEntrySetVariablesTest {
     assertEquals( "someValue", entry.getVariable( "variableNotNull" ) );
   }
 
+  @Test
+  public void testJobEntrySetVariablesExecute_VARIABLE_TYPE_ROOT_JOB_VariableNotNull() throws Exception {
+    List<DatabaseMeta> databases = mock( List.class );
+    List<SlaveServer> slaveServers = mock( List.class );
+    Repository repository = mock( Repository.class );
+    IMetaStore metaStore = mock( IMetaStore.class );
+    entry.loadXML( getEntryNode( "variableNotNull", "someValue", "ROOT_JOB" ), databases, slaveServers, repository, metaStore );
+    assertNull( System.getProperty( "variableNotNull" )  );
+    entry.setVariableName( new String[]{"TEST1"} );
+    Result result = entry.execute( new Result(), 0 );
+    assertTrue( "Result should be true", result.getResult() );
+  }
+
   //prepare xml for use
   public Node getEntryNode( String variable_name, String variable_value, String variable_type )
     throws ParserConfigurationException, SAXException, IOException {


### PR DESCRIPTION
Code is added to respect Variable Substitution flag so that variables declared in the Set Variables step operated as below

Variable will be overridden if the same variable is available in the property file and Variable Substitution flag is true
Variable will not be overridden if the Variable Substitution flag is false
Variable will be added if the variable is not available in the property file and Variable Substitution flag is true/false.