### PR TITLE
[BACKLOG-37825] Update guava to latest version and clean up dependencies

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -165,6 +165,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>org.owasp.encoder</groupId>

--- a/plugins/file-stream/pom.xml
+++ b/plugins/file-stream/pom.xml
@@ -72,7 +72,6 @@
     <target.jdk.version>1.8</target.jdk.version>
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
     <junit.version>4.12</junit.version>
-    <guava.version>17.0</guava.version>
     <mockito-all.version>1.9.5</mockito-all.version>
   </properties>
 

--- a/plugins/google-analytics/assemblies/plugin/pom.xml
+++ b/plugins/google-analytics/assemblies/plugin/pom.xml
@@ -46,21 +46,27 @@
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
-      <version>1.20.0</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
       <version>1.20.0</version>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
       <version>1.20.0</version>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -70,12 +76,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>1.3.9</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/plugins/json/core/pom.xml
+++ b/plugins/json/core/pom.xml
@@ -20,7 +20,6 @@
     <platform.version>9.6.0.0-SNAPSHOT</platform.version>
     <commons-lang.version>2.6</commons-lang.version>
     <encoder.version>1.2</encoder.version>
-    <guava.version>17.0</guava.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <mockito-all.version>1.9.5</mockito-all.version>
     <build.revision>${project.version}</build.revision>

--- a/plugins/pentaho-googledrive-vfs/assemblies/plugin/pom.xml
+++ b/plugins/pentaho-googledrive-vfs/assemblies/plugin/pom.xml
@@ -26,6 +26,12 @@
             <artifactId>pentaho-googledrive-vfs-core</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.http-client</groupId>
+                    <artifactId>google-http-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/plugins/pentaho-googledrive-vfs/core/pom.xml
+++ b/plugins/pentaho-googledrive-vfs/core/pom.xml
@@ -15,7 +15,7 @@
     <name>Pentaho Google Drive VFS Plugin Core</name>
 
     <properties>
-        <project.http.version>1.22.0</project.http.version>
+        <project.http.version>1.42.3</project.http.version>
         <project.oauth.version>1.22.0</project.oauth.version>
         <!--project.build.sourceEncoding>UTF-8</project.build.sourceEncoding-->
         <project.junit.version>4.4</project.junit.version>

--- a/plugins/streaming/impls/mqtt/pom.xml
+++ b/plugins/streaming/impls/mqtt/pom.xml
@@ -72,7 +72,6 @@
     <target.jdk.version>1.8</target.jdk.version>
     <maven-bundle-plugin.version>2.4.0</maven-bundle-plugin.version>
     <junit.version>4.12</junit.version>
-    <guava.version>17.0</guava.version>
   </properties>
 
   <dependencies>

--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTProducerMeta.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTProducerMeta.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.trans.step.mqtt;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.annotations.Step;
@@ -74,8 +75,8 @@ import static org.pentaho.di.trans.step.mqtt.MQTTConstants.TOPIC;
 import static org.pentaho.di.trans.step.mqtt.MQTTConstants.TOPIC_IN_FIELD;
 import static org.pentaho.di.trans.step.mqtt.MQTTConstants.USERNAME;
 import static org.pentaho.di.trans.step.mqtt.MQTTConstants.USE_SSL;
-import static org.pentaho.di.trans.step.mqtt.MQTTProducerMeta.MQTT_SERVER_METAVERSE; //NOSONAR
-import static org.pentaho.di.trans.step.mqtt.MQTTProducerMeta.MQTT_TOPIC_METAVERSE; //NOSONAR
+import static org.pentaho.di.trans.step.mqtt.MQTTProducerMeta.MQTT_SERVER_METAVERSE;
+import static org.pentaho.di.trans.step.mqtt.MQTTProducerMeta.MQTT_TOPIC_METAVERSE;
 import static org.pentaho.dictionary.DictionaryConst.CATEGORY_DATASOURCE;
 import static org.pentaho.dictionary.DictionaryConst.CATEGORY_MESSAGE_QUEUE;
 import static org.pentaho.dictionary.DictionaryConst.LINK_CONTAINS_CONCEPT;
@@ -289,7 +290,7 @@ public class MQTTProducerMeta extends BaseSerializingMeta implements StepMetaInt
   }
 
   @Override public String toString() {
-    return Objects.toStringHelper( this )
+    return MoreObjects.toStringHelper( this )
       .add( "mqttServer", mqttServer )
       .add( "clientId", clientId )
       .add( "topic", topic )

--- a/plugins/streaming/pom.xml
+++ b/plugins/streaming/pom.xml
@@ -17,7 +17,6 @@
 
   <properties>
     <pdi.version>9.6.0.0-SNAPSHOT</pdi.version>
-    <guava.version>19.0</guava.version>
     <pentaho-metaverse.version>9.6.0.0-SNAPSHOT</pentaho-metaverse.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <js.version>1.7R3</js.version>
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
-    <guava.version>17.0</guava.version>
+    <guava.version>32.0.1-jre</guava.version>
     <encoder.version>1.2</encoder.version>
     <wstx-asl.version>3.2.4</wstx-asl.version>
 
@@ -160,12 +160,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.owasp.encoder</groupId>


### PR DESCRIPTION
in poms. Needed to allow license manager code in EE to use Google dependencies.