### PR TITLE
[BACKLOG-36581] The convertLineToStrings method was attempting to

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -861,15 +861,15 @@ public class TextFileInputUtils {
               String replace = inf.content.escapeCharacter + enclosure;
               String replaceWith = enclosure;
 
-              pol = Const.replace(pol, replace, replaceWith);
+              pol = Const.replace( pol, replace, replaceWith );
             }
 
-            contains_escaped_escape = pol.contains(inf.content.escapeCharacter + inf.content.escapeCharacter);
+            contains_escaped_escape = !Utils.isEmpty( inf.content.escapeCharacter ) && pol.contains( inf.content.escapeCharacter + inf.content.escapeCharacter );
             if ( contains_escaped_escape ) {
               String replace = inf.content.escapeCharacter + inf.content.escapeCharacter;
               String replaceWith = inf.content.escapeCharacter;
 
-              pol = Const.replace(pol, replace, replaceWith);
+              pol = Const.replace( pol, replace, replaceWith );
             }
           }
 


### PR DESCRIPTION
replace escape characters using a regexp even when the user had not specified any escape character to use.  Corrected the boolean expression to check for an empty escape char string first.
Need to reconsider the use of Const.replace here in the future; regular expression parsing is expensive when done repeatedly.