### PR TITLE
[PDI-17309] - "Split every ... rows" option in Concat Field step does not work as expected after enabling the footer

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1218,6 +1218,9 @@ public class Const {
   // See PDI-19138 for details
   public static final String KETTLE_JSON_INPUT_INCLUDE_NULLS = "KETTLE_JSON_INPUT_INCLUDE_NULLS";
 
+  // See PDI-17309 for details
+  public static final String KETTLE_COMPATIBILITY_CONCAT_FIELDS_SPLIT_ROWS_HEADER_OFFSET = "KETTLE_COMPATIBILITY_CONCAT_FIELDS_SPLIT_ROWS_HEADER_OFFSET";
+
   /**
    * This property when set to Y force the same output file even when splits is required.
    * See PDI-19064 for details

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/concatfields/ConcatFieldsData.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/concatfields/ConcatFieldsData.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -41,6 +41,7 @@ public class ConcatFieldsData extends TextFileOutputData implements StepDataInte
   public String stringEnclosure;
   public String[] stringNullValue;
   public int targetFieldLengthFastDataDump; // for fast data dump (StringBuilder size)
+  public int headerOffsetForSplitRows;
 
   public ConcatFieldsData() {
     super(); // allocate TextFileOutputData

--- a/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/concatfields/ConcatFieldsTest.java
+++ b/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/concatfields/ConcatFieldsTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,21 +22,18 @@
 
 package org.pentaho.di.trans.steps.concatfields;
 
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.repository.Repository;
@@ -47,6 +44,17 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import org.pentaho.di.trans.steps.textfileoutput.TextFileField;
 import org.pentaho.metastore.api.IMetaStore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * User: Dzmitry Stsiapanau Date: 2/11/14 Time: 11:00 AM
@@ -97,11 +105,12 @@ public class ConcatFieldsTest {
 
     @Override
     Object[] putRowFromStream( Object[] r ) throws KettleStepException {
+      incrementLinesWritten();
       return prepareOutputRow( r );
     }
   }
 
-  private StepMockHelper<ConcatFieldsMeta, ConcatFieldsData> stepMockHelper;
+  private StepMockHelper<ConcatFieldsMetaHandler, ConcatFieldsData> stepMockHelper;
   private TextFileField textFileField = new TextFileField( "Name", 2, "", 10, 20, "", "", "", "" );
   private TextFileField textFileField2 = new TextFileField( "Surname", 2, "", 10, 20, "", "", "", "" );
   private TextFileField[] textFileFields = new TextFileField[] { textFileField, textFileField2 };
@@ -109,7 +118,7 @@ public class ConcatFieldsTest {
   @Before
   public void setUp() throws Exception {
     stepMockHelper =
-        new StepMockHelper<ConcatFieldsMeta, ConcatFieldsData>( "CONCAT FIELDS TEST", ConcatFieldsMeta.class,
+        new StepMockHelper<ConcatFieldsMetaHandler, ConcatFieldsData>( "CONCAT FIELDS TEST", ConcatFieldsMetaHandler.class,
             ConcatFieldsData.class );
     when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
         stepMockHelper.logChannelInterface );
@@ -190,5 +199,115 @@ public class ConcatFieldsTest {
 
     Assert.assertEquals( "one;two", headerString );
 
+  }
+
+  @Test
+  public void testPrepareOutputRowWithSplitRows() throws Exception {
+    String expected = "Name;Surname1;DATA12;DATA2Name;Surname3;DATA34;DATA45;DATA5";
+    processStep( false );
+
+    String result =  new String( ( (ConcatFieldsOutputStream) stepMockHelper.processRowsStepDataInterface.writer ).read() );
+    Assert.assertEquals( expected, result );
+  }
+
+  @Test
+  public void testPrepareOutputRowWithSplitRowsAndHeaderOffsetForSplitRowsAllowed() throws Exception {
+    String expected = "Name;Surname1;DATA12;DATA23;DATA3Name;Surname4;DATA45;DATA5";
+    processStep( true );
+
+    String result =  new String( ( (ConcatFieldsOutputStream) stepMockHelper.processRowsStepDataInterface.writer ).read() );
+    Assert.assertEquals( expected, result );
+  }
+
+  private void processStep( boolean enableHeaderOffsetForSplitRows ) throws KettleException {
+    List<Object[]> rows = createRowsData();
+    ConcatFieldsHandler concatFields = createConcatFieldsHandler( rows );
+
+    String headerOffsetFlag = enableHeaderOffsetForSplitRows ? "Y" : "N";
+    concatFields.setVariable( Const.KETTLE_COMPATIBILITY_CONCAT_FIELDS_SPLIT_ROWS_HEADER_OFFSET, headerOffsetFlag );
+
+    concatFields.init( stepMockHelper.processRowsStepMetaInterface, stepMockHelper.processRowsStepDataInterface );
+    for ( Object[] row : rows ) {
+      concatFields.setRow( row );
+      concatFields.processRow( stepMockHelper.processRowsStepMetaInterface, stepMockHelper.processRowsStepDataInterface );
+      concatFields.prepareOutputRow( row );
+    }
+    concatFields.setRow( null );
+  }
+
+  private ConcatFieldsHandler createConcatFieldsHandler( List<Object[]> rows ) throws KettleStepException {
+    ConcatFieldsHandler concatFields =
+      new ConcatFieldsHandler( stepMockHelper.stepMeta, stepMockHelper.stepDataInterface, 0, stepMockHelper.transMeta,
+        stepMockHelper.trans, true );
+
+    when( stepMockHelper.processRowsStepMetaInterface.getOutputFields() ).thenReturn( textFileFields );
+    when( stepMockHelper.processRowsStepMetaInterface.isFastDump() ).thenReturn( Boolean.FALSE );
+    when( stepMockHelper.processRowsStepMetaInterface.isFileAppended() ).thenReturn( Boolean.FALSE );
+    when( stepMockHelper.processRowsStepMetaInterface.isFileNameInField() ).thenReturn( Boolean.FALSE );
+    when( stepMockHelper.processRowsStepMetaInterface.isHeaderEnabled() ).thenReturn( Boolean.TRUE );
+    when( stepMockHelper.processRowsStepMetaInterface.isRemoveSelectedFields() ).thenReturn( Boolean.TRUE );
+    when( stepMockHelper.processRowsStepMetaInterface.isFooterEnabled() ).thenReturn( Boolean.TRUE );
+    when( stepMockHelper.processRowsStepMetaInterface.getSeparator() ).thenReturn( ";" );
+    when( stepMockHelper.processRowsStepMetaInterface.getEndedLine() ).thenReturn( "-" );
+    when( stepMockHelper.processRowsStepMetaInterface.getSplitEvery() ).thenReturn( 4 );
+
+    ValueMetaInterface[] metaWithFieldOptions = getValueMetaInterfaces();
+    when( stepMockHelper.processRowsStepMetaInterface.getMetaWithFieldOptions() ).thenReturn( metaWithFieldOptions );
+
+    when( stepMockHelper.processRowsStepMetaInterface.getTargetFieldName() ).thenCallRealMethod();
+    doCallRealMethod().when( stepMockHelper.processRowsStepMetaInterface ).setTargetFieldName( any( String.class ) );
+    doCallRealMethod().when( stepMockHelper.processRowsStepMetaInterface ).getFields(
+      any( RowMetaInterface.class ), any( String.class ), any(), any( StepMeta.class ),
+      any( VariableSpace.class ), any( Repository.class ), any( IMetaStore.class ) );
+
+    stepMockHelper.processRowsStepMetaInterface.setTargetFieldName( "target_result" );
+    stepMockHelper.processRowsStepMetaInterface.setDoNotOpenNewFileInit( true );
+
+    String[] fieldNames = new String[] { textFileField.getName(), textFileField2.getName() };
+    RowSet rowSet = stepMockHelper.getMockInputRowSet( rows );
+    RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
+    concatFields.setInputRowMeta( inputRowMeta );
+
+    when( rowSet.getRowWait( anyInt(), any( TimeUnit.class ) ) ).thenReturn(
+      rows.isEmpty() ? null : rows.iterator().next() );
+    when( rowSet.getRowMeta() ).thenReturn( inputRowMeta );
+    when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
+    when( inputRowMeta.getFieldNames() ).thenReturn( fieldNames );
+    when( inputRowMeta.size() ).thenReturn( textFileFields.length );
+
+    for ( int i = 0; i < textFileFields.length; i++ ) {
+      String name = textFileFields[ i ].getName();
+      ValueMetaString valueMetaString = new ValueMetaString( name );
+      when( inputRowMeta.getValueMeta( i ) ).thenReturn( valueMetaString );
+      when( inputRowMeta.indexOfValue( name ) ).thenReturn( i );
+    }
+
+    concatFields.addRowSetToInputRowSets( rowSet );
+    concatFields.addRowSetToOutputRowSets( rowSet );
+    return concatFields;
+  }
+
+  private List<Object[]> createRowsData() {
+    List<Object[]> rows = new ArrayList<>();
+    for ( long i = 1; i < 6; i++ ) {
+      rows.add( new Object[] { i, "DATA" + i } );
+    }
+    return rows;
+  }
+
+  private ValueMetaInterface[] getValueMetaInterfaces() {
+    ValueMetaInterface[] metaWithFieldOptions = new ValueMetaInterface[ textFileFields.length ];
+    ValueMetaInterface valueMeta1 = new ValueMetaString();
+    ValueMetaInterface valueMeta2 = new ValueMetaString();
+    metaWithFieldOptions[ 0 ] = valueMeta1;
+    metaWithFieldOptions[ 1 ] = valueMeta2;
+    return metaWithFieldOptions;
+  }
+
+  public class ConcatFieldsMetaHandler extends ConcatFieldsMeta {
+    @Override
+    protected synchronized ValueMetaInterface[] getMetaWithFieldOptions() {
+      return super.getMetaWithFieldOptions();
+    }
   }
 }


### PR DESCRIPTION
For backward compatibility, new Kettle property is added -  KETTLE_COMPATIBILITY_CONCAT_FIELDS_SPLIT_ROWS_HEADER_OFFSET

By default, value will be KETTLE_COMPATIBILITY_CONCAT_FIELDS_SPLIT_ROWS_HEADER_OFFSET= N indicating existing functionality and KETTLE_COMPATIBILITY_CONCAT_FIELDS_SPLIT_ROWS_HEADER_OFFSET= Y, which will correct the offset and populates the header at right position