### PR TITLE
Replace com.jcraft:jsch with com.github.mwiede:jsch

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,7 +29,7 @@
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-pool.version>1.5.7</commons-pool.version>
     <jug-lgpl.version>2.0.0</jug-lgpl.version>
-    <jsch.version>0.1.54</jsch.version>
+    <jsch.version>0.2.4</jsch.version>
     <jzlib.version>1.0.7</jzlib.version>
     <ognl.version>2.6.9</ognl.version>
     <scannotation.version>1.0.2</scannotation.version>
@@ -364,7 +364,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
       <version>${jsch.version}</version>
       <exclusions>
@@ -375,7 +375,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>com.github.mwiede</groupId>
       <artifactId>jzlib</artifactId>
       <version>${jzlib.version}</version>
       <scope>compile</scope>

--- a/plugins/google-analytics/core/pom.xml
+++ b/plugins/google-analytics/core/pom.xml
@@ -169,9 +169,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.1.54</version>
+      <version>0.2.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/plugins/json/core/pom.xml
+++ b/plugins/json/core/pom.xml
@@ -183,9 +183,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.1.54</version>
+      <version>0.2.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
JSch is no longer maintained (for 4 years now). A fork has been made some time ago with many security and functional improvements:
https://github.com/mwiede/jsch
https://www.matez.de/index.php/2020/06/22/the-future-of-jsch-without-ssh-rsa/

One of the problems fixed in this Jsch fork is a nasty deadlock when using a "Put files" step with a "sftp://..." URL with semi-large files (eg 15+ MB)
https://sourceforge.net/p/jsch/mailman/message/36872566/ https://issues.apache.org/jira/browse/VFS-627

This forked Jsch is a drop-in replacement, functions without any problems for me (and without deadlock)!
