### PR TITLE
[SP-6543] - Backport of PDI-20100 - 'Get subfolder names' step does not work with Windows mapped drive (9.3 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/fileinput/FileInputList.java
+++ b/core/src/main/java/org/pentaho/di/core/fileinput/FileInputList.java
@@ -328,7 +328,7 @@ public class FileInputList {
               try {
                 if ( fileObject instanceof LocalFile ) {
                   // fileObject.isReadable wrongly returns true in windows file system even if not readable
-                  return Files.isReadable( Paths.get( ( new File( fileObject.getName().getPath() ) ).toURI() ) );
+                  return Files.isReadable( Paths.get( ( new File( fileObject.getPath().toString() ) ).toURI() ) );
                 }
                 return fileObject.isReadable();
               } catch ( FileSystemException e ) {


### PR DESCRIPTION
Original PR:
 - https://github.com/pentaho/pentaho-kettle/pull/9318/

@pentaho/tatooine_dev 