### PR TITLE
 [SP-6506]-Backport of PDI-19752 - FTP Delete: the files are not deleted if it contains Japanese as a wildcard or full filename (9.3 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
@@ -1071,6 +1071,7 @@ public class JobEntryFTPDelete extends JobEntryBase implements Cloneable, JobEnt
 
     // Create ftp client to host:port ...
     ftpclient = new FTPClient();
+    ftpclient.setControlEncoding("UTF-8");
     ftpclient.setRemoteAddr( InetAddress.getByName( realServername ) );
     if ( realport != 0 ) {
       ftpclient.setRemotePort( realport );


### PR DESCRIPTION
 [SP-6506]-Backport of PDI-19752 - FTP Delete: the files are not deleted if it contains Japanese as a wildcard or full filename (9.3 Suite)

[SP-6506]: https://hv-eng.atlassian.net/browse/SP-6506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ