### PR TITLE
[PDI-20085] - KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL produces opposite display for NULLS - fixing inverted validations

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -4039,10 +4039,10 @@ public class ValueMetaBase implements ValueMetaInterface {
     boolean isStringValue = outValueType == Value.VALUE_TYPE_STRING;
     Object emptyValue = isStringValue ? Const.NULL_STRING : null;
 
-    boolean isEmptyAndNullDiffer = convertStringToBoolean(
+    boolean isEmptyAndNullDiffer = !convertStringToBoolean(
         Const.NVL( System.getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
 
-    boolean normalizeNullStringToEmpty = !convertStringToBoolean(
+    boolean normalizeNullStringToEmpty = convertStringToBoolean(
       Const.NVL( System.getProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" ), "N" ) );
 
     //the property KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY is only valid when KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y.

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -393,7 +393,7 @@ public class ValueMetaBaseTest {
     result =
       outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
     assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y and KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY = N: "
-      + "Conversion from null string must return empty string", StringUtils.EMPTY, result );
+      + "Conversion from null string must return null ", null, result );
 
     System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
     result =


### PR DESCRIPTION
Validations were inverted.

@smmribeiro 
@renato-s 
@befc 

