### PR TITLE
[BACKLOG-39189] Temporary workaround for bug in apache commons-vfs

### DIFF
--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/cubeinput/CubeInput.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/cubeinput/CubeInput.java
@@ -147,6 +147,14 @@ public class CubeInput extends BaseStep implements StepInterface {
       logError( BaseMessages.getString( PKG, "CubeInput.Log.ErrorClosingCube" ) + e.toString() );
       setErrors( 1 );
       stopAll();
+
+    // HACK! This is a temporary workaround for commons-vfs bug in 2.8.0 where a null pointer gets thrown
+    // when the stream gets closed from a different thread. This has been fixed in 2.9.0, but we can't move
+    // to that version due to a bug involving truncation on writes. This should be removed when can update
+    // this library. See BACKLOG-39189, https://github.com/apache/commons-vfs/pull/167
+    } catch ( NullPointerException e ) {
+      logDebug( "Catching exception to work around commons-vfs 2.8.0 close() bug: " + e.toString() );
+      stopAll();
     }
 
     super.dispose( smi, sdi );


### PR DESCRIPTION
This is a temporary workaround while we figure out what to do with this library. This bug is only present in commons-vfs 2.8.0 (not present in 2.7.0 and fixed in 2.9.0) but:
- we had to move off of 2.7.0 to get around an sftp bug
- we couldn't move up to 2.9.0 because of a bug where file writes were truncated

This issue was the simplest to workaround. We'll address this in a permanent way and revert this in another ticket.