### PR TITLE
[BACKLOG-36427]- PDI File open dialog, right click menu on File/Folder pane misses Cut Option

### DIFF
--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
@@ -192,6 +192,7 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
   protected Set<File> selectedItems = new HashSet<>();
 
   protected String pasteAction = null;
+  protected boolean isCutActionSelected = false;
   protected boolean isApplyToAll = false;
 
 
@@ -1190,26 +1191,64 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
       }
     };
     pasteItem.addSelectionListener( pasteAdapter );
-    fileTableViewer.getTable().setMenu( fileTableMenu );
+
+    MenuItem cutItem = new MenuItem( fileTableMenu, SWT.NONE );
+    cutItem.setText( "Cut" );
+
+    SelectionAdapter cutAdapter = new SelectionAdapter() {
+      @Override
+      public void widgetSelected( SelectionEvent e ) {
+        performCut( e );
+      }
+    };
+    cutItem.addSelectionListener( cutAdapter );
+
+    MenuItem deleteItem = new MenuItem( fileTableMenu, SWT.NONE );
+    deleteItem.setText( "Delete" );
+
+    SelectionAdapter deleteAdapter = new SelectionAdapter() {
+      @Override
+      public void widgetSelected( SelectionEvent e ) {
+        performDelete( e );
+      }
+    };
+    deleteItem.addSelectionListener( deleteAdapter );
+
+    if ( Spoon.getInstance().rep == null ) {
+      fileTableViewer.getTable().setMenu( fileTableMenu );
+    }
+
     fileTableViewer.getTable().addMenuDetectListener( new MenuDetectListener() {
       @Override
       public void menuDetected( MenuDetectEvent e ) {
         pasteItem.setEnabled( false );
         copyItem.setEnabled( false );
+        cutItem.setEnabled( false );
+        deleteItem.setEnabled( false );
         int selectionIndices[] = fileTableViewer.getTable().getSelectionIndices();
         if ( selectionIndices.length > 0 ) {
           copyItem.setEnabled( true );
+          cutItem.setEnabled( true );
+          deleteItem.setEnabled( true );
         }
         if ( selectedItems.size() > 0 ) {
           if ( selectionIndices.length == 0 ) {
-            pasteItem.setEnabled( true );
+            IStructuredSelection treeViewerSelection = (IStructuredSelection) treeViewer.getSelection();
+            File destFolder = (File) treeViewerSelection.getFirstElement();
+            if ( !StringUtils.equalsIgnoreCase( destFolder.getName(),
+              selectedItems.stream().findFirst().get().getName() ) ) {
+              pasteItem.setEnabled( true );
+            }
           } else if ( StringUtils.equalsIgnoreCase(
             fileTableViewer.getTable().getItem( selectionIndices[ 0 ] ).getText( 1 ), "Folder" ) ) {
-            pasteItem.setEnabled( true );
+            if ( !StringUtils.equalsIgnoreCase(
+              fileTableViewer.getTable().getItem( selectionIndices[ 0 ] ).getText( 0 ),
+              selectedItems.stream().findFirst().get().getName() ) ) {
+              pasteItem.setEnabled( true );
+            }
           }
         }
       }
-
     } );
 
     // Mouse Listner added to capture an event when the user click on empty space on Dialogue which deselects the file/folder
@@ -1347,43 +1386,81 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
     return browser;
   }
 
+  private void performDelete( SelectionEvent e ) {
+    selectedItems.clear();
+    for ( int index : fileTableViewer.getTable().getSelectionIndices() ) {
+      File file = (File) fileTableViewer.getTable().getItem( index ).getData();
+      selectedItems.add( file );
+    }
+    FILE_CONTROLLER.delete( new ArrayList<File>( selectedItems ) );
+    refreshDisplay( e );
+
+  }
+
+  private void performCut( SelectionEvent e ) {
+    selectedItems.clear();
+    for ( int index : fileTableViewer.getTable().getSelectionIndices() ) {
+      File file = (File) fileTableViewer.getTable().getItem( index ).getData();
+      fileTableViewer.getTable().getItem( index ).setGrayed( true );
+      selectedItems.add( file );
+      isCutActionSelected = true;
+    }
+  }
+
   private void performPaste() {
     selectedItems.forEach( ( file ) -> {
       Result result; //TODO: Use this result to propagate status of paste of each item.
       File destFolder;
       StructuredSelection fileTableViewerSelection = (StructuredSelection) ( fileTableViewer.getSelection() );
       IStructuredSelection treeViewerSelection = (IStructuredSelection) treeViewer.getSelection();
+      boolean deleteCutFileFlag = true;
       if ( fileTableViewerSelection.isEmpty() ) {
         destFolder = (File) treeViewerSelection.getFirstElement();
       } else {
         destFolder = (File) fileTableViewerSelection.getFirstElement();
       }
       String newFilePath = getNewFilePath( file.getName(), destFolder );
+
       if ( FILE_CONTROLLER.fileExists( destFolder, newFilePath ) == Boolean.TRUE ) {
-        if ( !isApplyToAll ) {
-          createPasteWarningDialog( file.getName() );
-        }
-        switch ( pasteAction ) {
-          case PASTE_ACTION_REPLACE:
-            copyFile( file, destFolder, newFilePath, true );
-            break;
-          case PASTE_ACTION_KEEP_BOTH:
-            if ( StringUtils.isNotEmpty( newFilePath ) ) {
-              result = FILE_CONTROLLER.getNewName( destFolder, newFilePath );
-              if ( result.getStatus() == Result.Status.SUCCESS ) {
-                FILE_CONTROLLER.copyFile( file, destFolder, (String) result.getData(), false );
+        if ( !isCutActionSelected ) {
+          if ( !isApplyToAll ) {
+            createPasteWarningDialog( file.getName() );
+          }
+          switch ( pasteAction ) {
+            case PASTE_ACTION_REPLACE:
+              copyFile( file, destFolder, newFilePath, true );
+              break;
+            case PASTE_ACTION_KEEP_BOTH:
+              if ( StringUtils.isNotEmpty( newFilePath ) ) {
+                result = FILE_CONTROLLER.getNewName( destFolder, newFilePath );
+                if ( result.getStatus() == Result.Status.SUCCESS ) {
+                  FILE_CONTROLLER.copyFile( file, destFolder, (String) result.getData(), false );
+                }
               }
-            }
-            break;
-          case PASTE_ACTION_SKIP:
-          default:
-            log.logBasic( file.getName() + " is skipped" );
+              break;
+            case PASTE_ACTION_SKIP:
+            default:
+              log.logBasic( file.getName() + " is skipped" );
+          }
+        } else {
+          if ( file.getParent() == destFolder.getPath() ) {
+            deleteCutFileFlag = false;
+          }
         }
+
       } else {
         result = copyFile( file, destFolder, newFilePath, false );
       }
+
+      if ( isCutActionSelected && deleteCutFileFlag ) {
+        List<File> cutFiles = new ArrayList<File>();
+        cutFiles.add( file );
+        FILE_CONTROLLER.delete( cutFiles );
+      }
     } );
+
     pasteAction = null;
+    isCutActionSelected = false;
     isApplyToAll = false;
     selectedItems.clear();
   }

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/local/LocalFileProvider.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/local/LocalFileProvider.java
@@ -168,13 +168,30 @@ public class LocalFileProvider extends BaseFileProvider<LocalFile> {
     List<LocalFile> deletedFiles = new ArrayList<>();
     for ( LocalFile file : files ) {
       try {
-        Files.delete( Paths.get( file.getPath() ) );
+        // Changed deletion logic to java.io.File as java.nio.file.Files will delete only empty folders
+        File indexFile = new File( file.getPath() );
+        if ( indexFile.isDirectory() ) {
+          deleteFolder( indexFile );
+        } else {
+          indexFile.delete();
+        }
         deletedFiles.add( file );
-      } catch ( IOException ignored ) {
+      } catch ( Exception ignored ) {
         // Don't add file to deleted array
       }
     }
     return deletedFiles;
+  }
+
+  public void deleteFolder( File file ) {
+    for ( File subFile : file.listFiles() ) {
+      if ( subFile.isDirectory() ) {
+        deleteFolder( subFile );
+      } else {
+        subFile.delete();
+      }
+    }
+    file.delete();
   }
 
   /**


### PR DESCRIPTION
It covers below fixes
[BACKLOG-36415](https://jira.pentaho.com/browse/BACKLOG-36415) - Copy and Paste a folder in the Open/Select File or Folder window resulting infinite subfolder with its contents
[BACKLOG-36427](https://jira.pentaho.com/browse/BACKLOG-36427) - PDI File open dialog, right click menu on File/Folder pane misses Cut Option
Disabling right click menu when connected to a repository(Similar to 9.3)
[BACKLOG-36412](https://jira.pentaho.com/browse/BACKLOG-36412) - PDI File open dialog, right click menu on File/Folder pane misses Delete Option