### PR TITLE
[PDI-19737] Provide the ability to filter records before handing them to

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1417,6 +1417,12 @@ public class Const {
    * <p>This environment variable is used by streaming consumer steps to limit the total of concurrent batches across transformations.</p>
    */
   public static final String SHARED_STREAMING_BATCH_POOL_SIZE = "SHARED_STREAMING_BATCH_POOL_SIZE";
+
+  /**
+   * <p>This environment variable is used by the Kinesis consumer to control the number of records retrieved
+   * by the PollingConfig, if used.  Ignored with Enhanced Fan Out./p>
+   */
+  public static final String KINESIS_POLLING_CONFIG_MAX_RECORDS = "KINESIS_POLLING_CONFIG_MAX_RECORDS";
 
   /**
    * <p>This environment variable is used to specify a location used to deploy a shim driver into PDI.</p>

--- a/engine/src/main/java/org/pentaho/di/trans/streaming/common/FixedTimeStreamWindow.java
+++ b/engine/src/main/java/org/pentaho/di/trans/streaming/common/FixedTimeStreamWindow.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,6 +24,7 @@ package org.pentaho.di.trans.streaming.common;
 
 import io.reactivex.Flowable;
 import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.RowMetaAndData;
@@ -59,6 +60,7 @@ public class FixedTimeStreamWindow<I extends List> implements StreamWindow<I, Re
   private SubtransExecutor subtransExecutor;
   private int parallelism;
   private final Consumer<Map.Entry<List<I>, Result>> postProcessor;
+  private final Function<List<I>, List<I>> bufferFilter;
   private int sharedStreamingBatchPoolSize = 0;
   private static ThreadPoolExecutor sharedStreamingBatchPool;
   private final int rxBatchCount;
@@ -70,12 +72,18 @@ public class FixedTimeStreamWindow<I extends List> implements StreamWindow<I, Re
 
   public FixedTimeStreamWindow( SubtransExecutor subtransExecutor, RowMetaInterface rowMeta, long millis,
                                 int batchSize, int parallelism, Consumer<Map.Entry<List<I>, Result>> postProcessor ) {
+    this( subtransExecutor, rowMeta, millis, batchSize, parallelism, postProcessor, ( p ) -> p );
+  }
+
+  public FixedTimeStreamWindow( SubtransExecutor subtransExecutor, RowMetaInterface rowMeta, long millis,
+                                int batchSize, int parallelism, Consumer<Map.Entry<List<I>, Result>> postProcessor, Function<List<I>, List<I>> bufferFilter ) {
     this.subtransExecutor = subtransExecutor;
     this.rowMeta = rowMeta;
     this.millis = millis;
     this.batchSize = batchSize;
     this.parallelism = parallelism;
     this.postProcessor = postProcessor;
+    this.bufferFilter = bufferFilter;
 
     //When only batchSize is provided and it is greater than 0 and less than the prefetchCount we can exactly
     //calculate how many batches rx will have to handle. When a time value is provided handle the full prefetchCount
@@ -110,6 +118,8 @@ public class FixedTimeStreamWindow<I extends List> implements StreamWindow<I, Re
       .runOn( sharedStreamingBatchPoolSize > 0 ? Schedulers.from( sharedStreamingBatchPool ) : Schedulers.io(),
         rxBatchCount )
       .filter( list -> !list.isEmpty() )
+      .map( this.bufferFilter ) // apply any filtering for data that should no longer be processed
+      .filter( list -> !list.isEmpty() ) // ensure at least one record is left before sending to subtrans
       .map( this::sendBufferToSubtrans )
       .filter( Optional::isPresent )
       .map( Optional::get )


### PR DESCRIPTION
a batch worker; required for kinesis to handle shard lease loss.  Adding a new Kettle parameter to control the number of records returned at a time by the KCL.