### PR TITLE
[PDI-20003] Add a new extension point before the Carte webserver is started

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/extension/KettleExtensionPoint.java
+++ b/core/src/main/java/org/pentaho/di/core/extension/KettleExtensionPoint.java
@@ -109,6 +109,7 @@ public enum KettleExtensionPoint {
     BeforeCheckStep( "BeforeCheckStep", "Right before a step is about to be verified." ),
     AfterCheckStep( "AfterCheckStep", "After a step has been checked for warnings/errors." ),
 
+    BeforeCarteStartup( "BeforeCarteStartup", "Right before the Carte webserver is started" ),
     CarteStartup( "CarteStartup", "Right after the Carte webserver has started and is fully functional" ),
     CarteShutdown( "CarteShutdown", "Right before the Carte webserver will shut down" ),
 

--- a/engine/src/main/java/org/pentaho/di/www/WebServer.java
+++ b/engine/src/main/java/org/pentaho/di/www/WebServer.java
@@ -282,7 +282,9 @@ public class WebServer {
     securityHandler.setHandler( handlers );
 
     server.setHandler( securityHandler );
-
+    
+    ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.BeforeCarteStartup.id, server );
+    
     // Start execution
     createListeners();
 
@@ -310,7 +312,7 @@ public class WebServer {
     } catch ( KettleException e ) {
       // Log error but continue regular operations to make sure Carte can be shut down properly.
       //
-      log.logError( "Error calling extension point CarteStartup", e );
+      log.logError( "Error calling extension point CarteShutdown", e );
     }
 
     try {


### PR DESCRIPTION
This extension point allows the embedded Jetty Server for Carte to be further configured beyond the default Handler setup in WebServer.java.