### PR TITLE
[BACKLOG-40356] Added bowl property to ConnectionManager

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/bowl/BaseBowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/BaseBowl.java
@@ -17,8 +17,8 @@
 package org.pentaho.di.core.bowl;
 
 import org.pentaho.di.connections.ConnectionManager;
-import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
 
 public abstract class BaseBowl implements Bowl {
 
@@ -33,7 +33,7 @@ public abstract class BaseBowl implements Bowl {
     synchronized( this ) {
       if ( connectionManager == null ) {
         IMetaStore metastore = getMetastore();
-        connectionManager = ConnectionManager.getInstance( () -> metastore );
+        connectionManager = ConnectionManager.getInstance( () -> metastore, this );
       }
       return connectionManager;
     }


### PR DESCRIPTION
This makes the bowl that creates and "owns" a connection manager accessible as a property of the connection manager.