### PR TITLE
[SP-6288] Backport of PDI-19352 - Default window size issue for 'Tools> Repository> Explore> Delete File(s)' when display scaling is set to > 100% (9.3 Suite)

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/repository/repositoryexplorer/controllers/BrowseController.java
+++ b/ui/src/main/java/org/pentaho/di/ui/repository/repositoryexplorer/controllers/BrowseController.java
@@ -115,7 +115,7 @@ public class BrowseController extends AbstractXulEventHandler implements IUISupp
 
   private Shell shell;
 
-  private static final int DIALOG_WIDTH = 357, DIALOG_HEIGHT = 165, DIALOG_COLOR = SWT.COLOR_WHITE;
+  private static final int DIALOG_WIDTH = 365, DIALOG_HEIGHT = 195, DIALOG_COLOR = SWT.COLOR_WHITE;
 
   protected static final String HOME_PATH = "/home", PUBLIC_PATH = "/public";
 


### PR DESCRIPTION
scaling fixes for delete box in Repository explore