### PR TITLE
[BACKLOG-36581] Further optimization for the case where no escape

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -991,7 +991,7 @@ public class TextFileInputUtils {
       + Pattern.quote( regexChar );
 
     // Remove even number of escaped characters to simplify proceeded escape character detection by regex
-    String textSanitized = text.replace( escapeCharacter + escapeCharacter, "" );
+    String textSanitized = StringUtils.isEmpty( escapeCharacter ) ? text : text.replace( escapeCharacter + escapeCharacter, "" );
 
     Pattern pattern = Pattern.compile( regex );
     Matcher matcher = pattern.matcher( textSanitized );


### PR DESCRIPTION
characters are used; searching for and replacing the empty string "" within a given string is a waste of resources.