### PR TITLE
[BACKLOG-37825] Library needed by google vfs plugin was missing from CE

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -56,6 +56,7 @@
     <pentaho-metadata.version>9.6.0.0-SNAPSHOT</pentaho-metadata.version>
     <xml-graphics-common.version>2.2</xml-graphics-common.version>
     <jdom.version>1.1.3</jdom.version>
+    <google-http-client.version>1.42.3</google-http-client.version>
   </properties>
 
   <dependencies>
@@ -633,6 +634,12 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <!-- needed for google vfs plugin and ee features -->
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>${google-http-client.version}</version>
     </dependency>
     <!-- pentaho-big-data-legacy-core is required in both artifacts because of the dependency in kafka streaming plugin -->
     <!-- otherwise this is only needed by the big data plugin -->


### PR DESCRIPTION
build.