### PR TITLE
[SP-6201] - Backport of PDI-19570 - 9.3: Job Entry with path variable (${Internal.Entry.Currenty.Directory}) cannot be resolved. (9.3 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
+++ b/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
@@ -160,12 +160,15 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
           } catch ( KettleException e ) {
             // try to load from repository, this trans may have been developed locally and later uploaded to the
             // repository
-            if ( isTransMeta() ) {
-              theMeta = rep == null ? (T) new TransMeta( realFilename, metaStore, null, true,
-                jobEntryBase.getParentVariableSpace(), null ) : getMetaFromRepository( rep, r, realFilename, tmpSpace );
-              if ( theMeta != null ) {
-                idContainer[ 0 ] = realFilename;
-              }
+            if ( rep == null ) {
+              theMeta = isTransMeta()
+                      ? (T) new TransMeta( realFilename, metaStore, null, true, jobEntryBase.getParentVariableSpace(), null )
+                      : (T) new JobMeta( jobEntryBase.getParentVariableSpace(), realFilename, rep, metaStore, null );
+            } else {
+              theMeta = getMetaFromRepository( rep, r, realFilename, tmpSpace );
+            }
+            if ( theMeta != null ) {
+              idContainer[ 0 ] = realFilename;
             }
           }
           break;


### PR DESCRIPTION
Original PR:
 - https://github.com/pentaho/pentaho-kettle/pull/8534

@andreramos89 
@bcostahitachivantara 
@smmribeiro 