### PR TITLE
[PDI-20085] - KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL produces opposite display for NULLS - fixing unit tests

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -3602,17 +3602,16 @@ public class ValueMetaBase implements ValueMetaInterface {
         return true;
       }
 
-      if ( emptyStringDiffersFromNull ) {
-        return false;
+      if ( StringUtils.EMPTY.equals( value ) ) {
+        return !emptyStringDiffersFromNull;
       }
 
       // If it's a string and the string is empty, it's a null value as well
       //
-      if ( isString() ) {
-        if ( value.toString().length() == 0 ) {
-          return true;
-        }
+      if ( isString() && value.toString().isEmpty() ) {
+        return true;
       }
+
 
       // We tried everything else so we assume this value is not null.
       //
@@ -4064,7 +4063,7 @@ public class ValueMetaBase implements ValueMetaInterface {
           // we have a match
           //
           if ( pol.equalsIgnoreCase( Const.rightPad( new StringBuilder( null_value ), pol.length() ) ) ) {
-            return emptyValue;
+            return isEmptyAndNullDiffer && pol.equalsIgnoreCase( "" ) ? emptyValue : null;
           }
         }
       } else {

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest_NullEmpty.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest_NullEmpty.java
@@ -36,8 +36,8 @@ public class ValueMetaBaseTest_NullEmpty {
    */
   @Test
   public void convertDataFromStringWithDefaults() throws Exception {
-    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
-    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" );
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
+    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
 
     ValueMetaBase out = new ValueMetaString();
     ValueMetaBase value = new ValueMetaString();

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaStringTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaStringTest.java
@@ -152,10 +152,10 @@ public class ValueMetaStringTest {
 
   @Test
   public void testIsNull_emptyIsNotNull() throws KettleValueException {
-    meta.setNullsAndEmptyAreDifferent( true );
+    meta.setNullsAndEmptyAreDifferent( false );
 
     assertEquals( true, meta.isNull( null ) );
-    assertEquals( false, meta.isNull( "" ) );
+    assertEquals( true, meta.isNull( "" ) );
 
     assertEquals( false, meta.isNull( "1" ) );
 
@@ -178,10 +178,10 @@ public class ValueMetaStringTest {
 
   @Test
   public void testIsNull_emptyIsNull() throws KettleValueException {
-    meta.setNullsAndEmptyAreDifferent( false );
+    meta.setNullsAndEmptyAreDifferent( true );
 
     assertEquals( true, meta.isNull( null ) );
-    assertEquals( true, meta.isNull( "" ) );
+    assertEquals( false, meta.isNull( "" ) );
 
     assertEquals( false, meta.isNull( "1" ) );
 
@@ -195,7 +195,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_LEFT );
     // assertEquals( true, meta.isNull( "    " ) ); //TODO: is it correct?
     assertEquals( false, meta.isNull( "    " ) ); // TODO: is it correct?
-    assertEquals( true, meta.isNull( meta.getString( "    " ) ) );
+    assertEquals( false, meta.isNull( meta.getString( "    " ) ) );
 
     assertEquals( false, meta.isNull( "  1  " ) );
     assertEquals( false, meta.isNull( meta.getString( "  1  " ) ) );
@@ -203,7 +203,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_RIGHT );
     // assertEquals( true, meta.isNull( "    " ) ); //TODO: is it correct?
     assertEquals( false, meta.isNull( "    " ) ); // TODO: is it correct?
-    assertEquals( true, meta.isNull( meta.getString( "    " ) ) );
+    assertEquals( false, meta.isNull( meta.getString( "    " ) ) );
 
     assertEquals( false, meta.isNull( "  1  " ) );
     assertEquals( false, meta.isNull( meta.getString( "  1  " ) ) );
@@ -211,7 +211,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_BOTH );
     // assertEquals( true, meta.isNull( "    " ) ); //TODO: is it correct?
     assertEquals( false, meta.isNull( "    " ) ); // TODO: is it correct?
-    assertEquals( true, meta.isNull( meta.getString( "    " ) ) );
+    assertEquals( false, meta.isNull( meta.getString( "    " ) ) );
 
     assertEquals( false, meta.isNull( "  1  " ) );
     assertEquals( false, meta.isNull( meta.getString( "  1  " ) ) );
@@ -271,19 +271,19 @@ public class ValueMetaStringTest {
 
   @Test
   public void testCompare_emptyIsNotNull() throws KettleValueException {
-    meta.setNullsAndEmptyAreDifferent( true );
+    meta.setNullsAndEmptyAreDifferent( false );
 
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_NONE );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
+    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < " "
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < " 1 "
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1 "
 
-    assertSignum( 1, meta.compare( "", null ) ); // "" > null
+    assertSignum( 0, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " " ) ); // "" < " "
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < " 1"
@@ -334,23 +334,23 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_LEFT );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
+    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < ""
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < "1 "
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1 "
 
-    assertSignum( 1, meta.compare( "", null ) ); // "" > null
+    assertSignum( 0, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
-    assertSignum( 0, meta.compare( "", " " ) ); // "" == ""
+    assertSignum( -1, meta.compare( "", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // "" < "1 "
     assertSignum( -1, meta.compare( "", "1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // "" < "1 "
 
     assertSignum( 1, meta.compare( " ", null ) ); // "" > null
-    assertSignum( 0, meta.compare( " ", "" ) ); // "" == ""
+    assertSignum( 1, meta.compare( " ", "" ) ); // "" == ""
     assertSignum( 0, meta.compare( " ", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( " ", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // "" < "1 "
@@ -392,23 +392,23 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_RIGHT );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
+    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < ""
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < " 1"
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 1, meta.compare( "", null ) ); // "" > null
+    assertSignum( 0, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
-    assertSignum( 0, meta.compare( "", " " ) ); // "" == ""
+    assertSignum( -1, meta.compare( "", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < " 1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // "" < " 1"
     assertSignum( -1, meta.compare( "", "1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // "" < "1"
 
     assertSignum( 1, meta.compare( " ", null ) ); // "" > null
-    assertSignum( 0, meta.compare( " ", "" ) ); // "" == ""
+    assertSignum( 1, meta.compare( " ", "" ) ); // "" == ""
     assertSignum( 0, meta.compare( " ", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( " ", " 1" ) ); // "" < " 1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // "" < " 1"
@@ -450,23 +450,23 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_BOTH );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
+    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < ""
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 1, meta.compare( "", null ) ); // "" > null
+    assertSignum( 0, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
-    assertSignum( 0, meta.compare( "", " " ) ); // "" == ""
+    assertSignum( -1, meta.compare( "", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // "" < "1"
 
     assertSignum( 1, meta.compare( " ", null ) ); // "" > null
-    assertSignum( 0, meta.compare( " ", "" ) ); // "" == ""
+    assertSignum( 1, meta.compare( " ", "" ) ); // "" == ""
     assertSignum( 0, meta.compare( " ", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( " ", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // "" < "1"
@@ -509,23 +509,23 @@ public class ValueMetaStringTest {
     meta.setIgnoreWhitespace( true );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
+    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < ""
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 1, meta.compare( "", null ) ); // "" > null
+    assertSignum( 0, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
-    assertSignum( 0, meta.compare( "", " " ) ); // "" == ""
+    assertSignum( -1, meta.compare( "", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // "" < "1"
 
     assertSignum( 1, meta.compare( " ", null ) ); // "" > null
-    assertSignum( 0, meta.compare( " ", "" ) ); // "" == ""
+    assertSignum( 1, meta.compare( " ", "" ) ); // "" == ""
     assertSignum( 0, meta.compare( " ", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( " ", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // "" < "1"
@@ -567,19 +567,19 @@ public class ValueMetaStringTest {
 
   @Test
   public void testCompare_emptyIsNull() throws KettleValueException {
-    meta.setNullsAndEmptyAreDifferent( false );
+    meta.setNullsAndEmptyAreDifferent( true );
 
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_NONE );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null == null
+    assertSignum( -1, meta.compare( null, "" ) ); // null == null
     assertSignum( -1, meta.compare( null, " " ) ); // null < " "
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < " 1 "
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1 "
 
-    assertSignum( 0, meta.compare( "", null ) ); // null > null
+    assertSignum( 1, meta.compare( "", null ) ); // null > null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
     assertSignum( -1, meta.compare( "", " " ) ); // null < " "
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < " 1"
@@ -630,7 +630,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_LEFT );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null < null
+    assertSignum( -1, meta.compare( null, "" ) ); // null < null
     // assertSignum( 0, meta.compare( null, " " ) ); // null == null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
@@ -638,10 +638,10 @@ public class ValueMetaStringTest {
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1 "
 
-    assertSignum( 0, meta.compare( "", null ) ); // null == null
+    assertSignum( 1, meta.compare( "", null ) ); // null == null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
     // assertSignum( 0, meta.compare( "", " " ) ); // null == null //TODO: Is it correct?
-    assertSignum( -1, meta.compare( "", " " ) ); // null < null //TODO: Is it correct?
+    assertSignum( 0, meta.compare( "", " " ) ); // null < null
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // null < "1 "
     assertSignum( -1, meta.compare( "", "1" ) ); // null < "1"
@@ -649,7 +649,7 @@ public class ValueMetaStringTest {
 
     assertSignum( 1, meta.compare( " ", null ) ); // null > null
     // assertSignum( 0, meta.compare( " ", "" ) ); // null == null //TODO: Is it correct?
-    assertSignum( 1, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
+    assertSignum( 0, meta.compare( " ", "" ) ); // null > null
     assertSignum( 0, meta.compare( " ", " " ) ); // null == null
     assertSignum( -1, meta.compare( " ", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // null < "1 "
@@ -691,7 +691,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_RIGHT );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null == null
+    assertSignum( -1, meta.compare( null, "" ) ); // null == null
     // assertSignum( 0, meta.compare( null, " " ) ); // null == null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < " 1"
@@ -699,10 +699,10 @@ public class ValueMetaStringTest {
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 0, meta.compare( "", null ) ); // null == null
+    assertSignum( 1, meta.compare( "", null ) ); // null == null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
     // assertSignum( 0, meta.compare( "", " " ) ); // null == null //TODO: Is it correct?
-    assertSignum( -1, meta.compare( "", " " ) ); // null < null //TODO: Is it correct?
+    assertSignum( 0, meta.compare( "", " " ) ); // null < null
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // null < " 1"
     assertSignum( -1, meta.compare( "", "1" ) ); // null < "1"
@@ -711,7 +711,7 @@ public class ValueMetaStringTest {
     // assertSignum( 0, meta.compare( " ", null ) ); // null == null //TODO: Is it correct?
     assertSignum( 1, meta.compare( " ", null ) ); // null > null //TODO: Is it correct?
     // assertSignum( 0, meta.compare( " ", "" ) ); // null == null //TODO: Is it correct?
-    assertSignum( 1, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
+    assertSignum( 0, meta.compare( " ", "" ) ); // null > null
     assertSignum( 0, meta.compare( " ", " " ) ); // null == null
     assertSignum( -1, meta.compare( " ", " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // null < " 1"
@@ -753,7 +753,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_BOTH );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null == null
+    assertSignum( -1, meta.compare( null, "" ) ); // null == null
     // assertSignum( 0, meta.compare( null, " " ) ); // null == null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
@@ -761,10 +761,10 @@ public class ValueMetaStringTest {
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 0, meta.compare( "", null ) ); // null == null
+    assertSignum( 1, meta.compare( "", null ) ); // null == null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
     // assertSignum( 0, meta.compare( "", " " ) ); // null == null //TODO: Is it correct?
-    assertSignum( -1, meta.compare( "", " " ) ); // null < null //TODO: Is it correct?
+    assertSignum( 0, meta.compare( "", " " ) ); // null < null
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( "", "1" ) ); // null < "1"
@@ -773,7 +773,7 @@ public class ValueMetaStringTest {
     // assertSignum( 0, meta.compare( " ", null ) ); // null == null //TODO: Is it correct?
     assertSignum( 1, meta.compare( " ", null ) ); // null > null //TODO: Is it correct?
     // assertSignum( 0, meta.compare( " ", "" ) ); // null == null //TODO: Is it correct?
-    assertSignum( 1, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
+    assertSignum( 0, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
     assertSignum( 0, meta.compare( " ", " " ) ); // null == null
     assertSignum( -1, meta.compare( " ", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // null < "1"
@@ -816,23 +816,23 @@ public class ValueMetaStringTest {
     meta.setIgnoreWhitespace( true );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null == null
+    assertSignum( -1, meta.compare( null, "" ) ); // null == null
     assertSignum( -1, meta.compare( null, " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 0, meta.compare( "", null ) ); // null == null
+    assertSignum( 1, meta.compare( "", null ) ); // null == null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
-    assertSignum( -1, meta.compare( "", " " ) ); // null < null //TODO: Is it correct?
+    assertSignum( 0, meta.compare( "", " " ) ); // null < null
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( "", "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // null < "1"
 
     assertSignum( 1, meta.compare( " ", null ) ); // null > null //TODO: Is it correct?
-    assertSignum( 1, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
+    assertSignum( 0, meta.compare( " ", "" ) ); // null > null
     assertSignum( 0, meta.compare( " ", " " ) ); // null == null
     assertSignum( -1, meta.compare( " ", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // null < "1"

--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -506,7 +506,7 @@ public class TextFileInputUtils {
         if ( fieldnr < strings.length ) {
           String pol = strings[ fieldnr ];
           try {
-            if ( valueMeta.isNull( pol ) || !Utils.isEmpty( nullif ) && nullif.equals( pol ) ) {
+            if ( null == pol  || Utils.isEmpty( nullif ) && nullif.equals( pol ) ) {
               pol = null;
             }
             value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
@@ -693,7 +693,7 @@ public class TextFileInput extends BaseStep implements StepInterface {
         if ( fieldnr < strings.length ) {
           String pol = strings[ fieldnr ];
           try {
-            if ( valueMeta.isNull( pol ) ) {
+            if (  null == pol  || Utils.isEmpty( nullif ) && nullif.equals( pol ) ) {
               pol = null;
             }
             value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
@@ -70,8 +70,8 @@ public class DataGrid_EmptyStringVsNull_Test {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
     List<Object[]> expected = Arrays.asList(
       new Object[] { "", "", " ", "", null },
-      new Object[] { null, "", null, "", null },
-      new Object[] { null, "", null, "", null }
+      new Object[] { "", "", "", "", null },
+      new Object[] { "", "", "", "", null }
     );
     executeAndAssertResults( expected );
   }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitterTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitterTest.java
@@ -141,7 +141,7 @@ public class FieldSplitterTest {
 
     RowSet outputRowSet = step.getOutputRowSets().get( 0 );
     Object[] actualRow = outputRowSet.getRow();
-    Object[] expectedRow = new Object[] { "before", null, "b=b", "after" };
+    Object[] expectedRow = new Object[] { "before", "", "b=b", "after" };
 
     assertEquals( "Output row is of an unexpected length", expectedRow.length, outputRowSet.getRowMeta().size() );
 

--- a/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter_EmptyStringVsNull_Test.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter_EmptyStringVsNull_Test.java
@@ -72,8 +72,8 @@ public class FieldSplitter_EmptyStringVsNull_Test {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
     List<Object[]> expected = Arrays.asList(
       new Object[] { "a", "", "a" },
-      new Object[] { "b", null, "b" },
-      new Object[] { null }
+      new Object[] { "b", "", "b" },
+      new Object[] { "", "", ""}
     );
     executeAndAssertResults( expected );
   }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputTest.java
@@ -30,6 +30,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.RowSet;
@@ -78,6 +79,8 @@ public class TextFileInputTest {
   @BeforeClass
   public static void initKettle() throws Exception {
     KettleEnvironment.init();
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
+    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
   }
 
   private static BufferedInputStreamReader getInputStreamReader( String data ) throws UnsupportedEncodingException {
@@ -175,6 +178,7 @@ public class TextFileInputTest {
   @Test
   public void readInputWithMissedValues() throws Exception {
     final String virtualFile = createVirtualFile( "pdi-14172.txt", "1,1,1\n", "2,,2\n" );
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
 
     BaseFileField field2 = field( "col2" );
     field2.setRepeated( true );
@@ -192,6 +196,7 @@ public class TextFileInputTest {
 
   @Test
   public void readInputWithNonEmptyNullif() throws Exception {
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
     final String virtualFile = createVirtualFile( "pdi-14358.txt", "-,-\n" );
 
     BaseFileField col2 = field( "col2" );
@@ -452,6 +457,7 @@ public class TextFileInputTest {
   @Test
   public void fieldsWithLineBreaksWithEmptyLinesTest() throws Exception {
 
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
     final String content = new StringBuilder()
       .append( "aaa,\"b" ).append( '\n' )
       .append( "bb\",ccc" ).append( '\n' )

--- a/engine/src/test/java/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
@@ -37,6 +37,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.exception.KettleValueException;
@@ -165,7 +166,8 @@ public class TextFileInputTest {
   @Test
   public void readInputWithMissedValues() throws Exception {
     final String virtualFile = createVirtualFile( "pdi-14172.txt", "1,1,1\n", "2,,2\n" );
-
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
+    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
     TextFileInputMeta meta = new TextFileInputMeta();
     TextFileInputField field2 = field( "col2" );
     field2.setRepeated( true );

--- a/ui/src/test/java/org/pentaho/di/ui/core/dialog/EditRowsDialog_EmptyStringVsNull_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/core/dialog/EditRowsDialog_EmptyStringVsNull_Test.java
@@ -55,14 +55,15 @@ public class EditRowsDialog_EmptyStringVsNull_Test {
   @Test
   public void emptyAndNullsAreNotDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
-    executeAndAssertResults( new String[]{ "", null, null } );
+    executeAndAssertResults( new String[]{ "", "", "" } );
   }
 
 
   @Test
   public void emptyAndNullsAreDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
-    executeAndAssertResults( new String[]{ "", "", "" } );
+    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
+    executeAndAssertResults( new String[]{ "", "", null } );
   }
 
   private void executeAndAssertResults( String[] expected ) throws Exception {


### PR DESCRIPTION
This is a squash and rebase of [pentaho-kettle#9324](https://github.com/pentaho/pentaho-kettle/pull/9324) but with the fix for the "unreachable statement" error (due to a return on line 3605)!

@pentaho/tatooine_dev 