### PR TITLE
[BACKLOG-38431] : Deprecate the CE GA plugin as it no longer supports

### DIFF
--- a/plugins/google-analytics/core/src/main/java/org/pentaho/di/trans/steps/googleanalytics/GaInputStepMeta.java
+++ b/plugins/google-analytics/core/src/main/java/org/pentaho/di/trans/steps/googleanalytics/GaInputStepMeta.java
@@ -62,8 +62,8 @@ import org.w3c.dom.Node;
   i18nPackageName = "org.pentaho.di.trans.steps.googleanalytics",
   name = "GoogleAnalytics.TypeLongDesc.GoogleAnalyticsStep",
   description = "GoogleAnalytics.TypeTooltipDesc.GoogleAnalyticsStep",
-  categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.Input",
-  image = "GAN.svg",
+  categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.Deprecated",
+  image = "ui/images/deprecated.svg",
 
   documentationUrl = "http://wiki.pentaho.com/display/EAI/Google+Analytics" )
 @InjectionSupported( localizationPrefix = "GoogleAnalytics.Injection.", groups = { "OUTPUT_FIELDS" } )


### PR DESCRIPTION
Cherry pick of https://github.com/pentaho/pentaho-kettle/pull/9047