### PR TITLE
[PDI-20038] - Pentaho 9.3.0.6 - Getting java.lang.OutOfMemoryError: Java heap space when running PDI Jobs

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/logging/LoggingObject.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/LoggingObject.java
@@ -60,7 +60,7 @@ public class LoggingObject implements LoggingObjectInterface {
     } else {
       grabObjectInformation( object );
     }
-    loggingObjectInUse = false;
+    loggingObjectInUse = true;
   }
 
   @Override


### PR DESCRIPTION
Fixing problem found during testing