### PR TITLE
[SP-6526]-Backport of PDI-19386 - FTP_Delete step: Not recognizing "Copy previous results to" option when enabled. (9.3 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
@@ -687,6 +687,9 @@ public class JobEntryFTPDelete extends JobEntryBase implements Cloneable, JobEnt
 
       // Get all the files in the current directory...
       String[] filelist = null;
+      if ( copyprevious ) {
+        realFtpDirectory = "";
+      }
       if ( protocol.equals( PROTOCOL_FTP ) ) {
         // If socks proxy server was provided
         if ( !Utils.isEmpty( socksProxyHost ) ) {
@@ -709,6 +712,9 @@ public class JobEntryFTPDelete extends JobEntryBase implements Cloneable, JobEnt
               PKG, "JobEntryFTPDelete.SocksProxy.IncompleteCredentials",
               environmentSubstitute( socksProxyHost ), getName() ) );
           }
+        }
+        if ( copyprevious ) {
+          realFtpDirectory = "";
         }
 
         // establish the connection


### PR DESCRIPTION
[SP-6526]-Backport of PDI-19386 - FTP_Delete step: Not recognizing "Copy previous results to" option when enabled. (9.3 Suite)