### PR TITLE
[PDI-19869] - TextFileOutput throws transformation runtime error if output field columns are changed

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileoutput/TextFileOutputMeta.java
@@ -1172,38 +1172,36 @@ public class TextFileOutputMeta extends BaseFileOutputMeta implements StepMetaIn
    * @param data
    */
   protected synchronized void calcMetaWithFieldOptions( TextFileOutputData data ) {
-    if ( null == metaWithFieldOptions ) {
-      if ( !Utils.isEmpty( getOutputFields() ) ) {
-        metaWithFieldOptions = new ValueMetaInterface[ getOutputFields().length ];
+    if ( !Utils.isEmpty( getOutputFields() ) ) {
+      metaWithFieldOptions = new ValueMetaInterface[ getOutputFields().length ];
 
-        for ( int i = 0; i < getOutputFields().length; ++i ) {
-          ValueMetaInterface v = data.outputRowMeta.getValueMeta( data.fieldnrs[ i ] );
+      for ( int i = 0; i < getOutputFields().length; ++i ) {
+        ValueMetaInterface v = data.outputRowMeta.getValueMeta( data.fieldnrs[ i ] );
 
-          if ( v != null ) {
-            metaWithFieldOptions[ i ] = v.clone();
+        if ( v != null ) {
+          metaWithFieldOptions[ i ] = v.clone();
 
-            TextFileField field = getOutputFields()[ i ];
-            metaWithFieldOptions[ i ].setLength( field.getLength() );
-            metaWithFieldOptions[ i ].setPrecision( field.getPrecision() );
-            if ( !Utils.isEmpty( field.getFormat() ) ) {
-              metaWithFieldOptions[ i ].setConversionMask( field.getFormat() );
-            }
-            metaWithFieldOptions[ i ].setDecimalSymbol( field.getDecimalSymbol() );
-            metaWithFieldOptions[ i ].setGroupingSymbol( field.getGroupingSymbol() );
-            metaWithFieldOptions[ i ].setCurrencySymbol( field.getCurrencySymbol() );
-            metaWithFieldOptions[ i ].setTrimType( field.getTrimType() );
-            if ( !Utils.isEmpty( getEncoding() ) ) {
-              metaWithFieldOptions[ i ].setStringEncoding( getEncoding() );
-            }
-
-            // enable output padding by default to be compatible with v2.5.x
-            //
-            metaWithFieldOptions[ i ].setOutputPaddingEnabled( true );
+          TextFileField field = getOutputFields()[ i ];
+          metaWithFieldOptions[ i ].setLength( field.getLength() );
+          metaWithFieldOptions[ i ].setPrecision( field.getPrecision() );
+          if ( !Utils.isEmpty( field.getFormat() ) ) {
+            metaWithFieldOptions[ i ].setConversionMask( field.getFormat() );
           }
+          metaWithFieldOptions[ i ].setDecimalSymbol( field.getDecimalSymbol() );
+          metaWithFieldOptions[ i ].setGroupingSymbol( field.getGroupingSymbol() );
+          metaWithFieldOptions[ i ].setCurrencySymbol( field.getCurrencySymbol() );
+          metaWithFieldOptions[ i ].setTrimType( field.getTrimType() );
+          if ( !Utils.isEmpty( getEncoding() ) ) {
+            metaWithFieldOptions[ i ].setStringEncoding( getEncoding() );
+          }
+
+          // enable output padding by default to be compatible with v2.5.x
+          //
+          metaWithFieldOptions[ i ].setOutputPaddingEnabled( true );
         }
-      } else {
-        metaWithFieldOptions = null;
       }
+    } else {
+      metaWithFieldOptions = null;
     }
   }
 


### PR DESCRIPTION
This issue is happening because metaWithFieldOptions is not refreshed every time changes are made to the step. Removed the null condition check in the beginning of the method, which is stopping the meta data to reload.