### PR TITLE
Add LoongArch support for shell scripts

### DIFF
--- a/assemblies/core/static/src/main/resources-filtered/spoon.sh
+++ b/assemblies/core/static/src/main/resources-filtered/spoon.sh
@@ -187,6 +187,10 @@ case `uname -s` in
 				LIBPATH=$CURRENTDIR/../libswt/linux/ppc64/
 				;;
 
+            loongarch64)
+                LIBPATH=$CURRENTDIR/../libswt/linux/loongarch64/
+                ;;
+
 			*)
 				echo "I'm sorry, this Linux platform [$ARCH] is not yet supported!"
 				exit

--- a/assemblies/static/src/main/resources-filtered/spoon.sh
+++ b/assemblies/static/src/main/resources-filtered/spoon.sh
@@ -187,6 +187,10 @@ case `uname -s` in
 				LIBPATH=$CURRENTDIR/../libswt/linux/ppc64/
 				;;
 
+            loongarch64)
+                LIBPATH=$CURRENTDIR/../libswt/linux/loongarch64/
+                ;;
+
 			*)
 				echo "I'm sorry, this Linux platform [$ARCH] is not yet supported!"
 				exit

--- a/translator.sh
+++ b/translator.sh
@@ -101,6 +101,9 @@ case `uname -s` in
 			ppc)
 				LIBPATH=$BASEDIR/libswt/linux/ppc/
 				;;
+            loongarch64)
+                LIBPATH=$CURRENTDIR/../libswt/linux/loongarch64/
+                ;;
 
 			*)	
 				echo "I'm sorry, this Linux platform [$ARCH] is not yet supported!"


### PR DESCRIPTION
LoongArch is a new RISC ISA, which is a bit like MIPS or RISC-V.
This patch support 64-bit version of LoongArch.

Due to the fact that the eclipse automatic build service currently does not have the Loongarch architecture, there are no pre compiled binary packages available. However, I use the manually compiled swt.jar,  PDI can run normally.

org.eclipse.swt.gtk.linux.loongarch64 already exists upstream:
https://github.com/eclipse-platform/eclipse.platform.swt.binaries/tree/master/bundles/org.eclipse.swt.gtk.linux.loongarch64