### PR TITLE
[SP-6248] Backport of PDI-19690 - 'Add a checksum' step errors when p…

### DIFF
--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/checksum/CheckSum.java
@@ -394,7 +394,13 @@ public class CheckSum extends BaseStep implements StepInterface {
     }
 
     private byte[] getBytesFromNonBinary( Object[] row ) throws KettleException {
-      return vmi.getNativeDataType( row[ fieldIndex ] ).toString().getBytes();
+      byte[] ret = null;
+
+      if ( null != row[ fieldIndex ] ) {
+        ret = vmi.getNativeDataType( row[ fieldIndex ] ).toString().getBytes();
+      }
+
+      return ret;
     }
   }
 }

--- a/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumTest.java
+++ b/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/checksum/CheckSumTest.java
@@ -618,7 +618,16 @@ public class CheckSumTest {
       results.getWritten().get( 0 )[ 2 ] );
   }
 
-  private Trans buildHexadecimalChecksumTrans( int checksumType, int evaluationMethod, boolean compatibilityMode,
+  @Test
+  public void test_pdi19690() throws Exception {
+    MockRowListener results =
+      executeHexTest( SHA256, CheckSumMeta.EVALUATION_METHOD_BYTES, false, null, string1Meta );
+    assertEquals( 1, results.getWritten().size() );
+    assertEquals( "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      results.getWritten().get( 0 )[ 1 ] );
+  }
+
+    private Trans buildHexadecimalChecksumTrans( int checksumType, int evaluationMethod, boolean compatibilityMode,
                                                String fieldSeparatorString, String[] fieldNames ) throws Exception {
     // Create a new transformation...
     TransMeta transMeta = new TransMeta();


### PR DESCRIPTION
…rocessing a field with a null value ('byte representation' evaluation method) (9.3 Suite)

(cherry picked from commit 8868c650c446372bd407d50dcde1d31501aa2d1e)

Original PR: [pentaho-kettle#8755](https://github.com/pentaho/pentaho-kettle/pull/8755)

@bcostahitachivantara @renato-s @andreramos89 