### PR TITLE
[BACKLOG-35995] Need to expose the ProviderService outside of this

### DIFF
--- a/plugins/file-open-save-new/api/src/main/java/org/pentaho/di/plugins/fileopensave/api/providers/exception/ProviderServiceInterface.java
+++ b/plugins/file-open-save-new/api/src/main/java/org/pentaho/di/plugins/fileopensave/api/providers/exception/ProviderServiceInterface.java
@@ -1,0 +1,31 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2022 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.plugins.fileopensave.api.providers.exception;
+
+import org.pentaho.di.plugins.fileopensave.api.providers.File;
+import org.pentaho.di.plugins.fileopensave.api.providers.FileProvider;
+
+public interface ProviderServiceInterface<T extends File> {
+
+  void addProviderService( FileProvider<T> fileProvider );
+}

--- a/plugins/file-open-save-new/core/pom.xml
+++ b/plugins/file-open-save-new/core/pom.xml
@@ -41,13 +41,6 @@
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-engine</artifactId>
     </dependency>
-    <!--
-    <dependency>
-        <groupId>pentaho</groupId>
-        <artifactId>pentaho-metastore-locator-api</artifactId>
-        <version>${pdi.version}</version>
-    </dependency>
-     -->
     <dependency>
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>file-open-save-new-api</artifactId>

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
@@ -197,7 +197,7 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
   private FlatButton flatBtnUp;
 
   static {
-    FILE_CONTROLLER = new FileController( FileCacheService.INSTANCE.get(), ProviderServiceService.INSTANCE.get() );
+    FILE_CONTROLLER = new FileController( FileCacheService.INSTANCE.get(), ProviderServiceService.get() );
   }
 
   public FileOpenSaveDialog( Shell parentShell, int width, int height, LogChannelInterface logger ) {
@@ -653,7 +653,7 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
     if ( !treeViewerSelection.isEmpty() ) {
       if ( treeViewerSelection.getFirstElement() instanceof Tree ) {
         try {
-          fileProvider = ProviderServiceService.INSTANCE.get().get( ( (Tree) treeViewerSelection.getFirstElement() )
+          fileProvider = ProviderServiceService.get().get( ( (Tree) treeViewerSelection.getFirstElement() )
             .getProvider() );
         } catch ( Exception ex ) {
           log.logDebug( "Unable to find provider" );
@@ -664,8 +664,7 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
         treeViewer.collapseAll();
       } else {
         try {
-          fileProvider =
-            ProviderServiceService.INSTANCE.get().get( ( (File) treeViewerSelection.getFirstElement() ).getProvider() );
+          fileProvider = ProviderServiceService.get().get( ( (File) treeViewerSelection.getFirstElement() ).getProvider() );
         } catch ( Exception ex ) {
           log.logDebug( "Unable to find provider" );
         }
@@ -684,7 +683,7 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
       treeViewer.setSelection( treeViewerSelection, true );
     } else if ( treeViewerSelection.isEmpty() && fileTableViewerSelection.isEmpty() ) {
       try {
-        fileProvider = ProviderServiceService.INSTANCE.get().get( fileDialogOperation.getProvider() );
+        fileProvider = ProviderServiceService.get().get( fileDialogOperation.getProvider() );
         fileProvider.clearProviderCache();
         treeViewer.setInput( FILE_CONTROLLER.load( ProviderFilterType.ALL_PROVIDERS.toString() ).toArray() );
         treeViewer.refresh( true );
@@ -1002,10 +1001,10 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
       }
 
       if ( selection instanceof Directory ) {
-        fileProvider = ProviderServiceService.INSTANCE.get().get( ( (Directory) selection ).getProvider() );
+        fileProvider = ProviderServiceService.get().get( ( (Directory) selection ).getProvider() );
         parentPathOfSelection = ( (Directory) selection ).getPath();
       } else if ( selection instanceof File ) {
-        fileProvider = ProviderServiceService.INSTANCE.get().get( ( (File) selection ).getProvider() );
+        fileProvider = ProviderServiceService.get().get( ( (File) selection ).getProvider() );
         parentPathOfSelection = Paths.get( ( (File) selection ).getParent() ).getParent().toString();
       }
 

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/extension/FileOpenSaveExtensionPoint.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/extension/FileOpenSaveExtensionPoint.java
@@ -59,7 +59,7 @@ public class FileOpenSaveExtensionPoint implements ExtensionPointInterface {
   private final ProviderService providerService;
 
   public FileOpenSaveExtensionPoint() {
-    this( ProviderServiceService.INSTANCE.get() );
+    this( ProviderServiceService.get() );
   }
 
   public FileOpenSaveExtensionPoint( ProviderService providerService ) {

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/ProviderService.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/ProviderService.java
@@ -46,4 +46,11 @@ public class ProviderService {
     return fileProviders;
   }
 
+  public void add( FileProvider fileProvider ) {
+    // only one provider for a given name and type
+    fileProviders.removeIf( p -> p.getType().equalsIgnoreCase( fileProvider.getType() )
+      && ( p.getName() == null || p.getName().equalsIgnoreCase( fileProvider.getName() ) ) );
+    fileProviders.add( fileProvider );
+  }
+
 }

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/service/ProviderServiceService.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/service/ProviderServiceService.java
@@ -1,44 +1,89 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2022 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.di.plugins.fileopensave.service;
 
-import java.util.Arrays;
-
 import org.pentaho.di.connections.ConnectionManager;
+import org.pentaho.di.core.service.ServiceProvider;
+import org.pentaho.di.core.service.ServiceProviderInterface;
 import org.pentaho.di.metastore.MetaStoreConst;
+import org.pentaho.di.plugins.fileopensave.api.providers.FileProvider;
+import org.pentaho.di.plugins.fileopensave.api.providers.exception.ProviderServiceInterface;
 import org.pentaho.di.plugins.fileopensave.providers.ProviderService;
 import org.pentaho.di.plugins.fileopensave.providers.local.LocalFileProvider;
 import org.pentaho.di.plugins.fileopensave.providers.recents.RecentFileProvider;
 import org.pentaho.di.plugins.fileopensave.providers.repository.RepositoryFileProvider;
 import org.pentaho.di.plugins.fileopensave.providers.vfs.VFSFileProvider;
 
-public enum ProviderServiceService {
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-    INSTANCE;
+@ServiceProvider( id = "ProviderServiceService", description = "Allows external file providers to register themselves and access to providers", provides = ProviderServiceInterface.class )
+public class ProviderServiceService implements ProviderServiceInterface, ServiceProviderInterface<ProviderServiceInterface> {
 
-    private ProviderService providerService;
+  private static ProviderService providerService;
 
-    private ProviderServiceService() {
+  public ProviderServiceService() {
+    initProviderService();
+  }
 
-        LocalFileProvider localProvider = new LocalFileProvider();
-        RepositoryFileProvider repoProvider = new RepositoryFileProvider();
-        RecentFileProvider recentProvider = new RecentFileProvider();
-        VFSFileProvider vfsProvider = new VFSFileProvider();
-
-        ConnectionManager.getInstance().setMetastoreSupplier( () -> {
-
-            try {
-                return MetaStoreConst.openLocalPentahoMetaStore();
-            } catch ( Exception e ) {
-                // Error getting metastore
-                throw new RuntimeException( e );
-            }
-        } );
-
-        this.providerService = new ProviderService( Arrays.asList( recentProvider, localProvider, repoProvider, vfsProvider ) );
-
+  private static void initProviderService() {
+    if ( null != providerService ) {
+      return;
     }
+    LocalFileProvider localProvider = new LocalFileProvider();
+    RepositoryFileProvider repoProvider = new RepositoryFileProvider();
+    RecentFileProvider recentProvider = new RecentFileProvider();
+    VFSFileProvider vfsProvider = new VFSFileProvider();
 
-    public ProviderService get() {
-        return providerService;
-    }
+    ConnectionManager.getInstance().setMetastoreSupplier( () -> {
 
+      try {
+        return MetaStoreConst.openLocalPentahoMetaStore();
+      } catch ( Exception e ) {
+        // Error getting metastore
+        throw new RuntimeException( e );
+      }
+    } );
+
+    List<FileProvider> fileProviders = new ArrayList<>();
+    fileProviders.addAll( Arrays.asList( recentProvider, localProvider, repoProvider, vfsProvider ) );
+    providerService =
+      new ProviderService( fileProviders );
+  }
+
+  public static ProviderService get() {
+    initProviderService();
+    return providerService;
+  }
+
+  @Override public void addProviderService( FileProvider fileProvider ) {
+    initProviderService();
+    providerService.add( fileProvider );
+  }
+
+  @Override
+  public boolean isSingleton() {
+    return true;
+  }
 }


### PR DESCRIPTION
plugin to allow file system providers to register themselves.  Updated
the ProviderServiceService to register itself with the
PluginServiceLoader. ProviderService will only allow one provider with a
given name/type pair to exist, in case a karaf bundle restarts and
re-registers itself.