### PR TITLE
[CLEANUP] fix for failing test in TransTest

### DIFF
--- a/engine/src/test/java/org/pentaho/di/trans/TransTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/TransTest.java
@@ -236,7 +236,7 @@ public class TransTest {
     when( meta.listVariables() ).thenReturn( new String[] {} );
     when( meta.listParameters() ).thenReturn( new String[] { testParam } );
     when( meta.getParameterValue( testParam ) ).thenReturn( testParamValue );
-    FileObject ktr = KettleVFS.createTempFile( "parameters", ".ktr", "ram://" );
+    FileObject ktr = KettleVFS.createTempFile( "parameters", ".ktr", KettleVFS.TEMP_DIR );
     try ( OutputStream outputStream = ktr.getContent().getOutputStream( true ) ) {
       InputStream inputStream = new ByteArrayInputStream( "<transformation></transformation>".getBytes() );
       IOUtils.copy( inputStream, outputStream );


### PR DESCRIPTION
using vfs filesystem "file" intstead of "ram"

This the test org.pentaho.di.trans.TransTest.testPDI12424ParametersFromMetaAreCopiedToTrans was started failing recently in branch 9.4 and in current master (9.5). The test works in branch 9.3.

Failing test in other pull requests:
https://github.com/pentaho/pentaho-kettle/pull/8759#issuecomment-1361313448
https://github.com/pentaho/pentaho-kettle/pull/8754#issuecomment-1370048608

the main failing of the test was the creation of the temporary file used to test ktr logic. The file location was VFS ram://.
The issue is on the Apache side where AbstractFileSystem#resolve(FileName name, boolean useCache) wasn't able to retrieve the ram:// from the cache. 

The ultimate reason why the caching stop for the ram:// is uknonwn. However, changing to creating the temporary file in an normal file system in the directory "java.io.tmpdir" passes the test.