### PR TITLE
Revert "[BAD-1930] - When Cloudera HIVE driver is used, a side effect in the LOGs with error messages start to show"

### DIFF
--- a/assemblies/core/static/src/main/resources-standard/classes/simplelogger.properties
+++ b/assemblies/core/static/src/main/resources-standard/classes/simplelogger.properties
@@ -1,8 +1,0 @@
-org.slf4j.simpleLogger.defaultLogLevel=WARN
-org.slf4j.simpleLogger.log.org.apache.sqoop=INFO
-org.slf4j.simpleLogger.log.org.apache.hadoop.mapreduce=INFO
-org.slf4j.simpleLogger.log.org.apache.hadoop.ipc.Client=ERROR
-
-#This is to solve the HIVE Error that does not affect connection, but comes when Kerberos authentication using Cloudera driver
-org.slf4j.simpleLogger.log.org.apache.hive.jdbc.HiveConnection=ERROR
-org.slf4j.simpleLogger.log.com.pentaho.hadoop.shim.hive.security.impersonation=OFF

--- a/assemblies/static/src/main/resources/classes/simplelogger.properties
+++ b/assemblies/static/src/main/resources/classes/simplelogger.properties
@@ -1,8 +1,0 @@
-org.slf4j.simpleLogger.defaultLogLevel=WARN
-org.slf4j.simpleLogger.log.org.apache.sqoop=INFO
-org.slf4j.simpleLogger.log.org.apache.hadoop.mapreduce=INFO
-org.slf4j.simpleLogger.log.org.apache.hadoop.ipc.Client=ERROR
-
-#This is to solve the HIVE Error that does not affect connection, but comes when Kerberos authentication using Cloudera driver
-org.slf4j.simpleLogger.log.org.apache.hive.jdbc.HiveConnection=ERROR
-org.slf4j.simpleLogger.log.com.pentaho.hadoop.shim.hive.security.impersonation=OFF


### PR DESCRIPTION
Reverts pentaho/pentaho-kettle#9109