### PR TITLE
[BACKLOG-37255] - PDI Step 'Elasticsearch bulk insert (deprecated)' shows incorrect icon

### DIFF
--- a/plugins/elasticsearch-bulk-insert/core/src/main/java/org/pentaho/di/trans/steps/elasticsearchbulk/ElasticSearchBulkMeta.java
+++ b/plugins/elasticsearch-bulk-insert/core/src/main/java/org/pentaho/di/trans/steps/elasticsearchbulk/ElasticSearchBulkMeta.java
@@ -62,7 +62,7 @@ import java.util.concurrent.TimeUnit;
 @Step( id = "ElasticSearchBulk", i18nPackageName = "org.pentaho.di.trans.steps.elasticsearch",
         name = "ElasticSearchBulk.TypeLongDesc.ElasticSearchBulk",
         description = "ElasticSearchBulk.TypeTooltipDesc.ElasticSearchBulk",
-        categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.Deprecated", image = "ESB.svg",
+        categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.Deprecated", image = "ui/images/deprecated.svg",
         documentationUrl = "Products/ElasticSearch_Bulk_Insert_(deprecated)" )
 @InjectionSupported( localizationPrefix = "ElasticSearchBulk.Injection." )
 public class ElasticSearchBulkMeta extends BaseStepMeta implements StepMetaInterface {


### PR DESCRIPTION
PDI Step 'Elasticsearch bulk insert (deprecated)' shows incorrect icon