### PR TITLE
[BACKLOG-36255][BACKLOG-36309][BACKLOG-36304]

### DIFF
--- a/plugins/connections/ui/src/main/java/org/pentaho/di/vfs/connections/ui/dialog/ConnectionDialog.java
+++ b/plugins/connections/ui/src/main/java/org/pentaho/di/vfs/connections/ui/dialog/ConnectionDialog.java
@@ -288,13 +288,13 @@ public class ConnectionDialog extends Dialog {
       vfsDetailsComposite = (VFSDetailsComposite) connectionDetails.openDialog( wDetailsWrapperComp, props );
     }
 
-    wConnectionTypeComp.layout();
-
-    wDetailsWrapperComp.pack();
-    wScrolledComposite.setMinSize( wDetailsWrapperComp.computeSize( SWT.DEFAULT, SWT.DEFAULT ) );
-    wScrolledComposite.setContent( wDetailsWrapperComp );
-    wScrolledComposite.setExpandHorizontal( true );
+    wScrolledComposite.setExpandHorizontal( false );
     wScrolledComposite.setExpandVertical( true );
+    wScrolledComposite.setContent( wDetailsWrapperComp );
+    wDetailsWrapperComp.pack();
+    wScrolledComposite.setMinSize(
+      wDetailsWrapperComp.computeSize( wConnectionTypeComp.getClientArea().width, SWT.DEFAULT ) );
+    wConnectionTypeComp.layout();
   }
 
   private void transferFieldsFromOldToNew( ConnectionDetails connectionDetails,
@@ -393,6 +393,11 @@ public class ConnectionDialog extends Dialog {
     }
     if ( isEmpty( connectionDetails.getName() ) ) {
       return BaseMessages.getString( PKG, "ConnectionDialog.validate.failure.noName" );
+    }
+    ConnectionDetails attemptReadDetails = connectionManager.getConnectionDetails( connectionDetails.getName() );
+    if ( attemptReadDetails != null && attemptReadDetails.getType() != connectionDetails.getType() ) {
+      return BaseMessages.getString( PKG, "ConnectionDialog.validate.failure.sameNameOnDifferentType",
+        connectionDetails.getName(), convertKeyToTypeLabel( attemptReadDetails.getType() ) );
     }
     return vfsDetailsComposite.validate();
   }

--- a/plugins/connections/ui/src/main/resources/org/pentaho/di/vfs/connections/ui/dialog/messages/messages_en_US.properties
+++ b/plugins/connections/ui/src/main/resources/org/pentaho/di/vfs/connections/ui/dialog/messages/messages_en_US.properties
@@ -17,4 +17,4 @@ ConnectionDialog.validate.failure.noName=You must give the connection a name to 
 ConnectionDialog.validate.failure.noDetailsObjectPresent=No Detail Object Present.
 ConnectionDialog.test.success=Connection was successfully established.
 ConnectionDialog.test.failure=Failed to establish a successfull connection.
-
+ConnectionDialog.validate.failure.sameNameOnDifferentType=Connection Name \"{0}\" is invalid.  It already exists under as a {1}.

--- a/ui/src/main/java/org/pentaho/di/core/vfs/connections/ui/dialog/VFSDetailsCompositeHelper.java
+++ b/ui/src/main/java/org/pentaho/di/core/vfs/connections/ui/dialog/VFSDetailsCompositeHelper.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.widgets.Composite;
@@ -163,7 +164,8 @@ public class VFSDetailsCompositeHelper {
     return passwordTextVar;
   }
 
-  public PasswordVisibleTextVar createPasswordVisibleTextVar( VariableSpace variableSpace, Composite composite, int flags,
+  public PasswordVisibleTextVar createPasswordVisibleTextVar( VariableSpace variableSpace, Composite composite,
+                                                              int flags,
                                                               Control topWidget, int width ) {
     PasswordVisibleTextVar PasswordVisibleTextVar = new PasswordVisibleTextVar( variableSpace, composite, flags );
     getProps().setLook( PasswordVisibleTextVar );
@@ -180,8 +182,9 @@ public class VFSDetailsCompositeHelper {
 
   /**
    * This method places a centered title at the top of the composite recieved
-   * @param composite The composite holding the details
-   * @param key The key to the message file
+   *
+   * @param composite    The composite holding the details
+   * @param key          The key to the message file
    * @param skipControls Controls that should not be lined up along a vertical column
    * @return
    */
@@ -224,11 +227,29 @@ public class VFSDetailsCompositeHelper {
       formData.top = new FormAttachment( topWidget, margin * 2 ); //Following Items
     }
     if ( width == 0 ) {
-      formData.right = new FormAttachment( 100, -margin ); //Fill
+      formData.right = new FormAttachment( 100, -margin - 9 ); //Fill but make sure scrollbar won't overlap hence subtracting 9 pixels
     }
     formData.left = new FormAttachment( 0, 0 );
     return formData;
   }
-  
+
+  /**
+   * Sets the Size of the Detail Composite to the track the Parent ScrolledComposites size.
+   *
+   * @param wComposite The DetailComposite
+   */
+  public static void setupCompositeResizeListener( Composite wComposite ) {
+    wComposite.getParent().addListener( SWT.Resize, arg0 -> {
+      updateScrollableRegion( wComposite );
+    } );
+  }
+
+  public static void updateScrollableRegion( Composite wComposite ) {
+    Rectangle r = wComposite.getParent().getClientArea();
+    if ( r.width != 0 ) {
+      wComposite.setSize( r.width, SWT.DEFAULT );
+    }
+  }
+
 }
 


### PR DESCRIPTION
- Fix widget expansion off screen when text is long
- Fix Variable assignment in S3 region combo box.  It was not saving the variable.
- Check if a same name connection exists in another type before saving and disallow if it does.