### PR TITLE
[CLEANUP] update test to use invalid type to force exception

### DIFF
--- a/plugins/avro-format/core/src/test/java/org/pentaho/di/trans/steps/avro/input/AvroInputMetaTest.java
+++ b/plugins/avro-format/core/src/test/java/org/pentaho/di/trans/steps/avro/input/AvroInputMetaTest.java
@@ -149,6 +149,7 @@ public class AvroInputMetaTest {
   @Test( expected = KettleStepException.class )
   public void testGetFields_unknownPluginForFieldType() throws KettleStepException {
     AvroInputField fld = mock( AvroInputField.class );
+    when( fld.getPentahoType() ).thenReturn( Integer.MIN_VALUE ); // invalid type
 
     meta.setInputFields( Arrays.asList( fld ) );
     meta.getFields( rowMeta, origin, info, nextStep, space, repository, metaStore );


### PR DESCRIPTION
setting type to be invalid type.

test failing in PR:
https://github.com/pentaho/pentaho-kettle/pull/8770#issuecomment-1373853815

When the mock is created #getPentahoType() will return "0" by default, since no mocking instructions were given.
An unrelated test is creating a pluginType that occupies the id of "0". I set the mock type to an unrealistic value.