### PR TITLE
[PDI-19761]-Sample Transformation "General General - check Sequence and Abort" fails due to incorrect column names

### DIFF
--- a/assemblies/samples/src/main/resources/transformations/General - check Sequence and Abort.ktr
+++ b/assemblies/samples/src/main/resources/transformations/General - check Sequence and Abort.ktr
@@ -753,7 +753,7 @@ See sample "Merge rows - mergs 2 streams of data and add a flag"</note>
         <trim_type>none</trim_type>
       </field>
       <field>
-        <name>value</name>
+        <name>val</name>
         <type>String</type>
         <format/>
         <currency/>


### PR DESCRIPTION
[PDI-19761]-Sample Transformation "General General - check Sequence and Abort" fails due to incorrect column names

[PDI-19761]: https://hv-eng.atlassian.net/browse/PDI-19761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ