### PR TITLE
[PDI-19755] fix database repository save tansformation maybe raised deadlock

### DIFF
--- a/engine/src/main/java/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryTransDelegate.java
+++ b/engine/src/main/java/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryTransDelegate.java
@@ -393,10 +393,6 @@ public class KettleDatabaseRepositoryTransDelegate extends KettleDatabaseReposit
       if ( monitor != null ) {
         monitor.subTask( BaseMessages.getString( PKG, "TransMeta.Monitor.UnlockingRepository" ) );
       }
-      repository.unlockRepository();
-
-      // Perform a commit!
-      repository.commit();
 
       transMeta.clearChanged();
       if ( monitor != null ) {


### PR DESCRIPTION
do not need to call a method repository.unlockRepository() in KettleDatabaseRepositoryTransDelegate saveTransformation()method, Because calling methods in the outer layer is also done. None of the other resources, save()method, calls unlockRepository()