### PR TITLE
[SP-6401] Backport of PDI-19848 - JSON Input: Double datatype is chos…

### DIFF
--- a/plugins/get-fields/core/src/main/java/org/pentaho/getfields/types/json/node/ObjectNode.java
+++ b/plugins/get-fields/core/src/main/java/org/pentaho/getfields/types/json/node/ObjectNode.java
@@ -22,12 +22,16 @@
 
 package org.pentaho.getfields.types.json.node;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
- * Represents a object node to be deduplicated
- *
+ * Represents an object node to be deduplicated
  * Created by bmorrise on 7/27/18.
  */
 public class ObjectNode extends Node {
@@ -41,6 +45,101 @@ public class ObjectNode extends Node {
 
   public void addValue( Node value ) {
     children.add( value );
+  }
+
+  /**
+   * This merge implementation has the main intent to merge json sample dato to make the data date of sample compatible with all records.
+   * @param currentNode
+   */
+  public void mergeValue( Node currentNode ) {
+
+    Node storedNode = getByKey( currentNode.getKey() );
+
+    if ( !( currentNode instanceof ValueNode ) || !( storedNode instanceof ValueNode ) ) {
+      return;
+    }
+
+    ValueNode<Object> currentValueNode = (ValueNode) currentNode;
+    ValueNode<Object> storedValueNode = (ValueNode) storedNode;
+
+    Object currentValue = currentValueNode.getValue();
+    Object storedValue = storedValueNode.getValue();
+    Object value = currentValue;
+
+    if ( value == null ) {
+      return;
+    }
+
+    if ( currentValue instanceof String || storedValue instanceof String ) {
+      // If anyone is string everyone need to be a string
+      value = longestString( currentValue.toString(), storedValue.toString() );
+    } else if ( currentValue.getClass().equals( Object.class ) || storedValue.getClass().equals( Object.class ) ) {
+      // If anyone is object type, we need to convert all into String and store the big one
+      value = longestString( currentValue.toString(), storedValue.toString() );
+    } else if ( currentValue instanceof BigDecimal || storedValue instanceof BigDecimal ) {
+      // If anyone is BigDecimal, we need to convert into BigDecimal, except if we are dealing with objets that are not Number
+      if ( !( currentValue instanceof Number ) || !( storedValue instanceof Number ) ) {
+        // Convert it into a generic string
+        value = longestString( currentValue.toString(), storedValue.toString() );
+      } else {
+        //We are dealing with Numbers, so we can convert it into BigDecimal
+        value = biggestNumber( new BigDecimal( currentValue.toString() ), new BigDecimal( storedValue.toString() ) );
+      }
+    } else if ( currentValue instanceof Double || storedValue instanceof Double ) {
+      // If anyone is Double, we need to convert into Double
+      if ( !( currentValue instanceof Number ) || !( storedValue instanceof Number ) ) {
+        // Convert it into a generic string
+        value = longestString( currentValue.toString(), storedValue.toString() );
+      } else {
+        //We are dealing with Numbers, so we can convert it into Double, because we already know it is not a DigDecimal
+        value = biggestNumber( Double.valueOf( currentValue.toString() ), Double.valueOf( storedValue.toString() ) );
+      }
+    } else if ( currentValue instanceof BigInteger || storedValue instanceof BigInteger ) {
+      // If anyone is BigInteger, we need to convert into BigInteger
+      if ( !( currentValue instanceof Number ) || !( storedValue instanceof Number ) ) {
+        // Convert it into a generic string
+        value = longestString( currentValue.toString(), storedValue.toString() );
+      } else {
+        //We are dealing with Numbers, so we can convert it into BigInteger, because we already know it is not a Double
+        value = biggestNumber( new BigInteger( currentValue.toString() ), new BigInteger( storedValue.toString() ) );
+      }
+    } else if ( currentValue instanceof Number || storedValue instanceof Number ) {
+      // If anyone is a generic Number, we need to convert into Integer
+      if ( !( currentValue instanceof Number ) || !( storedValue instanceof Number ) ) {
+        // Convert it into a generic string
+        value = longestString( currentValue.toString(), storedValue.toString() );
+      } else {
+        //We are dealing with Numbers, so we can convert it into Long, because we already know it is not a BigInteger
+        value = biggestNumber( Long.valueOf( currentValue.toString() ), Long.valueOf( storedValue.toString() ) );
+      }
+    } else if ( currentValue instanceof Boolean && !( storedValue instanceof Boolean ) ) {
+      // Convert it into a generic string if the stored value is not a Boolean
+      value = longestString( currentValue.toString(), storedValue.toString() );
+    } else if ( currentValue instanceof Date && !( storedValue instanceof Date ) ) {
+      // Convert it into a generic string if the stored value is not a Date
+      value = longestString( currentValue.toString(), storedValue.toString() );
+    } else if ( currentValue instanceof Timestamp && !( storedValue instanceof Timestamp ) ) {
+      // Convert it into a generic string if the stored value is not a Timestamp
+      value = longestString( currentValue.toString(), storedValue.toString() );
+    } else if ( currentValue instanceof InetAddress && !( storedValue instanceof InetAddress ) ) {
+      // Convert it into a generic string if the stored value is not a InetAddress
+      value = longestString( currentValue.toString(), storedValue.toString() );
+    }
+    // Update value on stored node
+    updateStoredNode( storedValueNode, value );
+  }
+
+
+  private void updateStoredNode( ValueNode<Object> valueNode, Object value ) {
+    valueNode.setValue( value );
+  }
+
+  private String longestString( String s1, String s2 ) {
+    return ( s1.length() > s2.length() ) ? s1 : s2;
+  }
+
+  private <T extends Comparable<T>> T biggestNumber( T n1, T n2 ) {
+    return n1.compareTo( n2 ) >= 0 ? n1 : n2;
   }
 
   public List<Node> getChildren() {
@@ -77,6 +176,8 @@ public class ObjectNode extends Node {
     for ( Node node : secondNode.getChildren() ) {
       if ( !containsKey( node.getKey() ) ) {
         addValue( node );
+      } else {
+        mergeValue( node );
       }
       if ( node instanceof ObjectNode ) {
         ObjectNode objectNode1 = (ObjectNode) getByKey( node.getKey() );

--- a/plugins/get-fields/core/src/main/javascript/app/components/tree/tree.component.js
+++ b/plugins/get-fields/core/src/main/javascript/app/components/tree/tree.component.js
@@ -110,10 +110,29 @@ define([
               key = "root";
             }
           }
-          paths.push(key + ":" + data + ":" + node.type);
+          paths.push(key + ":" + data + ":" + _convertJsonTypeToPentahoTypes(node.type));
         }
       }
       return paths;
+    }
+
+    function _convertJsonTypeToPentahoTypes(jsonType) {
+      if (jsonType === null) {
+        return null;
+      }
+      switch ( jsonType ) {
+        case "BigDecimal":
+          return "BigNumber";
+        case "BigInteger":
+          return "Integer";
+        case "Double":
+          return "Number";
+        case "Object":
+        case "Array":
+          return "String";
+        default:
+          return jsonType;
+      }
     }
 
     function _generatePath(node) {


### PR DESCRIPTION
…en by default instead of Number when selecting a field with decimal values. (9.3 Suite)

Based on the following PRs:

- [pentaho-kettle#8976](https://github.com/pentaho/pentaho-kettle/pull/8976)
- [pentaho-kettle#8990](https://github.com/pentaho/pentaho-kettle/pull/8990)

Between 9.3 and 9.5 (and current master branch - 10.1), some plugins have moved to new locations and/or been refactored.
This case is an example of that: "\plugins\json\core\src\main\java\org\pentaho\di\trans\steps\jsoninput\json\JsonSampler.java" does not exist on the 9.3 code line; in 9.3, that code is in "\plugins\get-fields\core\src\main\javascript\app\components\tree\tree.component.js" and it's implemented in Javascript.

@bcostahitachivantara  @renato-s  @andreramos89 