### PR TITLE
[SP-6367] - Backport of PDI-19723 - Input rows with only <null> Strings are skipped by Python Executor step (9.5 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1628,6 +1628,13 @@ public class Const {
   public static final String KETTLE_USE_META_FILE_CACHE_DEFAULT = "N";
 
   /**
+   * Value used to replace nulls in Python Executor Step Input Lines. Empty will mean no replacement will be done
+   */
+  public static final String KETTLE_PYTHON_STEP_REPLACE_NULLS = "KETTLE_PYTHON_STEP_REPLACE_NULLS";
+
+
+
+  /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer
    * overflow while rounding
    *

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -627,4 +627,11 @@
     <default-value>N</default-value>
   </kettle-variable>
 
+  <kettle-variable>
+    <description>Set this variable to have the Python Executor step consider null/empty lines. Consider the following behaviour: Leaving it empty, will have the step ignore null lines. Setting it will have the step replace these lines with the vallue added. (ex. NaN)
+    </description>
+    <variable>KETTLE_PYTHON_STEP_REPLACE_NULLS</variable>
+    <default-value></default-value>
+  </kettle-variable>
+
 </kettle-variables>


### PR DESCRIPTION
@smmribeiro 
@bcostahitachivantara 
@renato-s 