### PR TITLE
[BACKLOG-39451] Remove ehcache-core jar from build.  Causing conflict…

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -64,7 +64,6 @@
     <olap4j-xmla.version>1.2.0</olap4j-xmla.version>
     <wsdl4j.version>1.6.2</wsdl4j.version>
     <wsdl4j-qname.version>1.6.1</wsdl4j-qname.version>
-    <ehcache-core.version>2.5.1</ehcache-core.version>
     <hibernate-core.version>5.4.24.Final</hibernate-core.version>
     <hibernate-c3p0.version>5.4.24.Final</hibernate-c3p0.version>
     <hibernate-commons-annotations.version>3.2.0.Final</hibernate-commons-annotations.version>
@@ -630,17 +629,6 @@
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.1-api</artifactId>
       <version>1.0.2.Final</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache-core</artifactId>
-      <version>${ehcache-core.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
… in geomaps and no longer needed.