### PR TITLE
[SP-6286]-Backport of PDI-19128 - Job Executor step: The value of "fi…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMeta.java
@@ -513,7 +513,7 @@ public class JobExecutorMeta extends BaseStepMeta implements StepMetaInterface, 
     } else if ( nextStep != null
       && resultFilesTargetStepMeta != null && nextStep.equals( resultFilesTargetStepMeta ) ) {
       if ( !Utils.isEmpty( resultFilesFileNameField ) ) {
-        ValueMetaInterface value = new ValueMetaString( "filename", 255, 0 );
+        ValueMetaInterface value = new ValueMetaString( resultFilesFileNameField, 255, 0 );
         row.addValueMeta( value );
       }
     } else if ( nextStep != null


### PR DESCRIPTION
…eld name in result file" is not referenced from subsequent steps. (9.3 Suite)