### PR TITLE
[BACKLOG-36524] Determine the connection and file provider from the

### DIFF
--- a/plugins/file-open-save-new/core/pom.xml
+++ b/plugins/file-open-save-new/core/pom.xml
@@ -74,6 +74,12 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>
@@ -94,22 +100,10 @@
         <directory>src/main/resources</directory>
         <includes>
           <include>META-INF/**/*</include>
-          <!-- include>OSGI-INF/**/*</include -->
-          <!-- include>app/index.html</include -->
         </includes>
       </resource>
-      <!-- <resource> <directory>src/main/javascript</directory> <includes>
-          <include>**/*</include> </includes> </resource> -->
     </resources>
-    <!-- <plugins> <plugin> <artifactId>maven-remote-resources-plugin</artifactId>
-        <executions> <execution> <goals> <goal>bundle</goal> </goals> </execution>
-        </executions> <configuration> <includes> <include>**/*</include> </includes>
-        </configuration> </plugin> <plugin> <groupId>org.apache.felix</groupId> <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.4.0</version> <extensions>true</extensions> <configuration> <instructions>
-        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName> <Bundle-Version>${project.version}</Bundle-Version>
-        <Import-Package>org.apache.xerces.parsers, org.pentaho.di.osgi, *</Import-Package>
-        <Provide-Capability> org.pentaho.webpackage;root=/app </Provide-Capability>
-        </instructions> </configuration> </plugin> </plugins> -->
+
   </build>
   <repositories>
     <repository>

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
@@ -462,7 +462,10 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
     String targetPath = this.fileDialogOperation.getPath();
     if ( StringUtils.isNotEmpty( targetPath ) ) {
       // If the path is file, set the parent to be the target path
-      java.io.File filePath = new java.io.File(targetPath);
+      if ( targetPath.startsWith( "file:///" ) ) {
+        targetPath = targetPath.substring( 7 );
+      }
+      java.io.File filePath = new java.io.File( targetPath );
       if ( filePath.isFile() ) {
         targetPath = filePath.getParent();
       }
@@ -525,11 +528,11 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
                 if ( children.size() > 0 ) {
                   sortFileList( children );
                 }
-                targetPathArrayIndex++;
               } catch ( FileException e ) {
                 // Ignore
               }
             }
+            targetPathArrayIndex++;
           } while ( currentFile != null );
         }
       }


### PR DESCRIPTION
given path when using SelectionAdapterFileDialog and ensure that the FileOpenSaveDialog is able to open to the correct directory when they are specified in the FileDialogOperation.  Should work for VFS and cluster connections as well as local files.