### PR TITLE
[PDI-19386] FTP_Delete step: Not recognizing "Copy previous results to" option when enabled.

### DIFF
--- a/plugins/ftp-delete/impl/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
+++ b/plugins/ftp-delete/impl/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
@@ -694,6 +694,9 @@ public class JobEntryFTPDelete extends JobEntryBase implements Cloneable, JobEnt
 
       // Get all the files in the current directory...
       String[] filelist = null;
+      if ( copyprevious ) {
+        realFtpDirectory = "";
+      }
       if ( protocol.equals( PROTOCOL_FTP ) ) {
         // If socks proxy server was provided
         if ( !Utils.isEmpty( socksProxyHost ) ) {


### PR DESCRIPTION
[PDI-19386] FTP_Delete step: Not recognizing "Copy previous results to" option when enabled.

[PDI-19386]: https://hv-eng.atlassian.net/browse/PDI-19386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ