### PR TITLE
[BACKLOG-36549] File cache was being accessed when opening the dialog

### DIFF
--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/controllers/FileController.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/controllers/FileController.java
@@ -28,6 +28,7 @@ import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.plugins.fileopensave.providers.ProviderService;
 import org.pentaho.di.plugins.fileopensave.providers.local.LocalFileProvider;
+import org.pentaho.di.plugins.fileopensave.providers.repository.model.RepositoryFile;
 import org.pentaho.di.ui.core.events.dialog.ProviderFilterType;
 import org.pentaho.di.plugins.fileopensave.api.providers.File;
 import org.pentaho.di.plugins.fileopensave.api.providers.FileProvider;
@@ -109,7 +110,9 @@ public class FileController {
       FileProvider<File> fileProvider = providerService.get( file.getProvider() );
       if ( fileCache.containsKey( file ) && useCache ) {
         return fileCache.getFiles( file ).stream()
-          .filter( f -> f instanceof Directory || org.pentaho.di.plugins.fileopensave.api.providers.Utils.matches( f.getName(), filters ) )
+          .filter( f -> f instanceof Directory
+            || ( f instanceof RepositoryFile && ( (RepositoryFile) f).passesTypeFilter( filters ) )
+            || org.pentaho.di.plugins.fileopensave.api.providers.Utils.matches( f.getName(), filters ) )
           .collect( Collectors.toList() );
       } else {
         List<File> files = fileProvider.getFiles( file, filters, space );

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
@@ -667,17 +667,22 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
     btnSave.addSelectionListener( new SelectionAdapter() {
       @Override public void widgetSelected( SelectionEvent selectionEvent ) {
         StructuredSelection structuredSelection;
+        StructuredSelection treeSelection;
 
         if ( fileTableViewer.getSelection().isEmpty() ) {
           structuredSelection = (StructuredSelection) treeViewer.getSelection();
+          treeSelection = structuredSelection;
         } else {
           structuredSelection = (StructuredSelection) fileTableViewer.getSelection();
+          treeSelection = (StructuredSelection) treeViewer.getSelection();
         }
 
         if ( structuredSelection.getFirstElement() instanceof File
           && txtFileName.getText() != null
           && StringUtils.isNotEmpty( txtFileName.getText() ) ) {
           processOnSavePressed( (File) structuredSelection.getFirstElement() );
+          // clear the parent directory from the cache so the file shows up on next dialog open
+          FILE_CONTROLLER.clearCache( (File) ( treeSelection ).getFirstElement() );
         }
       }
     } );

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/repository/model/RepositoryFile.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/repository/model/RepositoryFile.java
@@ -24,6 +24,7 @@ package org.pentaho.di.plugins.fileopensave.providers.repository.model;
 
 import org.pentaho.di.core.LastUsedFile;
 import org.pentaho.di.plugins.fileopensave.api.providers.File;
+import org.pentaho.di.plugins.fileopensave.api.providers.Utils;
 import org.pentaho.di.plugins.fileopensave.providers.recents.RecentFileProvider;
 import org.pentaho.di.plugins.fileopensave.providers.repository.RepositoryFileProvider;
 import org.pentaho.di.repository.ObjectId;
@@ -143,5 +144,11 @@ public class RepositoryFile extends RepositoryObject implements File {
     RepositoryFile compare = (RepositoryFile) obj;
     return compare.getProvider().equals( getProvider() )
       && ( ( compare.getPath() == null && getPath() == null ) || compare.getPath().equals( getPath() ) );
+  }
+
+  // TODO: fix repository files so that the extension is populated consistently in the two build methods
+  // so that we don't need to use this method
+  public boolean passesTypeFilter( String filter ) {
+    return Utils.matches( getName() + ( TRANSFORMATION.equalsIgnoreCase( getType() ) ? KTR : KJB ), filter );
   }
 }


### PR DESCRIPTION
after saving a file, and the cache had not been updated to reflect the new file.  Cache is now cleared for the parent directory when saving a file so that it shows up later.
Also corrects an issue with filtering repository files when accessing the cache.