### PR TITLE
[BACKLOG-39430] - PDI - unable to close PDI instance after installation startup

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/core/PropsUI.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/PropsUI.java
@@ -50,6 +50,7 @@ import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.plugins.LifecyclePluginType;
 import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.laf.BasePropertyHandler;
 import org.pentaho.di.ui.core.gui.GUIResource;
@@ -251,6 +252,7 @@ public class PropsUI extends Props {
     lastUsedRepoFiles = new LinkedHashMap<>();
     openTabFiles = new ArrayList<LastUsedFile>();
     screens = new Hashtable<String, WindowProperty>();
+    lastUsedLocalFile = StringUtil.EMPTY_STRING;
 
     properties.setProperty( STRING_LOG_LEVEL, getLogLevel() );
     properties.setProperty( STRING_LOG_FILTER, getLogFilter() );
@@ -542,7 +544,7 @@ public class PropsUI extends Props {
           openItemTypes ) );
     }
 
-    lastUsedLocalFile = properties.getProperty( "lastUsedLocalFile" );
+    lastUsedLocalFile = Const.NVL( properties.getProperty( "lastUsedLocalFile" ), "" );
   }
 
   public void loadLastUsedRepoFiles() {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -4783,6 +4783,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       } else if ( fileDialogOperation.getPath() != null && fileDialogOperation.getFilename() != null ) {
         String filename = fileDialogOperation.getPath() + File.separator + fileDialogOperation.getFilename();
         lastFileOpened = filename;
+        props.setLastUsedLocalFile( filename );
         lastFileOpenedConnection = fileDialogOperation.getConnection();
         lastFileOpenedProvider = fileDialogOperation.getProvider();
         if ( lastFileOpenedConnection != null && meta instanceof VariableSpace ) {


### PR DESCRIPTION
Also fixes issue introduced with [PDI-19944](https://hv-eng.atlassian.net/browse/PDI-19944), where it was failing to save files (or exiting the Options dialog) if no file had been previously opened.

[PDI-19944]: https://hv-eng.atlassian.net/browse/PDI-19944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ