### PR TITLE
[SP-6519] - Backport of PDI-20033 - Sub-job is not executed when “Execute every input row” is checked. (10.1 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -732,7 +732,7 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
 
       while ( ( first && !execPerRow )
         || ( execPerRow && !rows.isEmpty() && iteration <= rows.size() && result.getNrErrors() == 0 )
-        || ( execPerRow && rows.isEmpty() && shouldConsiderOldBehaviourForEveryInputRow() ) ) {
+        || ( execPerRow && rows.isEmpty() && iteration <= rows.size() && shouldConsiderOldBehaviourForEveryInputRow() ) ) {
 
         first = false;
         // Clear the result rows of the result

--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -1399,7 +1399,7 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
   @Deprecated
   public JobMeta getJobMeta( Repository rep, VariableSpace space ) throws KettleException {
     parentJobMeta.getMetaFileCache( ); //Get the cache from the parent or create it
-    return getJobMeta( rep, getMetaStore(), space );
+      return getJobMeta( rep, getMetaStore(), space );
   }
 
   protected JobMeta getJobMetaFromRepository( Repository rep, CurrentDirectoryResolver r, String transPath, VariableSpace tmpSpace ) throws KettleException {

--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -731,8 +731,8 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
       List<RowMetaAndData> rows = new ArrayList<RowMetaAndData>( result.getRows() );
 
       while ( ( first && !execPerRow )
-        || ( execPerRow && rows != null && !rows.isEmpty() && iteration <= rows.size() && result.getNrErrors() == 0 )
-        || shouldConsiderOldBehaviourForEveryInputRow( rows.size() ) ) {
+        || ( execPerRow && !rows.isEmpty() && iteration <= rows.size() && result.getNrErrors() == 0 )
+        || ( execPerRow && rows.isEmpty() && shouldConsiderOldBehaviourForEveryInputRow() ) ) {
 
         first = false;
         // Clear the result rows of the result
@@ -1238,13 +1238,15 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
     return result;
   }
 
-  private boolean shouldConsiderOldBehaviourForEveryInputRow( int numOfRows ) {
+  private boolean shouldConsiderOldBehaviourForEveryInputRow( ) {
     boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
-    if ( numOfRows == 0 ) {
+    if ( "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "N" ) ) ) {
       if ( shouldExecuteWithZeroRows ) {
-        log.logBasic( "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+        log.logBasic(
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       } else {
-        log.logBasic( "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+        log.logBasic(
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       }
     }
     return shouldExecuteWithZeroRows;

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -745,8 +745,8 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
     List<RowMetaAndData> rows = new ArrayList<RowMetaAndData>( result.getRows() );
 
     while ( ( first && !execPerRow )
-      || ( execPerRow && rows != null && iteration <= rows.size() && result.getNrErrors() == 0
-      || shouldConsiderOldBehaviourForEveryInputRow( rows.size() ) )
+      || ( execPerRow && !rows.isEmpty() && iteration <= rows.size() && result.getNrErrors() == 0 )
+      || ( execPerRow && rows.isEmpty() && shouldConsiderOldBehaviourForEveryInputRow() )
       && !parentJob.isStopped() ) {
       // Clear the result rows of the result
       // Otherwise we double the amount of rows every iteration in the simple cases.
@@ -1264,13 +1264,15 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
     return result;
   }
 
-  private boolean shouldConsiderOldBehaviourForEveryInputRow( int numOfRows ) {
+  private boolean shouldConsiderOldBehaviourForEveryInputRow() {
     boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
-    if ( numOfRows == 0 ) {
+    if ( "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "N" ) ) ) {
       if ( shouldExecuteWithZeroRows ) {
-        log.logBasic( "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+        log.logBasic(
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       } else {
-        log.logBasic( "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+        log.logBasic(
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       }
     }
     return shouldExecuteWithZeroRows;

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -746,7 +746,7 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
 
     while ( ( first && !execPerRow )
       || ( execPerRow && !rows.isEmpty() && iteration <= rows.size() && result.getNrErrors() == 0 )
-      || ( execPerRow && rows.isEmpty() && shouldConsiderOldBehaviourForEveryInputRow() )
+      || ( execPerRow && rows.isEmpty() && iteration <= rows.size() && shouldConsiderOldBehaviourForEveryInputRow() )
       && !parentJob.isStopped() ) {
       // Clear the result rows of the result
       // Otherwise we double the amount of rows every iteration in the simple cases.
@@ -754,7 +754,8 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       if ( execPerRow ) {
         result.getRows().clear();
       }
-      if ( rows != null && execPerRow ) {
+
+      if ( rows != null && execPerRow && !rows.isEmpty() ) {
         resultRow = rows.get( iteration );
       } else {
         resultRow = null;


### PR DESCRIPTION
Original PRs:

https://github.com/pentaho/pentaho-kettle/pull/9196
https://github.com/pentaho/pentaho-kettle/pull/9246

@smmribeiro
@renato-s