### PR TITLE
[BACKLOG-36522] - moving jars into plugin/lib from PDI/lib

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -129,17 +129,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-    <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-mongo-utils</artifactId>
-      <version>${pentaho-mongodb-plugin.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongo-java-driver</artifactId>
-      <version>3.12.10</version>
-    </dependency>
     <!-- Updated Eclipse Dependencies -->
     <dependency>
       <groupId>org.eclipse.platform</groupId>


### PR DESCRIPTION
[BACKLOG-36522] - moving jars into plugin/lib from PDI/lib