### PR TITLE
[PDI-20033] - Sub-job is not executed when “Execute every input row” is checked.

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1642,7 +1642,20 @@ public class Const {
    */
   public static final String KETTLE_PYTHON_STEP_REPLACE_NULLS = "KETTLE_PYTHON_STEP_REPLACE_NULLS";
 
+  /**
+   Value to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as job input mode.
+  */
+  public static final String COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT = "COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT";
 
+  /**
+   Value to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as trans input mode.
+   */
+    public static final String COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT = "COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT";
+
+  /**
+   Value to show/not show the Warning messages regarding the configured behaviour of the flag "Execute every Input Row"
+   */
+  public static final String COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW = "COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW";
 
   /**
    * rounds double f to any number of places after decimal point Does arithmetic using BigDecimal class to avoid integer

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -745,7 +745,8 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
     List<RowMetaAndData> rows = new ArrayList<RowMetaAndData>( result.getRows() );
 
     while ( ( first && !execPerRow )
-      || ( execPerRow && rows != null && iteration < rows.size() && result.getNrErrors() == 0 )
+      || ( execPerRow && rows != null && iteration <= rows.size() && result.getNrErrors() == 0
+      || shouldConsiderOldBehaviourForEveryInputRow( rows.size() ) )
       && !parentJob.isStopped() ) {
       // Clear the result rows of the result
       // Otherwise we double the amount of rows every iteration in the simple cases.
@@ -1261,6 +1262,18 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
 
     setLoggingObjectInUse( false );
     return result;
+  }
+
+  private boolean shouldConsiderOldBehaviourForEveryInputRow( int numOfRows ) {
+    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
+    if ( numOfRows == 0 ) {
+      if ( shouldExecuteWithZeroRows ) {
+        log.logBasic( "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+      } else {
+        log.logBasic( "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+      }
+    }
+    return shouldExecuteWithZeroRows;
   }
 
   protected void updateResult( Result result ) {

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -640,4 +640,28 @@
     <default-value></default-value>
   </kettle-variable>
 
+  <kettle-variable>
+    <description>Set this variable to Y to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as job input mode.
+      See Jira issue PPP-20033 for details.
+    </description>
+    <variable>COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
+    <default-value>N</default-value>
+  </kettle-variable>
+
+  <kettle-variable>
+    <description>Set this variable to Y to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as trans input mode.
+      See Jira issue PPP-20033 for details.
+    </description>
+    <variable>COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
+    <default-value>N</default-value>
+  </kettle-variable>
+
+  <kettle-variable>
+    <description>Set this variable to Y/N to show/not show the Warning messages regarding the configured behaviour of the flag "Execute every Input Row".
+      See Jira issue PPP-20033 for details.
+    </description>
+    <variable>COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW</variable>
+    <default-value>Y</default-value>
+  </kettle-variable>
+
 </kettle-variables>


### PR DESCRIPTION
Changes as requested by CSS team with configurable behaviour.
These changes are expected to be reverted in future releases.

@smmribeiro 
@renato-s 