### PR TITLE
[PDI-19937]-Database Password Field shows password in plain text when searching for job's metadata

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -2181,7 +2181,7 @@ public class JobMeta extends AbstractMeta
         // if ( includePasswords )
         // {
         if ( meta.getPassword() != null ) {
-          stringList.add( new StringSearchResult( meta.getPassword(), meta, this,
+          stringList.add( new StringSearchResult( meta.getPassword().replaceAll(".","*"), meta, this,
               BaseMessages.getString( PKG, "JobMeta.SearchMetadata.DatabasePassword" ) ) );
           // }
         }


### PR DESCRIPTION
[PDI-19937]-Database Password Field shows password in plain text when searching for job's metadata