### PR TITLE
Revert "[PDI-20085] - KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL produces opposite display for NULLS"  

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -4039,10 +4039,10 @@ public class ValueMetaBase implements ValueMetaInterface {
     boolean isStringValue = outValueType == Value.VALUE_TYPE_STRING;
     Object emptyValue = isStringValue ? Const.NULL_STRING : null;
 
-    boolean isEmptyAndNullDiffer = !convertStringToBoolean(
+    boolean isEmptyAndNullDiffer = convertStringToBoolean(
         Const.NVL( System.getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
 
-    boolean normalizeNullStringToEmpty = convertStringToBoolean(
+    boolean normalizeNullStringToEmpty = !convertStringToBoolean(
       Const.NVL( System.getProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" ), "N" ) );
 
     //the property KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY is only valid when KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y.

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -23,7 +23,6 @@
 
 package org.pentaho.di.core.row.value;
 
-import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.compatibility.Value;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseInterface;
@@ -4039,17 +4038,15 @@ public class ValueMetaBase implements ValueMetaInterface {
     boolean isStringValue = outValueType == Value.VALUE_TYPE_STRING;
     Object emptyValue = isStringValue ? Const.NULL_STRING : null;
 
-    boolean isEmptyAndNullDiffer = convertStringToBoolean(
+    Boolean isEmptyAndNullDiffer = convertStringToBoolean(
         Const.NVL( System.getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
 
-    boolean normalizeNullStringToEmpty = !convertStringToBoolean(
+    Boolean normalizeNullStringToEmpty = !convertStringToBoolean(
       Const.NVL( System.getProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" ), "N" ) );
 
-    //the property KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY is only valid when KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y.
-    //the isEmptyAndNullDiffer means that null and empty string should be different. normalizeNullStringToEmpty stops pentaho from making this transaction.
-    if ( isEmptyAndNullDiffer && pol == null && isStringValue ) {
-      if ( normalizeNullStringToEmpty ) {
-        pol = StringUtils.EMPTY;
+    if ( normalizeNullStringToEmpty ) {
+      if ( pol == null && isStringValue && isEmptyAndNullDiffer ) {
+        pol = Const.NULL_STRING;
       }
     }
 

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -4039,16 +4039,18 @@ public class ValueMetaBase implements ValueMetaInterface {
     boolean isStringValue = outValueType == Value.VALUE_TYPE_STRING;
     Object emptyValue = isStringValue ? Const.NULL_STRING : null;
 
-    boolean isEmptyAndNullDiffer = convertStringToBoolean(
+    boolean isEmptyAndNullDiffer = !convertStringToBoolean(
         Const.NVL( System.getProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" ), "N" ) );
 
-    boolean normalizeNullStringToEmpty = !convertStringToBoolean(
+    boolean normalizeNullStringToEmpty = convertStringToBoolean(
       Const.NVL( System.getProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" ), "N" ) );
 
     //the property KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY is only valid when KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y.
     //the isEmptyAndNullDiffer means that null and empty string should be different. normalizeNullStringToEmpty stops pentaho from making this transaction.
-    if ( (isEmptyAndNullDiffer && pol == null && isStringValue && normalizeNullStringToEmpty) || (!isEmptyAndNullDiffer && pol == null && isStringValue ) ) {
-      pol = StringUtils.EMPTY;
+    if ( isEmptyAndNullDiffer && pol == null && isStringValue ) {
+      if ( normalizeNullStringToEmpty ) {
+        pol = StringUtils.EMPTY;
+      }
     }
 
     if ( pol == null ) {

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -3602,16 +3602,17 @@ public class ValueMetaBase implements ValueMetaInterface {
         return true;
       }
 
-      if ( StringUtils.EMPTY.equals( value ) ) {
-        return !emptyStringDiffersFromNull;
+      if ( emptyStringDiffersFromNull ) {
+        return false;
       }
 
       // If it's a string and the string is empty, it's a null value as well
       //
-      if ( isString() && value.toString().isEmpty() ) {
-        return true;
+      if ( isString() ) {
+        if ( value.toString().length() == 0 ) {
+          return true;
+        }
       }
-
 
       // We tried everything else so we assume this value is not null.
       //
@@ -4063,7 +4064,7 @@ public class ValueMetaBase implements ValueMetaInterface {
           // we have a match
           //
           if ( pol.equalsIgnoreCase( Const.rightPad( new StringBuilder( null_value ), pol.length() ) ) ) {
-            return isEmptyAndNullDiffer && pol.equalsIgnoreCase( "" ) ? emptyValue : null;
+            return emptyValue;
           }
         }
       } else {

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -390,17 +390,15 @@ public class ValueMetaBaseTest {
       + "Conversion from null string must return null", null, result );
 
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
-    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" );
     result =
-      outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
-    assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y and KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY = N: "
-      + "Conversion from null string must return empty string", StringUtils.EMPTY, result );
+      outValueMetaString.convertDataFromString( inputValueEmptyString, inValueMetaString, nullIf, ifNull, trim_type );
+    assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y: "
+      + "Conversion from empty string to string must return empty string", StringUtils.EMPTY, result );
 
-    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
     result =
       outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
-    assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y and KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY = Y: "
-      + "Conversion from null string must return null", null, result );
+    assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y: "
+      + "Conversion from null string must return empty string", StringUtils.EMPTY, result );
 
     // test KETTLE_DO_NOT_NORMALIZE_SPACES_ONLY_STRING_TO_EMPTY
     System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_SPACES_ONLY_STRING_TO_EMPTY, "Y" );

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -387,14 +387,14 @@ public class ValueMetaBaseTest {
     result =
       outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
     assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = N: "
-      + "Conversion from null string must return empty String", StringUtils.EMPTY, result );
+      + "Conversion from null string must return null", null, result );
 
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
     System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" );
     result =
       outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
     assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y and KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY = N: "
-      + "Conversion from null string must return empty String ", StringUtils.EMPTY, result );
+      + "Conversion from null string must return null ", null, result );
 
     System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
     result =

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest.java
@@ -394,7 +394,7 @@ public class ValueMetaBaseTest {
     result =
       outValueMetaString.convertDataFromString( inputValueNullString, inValueMetaString, nullIf, ifNull, trim_type );
     assertEquals( "KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL = Y and KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY = N: "
-      + "Conversion from null string must return null ", null, result );
+      + "Conversion from null string must return empty string", StringUtils.EMPTY, result );
 
     System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
     result =

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest_NullEmpty.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaBaseTest_NullEmpty.java
@@ -36,8 +36,8 @@ public class ValueMetaBaseTest_NullEmpty {
    */
   @Test
   public void convertDataFromStringWithDefaults() throws Exception {
-    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
-    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
+    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
+    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "N" );
 
     ValueMetaBase out = new ValueMetaString();
     ValueMetaBase value = new ValueMetaString();

--- a/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaStringTest.java
+++ b/core/src/test/java/org/pentaho/di/core/row/value/ValueMetaStringTest.java
@@ -152,10 +152,10 @@ public class ValueMetaStringTest {
 
   @Test
   public void testIsNull_emptyIsNotNull() throws KettleValueException {
-    meta.setNullsAndEmptyAreDifferent( false );
+    meta.setNullsAndEmptyAreDifferent( true );
 
     assertEquals( true, meta.isNull( null ) );
-    assertEquals( true, meta.isNull( "" ) );
+    assertEquals( false, meta.isNull( "" ) );
 
     assertEquals( false, meta.isNull( "1" ) );
 
@@ -178,10 +178,10 @@ public class ValueMetaStringTest {
 
   @Test
   public void testIsNull_emptyIsNull() throws KettleValueException {
-    meta.setNullsAndEmptyAreDifferent( true );
+    meta.setNullsAndEmptyAreDifferent( false );
 
     assertEquals( true, meta.isNull( null ) );
-    assertEquals( false, meta.isNull( "" ) );
+    assertEquals( true, meta.isNull( "" ) );
 
     assertEquals( false, meta.isNull( "1" ) );
 
@@ -195,7 +195,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_LEFT );
     // assertEquals( true, meta.isNull( "    " ) ); //TODO: is it correct?
     assertEquals( false, meta.isNull( "    " ) ); // TODO: is it correct?
-    assertEquals( false, meta.isNull( meta.getString( "    " ) ) );
+    assertEquals( true, meta.isNull( meta.getString( "    " ) ) );
 
     assertEquals( false, meta.isNull( "  1  " ) );
     assertEquals( false, meta.isNull( meta.getString( "  1  " ) ) );
@@ -203,7 +203,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_RIGHT );
     // assertEquals( true, meta.isNull( "    " ) ); //TODO: is it correct?
     assertEquals( false, meta.isNull( "    " ) ); // TODO: is it correct?
-    assertEquals( false, meta.isNull( meta.getString( "    " ) ) );
+    assertEquals( true, meta.isNull( meta.getString( "    " ) ) );
 
     assertEquals( false, meta.isNull( "  1  " ) );
     assertEquals( false, meta.isNull( meta.getString( "  1  " ) ) );
@@ -211,7 +211,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_BOTH );
     // assertEquals( true, meta.isNull( "    " ) ); //TODO: is it correct?
     assertEquals( false, meta.isNull( "    " ) ); // TODO: is it correct?
-    assertEquals( false, meta.isNull( meta.getString( "    " ) ) );
+    assertEquals( true, meta.isNull( meta.getString( "    " ) ) );
 
     assertEquals( false, meta.isNull( "  1  " ) );
     assertEquals( false, meta.isNull( meta.getString( "  1  " ) ) );
@@ -271,19 +271,19 @@ public class ValueMetaStringTest {
 
   @Test
   public void testCompare_emptyIsNotNull() throws KettleValueException {
-    meta.setNullsAndEmptyAreDifferent( false );
+    meta.setNullsAndEmptyAreDifferent( true );
 
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_NONE );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
+    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < " "
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < " 1 "
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1 "
 
-    assertSignum( 0, meta.compare( "", null ) ); // "" > null
+    assertSignum( 1, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " " ) ); // "" < " "
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < " 1"
@@ -334,23 +334,23 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_LEFT );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
+    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < ""
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < "1 "
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1 "
 
-    assertSignum( 0, meta.compare( "", null ) ); // "" > null
+    assertSignum( 1, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
-    assertSignum( -1, meta.compare( "", " " ) ); // "" == ""
+    assertSignum( 0, meta.compare( "", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // "" < "1 "
     assertSignum( -1, meta.compare( "", "1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // "" < "1 "
 
     assertSignum( 1, meta.compare( " ", null ) ); // "" > null
-    assertSignum( 1, meta.compare( " ", "" ) ); // "" == ""
+    assertSignum( 0, meta.compare( " ", "" ) ); // "" == ""
     assertSignum( 0, meta.compare( " ", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( " ", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // "" < "1 "
@@ -392,23 +392,23 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_RIGHT );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
+    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < ""
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < " 1"
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 0, meta.compare( "", null ) ); // "" > null
+    assertSignum( 1, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
-    assertSignum( -1, meta.compare( "", " " ) ); // "" == ""
+    assertSignum( 0, meta.compare( "", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < " 1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // "" < " 1"
     assertSignum( -1, meta.compare( "", "1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // "" < "1"
 
     assertSignum( 1, meta.compare( " ", null ) ); // "" > null
-    assertSignum( 1, meta.compare( " ", "" ) ); // "" == ""
+    assertSignum( 0, meta.compare( " ", "" ) ); // "" == ""
     assertSignum( 0, meta.compare( " ", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( " ", " 1" ) ); // "" < " 1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // "" < " 1"
@@ -450,23 +450,23 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_BOTH );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
+    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < ""
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 0, meta.compare( "", null ) ); // "" > null
+    assertSignum( 1, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
-    assertSignum( -1, meta.compare( "", " " ) ); // "" == ""
+    assertSignum( 0, meta.compare( "", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // "" < "1"
 
     assertSignum( 1, meta.compare( " ", null ) ); // "" > null
-    assertSignum( 1, meta.compare( " ", "" ) ); // "" == ""
+    assertSignum( 0, meta.compare( " ", "" ) ); // "" == ""
     assertSignum( 0, meta.compare( " ", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( " ", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // "" < "1"
@@ -509,23 +509,23 @@ public class ValueMetaStringTest {
     meta.setIgnoreWhitespace( true );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( 0, meta.compare( null, "" ) ); // null < ""
+    assertSignum( -1, meta.compare( null, "" ) ); // null < ""
     assertSignum( -1, meta.compare( null, " " ) ); // null < ""
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 0, meta.compare( "", null ) ); // "" > null
+    assertSignum( 1, meta.compare( "", null ) ); // "" > null
     assertSignum( 0, meta.compare( "", "" ) ); // "" == ""
-    assertSignum( -1, meta.compare( "", " " ) ); // "" == ""
+    assertSignum( 0, meta.compare( "", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( "", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // "" < "1"
 
     assertSignum( 1, meta.compare( " ", null ) ); // "" > null
-    assertSignum( 1, meta.compare( " ", "" ) ); // "" == ""
+    assertSignum( 0, meta.compare( " ", "" ) ); // "" == ""
     assertSignum( 0, meta.compare( " ", " " ) ); // "" == ""
     assertSignum( -1, meta.compare( " ", " 1" ) ); // "" < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // "" < "1"
@@ -567,19 +567,19 @@ public class ValueMetaStringTest {
 
   @Test
   public void testCompare_emptyIsNull() throws KettleValueException {
-    meta.setNullsAndEmptyAreDifferent( true );
+    meta.setNullsAndEmptyAreDifferent( false );
 
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_NONE );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null == null
+    assertSignum( 0, meta.compare( null, "" ) ); // null == null
     assertSignum( -1, meta.compare( null, " " ) ); // null < " "
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < " 1 "
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1 "
 
-    assertSignum( 1, meta.compare( "", null ) ); // null > null
+    assertSignum( 0, meta.compare( "", null ) ); // null > null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
     assertSignum( -1, meta.compare( "", " " ) ); // null < " "
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < " 1"
@@ -630,7 +630,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_LEFT );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null < null
+    assertSignum( 0, meta.compare( null, "" ) ); // null < null
     // assertSignum( 0, meta.compare( null, " " ) ); // null == null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
@@ -638,10 +638,10 @@ public class ValueMetaStringTest {
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1 "
 
-    assertSignum( 1, meta.compare( "", null ) ); // null == null
+    assertSignum( 0, meta.compare( "", null ) ); // null == null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
     // assertSignum( 0, meta.compare( "", " " ) ); // null == null //TODO: Is it correct?
-    assertSignum( 0, meta.compare( "", " " ) ); // null < null
+    assertSignum( -1, meta.compare( "", " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // null < "1 "
     assertSignum( -1, meta.compare( "", "1" ) ); // null < "1"
@@ -649,7 +649,7 @@ public class ValueMetaStringTest {
 
     assertSignum( 1, meta.compare( " ", null ) ); // null > null
     // assertSignum( 0, meta.compare( " ", "" ) ); // null == null //TODO: Is it correct?
-    assertSignum( 0, meta.compare( " ", "" ) ); // null > null
+    assertSignum( 1, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
     assertSignum( 0, meta.compare( " ", " " ) ); // null == null
     assertSignum( -1, meta.compare( " ", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // null < "1 "
@@ -691,7 +691,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_RIGHT );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null == null
+    assertSignum( 0, meta.compare( null, "" ) ); // null == null
     // assertSignum( 0, meta.compare( null, " " ) ); // null == null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < " 1"
@@ -699,10 +699,10 @@ public class ValueMetaStringTest {
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 1, meta.compare( "", null ) ); // null == null
+    assertSignum( 0, meta.compare( "", null ) ); // null == null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
     // assertSignum( 0, meta.compare( "", " " ) ); // null == null //TODO: Is it correct?
-    assertSignum( 0, meta.compare( "", " " ) ); // null < null
+    assertSignum( -1, meta.compare( "", " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // null < " 1"
     assertSignum( -1, meta.compare( "", "1" ) ); // null < "1"
@@ -711,7 +711,7 @@ public class ValueMetaStringTest {
     // assertSignum( 0, meta.compare( " ", null ) ); // null == null //TODO: Is it correct?
     assertSignum( 1, meta.compare( " ", null ) ); // null > null //TODO: Is it correct?
     // assertSignum( 0, meta.compare( " ", "" ) ); // null == null //TODO: Is it correct?
-    assertSignum( 0, meta.compare( " ", "" ) ); // null > null
+    assertSignum( 1, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
     assertSignum( 0, meta.compare( " ", " " ) ); // null == null
     assertSignum( -1, meta.compare( " ", " 1" ) ); // null < " 1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // null < " 1"
@@ -753,7 +753,7 @@ public class ValueMetaStringTest {
     meta.setTrimType( ValueMetaInterface.TRIM_TYPE_BOTH );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null == null
+    assertSignum( 0, meta.compare( null, "" ) ); // null == null
     // assertSignum( 0, meta.compare( null, " " ) ); // null == null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
@@ -761,10 +761,10 @@ public class ValueMetaStringTest {
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 1, meta.compare( "", null ) ); // null == null
+    assertSignum( 0, meta.compare( "", null ) ); // null == null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
     // assertSignum( 0, meta.compare( "", " " ) ); // null == null //TODO: Is it correct?
-    assertSignum( 0, meta.compare( "", " " ) ); // null < null
+    assertSignum( -1, meta.compare( "", " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( "", "1" ) ); // null < "1"
@@ -773,7 +773,7 @@ public class ValueMetaStringTest {
     // assertSignum( 0, meta.compare( " ", null ) ); // null == null //TODO: Is it correct?
     assertSignum( 1, meta.compare( " ", null ) ); // null > null //TODO: Is it correct?
     // assertSignum( 0, meta.compare( " ", "" ) ); // null == null //TODO: Is it correct?
-    assertSignum( 0, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
+    assertSignum( 1, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
     assertSignum( 0, meta.compare( " ", " " ) ); // null == null
     assertSignum( -1, meta.compare( " ", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // null < "1"
@@ -816,23 +816,23 @@ public class ValueMetaStringTest {
     meta.setIgnoreWhitespace( true );
 
     assertSignum( 0, meta.compare( null, null ) ); // null == null
-    assertSignum( -1, meta.compare( null, "" ) ); // null == null
+    assertSignum( 0, meta.compare( null, "" ) ); // null == null
     assertSignum( -1, meta.compare( null, " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( null, " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( null, "1 " ) ); // null < "1"
 
-    assertSignum( 1, meta.compare( "", null ) ); // null == null
+    assertSignum( 0, meta.compare( "", null ) ); // null == null
     assertSignum( 0, meta.compare( "", "" ) ); // null == null
-    assertSignum( 0, meta.compare( "", " " ) ); // null < null
+    assertSignum( -1, meta.compare( "", " " ) ); // null < null //TODO: Is it correct?
     assertSignum( -1, meta.compare( "", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( "", " 1 " ) ); // null < "1"
     assertSignum( -1, meta.compare( "", "1" ) ); // null < "1"
     assertSignum( -1, meta.compare( "", "1 " ) ); // null < "1"
 
     assertSignum( 1, meta.compare( " ", null ) ); // null > null //TODO: Is it correct?
-    assertSignum( 0, meta.compare( " ", "" ) ); // null > null
+    assertSignum( 1, meta.compare( " ", "" ) ); // null > null //TODO: Is it correct?
     assertSignum( 0, meta.compare( " ", " " ) ); // null == null
     assertSignum( -1, meta.compare( " ", " 1" ) ); // null < "1"
     assertSignum( -1, meta.compare( " ", " 1 " ) ); // null < "1"

--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputUtils.java
@@ -506,7 +506,7 @@ public class TextFileInputUtils {
         if ( fieldnr < strings.length ) {
           String pol = strings[ fieldnr ];
           try {
-            if ( null == pol  || Utils.isEmpty( nullif ) && nullif.equals( pol ) ) {
+            if ( valueMeta.isNull( pol ) || !Utils.isEmpty( nullif ) && nullif.equals( pol ) ) {
               pol = null;
             }
             value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );

--- a/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/textfileinput/TextFileInput.java
@@ -693,7 +693,7 @@ public class TextFileInput extends BaseStep implements StepInterface {
         if ( fieldnr < strings.length ) {
           String pol = strings[ fieldnr ];
           try {
-            if (  null == pol  || Utils.isEmpty( nullif ) && nullif.equals( pol ) ) {
+            if ( valueMeta.isNull( pol ) ) {
               pol = null;
             }
             value = valueMeta.convertDataFromString( pol, convertMeta, nullif, ifnull, trim_type );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/datagrid/DataGrid_EmptyStringVsNull_Test.java
@@ -70,8 +70,8 @@ public class DataGrid_EmptyStringVsNull_Test {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
     List<Object[]> expected = Arrays.asList(
       new Object[] { "", "", " ", "", null },
-      new Object[] { "", "", "", "", null },
-      new Object[] { "", "", "", "", null }
+      new Object[] { null, "", null, "", null },
+      new Object[] { null, "", null, "", null }
     );
     executeAndAssertResults( expected );
   }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitterTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitterTest.java
@@ -141,7 +141,7 @@ public class FieldSplitterTest {
 
     RowSet outputRowSet = step.getOutputRowSets().get( 0 );
     Object[] actualRow = outputRowSet.getRow();
-    Object[] expectedRow = new Object[] { "before", "", "b=b", "after" };
+    Object[] expectedRow = new Object[] { "before", null, "b=b", "after" };
 
     assertEquals( "Output row is of an unexpected length", expectedRow.length, outputRowSet.getRowMeta().size() );
 

--- a/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter_EmptyStringVsNull_Test.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/fieldsplitter/FieldSplitter_EmptyStringVsNull_Test.java
@@ -72,8 +72,8 @@ public class FieldSplitter_EmptyStringVsNull_Test {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
     List<Object[]> expected = Arrays.asList(
       new Object[] { "a", "", "a" },
-      new Object[] { "b", "", "b" },
-      new Object[] { "", "", ""}
+      new Object[] { "b", null, "b" },
+      new Object[] { null }
     );
     executeAndAssertResults( expected );
   }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputTest.java
@@ -30,7 +30,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.RowSet;
@@ -79,8 +78,6 @@ public class TextFileInputTest {
   @BeforeClass
   public static void initKettle() throws Exception {
     KettleEnvironment.init();
-    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
-    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
   }
 
   private static BufferedInputStreamReader getInputStreamReader( String data ) throws UnsupportedEncodingException {
@@ -178,7 +175,6 @@ public class TextFileInputTest {
   @Test
   public void readInputWithMissedValues() throws Exception {
     final String virtualFile = createVirtualFile( "pdi-14172.txt", "1,1,1\n", "2,,2\n" );
-    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
 
     BaseFileField field2 = field( "col2" );
     field2.setRepeated( true );
@@ -196,7 +192,6 @@ public class TextFileInputTest {
 
   @Test
   public void readInputWithNonEmptyNullif() throws Exception {
-    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
     final String virtualFile = createVirtualFile( "pdi-14358.txt", "-,-\n" );
 
     BaseFileField col2 = field( "col2" );
@@ -457,7 +452,6 @@ public class TextFileInputTest {
   @Test
   public void fieldsWithLineBreaksWithEmptyLinesTest() throws Exception {
 
-    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
     final String content = new StringBuilder()
       .append( "aaa,\"b" ).append( '\n' )
       .append( "bb\",ccc" ).append( '\n' )

--- a/engine/src/test/java/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/textfileinput/TextFileInputTest.java
@@ -37,7 +37,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.exception.KettleValueException;
@@ -166,8 +165,7 @@ public class TextFileInputTest {
   @Test
   public void readInputWithMissedValues() throws Exception {
     final String virtualFile = createVirtualFile( "pdi-14172.txt", "1,1,1\n", "2,,2\n" );
-    System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
-    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
+
     TextFileInputMeta meta = new TextFileInputMeta();
     TextFileInputField field2 = field( "col2" );
     field2.setRepeated( true );

--- a/ui/src/test/java/org/pentaho/di/ui/core/dialog/EditRowsDialog_EmptyStringVsNull_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/core/dialog/EditRowsDialog_EmptyStringVsNull_Test.java
@@ -55,15 +55,14 @@ public class EditRowsDialog_EmptyStringVsNull_Test {
   @Test
   public void emptyAndNullsAreNotDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "N" );
-    executeAndAssertResults( new String[]{ "", "", "" } );
+    executeAndAssertResults( new String[]{ "", null, null } );
   }
 
 
   @Test
   public void emptyAndNullsAreDifferent() throws Exception {
     System.setProperty( Const.KETTLE_EMPTY_STRING_DIFFERS_FROM_NULL, "Y" );
-    System.setProperty( Const.KETTLE_DO_NOT_NORMALIZE_NULL_STRING_TO_EMPTY, "Y" );
-    executeAndAssertResults( new String[]{ "", "", null } );
+    executeAndAssertResults( new String[]{ "", "", "" } );
   }
 
   private void executeAndAssertResults( String[] expected ) throws Exception {


### PR DESCRIPTION
This reverts all development done under PDI-20085 in the last three weeks, namely the following PRs:

1. [pentaho-kettle#9311](https://github.com/pentaho/pentaho-kettle/pull/9311) - merged May 9<sup>th</sup>
2. [pentaho-kettle#9311](https://github.com/pentaho/pentaho-kettle/pull/9317) - merged May 14<sup>th</sup>
3. [pentaho-kettle#9311](https://github.com/pentaho/pentaho-kettle/pull/9321) - merged May 16<sup>th</sup>
4. [pentaho-kettle#9311](https://github.com/pentaho/pentaho-kettle/pull/9347) - merged May 27<sup>th</sup>

For easier review, I made four individual commits (one for each PR) but these can be squashed at the end.

@pentaho/tatooine_dev 