### PR TITLE
[SP-6242] Backport of PDI-19627 - Add a checksum：When "Compatibility …

### DIFF
--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -263,10 +263,6 @@ public class CheckSum extends BaseStep implements StepInterface {
     if ( super.init( smi, sdi ) ) {
       if ( Utils.isEmpty( meta.getResultFieldName() ) ) {
         logError( BaseMessages.getString( PKG, "CheckSum.Error.ResultFieldMissing" ) );
-        return false;
-      }
-      if ( meta.isCompatibilityMode() && CheckSumMeta.TYPE_SHA256.equals( meta.getCheckSumType() ) ) {
-        logError( BaseMessages.getString( PKG, "CheckSumMeta.CheckResult.CompatibilityModeSHA256Error" ) );
         return false;
       }
       return true;

--- a/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumTest.java
+++ b/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -616,33 +616,6 @@ public class CheckSumTest {
     assertEquals( 1, results.getWritten().size() );
     assertEquals( "a3aa77adf7a0bc55c91bc2e482db25bb520d5903fe7adcee9f6a09fd5ae200f6",
       results.getWritten().get( 0 )[ 2 ] );
-  }
-
-  /**
-   * SHA-256 is not supported for compatibility mode: this test is expected to end with an exception
-   */
-  @Test( expected = KettleException.class )
-  public void testHexOutput_sha256_bytes_withCompatibility() throws Exception {
-    executeHexTest( SHA256, CheckSumMeta.EVALUATION_METHOD_BYTES, true, TEST_STRING1, string1Meta );
-    fail( "SHA-256 is not supported for compatibility mode" );
-  }
-
-  /**
-   * SHA-256 is not supported for compatibility mode: this test is expected to end with an exception
-   */
-  @Test( expected = KettleException.class )
-  public void testHexOutput_sha256_pentahoStrings_withCompatibility() throws Exception {
-    executeHexTest( SHA256, CheckSumMeta.EVALUATION_METHOD_PENTAHO_STRINGS, true, TEST_STRING1, string1Meta );
-    fail( "SHA-256 is not supported for compatibility mode" );
-  }
-
-  /**
-   * SHA-256 is not supported for compatibility mode: this test is expected to end with an exception
-   */
-  @Test( expected = KettleException.class )
-  public void testHexOutput_sha256_nativeStrings_withCompatibility() throws Exception {
-    executeHexTest( SHA256, CheckSumMeta.EVALUATION_METHOD_NATIVE_STRINGS, true, TEST_STRING1, string1Meta );
-    fail( "SHA-256 is not supported for compatibility mode" );
   }
 
   private Trans buildHexadecimalChecksumTrans( int checksumType, int evaluationMethod, boolean compatibilityMode,


### PR DESCRIPTION
…Mode" is checked and "Type" set to SHA-256, transformation errors out. (9.4 Suite)

(cherry picked from commit 67b600f349fcf812eb8c642fd48459c5a3225db4)

Original PR: [pentaho-kettle#8729](https://github.com/pentaho/pentaho-kettle/pull/8729)

@bcostahitachivantara @renato-s @andreramos89 