### PR TITLE
[BACKLOG-40843] Unit test fixes for JDK17

### DIFF
--- a/engine/src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,21 +22,6 @@
 
 package org.pentaho.di.trans.steps.mock;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -53,6 +38,21 @@ import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class StepMockHelper<Meta extends StepMetaInterface, Data extends StepDataInterface> {
   public final StepMeta stepMeta;
@@ -98,7 +98,7 @@ public class StepMockHelper<Meta extends StepMetaInterface, Data extends StepDat
         return i < rows.size() ? rows.get( i ) : null;
       }
     };
-    when( rowSet.getRowWait( anyLong(), any( TimeUnit.class ) ) ).thenAnswer( answer );
+    lenient().when( rowSet.getRowWait( anyLong(), any( TimeUnit.class ) ) ).thenAnswer( answer );
     when( rowSet.getRow() ).thenAnswer( answer );
     when( rowSet.isDone() ).thenAnswer( new Answer<Boolean>() {
 

--- a/plugins/xml/core/pom.xml
+++ b/plugins/xml/core/pom.xml
@@ -77,7 +77,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>
@@ -107,6 +107,11 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/addxml/AddXMLTest.java
+++ b/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/addxml/AddXMLTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,12 +21,6 @@
  ******************************************************************************/
 package org.pentaho.di.trans.steps.addxml;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
-import static java.util.Arrays.asList;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +30,12 @@ import org.pentaho.di.core.logging.LoggingObjectInterface;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import org.pentaho.di.www.SocketRepository;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AddXMLTest {
 

--- a/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/getxmldata/GetXMLDataMetaTest.java
+++ b/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/getxmldata/GetXMLDataMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2020-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,14 +27,13 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.metastore.api.IMetaStore;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.internal.util.reflection.Whitebox.getInternalState;
-import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
 
 public class GetXMLDataMetaTest {
 
@@ -43,8 +42,8 @@ public class GetXMLDataMetaTest {
     GetXMLDataMeta getXMLDataMeta = new GetXMLDataMeta();
     String[] fileName = new String[] {};
     GetXMLDataField[] inputFields = new GetXMLDataField[] {};
-    setInternalState( getXMLDataMeta, "fileName", fileName );
-    setInternalState( getXMLDataMeta, "inputFields", inputFields );
+    ReflectionTestUtils.setField( getXMLDataMeta, "fileName", fileName );
+    ReflectionTestUtils.setField( getXMLDataMeta, "inputFields", inputFields );
 
     Repository rep = mock( Repository.class );
     IMetaStore metaStore = mock( IMetaStore.class );
@@ -52,21 +51,21 @@ public class GetXMLDataMetaTest {
     ObjectId idStep = mock( ObjectId.class );
 
     String shortFileFieldName = UUID.randomUUID().toString();
-    setInternalState( getXMLDataMeta, "shortFileFieldName", shortFileFieldName );
+    ReflectionTestUtils.setField( getXMLDataMeta, "shortFileFieldName", shortFileFieldName );
     String extensionFieldName = UUID.randomUUID().toString();
-    setInternalState( getXMLDataMeta, "extensionFieldName", extensionFieldName );
+    ReflectionTestUtils.setField( getXMLDataMeta, "extensionFieldName", extensionFieldName );
     String pathFieldName = UUID.randomUUID().toString();
-    setInternalState( getXMLDataMeta, "pathFieldName", pathFieldName );
+    ReflectionTestUtils.setField( getXMLDataMeta, "pathFieldName", pathFieldName );
     String sizeFieldName = UUID.randomUUID().toString();
-    setInternalState( getXMLDataMeta, "sizeFieldName", sizeFieldName );
+    ReflectionTestUtils.setField( getXMLDataMeta, "sizeFieldName", sizeFieldName );
     String hiddenFieldName = UUID.randomUUID().toString();
-    setInternalState( getXMLDataMeta, "hiddenFieldName", hiddenFieldName );
+    ReflectionTestUtils.setField( getXMLDataMeta, "hiddenFieldName", hiddenFieldName );
     String lastModificationTimeFieldName = UUID.randomUUID().toString();
-    setInternalState( getXMLDataMeta, "lastModificationTimeFieldName", lastModificationTimeFieldName );
+    ReflectionTestUtils.setField( getXMLDataMeta, "lastModificationTimeFieldName", lastModificationTimeFieldName );
     String uriNameFieldName = UUID.randomUUID().toString();
-    setInternalState( getXMLDataMeta, "uriNameFieldName", uriNameFieldName );
+    ReflectionTestUtils.setField( getXMLDataMeta, "uriNameFieldName", uriNameFieldName );
     String rootUriNameFieldName = UUID.randomUUID().toString();
-    setInternalState( getXMLDataMeta, "rootUriNameFieldName", rootUriNameFieldName );
+    ReflectionTestUtils.setField( getXMLDataMeta, "rootUriNameFieldName", rootUriNameFieldName );
 
     getXMLDataMeta.saveRep( rep, metaStore, idTransformation, idStep );
 

--- a/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/getxmldata/GetXMLDataStepAnalyzerTest.java
+++ b/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/getxmldata/GetXMLDataStepAnalyzerTest.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  * ******************************************************************************
  *
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -57,13 +57,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by mburgess on 4/24/15.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class GetXMLDataStepAnalyzerTest {
 
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
@@ -173,7 +184,7 @@ public class GetXMLDataStepAnalyzerTest {
     when( meta.getInputFields() ).thenReturn( fields );
 
     IAnalysisContext context = mock( IAnalysisContext.class );
-    doReturn( "thisStepName" ).when( analyzer ).getStepName();
+    lenient().doReturn( "thisStepName" ).when( analyzer ).getStepName();
     when( node.getLogicalId() ).thenReturn( "logical id" );
     ValueMetaInterface vmi = new ValueMeta( "name", 1 );
 
@@ -200,10 +211,10 @@ public class GetXMLDataStepAnalyzerTest {
 
   @Test
   public void testGetInputRowMetaInterfaces_isInFields() throws Exception {
-    when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
+    when( parentTransMeta.getPrevStepNames( Mockito.<StepMeta>any() ) ).thenReturn( null );
 
     RowMetaInterface rowMetaInterface = mock( RowMetaInterface.class );
-    doReturn( rowMetaInterface ).when( analyzer ).getOutputFields( meta );
+    lenient().doReturn( rowMetaInterface ).when( analyzer ).getOutputFields( meta );
     when( meta.isInFields() ).thenReturn( true );
     when( meta.getIsAFile() ).thenReturn( false );
     when( meta.isReadUrl() ).thenReturn( false );
@@ -225,7 +236,7 @@ public class GetXMLDataStepAnalyzerTest {
     when( inputRmi.getValueMetaList() ).thenReturn( vmis );
     inputs.put( "test", inputRmi );
     doReturn( inputs ).when( analyzer ).getInputFields( meta );
-    when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
+    lenient().when( parentTransMeta.getPrevStepNames( parentStepMeta ) ).thenReturn( null );
 
     RowMetaInterface rowMetaInterface = new RowMeta();
     rowMetaInterface.addValueMeta( vmi );
@@ -309,13 +320,13 @@ public class GetXMLDataStepAnalyzerTest {
     when( meta.getIsAFile() ).thenReturn( true );
     assertTrue( consumer.isDataDriven( meta ) );
     assertTrue( consumer.getResourcesFromMeta( meta ).isEmpty() );
-    when( rmi.getString( Mockito.any( Object[].class ), anyString(), anyString() ) )
+    when( rmi.getString( Mockito.any( Object[].class ), any(), any() ) )
       .thenReturn( "/path/to/row/file" );
     resources = consumer.getResourcesFromRow( data, rmi, new String[]{ "id", "name" } );
     assertFalse( resources.isEmpty() );
     assertEquals( 1, resources.size() );
 
-    when( rmi.getString( Mockito.any( Object[].class ), anyString(), anyString() ) )
+    when( rmi.getString( any( Object[].class ), any(), any() ) )
       .thenThrow( new KettleValueException() );
     resources = consumer.getResourcesFromRow( data, rmi, new String[]{ "id", "name" } );
     assertTrue( resources.isEmpty() );

--- a/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmlinputstream/XMLInputStreamTest.java
+++ b/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmlinputstream/XMLInputStreamTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,18 +21,6 @@
  ******************************************************************************/
 package org.pentaho.di.trans.steps.xmlinputstream;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.Writer;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -47,6 +35,18 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.trans.step.RowAdapter;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Tatsiana_Kasiankova

--- a/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmljoin/XmlJoinOmitNullValuesTest.java
+++ b/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmljoin/XmlJoinOmitNullValuesTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,14 +22,11 @@
 
 package org.pentaho.di.trans.steps.xmljoin;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleStepException;
@@ -38,13 +35,20 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.RowAdapter;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
 /**
  * Test for XmlJoin step
  * 
  * @author Pavel Sakun
  * @see XMLJoin
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class XmlJoinOmitNullValuesTest {
   StepMockHelper<XMLJoinMeta, XMLJoinData> smh;
 
@@ -72,13 +76,13 @@ public class XmlJoinOmitNullValuesTest {
     doReturn( createTargetRowSet( targetXml ) ).when( spy ).findInputRowSet( "target" );
 
     XMLJoinMeta stepMeta = smh.initStepMetaInterface;
-    when( stepMeta.getSourceXMLstep() ).thenReturn( "source" );
-    when( stepMeta.getTargetXMLstep() ).thenReturn( "target" );
-    when( stepMeta.getSourceXMLfield() ).thenReturn( "sourceField" );
-    when( stepMeta.getTargetXMLfield() ).thenReturn( "targetField" );
-    when( stepMeta.getValueXMLfield() ).thenReturn( "resultField" );
-    when( stepMeta.getTargetXPath() ).thenReturn( "//root" );
-    when( stepMeta.isOmitNullValues() ).thenReturn( true );
+    lenient().when( stepMeta.getSourceXMLstep() ).thenReturn( "source" );
+    lenient().when( stepMeta.getTargetXMLstep() ).thenReturn( "target" );
+    lenient().when( stepMeta.getSourceXMLfield() ).thenReturn( "sourceField" );
+    lenient().when( stepMeta.getTargetXMLfield() ).thenReturn( "targetField" );
+    lenient().when( stepMeta.getValueXMLfield() ).thenReturn( "resultField" );
+    lenient().when( stepMeta.getTargetXPath() ).thenReturn( "//root" );
+    lenient().when( stepMeta.isOmitNullValues() ).thenReturn( true );
 
     spy.init( stepMeta, smh.initStepDataInterface );
 
@@ -96,7 +100,7 @@ public class XmlJoinOmitNullValuesTest {
   private RowSet createSourceRowSet( String sourceXml ) {
     RowSet sourceRowSet = smh.getMockInputRowSet( new String[] { sourceXml } );
     RowMetaInterface sourceRowMeta = mock( RowMetaInterface.class );
-    when( sourceRowMeta.getFieldNames() ).thenReturn( new String[] { "sourceField" } );
+    lenient().when( sourceRowMeta.getFieldNames() ).thenReturn( new String[] { "sourceField" } );
     when( sourceRowSet.getRowMeta() ).thenReturn( sourceRowMeta );
 
     return sourceRowSet;

--- a/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmloutput/XMLOutputMetaTest.java
+++ b/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmloutput/XMLOutputMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,22 +21,6 @@
  ******************************************************************************/
 
 package org.pentaho.di.trans.steps.xmloutput;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import org.apache.commons.vfs2.FileObject;
 import org.junit.BeforeClass;
@@ -61,6 +45,22 @@ import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class XMLOutputMetaTest {
   @BeforeClass

--- a/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmloutput/XMLOutputStepAnalyzerTest.java
+++ b/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmloutput/XMLOutputStepAnalyzerTest.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  * ******************************************************************************
  *
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -42,10 +42,18 @@ import org.pentaho.metaverse.api.model.IExternalResourceInfo;
 import java.util.Collection;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class XMLOutputStepAnalyzerTest {
 
   private XMLOutputStepAnalyzer analyzer;
@@ -87,14 +95,14 @@ public class XMLOutputStepAnalyzerTest {
     analyzer.setDescriptor( descriptor );
     analyzer.setObjectFactory( metaverseObjectFactory );
 
-    when( mockXMLOutput.getStepDataInterface() ).thenReturn( data );
-    when( mockXMLOutput.getStepMeta() ).thenReturn( parentStepMeta );
+    lenient().when( mockXMLOutput.getStepDataInterface() ).thenReturn( data );
+    lenient().when( mockXMLOutput.getStepMeta() ).thenReturn( parentStepMeta );
 
-    when( meta.getParentStepMeta() ).thenReturn( parentStepMeta );
-    when( parentStepMeta.getStepMetaInterface() ).thenReturn( meta );
-    when( parentStepMeta.getParentTransMeta() ).thenReturn( mockTransMeta );
-    when( parentStepMeta.getName() ).thenReturn( "test" );
-    when( parentStepMeta.getStepID() ).thenReturn( "XmlOutputStep" );
+    lenient().when( meta.getParentStepMeta() ).thenReturn( parentStepMeta );
+    lenient().when( parentStepMeta.getStepMetaInterface() ).thenReturn( meta );
+    lenient().when( parentStepMeta.getParentTransMeta() ).thenReturn( mockTransMeta );
+    lenient().when( parentStepMeta.getName() ).thenReturn( "test" );
+    lenient().when( parentStepMeta.getStepID() ).thenReturn( "XmlOutputStep" );
   }
 
   @Test
@@ -147,7 +155,6 @@ public class XMLOutputStepAnalyzerTest {
 
     when( this.meta.getParentStepMeta() ).thenReturn( spyMeta );
     when( spyMeta.getParentTransMeta() ).thenReturn( mockTransMeta );
-    when( this.meta.getFileName() ).thenReturn( null );
     String[] filePaths = { "/path/to/file1", "/another/path/to/file2" };
     when( this.meta.getFiles( Mockito.any( VariableSpace.class ) ) ).thenReturn( filePaths );
 
@@ -156,7 +163,7 @@ public class XMLOutputStepAnalyzerTest {
     assertFalse( resources.isEmpty() );
     assertEquals( 2, resources.size() );
 
-    when( this.meta.getExtension() ).thenReturn( "txt" );
+    lenient().when( this.meta.getExtension() ).thenReturn( "txt" );
 
     assertEquals( XMLOutputMeta.class, consumer.getMetaClass() );
   }

--- a/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmloutput/XMLOutputTest.java
+++ b/plugins/xml/core/src/test/java/org/pentaho/di/trans/steps/xmloutput/XMLOutputTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,7 +28,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Matchers;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.exception.KettleException;
@@ -52,7 +51,6 @@ import org.w3c.dom.Document;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -61,12 +59,13 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -137,7 +136,7 @@ public class XMLOutputTest {
     when( stepMockHelper.logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn(
         stepMockHelper.logChannelInterface );
     StepMeta mockMeta = mock( StepMeta.class );
-    when( stepMockHelper.transMeta.findStep( Matchers.anyString() ) ).thenReturn( mockMeta );
+    when( stepMockHelper.transMeta.findStep( anyString() ) ).thenReturn( mockMeta );
     when( trans.getLogLevel() ).thenReturn( LogLevel.DEBUG );
 
     // Create and set Meta with some realistic data

--- a/plugins/xml/pom.xml
+++ b/plugins/xml/pom.xml
@@ -34,7 +34,7 @@
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <pdi.version>10.2.0.0-SNAPSHOT</pdi.version>
-    <mockito.version>1.9.5</mockito.version>
+    <mockito.version>5.10.0</mockito.version>
     <saxon.version>8.7</saxon.version>
     <poi.version>4.1.1</poi.version>
     <platform.version>10.2.0.0-SNAPSHOT</platform.version>
@@ -120,7 +120,7 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
@@ -140,6 +140,12 @@
         <groupId>net.sf.saxon</groupId>
         <artifactId>saxon-dom</artifactId>
         <version>${saxon.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-test</artifactId>
+        <version>${spring.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
There was an unused mock error coming from the engine `StepMockHelper` that got used in one test, so I threw a `lenient` in there, only usual thing about this one