### PR TITLE
[CLEANUP] fix for failing test in TransTest

### DIFF
--- a/engine/src/test/java/org/pentaho/di/trans/TransTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/TransTest.java
@@ -236,7 +236,7 @@ public class TransTest {
     when( meta.listVariables() ).thenReturn( new String[] {} );
     when( meta.listParameters() ).thenReturn( new String[] { testParam } );
     when( meta.getParameterValue( testParam ) ).thenReturn( testParamValue );
-    FileObject ktr = KettleVFS.createTempFile( "parameters", ".ktr", "ram://" );
+    FileObject ktr = KettleVFS.createTempFile( "parameters", ".ktr", KettleVFS.TEMP_DIR );
     try ( OutputStream outputStream = ktr.getContent().getOutputStream( true ) ) {
       InputStream inputStream = new ByteArrayInputStream( "<transformation></transformation>".getBytes() );
       IOUtils.copy( inputStream, outputStream );


### PR DESCRIPTION
using vfs filesystem "file" instead of "ram"

(cherry picked from commit 1de6f5e8999c262fec16b8b0f64d6471b32cefad)