### PR TITLE
[SP-6472] - Backport of PDI-19109 - "Wait for a file" job entry does not throw an error when the "Check cycle time" field is set with a non-numeric value. (9.3 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/waitforfile/JobEntryWaitForFile.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/waitforfile/JobEntryWaitForFile.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.job.entries.waitforfile;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.pentaho.di.job.entry.validator.AndValidator;
 import org.pentaho.di.job.entry.validator.JobEntryValidatorUtils;
 
@@ -169,6 +170,27 @@ public class JobEntryWaitForFile extends JobEntryBase implements Cloneable, JobE
   public Result execute( Result previousResult, int nr ) {
     Result result = previousResult;
     result.setResult( false );
+
+    // Validate if Real Maximum Timeout is only digits.
+    int errorsCount = 0;
+    if ( !NumberUtils.isDigits( getRealMaximumTimeout() ) ) {
+      errorsCount++;
+      logError( "Invalid value for Maximum Timeout." );
+      return result;
+    }
+
+    // Validate if Real Check Cycle Time is only digits.
+    if ( !NumberUtils.isDigits( getRealCheckCycleTime() ) ) {
+      errorsCount++;
+      logError( "Invalid value for Check Cycle Time." );
+      return result;
+    }
+
+    if ( errorsCount > 0 ) {
+      result.setResult( false );
+      result.setNrErrors( errorsCount );
+    }
+
 
     // starttime (in seconds)
     long timeStart = System.currentTimeMillis() / 1000;


### PR DESCRIPTION
Original PR:
 - https://github.com/pentaho/pentaho-kettle/pull/9145/