### PR TITLE
[PDI-20033] - Sub-job is not executed when “Execute every input row” is checked.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -731,7 +731,7 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
       List<RowMetaAndData> rows = new ArrayList<RowMetaAndData>( result.getRows() );
 
       while ( ( first && !execPerRow )
-        || ( execPerRow && rows != null && iteration < rows.size() && result.getNrErrors() == 0 ) ) {
+        || ( execPerRow && rows != null && !rows.isEmpty() && iteration <= rows.size() && result.getNrErrors() == 0 ) ) {
 
         first = false;
         // Clear the result rows of the result


### PR DESCRIPTION
Fixing issue already described in PDI-18776, later revised in PDI-19275, and unconsidering 0 rows to process

@smmribeiro 
@renato-s 