### PR TITLE
[BACKLOG-39454]-Lots of errors coming up on logs when server 10.1 is configured to use Java 8 [updating jboss-logging jar ]

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -68,7 +68,7 @@
     <hibernate-c3p0.version>5.4.24.Final</hibernate-c3p0.version>
     <hibernate-commons-annotations.version>3.2.0.Final</hibernate-commons-annotations.version>
     <hibernate-ehcache.version>5.4.24.Final</hibernate-ehcache.version>
-    <jboss-logging.version>3.5.3.Final</jboss-logging.version>
+    <jboss-logging.version>3.4.3.Final</jboss-logging.version>
     <javax.persistence-api.version>2.2</javax.persistence-api.version>
     <byte-buddy.version>1.12.16</byte-buddy.version>
     <cglib-nodep.version>2.2</cglib-nodep.version>


### PR DESCRIPTION
[BACKLOG-39454]-Lots of errors coming up on logs when server 10.1 is configured to use Java 8 [updating jboss-logging jar ]

[BACKLOG-39454]: https://hv-eng.atlassian.net/browse/BACKLOG-39454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ