### PR TITLE
[PDI-20085] - KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL produces opposite display for NULLS - fixing inverted validations

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -4047,10 +4047,10 @@ public class ValueMetaBase implements ValueMetaInterface {
 
     //the property KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY is only valid when KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y.
     //the isEmptyAndNullDiffer means that null and empty string should be different. normalizeNullStringToEmpty stops pentaho from making this transaction.
-    if ( isEmptyAndNullDiffer && pol == null && isStringValue ) {
-      if ( normalizeNullStringToEmpty ) {
+    if ( isEmptyAndNullDiffer && pol == null && isStringValue && normalizeNullStringToEmpty ) {
         pol = StringUtils.EMPTY;
-      }
+    } else if ( !isEmptyAndNullDiffer && pol == null && isStringValue ) {
+      pol = StringUtils.EMPTY;
     }
 
     if ( pol == null ) {

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -386,14 +386,14 @@ public class ValueMetaBaseTest {
     result =
       outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
     assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = N: "
-      + "Conversion from null string must return null", null, result );
+      + "Conversion from null string must return empty String", StringUtils.EMPTY, result );
 
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
     System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" );
     result =
       outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
     assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y and KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY = N: "
-      + "Conversion from null string must return empty string", StringUtils.EMPTY, result );
+      + "Conversion from null string must return Empty String ", StringUtils.EMPTY, result );
 
     System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
     result =


### PR DESCRIPTION
@pentaho/tatooine_dev 
Fixing issues with expected behaviour