### PR TITLE
[SP-6421] Backport of PDI-19762 - Performance Regression, specifically in SP 9.3.0.2, in Text File Input step if no Escape character is provided, caused by PDI-18825 (9.3 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -868,7 +868,8 @@ public class TextFileInputUtils {
           }
 
           // replace the escaped escape with escape...
-          contains_escaped_escape = pol.contains( inf.content.escapeCharacter + inf.content.escapeCharacter );
+          contains_escaped_escape = !Utils.isEmpty( inf.content.escapeCharacter ) && pol.contains( inf.content.escapeCharacter + inf.content.escapeCharacter );
+
           if ( contains_escaped_escape ) {
             String replace = inf.content.escapeCharacter + inf.content.escapeCharacter;
             String replaceWith = inf.content.escapeCharacter;

--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -987,7 +987,7 @@ public class TextFileInputUtils {
       + Pattern.quote( regexChar );
 
     // Remove even number of escaped characters to simplify proceeded escape character detection by regex
-    String textSanitized = text.replace( escapeCharacter + escapeCharacter, "" );
+    String textSanitized = StringUtils.isEmpty( escapeCharacter ) ? text : text.replace( escapeCharacter + escapeCharacter, "" );
 
     Pattern pattern = Pattern.compile( regex );
     Matcher matcher = pattern.matcher( textSanitized );


### PR DESCRIPTION

Original PRs (better compare ignoring whitespaces):

1. https://github.com/pentaho/pentaho-kettle/pull/8705
2. https://github.com/pentaho/pentaho-kettle/pull/8716

@bcostahitachivantara @renato-s @andreramos89 