### PR TITLE
[BACKLOG-40476] Change PDI File Browser to use PVFS URI on Backend

### DIFF
--- a/core/src/main/java/org/pentaho/di/connections/utils/ConnectionUriParser.java
+++ b/core/src/main/java/org/pentaho/di/connections/utils/ConnectionUriParser.java
@@ -1,0 +1,220 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2024 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.di.connections.utils;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helper class to extract information from the
+ * {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME} URI and more general VFS URIs.
+ * This class handles special characters in the connection name section of the
+ * {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME} URI by simply parsing
+ * the connection name as is. This class has limited functionality.
+ * <p/>
+ * The goal of this class is to support international characters and {@link #SPECIAL_CHARACTERS_FULL_SET}
+ * in the connection name {@link #connectionName}.
+ * <p/>
+ * Main motivation for this class is not being able to use directly {@link java.net.URI}
+ * due to special characters in the {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME} URI.
+ * Future efforts should look into {@link org.apache.commons.vfs2.provider.UriParser#encode(String, char[])}.
+ *
+ * @see #SPECIAL_CHARACTERS_FULL_SET
+ */
+public class ConnectionUriParser {
+
+  /**
+   * Full set of special characters the connection name can be. Only excluding the character '/' which is a file path deliminator.
+   * <p/>
+   * Special characters in this context are characters that generally have to be encoded
+   * otherwise the use of {@link java.net.URI } will throw {@link java.net.URISyntaxException} when during
+   * object instantiation or subsequent method calls.
+   *
+   */
+  public static final String SPECIAL_CHARACTERS_FULL_SET = "!\"#$%&'()*+,-.:;<=>?@[\\] \t\n\r^_`{|}~";
+
+  /**
+   * Pattern to match a {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME} URI
+   *  with scheme, connection name, and connection path.
+   * <p/> Some Examples:
+   * <ul>
+   *   <li>For PVFS URI: "pvfs://connectionName/someFolderA/SomeFolderB/someFile.txt"</li>
+   *      <ul>
+   *        <li>scehme: "pvfs"</li>
+   *        <li>connection Name: "connectionName"</li>
+   *        <li>pvfs path: "/someFolderA/SomeFolderB/someFile.txt"</li>
+   *
+   *      </ul>
+   * </ul>
+   * Regex should be encompass {@link org.pentaho.di.connections.vfs.provider.ConnectionFileSystem#DOMAIN_ROOT}
+   */
+  public static final Pattern CONNECTION_URI_WITH_CONNECTION_NAME_AND_PATH_PATTERN
+    = Pattern.compile(  "^(\\w+)://([^/]+)(/.+)" );
+
+  /**
+   * Pattern to match a URI with scheme and connection name or first path segment.
+   * <p/> Some Examples:
+   * <ul>
+   *   <li>For PVFS URI: "pvfs://connectionName"</li>
+   *   <li>For VFS URI: "xyz://firstSegment"</li>
+   * </ul>
+   * Regex should be encompass {@link org.pentaho.di.connections.vfs.provider.ConnectionFileSystem#DOMAIN_ROOT}
+   */
+  public static final Pattern CONNECTION_URI_WITH_CONNECTION_NAME_PATTERN
+      = Pattern.compile(  "^(\\w+)://([^/]+)/?" );
+
+  /**
+   * Pattern to match a URI with just a scheme.
+   * <p/> Some Examples:
+   * <ul>
+   *   <li>For PVFS URI: "pvfs://"</li>
+   *   <li>For VFS URI: "xyz://"</li>
+   * </ul>
+   * Regex should be encompass {@link org.pentaho.di.connections.vfs.provider.ConnectionFileSystem#DOMAIN_ROOT}
+   */
+  public static final Pattern CONNECTION_URI_NAME_PATTERN = Pattern.compile(  "^(\\w+)://" );
+
+  /**
+   * {@link #scheme} index for {@link Matcher#group(int)}
+   */
+  private static final int GROUP_INDEX_SCHEME = 1;
+
+  /**
+   * {@link #connectionName} index for {@link Matcher#group(int)}
+   */
+  private static final int GROUP_INDEX_CONNECTION_NAME = 2;
+
+  /**
+   * {@link #connectionPath} index for {@link Matcher#group(int)}
+   */
+  private static final int GROUP_INDEX_CONNECTION_PATH = 3;
+
+  /**
+   * VFS URI. Can be general 'vfs" URI
+   * or {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME} URI
+   */
+  private final String vfsUri;
+
+  /**
+   * URI scheme or prefix
+   */
+  private String scheme;
+
+  /**
+   * URI connection name for {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME} URI
+   * or first path segment for VFS URI
+   */
+  private String connectionName;
+
+  /**
+   * Actual path segment for {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME} URI
+   */
+  private String connectionPath;
+
+
+  public ConnectionUriParser( String vfsUri ) {
+    this.vfsUri = vfsUri;
+    executeMatchers();
+  }
+
+  /**
+   * Call the matchers to determine the various variables:
+   * <ul>
+   *   <li>{@link #scheme}</li>
+   *   <li>{@link #connectionName}</li>
+   *   <li>{@link #connectionPath}</li>
+   * </ul>
+   */
+  private void executeMatchers() {
+    try {
+      // order of precedence for matchers
+      Matcher[] matchers = new Matcher[] {
+        CONNECTION_URI_WITH_CONNECTION_NAME_AND_PATH_PATTERN.matcher( this.vfsUri ),
+        CONNECTION_URI_WITH_CONNECTION_NAME_PATTERN.matcher( this.vfsUri ),
+        CONNECTION_URI_NAME_PATTERN.matcher( this.vfsUri )
+      };
+
+      Matcher matcher = Arrays.stream( matchers ).filter( Matcher::find ).findFirst().orElse( null );
+
+      if ( matcher != null ) {
+        setVariables( matcher );
+      }
+
+    } catch ( NullPointerException e ) {
+      // do nothing
+    }
+  }
+
+  /**
+   * sets the variables based on the <code>matcher</code>:
+   * <p/>
+   * Variables to set, if matched:
+   * <ul>
+   *   <li>{@link #scheme}</li>
+   *   <li>{@link #connectionName}</li>
+   *   <li>{@link #connectionPath}</li>
+   * </ul>
+   */
+  private void setVariables( Matcher matcher ) {
+    this.scheme = getGroup( matcher, GROUP_INDEX_SCHEME, null );
+    this.connectionName = getGroup( matcher, GROUP_INDEX_CONNECTION_NAME, null );
+    this.connectionPath = getGroup( matcher, GROUP_INDEX_CONNECTION_PATH, null );
+  }
+
+  /**
+   * Wrapper around {@link Matcher#group(String)}. If <code>index</code> is out of bounds,
+   * then <code>defaultValue</code> will be returned.
+   * @param matcher
+   * @param index group index see {@link Matcher#group(String)}
+   * @param defaultValue
+   * @return value from {@link Matcher#group(String)}, otherwise <code>defaultValue</code>
+   */
+  private String getGroup( Matcher matcher, int index, String defaultValue ) {
+    return index <= matcher.groupCount() ? matcher.group( index ) : defaultValue;
+  }
+
+  /**
+   * Get the scheme
+   * @see #scheme
+   * @return scheme or null otherwise.
+   */
+  public String getScheme() {
+    return scheme;
+  }
+
+  /**
+   * Get the connection name or first segment of URI.
+   * @see #connectionName
+   * @return connection name or null otherwise
+   */
+  public String getConnectionName() {
+    return connectionName;
+  }
+
+  /**
+   * Get connection path of {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME} URI,
+   * does not include the {@link #connectionName}
+   * @see #connectionPath
+   * @return connection path or null otherwise
+   */
+  public String getConnectionPath() {
+    return connectionPath;
+  }
+
+}

--- a/core/src/test/java/org/pentaho/di/connections/utils/ConnectionUriParserTest.java
+++ b/core/src/test/java/org/pentaho/di/connections/utils/ConnectionUriParserTest.java
@@ -1,0 +1,204 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2024 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.di.connections.utils;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.pentaho.di.connections.utils.ConnectionUriParser.SPECIAL_CHARACTERS_FULL_SET;
+
+public class ConnectionUriParserTest extends TestCase {
+
+  /**
+   * Full set of alphanumeric characters the connection name can be.
+   */
+  public static final String ALPHANUMERIC_CHARACTERS_FULL_SET =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+  /**
+   * Full set of accepted characters the connection name can be.
+   */
+  public static final String ACCEPTED_CHARACTERS_FULL_SET =
+    SPECIAL_CHARACTERS_FULL_SET + ALPHANUMERIC_CHARACTERS_FULL_SET;
+
+  @Test
+  public void testConnectionUriParser_Negative_Example_URIs() throws Exception {
+
+    assertNullValues( new ConnectionUriParser( null ) );
+
+    assertNullValues( new ConnectionUriParser( "" ) );
+
+    assertNullValues( new ConnectionUriParser( "      " ) );
+
+    assertNullValues( new ConnectionUriParser( "someGarbage" ) );
+
+  }
+
+  @Test
+  public void testConnectionUriParser_Negative_Example_Non_URIs() throws Exception {
+
+    assertNullValues( new ConnectionUriParser( "/someUser/someUnixFile" ) );
+
+    assertNullValues( new ConnectionUriParser(  "T:\\Users\\RandomSUser\\Documents\\someWindowsFile" ) );
+
+    assertNullValues( new ConnectionUriParser(  "//home/randomUser/randomFile.rpt" ) ); // Pentaho repository
+
+  }
+
+  @Test
+  public void testConnectionUriParser_Example_URIs() throws Exception {
+
+    String uri_01 = "xyz://";
+    assertEquals( "xyz", new ConnectionUriParser( uri_01 ) );
+
+    String uri_02 = "xyz:///";
+    assertEquals( "xyz", new ConnectionUriParser( uri_02 ) );
+
+    String uri_03 = "pvfs://";
+    assertEquals( "pvfs", new ConnectionUriParser( uri_03 ) );
+
+    String uri_04 = "pvfs:///";
+    assertEquals( "pvfs", new ConnectionUriParser( uri_04 ) );
+
+    String uri_05 = "xyz://abc";
+    assertEquals( "xyz", "abc", new ConnectionUriParser( uri_05 ) );
+
+    String uri_06 = "xyz://abc/";
+    assertEquals( "xyz", "abc", new ConnectionUriParser( uri_06 ) );
+
+    String uri_07 = "xyz://abc/someDir/somePath/someFile.txt";
+    assertEquals( "xyz",
+      "abc",
+      "/someDir/somePath/someFile.txt",
+      new ConnectionUriParser( uri_07 ) );
+
+    String uri_08 = "pvfs://some-ConnectionName_123/";
+    assertEquals( "pvfs",
+      "some-ConnectionName_123",
+      new ConnectionUriParser( uri_08 ) );
+
+    String uri_09 = "pvfs://some-ConnectionName_123";
+    assertEquals( "pvfs",
+      "some-ConnectionName_123",
+      new ConnectionUriParser( uri_09 ) );
+
+    String uri_10 = "pvfs://some-ConnectionName_123/someFolderA/someFolderB/someFolderC/sales_data.csv";
+    assertEquals( "pvfs",
+        "some-ConnectionName_123",
+        "/someFolderA/someFolderB/someFolderC/sales_data.csv",
+        new ConnectionUriParser( uri_10 ) );
+
+    // TEST : can handle special characters, passing connection name as-is per "current" requirements based on connection creation logic
+    String uri_11 = "pvfs://Special Character name &#! <> why would you do this/someFolderA/someFolderB/someFolderC/sales_data.csv";
+    assertEquals( "pvfs",
+      "Special Character name &#! <> why would you do this",
+      "/someFolderA/someFolderB/someFolderC/sales_data.csv",
+      new ConnectionUriParser( uri_11 ) );
+
+    String uri_12 = "pvfs://Special Character name &#! <> why would you do this";
+    assertEquals( "pvfs",
+      "Special Character name &#! <> why would you do this",
+      new ConnectionUriParser( uri_12 ) );
+
+    String uri_13 = "pvfs://Special Character name &#! <> why would you do this/";
+    assertEquals( "pvfs",
+      "Special Character name &#! <> why would you do this",
+      new ConnectionUriParser( uri_13 ) );
+
+    String specialCharacterConnectionName = shuffleString( ACCEPTED_CHARACTERS_FULL_SET );
+
+    // want to make sure it has a good representation of characters
+    assertTrue( specialCharacterConnectionName.length() > 60 );
+    // sanity checks and guard against changes to source code
+    assertTrue( specialCharacterConnectionName.contains( "<" ) && SPECIAL_CHARACTERS_FULL_SET.contains( "<" ) );
+    assertTrue( specialCharacterConnectionName.contains( "$" ) && SPECIAL_CHARACTERS_FULL_SET.contains( "$" ) );
+    assertTrue( specialCharacterConnectionName.contains( "-" ) && SPECIAL_CHARACTERS_FULL_SET.contains( "-" ) );
+    assertTrue( specialCharacterConnectionName.contains( "_" ) && SPECIAL_CHARACTERS_FULL_SET.contains( "_" ) );
+    assertTrue( specialCharacterConnectionName.contains( " " ) && SPECIAL_CHARACTERS_FULL_SET.contains( " " ) );
+    assertTrue( specialCharacterConnectionName.contains( "<" ) && SPECIAL_CHARACTERS_FULL_SET.contains( "<" ) );
+    assertTrue( specialCharacterConnectionName.contains( "!" ) && SPECIAL_CHARACTERS_FULL_SET.contains( "!" ) );
+
+    // TEST robust example of special characters
+    String uri_14 = "pvfs://" + specialCharacterConnectionName;
+    assertEquals( "pvfs",
+      specialCharacterConnectionName,
+      new ConnectionUriParser( uri_14 ) );
+
+    String uri_15 = "pvfs://" + specialCharacterConnectionName + "/";
+    assertEquals( "pvfs",
+      specialCharacterConnectionName,
+      new ConnectionUriParser( uri_15 ) );
+
+    String absolutePVFSPath = "/someFolderA/someFolderB/someFolderC/sales_data.csv";
+
+    String uri_16 = "pvfs://" + specialCharacterConnectionName + absolutePVFSPath;
+    assertEquals( "pvfs",
+      specialCharacterConnectionName,
+      absolutePVFSPath,
+      new ConnectionUriParser( uri_16 ) );
+
+    // Test to verify internation characters are possible
+    String internationalConnectionName = "some_Cool_characters_é";
+
+    String uri_17 = "pvfs://" + internationalConnectionName + absolutePVFSPath;
+    assertEquals( "pvfs",
+      internationalConnectionName,
+      absolutePVFSPath,
+      new ConnectionUriParser( uri_17 ) );
+
+  }
+
+  protected String shuffleString( String characterSet ) {
+    List<Character> characterSetList = characterSet.chars().mapToObj( c -> (char) c ).collect( Collectors.toList() );
+    Collections.shuffle( characterSetList );
+    StringBuilder sb = new StringBuilder( characterSet.length() );
+    characterSetList.stream().forEach( sb::append );
+    return sb.toString();
+
+  }
+
+  protected void assertEquals( String expectedScheme, String expectedConnectionName, String expectedPvfsPath,
+                              ConnectionUriParser actualConnectionUriParser ) {
+    assertEquals( expectedScheme, actualConnectionUriParser.getScheme() );
+    assertEquals( expectedConnectionName, actualConnectionUriParser.getConnectionName() );
+    assertEquals( expectedPvfsPath, actualConnectionUriParser.getConnectionPath() );
+  }
+
+  protected void assertEquals( String expectedScheme, String expectedConnectionName,
+                               ConnectionUriParser actualConnectionUriParser ) {
+    assertEquals( expectedScheme, actualConnectionUriParser.getScheme() );
+    assertEquals( expectedConnectionName, actualConnectionUriParser.getConnectionName() );
+    assertEquals( null, actualConnectionUriParser.getConnectionPath() );
+  }
+
+  protected void assertEquals( String expectedScheme,
+                               ConnectionUriParser actualConnectionUriParser ) {
+    assertEquals( expectedScheme, actualConnectionUriParser.getScheme() );
+    assertEquals( null, actualConnectionUriParser.getConnectionName() );
+    assertEquals( null, actualConnectionUriParser.getConnectionPath() );
+  }
+
+  protected void assertNullValues( ConnectionUriParser actualConnectionUriParser ) {
+    assertEquals( null, null, null, actualConnectionUriParser );
+  }
+
+}

--- a/engine/src/main/java/org/pentaho/di/core/LastUsedFile.java
+++ b/engine/src/main/java/org/pentaho/di/core/LastUsedFile.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -49,6 +49,12 @@ public class LastUsedFile {
   private String repositoryName;
   private Date lastOpened;
   private String username;
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   private String connection;
 
   private boolean opened;
@@ -266,10 +272,22 @@ public class LastUsedFile {
     this.username = username;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public String getConnection() {
     return connection;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public void setConnection( String connection ) {
     this.connection = connection;
   }

--- a/plugins/file-open-save-new/api/src/main/java/org/pentaho/di/plugins/fileopensave/api/providers/BaseFileProvider.java
+++ b/plugins/file-open-save-new/api/src/main/java/org/pentaho/di/plugins/fileopensave/api/providers/BaseFileProvider.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -39,7 +39,7 @@ public abstract class BaseFileProvider<T extends File> implements FileProvider<T
   @Override public void setFileProperties( FileDetails fileDetails, FileDialogOperation fileDialogOperation ) {
     fileDialogOperation.setPath( fileDetails.getPath() );
     fileDialogOperation.setFilename( fileDetails.getName() );
-    fileDialogOperation.setConnection( fileDetails.getConnection() );
+    fileDialogOperation.setConnection( null );
     fileDialogOperation.setProvider( fileDetails.getProvider() );
   }
 

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dialog/FileOpenSaveDialog.java
@@ -195,6 +195,13 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
   private String path;
   private String parentPath;
   private String type;
+
+  /**
+   * separate VFS connection name variable is no longer needed
+   * @deprecated
+   * The connection name is in the URI since full pvfs paths are being used.
+   */
+  @Deprecated
   private String connection;
   private String provider;
   private String providerFilter;
@@ -2202,10 +2209,22 @@ public class FileOpenSaveDialog extends Dialog implements FileDetails {
     this.type = type;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public String getConnection() {
     return connection;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public void setConnection( String connection ) {
     this.connection = connection;
   }

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dragdrop/Element.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dragdrop/Element.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2023-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -57,7 +57,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
+import java.util.Objects;
 
 public class Element {
   private String name = "";
@@ -65,8 +65,21 @@ public class Element {
   private String path = "";
   private String provider = "";
   private String repositoryName = "";//For repository types
-  //For VFS types
-  private String domain = "";
+
+  /**
+   * Separate VFS domain variable is no longer needed.
+   * @deprecated
+   * The domain handled is internally with the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
+  private String domain = "";  //For VFS types
+
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   private String connection = ""; //The VFS connection name
 
   @VisibleForTesting
@@ -80,27 +93,13 @@ public class Element {
     this( name, entityType, path, provider, "" );
   }
 
-  // Use for repository items
   public Element( String name, EntityType entityType, String path, String provider, String repositoryName ) {
-    this( name, entityType, path, provider, repositoryName, "", "" );
-  }
-
-  // Use for VFS items
-  public Element( String name, EntityType entityType, String path, String provider, String domain, String connection ) {
-    this( name, entityType, path, provider, "", domain, connection );
-  }
-
-  public Element( String name, EntityType entityType, String path, String provider, String repositoryName,
-                  String domain, String connection ) {
     this.name = name;
     this.entityType = entityType;
     this.path = path;
     this.provider = provider;
     this.repositoryName = repositoryName;
-    this.domain = domain;
-    this.connection = connection;
   }
-
 
   public Element( Object genericObject ) {
     if ( !( genericObject instanceof Entity ) ) {
@@ -126,14 +125,12 @@ public class Element {
         provider = file.getProvider();
         if ( entityType.isRepositoryType() ) {
           repositoryName = ( (RepositoryFile) file ).getRepository();
-        } else if ( entityType.isVFSType() ) {
-          domain = ( (VFSFile) file ).getDomain();
-          connection = ( (VFSFile) file ).getConnection();
         }
       }
     }
   }
 
+  @Override
   public boolean equals( Object object ) {
     if ( !( object instanceof Element ) ) {
       return false;
@@ -141,8 +138,15 @@ public class Element {
     if ( this == object ) {
       return true;
     }
-    Element element = ( (Element) object );
-    return name.equals( element.name ) && path.equals( element.path ) && provider.equals( element.provider );
+    Element other = ( (Element) object );
+    return Objects.equals( this.name, other.name )
+        && Objects.equals( this.path, other.path )
+        && Objects.equals( this.provider, other.provider );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash( name, path, provider );
   }
 
   public String getName() {
@@ -169,20 +173,34 @@ public class Element {
     return repositoryName;
   }
 
+  /**
+   * Separate VFS domain variable is no longer needed.
+   * @deprecated
+   * The domain handled is internally with the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public String getDomain() {
     return domain;
   }
 
+  /**
+   * Separate VFS domain variable is no longer needed.
+   * @deprecated
+   * The domain handled is internally with the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public void setDomain( String domain ) {
     this.domain = domain;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public String getConnection() {
     return connection;
-  }
-
-  public int hashCode() {
-    return name.hashCode() + path.hashCode() + provider.hashCode();
   }
 
   public EntityType getEntityType() {
@@ -346,7 +364,7 @@ public class Element {
 
       switch( scheme ) {
         case "pvfs":
-          newElement = new Element( name, EntityType.VFS_FILE, path, VFSFileProvider.TYPE, domain, connection );
+          newElement = new Element( name, EntityType.VFS_FILE, path, VFSFileProvider.TYPE );
           break;
         case "hc":
           newElement = new Element( name, EntityType.NAMED_CLUSTER_FILE, path, "clusters" );

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementDragListener.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementDragListener.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2023-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,7 +31,6 @@ import org.pentaho.di.plugins.fileopensave.api.providers.Utils;
 import org.pentaho.di.plugins.fileopensave.dialog.FileOpenSaveDialog;
 import org.pentaho.di.plugins.fileopensave.providers.repository.RepositoryFileProvider;
 import org.pentaho.di.plugins.fileopensave.providers.repository.model.RepositoryFile;
-import org.pentaho.di.plugins.fileopensave.util.Util;
 
 /**
  * Supports dragging elements from a structured viewer.
@@ -84,7 +83,6 @@ public class ElementDragListener extends DragSourceAdapter {
           }
         }
       }
-      Util.rawElementMassage( rawElements[ i ] );
     }
     if ( ElementTransfer.getInstance().isSupportedType( event.dataType ) ) {
       event.data = rawElements;

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementTransfer.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementTransfer.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2023-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -125,16 +125,12 @@ public class ElementTransfer extends ByteArrayTransfer {
      * (String) Complete path to entity and identifier.
      * (String) provider
      * (String) repositoryName
-     * (String) domain
-     * (String) connection
      */
     String name = dataIn.readUTF();
     EntityType entityType = EntityType.fromValue( dataIn.readInt() );
     String path = dataIn.readUTF();
     String provider = dataIn.readUTF();
     String repositoryName = dataIn.readUTF();
-    String domain = dataIn.readUTF();
-    String connection = dataIn.readUTF();
     // This handles the fact the repository files do not store their extension on the end of the name.  I guess we
     // corrupt our data in the name of cosmetics.  Anyway it will break everything downstream if we don't fix it.
     if ( entityType == EntityType.REPOSITORY_FILE && ( path.endsWith( ".ktr" ) || path.endsWith( ".kjb" ) )
@@ -142,7 +138,7 @@ public class ElementTransfer extends ByteArrayTransfer {
 
       name += path.substring( path.length() - 4 );
     }
-    return new Element( name, entityType, path, provider, repositoryName, domain, connection );
+    return new Element( name, entityType, path, provider, repositoryName );
   }
 
   protected byte[] toByteArray( Element[] elements ) {
@@ -190,7 +186,5 @@ public class ElementTransfer extends ByteArrayTransfer {
     dataOut.writeUTF( element.getPath() );
     dataOut.writeUTF( element.getProvider() );
     dataOut.writeUTF( element.getRepositoryName() == null ? "" : element.getRepositoryName() );
-    dataOut.writeUTF( element.getDomain() == null ? "" : element.getDomain() );
-    dataOut.writeUTF( element.getConnection() == null ? "" : element.getConnection() );
   }
 }

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementTreeDropAdapter.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementTreeDropAdapter.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2023-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -32,15 +32,11 @@ import org.eclipse.swt.widgets.MessageBox;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.plugins.fileopensave.api.overwrite.OverwriteStatus;
 import org.pentaho.di.plugins.fileopensave.api.providers.Entity;
 import org.pentaho.di.plugins.fileopensave.api.providers.EntityType;
 import org.pentaho.di.plugins.fileopensave.api.providers.File;
-import org.pentaho.di.plugins.fileopensave.controllers.FileController;
-import org.pentaho.di.plugins.fileopensave.api.overwrite.OverwriteStatus;
 import org.pentaho.di.plugins.fileopensave.providers.vfs.model.VFSLocation;
-import org.pentaho.di.plugins.fileopensave.service.FileCacheService;
-import org.pentaho.di.plugins.fileopensave.service.ProviderServiceService;
-import org.pentaho.di.plugins.fileopensave.util.Util;
 
 import java.util.Arrays;
 
@@ -71,7 +67,6 @@ public class ElementTreeDropAdapter extends ViewerDropAdapter {
       errorBox.open();
       return false;
     }
-    Util.rawElementMassage( genericTarget );
     Element target = new Element( genericTarget );
 
     log.logDebug( "TreeDrop: last target element was \"" + target.getPath() + "\" location was " + location );
@@ -86,8 +81,7 @@ public class ElementTreeDropAdapter extends ViewerDropAdapter {
         String name = parent.replaceAll( "^.*[\\/\\\\]", "" ); //Strip off the path leaving file name
         // Making parent of target the new actual target to use.
         target =
-          new Element( name, target.calcParentEntityType(), parent, target.getProvider(), target.getRepositoryName(),
-            target.getDomain(), target.getConnection() );
+          new Element( name, target.calcParentEntityType(), parent, target.getProvider(), target.getRepositoryName() );
       }
     }
 

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/extension/FileOpenSaveExtensionPoint.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/extension/FileOpenSaveExtensionPoint.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2017-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2017-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -55,7 +55,7 @@ public class FileOpenSaveExtensionPoint implements ExtensionPointInterface {
   private static final int WIDTH = ( Const.isOSX() || Const.isLinux() ) ? 930 : 947;
   private static final int HEIGHT = ( Const.isOSX() || Const.isLinux() ) ? 618 : 626;
 
-  private Supplier<Spoon> spoonSupplier = Spoon::getInstance;
+  private final Supplier<Spoon> spoonSupplier;
   private final ProviderService providerService;
 
   public FileOpenSaveExtensionPoint() {
@@ -63,7 +63,12 @@ public class FileOpenSaveExtensionPoint implements ExtensionPointInterface {
   }
 
   public FileOpenSaveExtensionPoint( ProviderService providerService ) {
+    this( providerService, Spoon::getInstance );
+  }
+
+  public FileOpenSaveExtensionPoint( ProviderService providerService, Supplier<Spoon> spoonSupplier  ) {
     this.providerService = providerService;
+    this.spoonSupplier = spoonSupplier;
   }
 
   @Override public void callExtensionPoint( LogChannelInterface logChannelInterface, Object o ) throws KettleException {
@@ -74,8 +79,8 @@ public class FileOpenSaveExtensionPoint implements ExtensionPointInterface {
     final FileOpenSaveDialog fileOpenSaveDialog =
             new FileOpenSaveDialog( spoonSupplier.get().getShell(), WIDTH, HEIGHT, logChannelInterface );
 
-    fileOpenSaveDialog.setProviderFilter(fileDialogOperation.getProviderFilter());
-    fileOpenSaveDialog.open(fileDialogOperation);
+    fileOpenSaveDialog.setProviderFilter( fileDialogOperation.getProviderFilter() );
+    fileOpenSaveDialog.open( fileDialogOperation );
 
     fileDialogOperation.setPath( null );
     fileDialogOperation.setFilename( null );
@@ -92,15 +97,38 @@ public class FileOpenSaveExtensionPoint implements ExtensionPointInterface {
     }
   }
 
-  private void resolveProvider( FileDialogOperation op ) {
+  /**
+   * Calls {@link FileDialogOperation#setProvider(String)} for <code>op</code> with a best guess.
+   * @param op
+   */
+  protected void resolveProvider( FileDialogOperation op ) {
     if ( op.getProvider() == null ) {
-      if ( op.getConnection() != null ) {
+      if ( isVfsPath( op.getPath() ) ) {
         op.setProvider( VFSFileProvider.TYPE );
-      } else if ( spoonSupplier.get().rep != null ) {
+      } else if ( spoonSupplier.get().getRepository() != null ) {
         op.setProvider( RepositoryFileProvider.TYPE );
       } else {
         op.setProvider( LocalFileProvider.TYPE );
       }
     }
+  }
+
+  /**
+   * Determines if the <code>filePath</code> is a file from a provider of type {@value VFSFileProvider#TYPE}
+   * @param filePath
+   * @return file from a provider of type {@value VFSFileProvider#TYPE}, false otherwise
+   */
+  protected boolean isVfsPath( String filePath ) {
+    boolean ret = false;
+    try {
+      VFSFileProvider vfsFileProvider = (VFSFileProvider) providerService.get( VFSFileProvider.TYPE );
+      if ( vfsFileProvider == null ) {
+        return false;
+      }
+      return vfsFileProvider.isSupported( filePath );
+    } catch ( InvalidFileProviderException | ClassCastException e ) {
+      // DO NOTHING
+    }
+    return ret;
   }
 }

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/model/VFSDirectory.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/model/VFSDirectory.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2019-2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -84,6 +84,11 @@ public class VFSDirectory extends VFSFile implements Directory {
   /**
    * Create a VFSDirectory.  Note that this creates an VFSDirectory object, it does not physically create the
    * directory.
+   * <p/>
+   * NOTE: logic for {@link #setRoot(String)} and {@link #setConnection(String)} is only used in
+   * {@link org.pentaho.di.plugins.fileopensave.dragdrop.ElementDragListener#dragSetData(org.eclipse.swt.dnd.DragSourceEvent)} for the
+   * scenario of "Recent Repository File".
+   *
    * @param parent The path to the parent folder
    * @param fileObject A VFSFileObject for the actual folder being created
    * @param connection The VFS connection associated with the directory

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/model/VFSFile.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/model/VFSFile.java
@@ -24,10 +24,7 @@ package org.pentaho.di.plugins.fileopensave.providers.vfs.model;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileObject;
-import org.apache.commons.vfs2.FileSystemException;
-import org.pentaho.di.connections.vfs.provider.ConnectionFileProvider;
 import org.pentaho.di.core.util.Utils;
-import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.plugins.fileopensave.api.providers.BaseEntity;
 import org.pentaho.di.plugins.fileopensave.api.providers.EntityType;
 import org.pentaho.di.plugins.fileopensave.api.providers.File;
@@ -54,42 +51,59 @@ public class VFSFile extends BaseEntity implements File {
     return VFSFileProvider.TYPE;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public String getConnection() {
     return connection;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public void setConnection( String connection ) {
     this.connection = connection;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated Use {@link #getPath()}.
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public String getConnectionPath() {
-    return getConnectionPath( getPath() );
+    return getPath();
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated Use {@link #getParent()}.
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public String getConnectionParentPath() {
-    return getConnectionPath( getParent() );
+    return  getParent();
   }
 
-  private String getConnectionPath( String root ) {
-    if ( root == null || connection == null ) {
-      return null;
-    }
-    if ( ConnectionFileProvider.SCHEME.equals( "pvfs") && root.startsWith( KettleVFS.SMB_SCHEME_COLON ) ) {
-      return root.replaceFirst( KettleVFS.SMB_SCHEME, "pvfs" );
-    } else {
-      String replacement = DOMAIN_ROOT + ( Utils.isEmpty( domain ) ? "" : domain );
-      StringBuilder path = new StringBuilder();
-      path.append( ConnectionFileProvider.SCHEME );
-      path.append( PROTOCOL_SEPARATOR );
-      path.append( connection );
-      if ( Utils.isEmpty( domain ) ) {
-        path.append( DELIMITER );
-      }
-      path.append( root.replaceAll( replacement, "" ) );
-      return path.toString();
-    }
-  }
 
+  /**
+   * Builder method to create an instance of  {@link VFSFile}.
+   * <p/>
+   * NOTE: logic for {@link #setRoot(String)} and {@link #setConnection(String)} is only used in
+   * {@link org.pentaho.di.plugins.fileopensave.dragdrop.ElementDragListener#dragSetData(org.eclipse.swt.dnd.DragSourceEvent)} for the
+   * scenario of "Recent Repository File".
+   * @param parent
+   * @param fileObject
+   * @param connection
+   * @param domain
+   * @return new instance with some populated values.
+   */
   public static VFSFile create( String parent, FileObject fileObject, String connection, String domain ) {
     VFSFile vfsFile = new VFSFile();
     String filename = null;
@@ -125,10 +139,22 @@ public class VFSFile extends BaseEntity implements File {
     return vfsFile;
   }
 
+  /**
+   * Separate VFS domain variable is no longer needed.
+   * @deprecated
+   * The domain handled is internally with the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public String getDomain() {
     return domain;
   }
 
+  /**
+   * Separate VFS domain variable is no longer needed.
+   * @deprecated
+   * The domain handled is internally with the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public void setDomain( String domain ) {
     this.domain = domain;
   }

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/service/KettleVFSService.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/service/KettleVFSService.java
@@ -1,0 +1,68 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2024 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.plugins.fileopensave.providers.vfs.service;
+
+import org.apache.commons.vfs2.FileObject;
+import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.vfs.IKettleVFS;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.plugins.fileopensave.api.providers.exception.FileException;
+
+/**
+ * Simple wrapper class around {@link IKettleVFS}
+ */
+public class KettleVFSService {
+
+  protected IKettleVFS iKettleVFS;
+
+  public KettleVFSService() {
+    this( DefaultBowl.getInstance() );
+  }
+
+  public KettleVFSService( Bowl bowl ) {
+    this( KettleVFS.getInstance( bowl ) );
+  }
+
+  public KettleVFSService( IKettleVFS iKettleVFS ) {
+    this.iKettleVFS = iKettleVFS;
+  }
+
+  /**
+   * Wrapper around {@link IKettleVFS#getFileObject(String, VariableSpace)}
+   * @param vfsPath - file object where <code>vfsFile.getPath()</code> returns a URI
+   *  with the prefix or scheme equal to {@value  org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME}
+   * @param space
+   * @return
+   * @throws FileException
+   */
+  public FileObject getFileObject( String vfsPath, VariableSpace space ) throws FileException {
+    try {
+      return iKettleVFS.getFileObject( vfsPath, space );
+    } catch ( KettleFileException kfe ) {
+      throw new FileException( "error calling IKettleVFS.getFileObject", kfe );
+    }
+  }
+}

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/util/Util.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/util/Util.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2017-2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2017-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,11 +22,6 @@
 
 package org.pentaho.di.plugins.fileopensave.util;
 
-import org.pentaho.di.connections.vfs.provider.ConnectionFileProvider;
-import org.pentaho.di.plugins.fileopensave.providers.vfs.model.VFSFile;
-
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.regex.Pattern;
 
 /**
@@ -64,25 +59,5 @@ public class Util {
       }
     }
     return path.substring( 0, path.lastIndexOf( "/" ) );
-  }
-
-  public static void rawElementMassage( Object rawElement ) {
-    //Performs conversion of raw elements from drag and drop to something the system understands
-    if ( rawElement instanceof VFSFile ) {
-      VFSFile vfsFile = (VFSFile) rawElement;
-      if ( vfsFile.getPath().startsWith( "hcp://" ) ) {
-        //HCP Files come back like this "hcp://hcp.hitachi.com:443/path1/filename" and for some reason this does not
-        // work with HCP.  We work around this by converting the URL to pvfs like this
-        // ( ie: pvfs://myconnectionName/path1/filename ).  The displayed name is what we want.
-        try {
-          URI uri = new URI( vfsFile.getPath() );
-          vfsFile.setPath( ConnectionFileProvider.SCHEME + "://" + vfsFile.getConnection() + uri.getPath() );
-          vfsFile.setParent( Util.getFolder( vfsFile.getPath() ) );
-        } catch ( URISyntaxException e ) {
-          // Since we are just trying to mutate a properly formed hcp: uri to a pvfs: one, if the URI parsing fails
-          // we can only let it go through as is, like all the rest of providers do it.
-        }
-      }
-    }
   }
 }

--- a/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementTest.java
+++ b/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2023-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -48,7 +48,9 @@ import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.ui.spoon.Spoon;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +96,9 @@ public class ElementTest {
     // Changing the file type does not effect equals because in a map, if the path and provider are the same then
     // the files would live in the same physical space.
     assertEquals( element1, element2 );
+
+    // future proofing for unexpected null values
+    assertNotEquals( new Element( null, null, null, null ), element2 );
   }
 
   @Test
@@ -132,13 +137,6 @@ public class ElementTest {
   }
 
   @Test
-  public void getConnection() {
-    assertEquals( "", element1.getConnection() );
-    Element element2 = new Element( NAME, TYPE, PATH, LOCAL_PROVIDER, DOMAIN, DUMMY_STRING );
-    assertEquals( DUMMY_STRING, element2.getConnection() );
-  }
-
-  @Test
   public void testHashCode() {
     Element element2 = new Element( NAME, TYPE, PATH, LOCAL_PROVIDER );
     assertEquals( element1.hashCode(), element2.hashCode() );
@@ -150,6 +148,10 @@ public class ElementTest {
     // Changing the file type does not effect equals because in a map, if the path and provider are the same then
     // the files would live in the same physical space.
     assertEquals( element1.hashCode(), element2.hashCode() );
+
+    // future proofing for unexpected null values
+    assertNotEquals( new Element( null, null, null, null ).hashCode(),
+        element2.hashCode() );
   }
 
   @Test
@@ -210,7 +212,7 @@ public class ElementTest {
 
     //Recent file - VFSFile
     String path = "pvfs://" + CONNECTION + PATH;
-    element = new Element( NAME, EntityType.RECENT_FILE, path, RECENT_PROVIDER, DOMAIN, CONNECTION );
+    element = new Element( NAME, EntityType.RECENT_FILE, path, RECENT_PROVIDER );
     checkRecentFileConversion( element, path, false );
     assertEquals( EntityType.VFS_FILE, element.convertRecent().getEntityType() );
 
@@ -259,7 +261,7 @@ public class ElementTest {
     //VFS Directory
     String path = "pvfs://" + CONNECTION + PATH;
     Element element =
-      new Element( NAME, EntityType.VFS_DIRECTORY, path, VFS_PROVIDER, DOMAIN, CONNECTION );
+      new Element( NAME, EntityType.VFS_DIRECTORY, path, VFS_PROVIDER );
     File file = element.convertToFile( space );
     assertTrue( file instanceof VFSDirectory );
     assertEquals( EntityType.VFS_DIRECTORY, file.getEntityType() );
@@ -276,7 +278,7 @@ public class ElementTest {
     //VFS Directory
     String path = "pvfs://" + CONNECTION + PATH;
     Element element =
-      new Element( NAME, EntityType.VFS_FILE, path, VFS_PROVIDER, DOMAIN, CONNECTION );
+      new Element( NAME, EntityType.VFS_FILE, path, VFS_PROVIDER );
     File file = element.convertToFile( space );
     assertTrue( file instanceof VFSFile );
     assertEquals( EntityType.VFS_FILE, file.getEntityType() );
@@ -294,7 +296,7 @@ public class ElementTest {
     String path = "hc://myCluster" + CONNECTION;
     setupNamedClusterMocks( path, EntityType.NAMED_CLUSTER_DIRECTORY );
     Element element =
-      new Element( NAME, EntityType.NAMED_CLUSTER_DIRECTORY, path, NAMED_CLUSTER_PROVIDER, DOMAIN, CONNECTION );
+      new Element( NAME, EntityType.NAMED_CLUSTER_DIRECTORY, path, NAMED_CLUSTER_PROVIDER );
     File file = element.convertToFile( space );
     assertEquals( EntityType.NAMED_CLUSTER_DIRECTORY, file.getEntityType() );
     assertEquals( NAME, file.getName() );
@@ -311,7 +313,7 @@ public class ElementTest {
     String path = "hc://myCluster" + CONNECTION;
     setupNamedClusterMocks( path, EntityType.NAMED_CLUSTER_FILE );
     Element element =
-      new Element( NAME, EntityType.NAMED_CLUSTER_FILE, path, NAMED_CLUSTER_PROVIDER, DOMAIN, CONNECTION );
+      new Element( NAME, EntityType.NAMED_CLUSTER_FILE, path, NAMED_CLUSTER_PROVIDER );
     File file = element.convertToFile( space );
     assertEquals( EntityType.NAMED_CLUSTER_FILE, file.getEntityType() );
     assertEquals( NAME, file.getName() );

--- a/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementTransferTest.java
+++ b/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/dragdrop/ElementTransferTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2023-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -19,43 +19,50 @@
  * limitations under the License.
  *
  ******************************************************************************/
+
 package org.pentaho.di.plugins.fileopensave.dragdrop;
 
-import org.eclipse.swt.dnd.ByteArrayTransfer;
 import org.eclipse.swt.dnd.TransferData;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.plugins.fileopensave.api.providers.EntityType;
+import org.pentaho.di.plugins.fileopensave.providers.local.LocalFileProvider;
 import org.pentaho.di.plugins.fileopensave.providers.repository.RepositoryFileProvider;
 import org.pentaho.di.plugins.fileopensave.providers.vfs.VFSFileProvider;
 
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ElementTransferTest {
-  private static final String slash = "\\" + java.io.File.separator;
-  private static final String NAME = "filename";
-  private static final EntityType TYPE = EntityType.LOCAL_FILE;
-  private static final String PATH = "/tmp/" + NAME;
-  private static final String LOCAL_PROVIDER = "local";
-
   private VariableSpace space = new Variables();
-
   ElementTransfer elementTransfer;
   private static boolean skipTests = false;
 
+  /**
+   * To configure swt
+   * There are three options:
+   * <ol>
+   *   <li><code>-Djava.library.path={runtime-library-path}</code></li>
+   *   <li>environment variable: <code>LD_LIBRARY_PATH</code></li>
+   *   <li>Copy the SWT library (swt.jar) to a directory that is already on the Java library path</li>
+   * </ol>
+   *
+   * For more complete instructions @see <a href="https://www.eclipse.org/swt/faq.php#missingdll">Elipse SWT FAQ: Missing DLL </a>.
+   * @throws Exception
+   */
   @Before
   public void setUp() throws Exception {
     org.junit.Assume.assumeFalse( skipTests );
     try {
       elementTransfer = ElementTransfer.getInstance();
     } catch ( UnsatisfiedLinkError e ) {
-      System.out.println( "UnsatisfiedLinkError likely due to swt configuration.  Skipping tests" );
+      System.out.println( "UnsatisfiedLinkError likely due to swt configuration, "
+          + "os specific swt.jar needs to be added to classpath. Skipping tests" );
+      e.printStackTrace();
       skipTests = true;
       org.junit.Assume.assumeFalse( skipTests );
     }
@@ -75,18 +82,40 @@ public class ElementTransferTest {
 
   @Test
   public void javaToNativeAndBack() {
-    Element element = new Element( NAME, TYPE, adjustSlashes( PATH ), LOCAL_PROVIDER );
-    TransferData transferData = new TransferData();
-    elementTransfer.javaToNative( new Object[] { element.convertToFile( space ) }, transferData );
-    Element[] elements = (Element[]) elementTransfer.nativeToJava( transferData );
-    assertEquals( element, elements[0] );
-  }
+    // SETUP
+    String testLocalFileName = "testFile.csv";
+    String testLocalPath = Paths.get( System.getProperty( "java.io.tmpdir" ) ).resolve( testLocalFileName ).toString();
+    Element elementLocal = new Element( testLocalFileName, EntityType.LOCAL_FILE,
+        testLocalPath, LocalFileProvider.TYPE );
 
-  private String adjustSlashes( String target ) {
-    target = target.replaceAll( "/", slash );
-    if ( target.startsWith( "\\" ) ) {
-      target = "c:" + target;
-    }
-    return target;
+    String testRepoFileName = "randomFile.rpt";
+    String testRepoPath = "//home/randomUser/" + testRepoFileName;
+    String testRepositoryName = "testRepositoryName";
+    Element elementRepository = new Element( testRepoFileName, EntityType.REPOSITORY_FILE, testRepoPath,
+        RepositoryFileProvider.TYPE, testRepositoryName );
+
+    String testVfsFileName = "someFile.txt";
+    String testVfsPath = "pvfs://randomConnectionName/someDir/" + testVfsFileName;
+    Element elementVfs = new Element( testVfsFileName, EntityType.VFS_FILE, testVfsPath,
+        VFSFileProvider.TYPE );
+
+    TransferData transferData = new TransferData();
+
+    Object[] transferObjects = new Object[] {
+        elementLocal.convertToFile( space ),
+        elementRepository.convertToFile( space ),
+        elementVfs.convertToFile( space )
+    };
+
+    // EXECUTE
+    elementTransfer.javaToNative( transferObjects, transferData );
+    Element[] elements = (Element[]) elementTransfer.nativeToJava( transferData );
+
+    // VERIFY
+    assertEquals( transferObjects.length, elements.length );
+    assertEquals( elementLocal, elements[0] );
+    assertEquals( elementRepository, elements[1] );
+    assertEquals( elementRepository.getRepositoryName(), elements[1].getRepositoryName() );
+    assertEquals( elementVfs, elements[2] );
   }
 }

--- a/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/extension/FileOpenSaveExtensionPointTest.java
+++ b/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/extension/FileOpenSaveExtensionPointTest.java
@@ -1,0 +1,182 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2024 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.di.plugins.fileopensave.extension;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pentaho.di.plugins.fileopensave.api.providers.FileProvider;
+import org.pentaho.di.plugins.fileopensave.providers.ProviderService;
+import org.pentaho.di.plugins.fileopensave.providers.local.LocalFileProvider;
+import org.pentaho.di.plugins.fileopensave.providers.repository.RepositoryFileProvider;
+import org.pentaho.di.plugins.fileopensave.providers.vfs.VFSFileProvider;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.ui.core.FileDialogOperation;
+import org.pentaho.di.ui.spoon.Spoon;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith( MockitoJUnitRunner.class )
+public class FileOpenSaveExtensionPointTest extends TestCase {
+
+  private static final String FILE_OP_DUMMY_COMMAND = "testDummyCommand";
+
+  @Test
+  public void testResolveProvider_AlreadySet() throws Exception {
+    // SETUP
+    FileOpenSaveExtensionPoint testInstance = new FileOpenSaveExtensionPoint( null, null );
+
+    FileDialogOperation opAlreadySet = new FileDialogOperation( FILE_OP_DUMMY_COMMAND  );
+    String providerNonProductionValue = "DontChangeMe"; // NON production value, just want to ensure it deosn't get overwritten
+    opAlreadySet.setProvider( providerNonProductionValue );
+    opAlreadySet.setPath( "/tmp/someRandomPath" );
+
+    // EXECUTE
+    testInstance.resolveProvider( opAlreadySet );
+
+    // VERIFY
+    assertEquals( providerNonProductionValue, opAlreadySet.getProvider() );
+  }
+
+  @Test
+  public void testResolveProvider_Vfs() throws Exception {
+    // SETUP
+    String vfsPath = "pvfs://someConnection/someFilePath";
+    ProviderService mockProviderService = mock( ProviderService.class );
+    VFSFileProvider mockVFSFileProvider = mock( VFSFileProvider.class );
+    when( mockProviderService.get( VFSFileProvider.TYPE ) ).thenReturn( mockVFSFileProvider );
+    when( mockVFSFileProvider.isSupported(  vfsPath ) ).thenReturn( true );
+
+    FileOpenSaveExtensionPoint testInstance = new FileOpenSaveExtensionPoint( mockProviderService, null );
+
+    FileDialogOperation opVfs = new FileDialogOperation( FILE_OP_DUMMY_COMMAND  );
+    opVfs.setProvider( null );
+    opVfs.setPath( vfsPath );
+
+    // EXECUTE
+    testInstance.resolveProvider( opVfs );
+
+    // VERIFY
+    assertEquals( VFSFileProvider.TYPE, opVfs.getProvider() );
+  }
+
+  @Test
+  public void testResolveProvider_Repository() throws Exception  {
+    // SETUP
+    ProviderService mockProviderService = mock( ProviderService.class );
+    VFSFileProvider mockVFSFileProvider = mock( VFSFileProvider.class );
+    when( mockProviderService.get( VFSFileProvider.TYPE ) ).thenReturn( mockVFSFileProvider );
+    when( mockVFSFileProvider.isSupported( any() ) ).thenReturn( false );
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getRepository() ).thenReturn( null );
+    Repository mockRepository = mock( Repository.class );
+    when( mockSpoon.getRepository() ).thenReturn( mockRepository );
+    FileOpenSaveExtensionPoint testInstance = new FileOpenSaveExtensionPoint( mockProviderService, () -> mockSpoon );
+
+    FileDialogOperation opRepository = new FileDialogOperation( FILE_OP_DUMMY_COMMAND  );
+    opRepository.setProvider( null );
+    opRepository.setPath( "//home/randomUser/randomFile.rpt" );
+
+    // EXECUTE
+    testInstance.resolveProvider( opRepository );
+
+    // VERIFY
+    assertEquals( RepositoryFileProvider.TYPE, opRepository.getProvider() );
+  }
+
+  @Test
+  public void testResolveProvider_Local() throws Exception  {
+    // SETUP
+    ProviderService mockProviderService = mock( ProviderService.class );
+    VFSFileProvider mockVFSFileProvider = mock( VFSFileProvider.class );
+    when( mockProviderService.get( VFSFileProvider.TYPE ) ).thenReturn( mockVFSFileProvider );
+    when( mockVFSFileProvider.isSupported( any() ) ).thenReturn( false );
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getRepository() ).thenReturn( null );
+    FileOpenSaveExtensionPoint testInstance = new FileOpenSaveExtensionPoint( mockProviderService, () -> mockSpoon );
+
+    FileDialogOperation opLocal = new FileDialogOperation( FILE_OP_DUMMY_COMMAND  );
+    opLocal.setProvider( null );
+    opLocal.setPath( "/someUser/someUnixFile" );
+
+    // EXECUTE
+    testInstance.resolveProvider( opLocal );
+
+    // VERIFY
+    assertEquals( LocalFileProvider.TYPE, opLocal.getProvider() );
+  }
+
+  @Test
+  public void testIsVfsPath_nullFileProvider() throws Exception {
+    // SETUP
+    String vfsPath = "pvfs://someConnection/someFilePath";
+    ProviderService mockProviderService = mock( ProviderService.class );
+    when( mockProviderService.get( VFSFileProvider.TYPE ) ).thenReturn( null );
+
+    FileOpenSaveExtensionPoint testInstance = new FileOpenSaveExtensionPoint( mockProviderService, null );
+
+    assertFalse( testInstance.isVfsPath( vfsPath ) );
+  }
+
+  @Test
+  public void testIsVfsPath_NotCorrectInstance() throws Exception {
+    // SETUP
+    String vfsPath = "pvfs://someConnection/someFilePath";
+    ProviderService mockProviderService = mock( ProviderService.class );
+    FileProvider mockGenericFileProvider = mock( FileProvider.class );
+    when( mockProviderService.get( VFSFileProvider.TYPE ) ).thenReturn( mockGenericFileProvider );
+
+    FileOpenSaveExtensionPoint testInstance = new FileOpenSaveExtensionPoint( mockProviderService, null );
+
+    assertFalse( testInstance.isVfsPath( vfsPath ) );
+  }
+
+  @Test
+  public void testIsVfsPath_NotSupported() throws Exception {
+    // SETUP
+    String vfsPath = "pvfs://someConnection/someFilePath";
+    ProviderService mockProviderService = mock( ProviderService.class );
+    VFSFileProvider mockVFSFileProvider = mock( VFSFileProvider.class );
+    when( mockProviderService.get( VFSFileProvider.TYPE ) ).thenReturn( mockVFSFileProvider );
+    when( mockVFSFileProvider.isSupported( any() ) ).thenReturn( false );
+
+    FileOpenSaveExtensionPoint testInstance = new FileOpenSaveExtensionPoint( mockProviderService, null );
+
+    assertFalse( testInstance.isVfsPath( vfsPath ) );
+  }
+
+  @Test
+  public void testIsVfsPath() throws Exception {
+    // SETUP
+    String vfsPath = "pvfs://someConnection/someFilePath";
+    ProviderService mockProviderService = mock( ProviderService.class );
+    VFSFileProvider mockVFSFileProvider = mock( VFSFileProvider.class );
+    when( mockProviderService.get( VFSFileProvider.TYPE ) ).thenReturn( mockVFSFileProvider );
+    when( mockVFSFileProvider.isSupported( any() ) ).thenReturn( true );
+
+    FileOpenSaveExtensionPoint testInstance = new FileOpenSaveExtensionPoint( mockProviderService, null );
+
+    assertTrue( testInstance.isVfsPath( vfsPath ) );
+  }
+}

--- a/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/providers/vfs/VFSFileProviderTest.java
+++ b/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/providers/vfs/VFSFileProviderTest.java
@@ -1,0 +1,243 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2024 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.plugins.fileopensave.providers.vfs;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.pentaho.di.connections.ConnectionDetails;
+import org.pentaho.di.connections.vfs.VFSConnectionDetails;
+import org.pentaho.di.plugins.fileopensave.api.providers.File;
+import org.pentaho.di.plugins.fileopensave.providers.vfs.model.VFSFile;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VFSFileProviderTest extends TestCase {
+
+  public void testIsConnectionRoot() {
+
+    VFSFileProvider testInstance = createTestInstance();
+
+    // TEST - simple negative tests before "pvfs://domain"
+    assertFalse( testInstance.isConnectionRoot( null ) );
+
+    assertFalse( testInstance.isConnectionRoot( createTestInstance( null ) ) );
+
+    assertFalse( testInstance.isConnectionRoot( createTestInstance( "" ) ) );
+
+    assertFalse( testInstance.isConnectionRoot( createTestInstance( " " ) ) );
+
+    assertFalse( testInstance.isConnectionRoot( createTestInstance( "pvfs" ) ) );
+
+    assertFalse( testInstance.isConnectionRoot( createTestInstance( "pvfs:" ) ) );
+
+    assertFalse( testInstance.isConnectionRoot( createTestInstance( "pvfs:/" ) ) );
+
+    assertFalse( testInstance.isConnectionRoot( createTestInstance( "pvfs://" ) ) );
+
+    assertFalse( testInstance.isConnectionRoot( createTestInstance( "pvfs:///" ) ) );
+
+    // TEST "pvfs://domain"
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://someConnection" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://some_Connection" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://some-Connection" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://someConnection123" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://123someConnection123" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://someConnection/" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://some_Connection/" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://some-Connection/" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://someConnection123/" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://123someConnection123/" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://Special Character name &#! <>/" ) ) );
+
+    assertTrue( testInstance.isConnectionRoot( createTestInstance( "pvfs://Special Character name &#! <>" ) ) );
+
+    // TEST now we have past the root domain
+    assertFalse( testInstance.isConnectionRoot( createTestInstance( "pvfs://someConnection/someFolderA" ) ) );
+
+    assertFalse( testInstance.isConnectionRoot(
+        createTestInstance( "pvfs://someConnection/someFolderA/directory2" ) ) );
+
+    assertFalse( testInstance.isConnectionRoot(
+        createTestInstance( "pvfs://someConnection/someFolderA/directory2/randomFileC.txt" ) ) );
+
+    assertFalse( testInstance.isConnectionRoot(
+      createTestInstance( "pvfs://Special Character name &#! <>/someFolderA/directory2/randomFileC.txt" ) ) );
+  }
+
+  public void testHasBuckets() {
+
+    VFSFileProvider testInstance = createTestInstance();
+
+    // TEST non VFSConnectionDetails
+    ConnectionDetails mockConnectionDetails  = mock( ConnectionDetails.class );
+    assertFalse( testInstance.hasBuckets( mockConnectionDetails ) );
+
+    // TEST  does not have buckets
+    VFSConnectionDetails mock_NoBuckets_VFSConnectionDetails  = mock( VFSConnectionDetails.class );
+    when( mock_NoBuckets_VFSConnectionDetails.hasBuckets() ).thenReturn( false );
+    assertFalse( testInstance.hasBuckets( mock_NoBuckets_VFSConnectionDetails ) );
+
+    // TEST has buckets
+    VFSConnectionDetails mock_Buckets_VFSConnectionDetails  = mock( VFSConnectionDetails.class );
+    when( mock_Buckets_VFSConnectionDetails.hasBuckets() ).thenReturn( true );
+    assertTrue( testInstance.hasBuckets( mock_Buckets_VFSConnectionDetails ) );
+  }
+
+  @Test
+  public void testIsSupported() throws Exception {
+
+    VFSFileProvider testInstance = createTestInstance();
+
+    assertFalse( testInstance.isSupported( null ) );
+
+    assertFalse( testInstance.isSupported( "" ) );
+
+    assertFalse( testInstance.isSupported( "    " ) );
+
+    assertFalse( testInstance.isSupported( "someGarbage" ) );
+
+    assertFalse( testInstance.isSupported( "/someUser/someUnixFile" ) );
+
+    assertFalse( testInstance.isSupported( "T:\\Users\\RandomSUser\\Documents\\someWindowsFile" ) );
+
+    assertFalse( testInstance.isSupported( "//home/randomUser/randomFile.rpt" ) );
+
+    assertTrue( testInstance.isSupported( "pvfs://someConnection/someFilePath" ) );
+
+    assertTrue( testInstance.isSupported( "pvfs://Special Character name &#! <>/someFilePath" ) );
+  }
+
+  @Test
+  public void testGetConnectionName() throws Exception {
+
+    VFSFileProvider testInstance = createTestInstance();
+
+    assertNull( testInstance.getConnectionName( createTestInstance( null ) ) );
+
+    assertNull( testInstance.getConnectionName( createTestInstance( "" ) ) );
+
+    assertNull( testInstance.getConnectionName( createTestInstance( "    " ) ) );
+
+    assertNull( testInstance.getConnectionName( createTestInstance( "someGarbage" ) ) );
+
+    assertNull( testInstance.getConnectionName( createTestInstance( "xyz:/123" ) ) ); // missing slash "/"
+
+    assertNull( testInstance.getConnectionName( createTestInstance( "xyz://" ) ) );
+
+    assertEquals( "abc", testInstance.getConnectionName( createTestInstance( "xyz://abc" ) ) );
+
+    assertEquals( "abc", testInstance.getConnectionName( createTestInstance( "xyz://abc/" ) ) );
+
+    assertEquals( "abc", testInstance.getConnectionName( createTestInstance( "xyz://abc/def/ghi/jkl/mno.csv" ) ) );
+
+    assertEquals( "Special Character name &#! <>", testInstance.getConnectionName(
+        createTestInstance( "xyz://Special Character name &#! <>/def/ghi/jkl/mno.csv" ) ) );
+  }
+
+  @Test
+  public void testGetScheme() throws Exception {
+
+    VFSFileProvider testInstance = createTestInstance();
+
+    assertNull( testInstance.getScheme( createTestInstance( null ) ) );
+
+    assertNull( testInstance.getScheme( createTestInstance( "" ) ) );
+
+    assertNull( testInstance.getScheme( createTestInstance( "    " ) ) );
+
+    assertNull( testInstance.getScheme( createTestInstance( "someGarbage" ) ) );
+
+    assertEquals( "xyz", testInstance.getScheme( createTestInstance( "xyz://abc" ) ) );
+
+    assertEquals( "xyz", testInstance.getScheme(
+        createTestInstance( "xyz://abc/def/ghi/jkl/mno.csv" ) ) );
+
+    assertEquals( "xyz", testInstance.getScheme(
+        createTestInstance( "xyz://Special Character name &#! <>/def/ghi/jkl/mno.csv" ) ) );
+  }
+
+  @Test
+  public void testIsSame_DifferentTypes() throws Exception {
+    VFSFileProvider testInstance = createTestInstance();
+
+    File file1 = mock( File.class );
+    File file2 = mock( File.class );
+
+    File vfsFile = createTestInstance( "xyz://abc/someDir/somePath/someFile.txt" );
+
+    assertFalse( testInstance.isSame( file1, file2 ) );
+
+    assertFalse( testInstance.isSame( file1, vfsFile ) );
+
+    assertFalse( testInstance.isSame( vfsFile, file2 ) );
+
+    File vfsFile_ABC_SomeDir = createTestInstance( "xyz://abc/someDir/anotherDir/someFile.txt" );
+
+    File vfsFile_ABC_FolderA = createTestInstance( "xyz://abc/FolderA" );
+
+    File vfsFile_MNO_Path1 = createTestInstance( "xyz://mno/Path1/Path2" );
+
+    assertFalse( testInstance.isSame( vfsFile_ABC_SomeDir, vfsFile_MNO_Path1 ) );
+
+    assertFalse( testInstance.isSame( vfsFile_MNO_Path1, vfsFile_ABC_SomeDir ) );
+
+    assertFalse( testInstance.isSame( createTestInstance( "xyz://" ), vfsFile_ABC_SomeDir ) ); // malformed VFS files
+
+    assertFalse( testInstance.isSame( createTestInstance( "xyz:/" ), vfsFile_ABC_SomeDir ) ); // malformed VFS files
+
+    assertTrue( testInstance.isSame( vfsFile_ABC_SomeDir, vfsFile_ABC_SomeDir ) );
+
+    assertTrue( testInstance.isSame( vfsFile_ABC_SomeDir, vfsFile_ABC_FolderA ) );
+
+    File vfsFile_SpecialCharacters_Path1 = createTestInstance( "xyz://Special Character name &#! <>/Path1/Path2" );
+
+    File vfsFile_SpecialCharacters_DirectoryA = createTestInstance( "xyz://Special Character name &#! <>/DirectoryA/DirectoryB/DirectoryC" );
+
+    assertTrue( testInstance.isSame( vfsFile_SpecialCharacters_Path1, vfsFile_SpecialCharacters_DirectoryA ) );
+
+    assertFalse( testInstance.isSame( vfsFile_SpecialCharacters_Path1, vfsFile_ABC_SomeDir ) );
+  }
+
+  protected VFSFile createTestInstance( String path ) {
+    VFSFile vfsFile = new VFSFile();
+    vfsFile.setPath( path );
+    return vfsFile;
+  }
+
+  public VFSFileProvider createTestInstance() {
+    VFSFileProvider testInstance = new VFSFileProvider( null, null );
+    return testInstance;
+  }
+
+}

--- a/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/providers/vfs/model/VFSFileTest.java
+++ b/plugins/file-open-save-new/core/src/test/java/org/pentaho/di/plugins/fileopensave/providers/vfs/model/VFSFileTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,47 +24,46 @@ package org.pentaho.di.plugins.fileopensave.providers.vfs.model;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.pentaho.di.connections.vfs.provider.ConnectionFileProvider;
 
 public class VFSFileTest {
 
   @Test
   public void getConnectionPathTest() {
     VFSFile file = new VFSFile();
-    file.setPath( "ts://bucket/to/file/file.txt" );
-    file.setConnection( "Connection Name" );
-    Assert.assertEquals( ConnectionFileProvider.SCHEME + "://" + file.getConnection() + "/bucket/to/file/file.txt",
-      file.getConnectionPath() );
-    System.out.println( file.getConnectionPath() );
+    String pvfsPath = "pvfs://someConnectionName/bucket/to/file/file.txt";
+    file.setPath( pvfsPath );
+    file.setConnection( "someConnectionName" );
+    Assert.assertEquals( pvfsPath, file.getConnectionPath() );
   }
 
   @Test
   public void getConnectionPathRootTest() {
     VFSFile file = new VFSFile();
-    file.setPath( "ts://bucket" );
-    file.setConnection( "Connection Name" );
-    Assert.assertEquals( ConnectionFileProvider.SCHEME + "://" + file.getConnection() + "/bucket",
-      file.getConnectionPath() );
+    String pvfsPath = "pvfs://someConnectionName/bucket";
+    file.setPath( pvfsPath );
+    file.setConnection( "someConnectionName" );
+    Assert.assertEquals( pvfsPath, file.getConnectionPath() );
   }
 
   @Test
   public void getConnectionPathWithDomainTest() {
     VFSFile file = new VFSFile();
-    file.setPath( "ts://fake.com/path/to/file/file.txt" );
-    file.setConnection( "Connection Name" );
+    String pvfsPath = "pvfs://someConnectionName/path/to/file/file.txt";
+    file.setPath( pvfsPath );
+    file.setConnection( "someConnectionName" );
     file.setDomain( "fake.com" );
-    Assert.assertEquals( ConnectionFileProvider.SCHEME + "://" + file.getConnection() + "/path/to/file/file.txt",
-      file.getConnectionPath() );
+    Assert.assertEquals( pvfsPath, file.getConnectionPath() );
 
   }
 
   @Test
   public void getConnectionPathWithDomainRootTest() {
     VFSFile file = new VFSFile();
-    file.setPath( "ts://fake.com" );
-    file.setConnection( "Connection Name" );
+    String pvfsPath = "pvfs://someConnectionName";
+    file.setPath( pvfsPath );
+    file.setConnection( "someConnectionName" );
     file.setDomain( "fake.com" );
-    Assert.assertEquals( ConnectionFileProvider.SCHEME + "://" + file.getConnection(), file.getConnectionPath() );
+    Assert.assertEquals( pvfsPath, file.getConnectionPath() );
   }
 
 }

--- a/ui/src/main/java/org/pentaho/di/ui/core/FileDialogOperation.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/FileDialogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Hitachi Vantara. All rights reserved.
+ * Copyright 2017-2024 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,10 +199,22 @@ public class FileDialogOperation {
     this.path = path;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public String getConnection() {
     return connection;
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public void setConnection( String connection ) {
     this.connection = connection;
   }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -376,6 +376,12 @@ import java.util.Objects;
 public class Spoon extends ApplicationWindow implements AddUndoPositionInterface, TabListener, SpoonInterface,
   OverwritePrompter, PDIObserver, LifeEventHandler, XulEventSource, XulEventHandler, PartitionSchemasProvider {
   private static final String userHomeDir = System.getProperty( "user.home" );
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   public static final String CONNECTION = "connection";
   private static final String XML_EXTENSION = "xml";
   public static final String SPOON_DIALOG_PROMPT_OVERWRITE_FILE = "Spoon.Dialog.PromptOverwriteFile.";
@@ -4603,6 +4609,12 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     }
   }
 
+  /**
+   * Separate VFS connection name variable is no longer needed.
+   * @deprecated
+   * The connection name is in the URI since full {@value org.pentaho.di.connections.vfs.provider.ConnectionFileProvider#SCHEME } paths are being used.
+   */
+  @Deprecated
   private String lastFileOpenedConnection;
   private String lastFileOpenedProvider;
 
@@ -4656,7 +4668,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         // We are able to find the index of forward or backward slash set the folder to be the path before slash
         String folder = lastFileOpened.substring( 0, parentIndex );
         fileDialogOperation.setPath( folder );
-        fileDialogOperation.setConnection( lastFileOpenedConnection );
+        fileDialogOperation.setConnection( null );
         fileDialogOperation.setProvider( lastFileOpenedProvider );
       } else {
         // We were unable to find the folder path from the last file opened. We will set the file open dialog to
@@ -4687,7 +4699,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         openFile( path, variables, importFile );
         lastFileOpened = path;
         props.setLastUsedLocalFile( path );
-        lastFileOpenedConnection = fileDialogOperation.getConnection();
+        lastFileOpenedConnection = null;
         lastFileOpenedProvider = fileDialogOperation.getProvider();
       }
     } catch ( KettleException e ) {
@@ -4780,7 +4792,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       setFileOperatioPathForNonRepositoryFile(fileDialogOperation, meta, export );
     }
     if ( meta instanceof VariableSpace ) {
-      fileDialogOperation.setConnection( ( (VariableSpace) meta ).getVariable( CONNECTION ) );
+      fileDialogOperation.setConnection( null );
     }
     boolean saved = false;
     try {
@@ -4795,7 +4807,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         String filename = fileDialogOperation.getPath() + File.separator + fileDialogOperation.getFilename();
         lastFileOpened = filename;
         props.setLastUsedLocalFile( filename );
-        lastFileOpenedConnection = fileDialogOperation.getConnection();
+        lastFileOpenedConnection = null;
         lastFileOpenedProvider = fileDialogOperation.getProvider();
         if ( lastFileOpenedConnection != null && meta instanceof VariableSpace ) {
           ( (VariableSpace) meta ).setVariable( CONNECTION, lastFileOpenedConnection );
@@ -5815,7 +5827,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       if (fileDialogOperation.getPath() != null && fileDialogOperation.getFilename() != null) {
         zipFilename = fileDialogOperation.getPath() + File.separator + fileDialogOperation.getFilename();
         lastFileOpened = zipFilename;
-        lastFileOpenedConnection = fileDialogOperation.getConnection();
+        lastFileOpenedConnection = null;
         lastFileOpenedProvider = fileDialogOperation.getProvider();
         FileObject zipFileObject = KettleVFS.getFileObject(zipFilename);
         if (zipFileObject.exists()) {

--- a/ui/src/test/java/org/pentaho/di/ui/core/events/dialog/SelectionAdapterFileDialogTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/core/events/dialog/SelectionAdapterFileDialogTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -39,6 +39,7 @@ import org.pentaho.di.ui.core.events.dialog.extension.ExtensionPointWrapper;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -329,6 +330,33 @@ public class SelectionAdapterFileDialogTest {
       extensionPointWrapper );
 
     assertFalse( testInstance2.isConnectedToRepository() );
+  }
+
+  @Test
+  public void testSetProvider() throws Exception {
+
+    // TEST PVFS , ProviderFilter null
+    String pvfsPath = "pvfs://someConnectionName/dirA/dir2/dirC/randomFile.txt";
+    URI uriPvfs = new URI( pvfsPath );
+    FileObject foPvfs = mock( FileObject.class );
+    when( foPvfs.getURI() ).thenReturn( uriPvfs );
+
+    FileDialogOperation fileDialogOperationPvfs_ProviderFilterNull = createFileDialogOperation();
+    fileDialogOperationPvfs_ProviderFilterNull.setProviderFilter( null );
+
+    testInstance.setProvider( fileDialogOperationPvfs_ProviderFilterNull, foPvfs );
+
+    assertEquals( ProviderFilterType.VFS.toString(), fileDialogOperationPvfs_ProviderFilterNull.getProvider() );
+
+
+    // TEST PVFS , ProviderFilter Default
+    FileDialogOperation fileDialogOperationPvfs_ProviderFilterDefault = createFileDialogOperation();
+    fileDialogOperationPvfs_ProviderFilterDefault.setProviderFilter( ProviderFilterType.DEFAULT.toString() );
+
+    testInstance.setProvider( fileDialogOperationPvfs_ProviderFilterDefault, foPvfs );
+
+    assertEquals( ProviderFilterType.VFS.toString(), fileDialogOperationPvfs_ProviderFilterDefault.getProvider() );
+
   }
 
   protected FileDialogOperation createFileDialogOperation() {


### PR DESCRIPTION
- only use "pvfs://..." URI in VFSFileProvider
- remove or deprecated the use of the variables 'connection' and 'domain'

gains:

1. simplifies code for VFSFileProvider.java by using the abstraction layer of PVFS
2. VFSFileProvider does not have to contain every VFS Providers URl logic for Provider URI <--> PVFS URI

I  removed (ie set null, set "", or eliminated ) or deprecated all the uses of connection and domain variables and code. I was running out of time for to fully remove them. I created https://hv-eng.atlassian.net/browse/BACKLOG-40656 to track this. As the code is harmless.  Currently the sonarqube code smells/bugs are related to me adding @depracted or unreachable code, which is expected.

PR dependencies:

- The new root logic in VFSFileProvider#getRoot depends correct bucket flags. A coupe of providers need to be updated see PR: https://github.com/pentaho/pdi-plugins-ee/pull/1066 