### PR TITLE
[SP-6524] - Backport of PDI-19734 - Jobs getting failed due to same name in sub job & sub transformation in v9.3: org.pentaho.di.job.JobMeta cannot be cast to org.pentaho.di.trans.TransMeta (10.1 Suite)

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/MetaFileCacheImpl.java
+++ b/engine/src/main/java/org/pentaho/di/base/MetaFileCacheImpl.java
@@ -26,10 +26,12 @@ import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.trans.TransMeta;
 
 import java.sql.Timestamp;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class MetaFileCacheImpl implements IMetaFileCache {
+
   private LogChannelInterface logger;
 
   protected Map<String, MetaFileCacheEntry<? extends AbstractMeta>> cacheMap = new ConcurrentHashMap<>();
@@ -38,20 +40,27 @@ public class MetaFileCacheImpl implements IMetaFileCache {
     this.logger = logger;
   }
 
+  public static final String KTR = ".ktr";
+  public static final String KJB = ".kjb";
+
   @Override public JobMeta getCachedJobMeta( String key ) {
-    return cacheMap.get( key ) == null ? null : ( (JobMeta) cacheMap.get( key ).getMeta() );
+    String keyNormalized = key.endsWith( KJB ) ? key : key + KJB;
+    return cacheMap.get( keyNormalized ) == null ? null : ( (JobMeta) cacheMap.get( keyNormalized ).getMeta() );
   }
 
   @Override public TransMeta getCachedTransMeta( String key ) {
-    return cacheMap.get( key ) == null ? null : ( (TransMeta) cacheMap.get( key ).getMeta() );
+    String keyNormalized = key.endsWith( KTR ) ? key : key + KTR;
+    return cacheMap.get( keyNormalized ) == null ? null : ( (TransMeta) cacheMap.get( keyNormalized ).getMeta() );
   }
 
   @Override public void cacheMeta( String key, JobMeta meta ) {
-    cacheMap.put( key, new MetaFileCacheEntry<>( key, (JobMeta) meta.realClone( false ) ) );
+    String keyNormalized = key.endsWith( KJB ) ? key : key + KJB;
+    cacheMap.put( keyNormalized,  new MetaFileCacheEntry<>( key, (JobMeta) meta.realClone( false ) ) );
   }
 
   @Override public void cacheMeta( String key, TransMeta meta ) {
-    cacheMap.put( key, new MetaFileCacheEntry<>( key, (TransMeta) meta.realClone( false ) ) );
+    String keyNormalized = key.endsWith( KTR ) ? key : key + KTR;
+    cacheMap.put( keyNormalized, new MetaFileCacheEntry<>( key, (TransMeta) meta.realClone( false ) ) );
   }
 
   @Override public void logCacheSummary( LogChannelInterface log ) {
@@ -76,10 +85,12 @@ public class MetaFileCacheImpl implements IMetaFileCache {
     String key;
 
     MetaFileCacheEntry( String key, T meta ) {
-      this.key = key;
+
       if ( meta instanceof JobMeta ) {
+        this.key = key.endsWith( KJB ) ? key : key + KJB;
         this.meta = (T) ( (JobMeta) meta ).realClone( false );  //always clone the meta
       } else if ( meta instanceof TransMeta ) {
+        this.key = key.endsWith( KTR ) ? key : key + KTR;
         this.meta = (T) ( (TransMeta) meta ).realClone( false );  //always clone the meta
       }
     }

--- a/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
+++ b/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
@@ -62,6 +62,7 @@ import static org.pentaho.di.core.Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAM
  * @param <T> Either a TransMeta or JobMeta
  */
 public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
+
   JobEntryBase jobEntryBase;
 
   private ObjectLocationSpecificationMethod specificationMethod;
@@ -74,6 +75,9 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
   private String filename;
 
   private BaseStepMeta baseStepMeta;
+
+  public static final String KJB = ".kjb";
+  public static final String KTR = ".ktr";
 
   /**
    * @param jobEntryBase        either a JobEntryTrans or JobEntryJob Object
@@ -260,13 +264,13 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
         TransMeta transMeta = (TransMeta) theMeta;
         transMeta.setMetaFileCache( metaFileCache );
         if ( cacheKey != null ) {
-          metaFileCache.cacheMeta( metaFileCache.getKey( specificationMethod, cacheKey ), transMeta );
+          metaFileCache.cacheMeta( metaFileCache.getKey( specificationMethod, cacheKey.endsWith( KTR ) ? cacheKey : cacheKey + KTR ), transMeta );
         }
       } else {
         JobMeta jobMeta = (JobMeta) theMeta;
         jobMeta.setMetaFileCache( metaFileCache );
         if ( cacheKey != null ) {
-          metaFileCache.cacheMeta( metaFileCache.getKey( specificationMethod, cacheKey ), jobMeta );
+          metaFileCache.cacheMeta( metaFileCache.getKey( specificationMethod, cacheKey.endsWith( KJB ) ? cacheKey : cacheKey + KJB ), jobMeta );
         }
       }
     }
@@ -333,8 +337,8 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
       return null;
     }
     return isTransMeta()
-      ? (T) metaFileCache.getCachedTransMeta( metaFileCache.getKey( specificationMethod, realFilename ) )
-      : (T) metaFileCache.getCachedJobMeta( metaFileCache.getKey( specificationMethod, realFilename ) );
+      ? (T) metaFileCache.getCachedTransMeta( metaFileCache.getKey( specificationMethod, realFilename.endsWith( KTR ) ? realFilename : realFilename + KTR ) )
+      : (T) metaFileCache.getCachedJobMeta( metaFileCache.getKey( specificationMethod, realFilename.endsWith( KJB ) ? realFilename : realFilename + KJB ) );
   }
 
   private boolean isTransMeta() {

--- a/engine/src/test/java/org/pentaho/di/base/MetaFileCacheImplTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/MetaFileCacheImplTest.java
@@ -64,7 +64,7 @@ public class MetaFileCacheImplTest {
     assertEquals( transMeta, metaFileCacheImpl.getCachedTransMeta( TRANS_KEY ) );
 
     metaFileCacheImpl.getCachedJobMeta( JOB_KEY );
-    MetaFileCacheImpl.MetaFileCacheEntry entry = metaFileCacheImpl.cacheMap.get( JOB_KEY );
+    MetaFileCacheImpl.MetaFileCacheEntry entry = metaFileCacheImpl.cacheMap.get( JOB_KEY + ".kjb" );
     assertEquals( 2, entry.getTimesUsed() );
   }
 
@@ -72,6 +72,6 @@ public class MetaFileCacheImplTest {
   public void logCacheSummaryTest() {
     cacheMetaAndGetCacheTest();
     metaFileCacheImpl.logCacheSummary( logger );
-    verify( logger, times(3) ).logDetailed( anyString() );
+    verify( logger, times( 3 ) ).logDetailed( anyString() );
   }
 }


### PR DESCRIPTION
Original PR:
 - https://github.com/pentaho/pentaho-kettle/pull/9271