### PR TITLE
[SP-6526]-Backport of PDI-19386 - FTP_Delete step: Not recognizing "Copy previous results to" option when enabled. (10.1 Suite)

### DIFF
--- a/plugins/ftp-delete/impl/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
+++ b/plugins/ftp-delete/impl/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
@@ -694,6 +694,9 @@ public class JobEntryFTPDelete extends JobEntryBase implements Cloneable, JobEnt
 
       // Get all the files in the current directory...
       String[] filelist = null;
+      if ( copyprevious ) {
+        realFtpDirectory = "";
+      }
       if ( protocol.equals( PROTOCOL_FTP ) ) {
         // If socks proxy server was provided
         if ( !Utils.isEmpty( socksProxyHost ) ) {


### PR DESCRIPTION
[SP-6526]-Backport of PDI-19386 - FTP_Delete step: Not recognizing "Copy previous results to" option when enabled. (10.1 Suite)