### PR TITLE
[BACKLOG-40513] Integrate SMB VFS as a PVFS "Bucketed" Connection

### DIFF
--- a/core/src/main/java/org/pentaho/di/connections/ConnectionDetails.java
+++ b/core/src/main/java/org/pentaho/di/connections/ConnectionDetails.java
@@ -67,10 +67,6 @@ public interface ConnectionDetails {
 
   void setSpace( VariableSpace space );
 
-  default boolean hasBuckets() {
-    return true;
-  }
-
   /**
    * Clones the connection details instance.
    * <p>

--- a/core/src/main/java/org/pentaho/di/connections/vfs/VFSConnectionDetails.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/VFSConnectionDetails.java
@@ -39,6 +39,14 @@ public interface VFSConnectionDetails extends ConnectionDetails {
   }
 
   /**
+   * Returns true if vfs connections supports buckets. Defaults to {@code true}
+   * @return true if has buckets, false otherwise
+   */
+  default boolean hasBuckets() {
+    return true;
+  }
+
+  /**
    * Returns true if vfs connection supports root path
    * Defaults to {@code false}.
    *

--- a/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileObject.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileObject.java
@@ -146,13 +146,9 @@ public class ConnectionFileObject extends AbstractFileObject<ConnectionFileSyste
     String connectionName = ( (ConnectionFileName) this.getName() ).getConnection();
     StringBuilder connectionPath = new StringBuilder();
     connectionPath.append( ConnectionFileProvider.SCHEME );
-    if ( fileObject.getName().toString().toLowerCase().startsWith( KettleVFS.SMB_SCHEME_COLON ) ) {
-      connectionPath.append( ":/" );
-    } else {
-      connectionPath.append( "://" );
-      connectionPath.append( connectionName );
-      connectionPath.append( DELIMITER );
-    }
+    connectionPath.append( "://" );
+    connectionPath.append( connectionName );
+    connectionPath.append( DELIMITER );
     if ( domain == null || domain.equals( "" ) ) {
       // S3 does not return a URLFleName; but Google does hence the difference here
       if ( fileObject.getName() instanceof URLFileName ) {

--- a/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileSystem.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileSystem.java
@@ -65,15 +65,12 @@ public class ConnectionFileSystem extends AbstractFileSystem implements FileSyst
     String url = null;
 
     if ( vfsConnectionDetails != null ) {
-      if ( KettleVFS.SMB_SCHEME.equalsIgnoreCase( vfsConnectionDetails.getType() ) ) {
-        url = abstractFileName.getURI().replaceFirst( "pvfs:", KettleVFS.SMB_SCHEME_COLON );
-      } else {
-        String domain = vfsConnectionDetails.getDomain();
-        if ( !domain.equals( "" ) ) {
-          domain = "/" + domain;
-        }
-        url = vfsConnectionDetails.getType() + ":/" + domain + abstractFileName.getPath();
+      String domain = vfsConnectionDetails.getDomain();
+      if ( !domain.equals( "" ) ) {
+        domain = "/" + domain;
       }
+      url = vfsConnectionDetails.getType() + ":/" + domain + abstractFileName.getPath();
+      //TODO Looks like a bug. For now excluding this for connections with hasBuckets. For future, needs to be re-analyzed.
       if ( url.matches( DOMAIN_ROOT ) && vfsConnectionDetails.hasBuckets() ) {
         url += vfsConnectionDetails.getName();
       }

--- a/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
@@ -65,8 +65,6 @@ import java.util.regex.Pattern;
  */
 public class KettleVFS {
   public static final String TEMP_DIR = System.getProperty( "java.io.tmpdir" );
-  public static final String SMB_SCHEME = "smb";
-  public static final String SMB_SCHEME_COLON = SMB_SCHEME + ":";
 
   private static Class<?> PKG = KettleVFS.class; // for i18n purposes, needed by Translator2!!
 

--- a/core/src/main/java/org/pentaho/di/core/vfs/KettleVFSImpl.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/KettleVFSImpl.java
@@ -66,8 +66,6 @@ public class KettleVFSImpl implements IKettleVFS {
   private static Class<?> PKG = KettleVFS.class; // for i18n purposes, needed by Translator2!!
   private static final int TIMEOUT_LIMIT = 9000;
   private static final int TIME_TO_SLEEP_STEP = 50;
-  private static final String PROVIDER_PATTERN_SCHEME = "^[\\w\\d]+://(.*)";
-  private static final Pattern SMB_PATTERN = Pattern.compile( "^[Ss][Mm][Bb]://[/]?([^:/]+)(?::([^/]+))?.*$" );
 
   private final Bowl bowl;
 
@@ -186,16 +184,10 @@ public class KettleVFSImpl implements IKettleVFS {
     configBuilder.setBowl( fsOptions, bowl );
 
     try {
-      if ( scheme.equals( KettleVFS.SMB_SCHEME ) ) {
-        Matcher matcher = SMB_PATTERN.matcher( vfsFilename );
-        if ( matcher.matches() ) {
-          return VFSHelper.getOpts( bowl, vfsFilename, matcher.group( 1 ), varSpace );
-        }
-      }
 
       String[] varList = varSpace.listVariables();
 
-      for (String var : varList) {
+      for ( String var : varList ) {
         if ( var.equalsIgnoreCase( CONNECTION ) && varSpace.getVariable( var ) != null ) {
           FileSystemOptions fileSystemOptions = VFSHelper.getOpts( bowl, vfsFilename, varSpace.getVariable( var ),
                                                                    varSpace );


### PR DESCRIPTION
See commit message for details or jira comment - https://hv-eng.atlassian.net/browse/BACKLOG-40513?focusedCommentId=2011165


manually setting ConnectionFileSystem#getUrl to pre SMB
- https://github.com/pentaho/pentaho-kettle/blob/1da3c08f00bb6fac2999d08ed35d6cb04fe87dd8/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileSystem.java

manually reverting hard coded SMB into KettleVFS(Impl).java#buildFsOption and ConnectionFileObject.java#getChild
- introduced by https://github.com/pentaho/pentaho-kettle/commit/089b78b720bbee248ffad1d4eb131f128984312c

Move ConnectionDetails.java#hasBuckets to VFSConnectionDetails.java#hasBuckets


**PR depends on:**

1. https://github.com/pentaho/pdi-plugins-ee/pull/1109

Should be merged together, only side effect will be, SMB VFS will break KettleVFS and PDI File Open Save Browser