### PR TITLE
addShutdownHook to stop the timer

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/logging/LoggingRegistry.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/LoggingRegistry.java
@@ -102,6 +102,15 @@ public class LoggingRegistry {
 
     updateFromProperties();
     installPurgeTimer();
+    Runtime.getRuntime().addShutdownHook( new Thread( new Runnable() {
+      @Override
+      public void run() {
+        if ( purgeTimer != null ) {
+          purgeTimer.cancel();
+          purgeTimer.purge();
+        }
+      }
+    } ) );
   }
 
   public static LoggingRegistry getInstance() {
@@ -470,7 +479,7 @@ public class LoggingRegistry {
       }
     }
   }
-
+  
   /**
    * Method that performs the cleanup the Registry on the PurgeTimerTasks.
    */


### PR DESCRIPTION
When used in a tomcat, at the stop it fails to turn off the Thread with the name `LoggingRegistryPurgeTimer`