### PR TITLE
[SP-6496] - Backport of PDI-20038 - Pentaho 9.3.0.6 - Getting java.lang.OutOfMemoryError: Java heap space when running PDI Jobs (9.3 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/logging/LoggingObject.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/LoggingObject.java
@@ -47,7 +47,6 @@ public class LoggingObject implements LoggingObjectInterface {
 
   private LoggingObjectInterface parent;
 
-  private LoggingObjectInterface loggingObject;
 
   private boolean loggingObjectInUse;
   private Date registrationDate;
@@ -157,7 +156,6 @@ public class LoggingObject implements LoggingObjectInterface {
     containerObjectId = loggingObject.getContainerObjectId();
     forcingSeparateLogging = loggingObject.isForcingSeparateLogging();
     gatheringMetrics = loggingObject.isGatheringMetrics();
-    this.loggingObject = loggingObject;
 
     if ( loggingObject.getParent() != null ) {
       getParentLoggingObject( loggingObject.getParent() );
@@ -170,12 +168,11 @@ public class LoggingObject implements LoggingObjectInterface {
     objectType = LoggingObjectType.GENERAL;
     objectName = object.toString(); // name of class or name of object..
     parent = null;
-    loggingObject = null;
   }
 
   @Override
   public boolean isLoggingObjectInUse() {
-    return loggingObject == null ? loggingObjectInUse : loggingObject.isLoggingObjectInUse() || loggingObjectInUse;
+    return loggingObjectInUse || ( parent != null && parent.isLoggingObjectInUse() );
   }
 
   public void setLoggingObjectInUse( boolean loggingObjectInUse ) {


### PR DESCRIPTION
Original PR:
 - https://github.com/pentaho/pentaho-kettle/pull/9198