### PR TITLE
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -546,7 +546,7 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
   /**
    * Connect using the correct classname
    *
-   * @param classname for example "org.gjt.mm.mysql.Driver"
+   * @param classname for example "com.mysql.jdbc.Driver"
    * @return true if the connect was successful, false if something went wrong.
    */
   private void connectUsingClass( String classname, String partitionId ) throws KettleDatabaseException {

--- a/core/src/main/java/org/pentaho/di/core/database/MySQLDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/MySQLDatabaseMeta.java
@@ -112,7 +112,7 @@ public class MySQLDatabaseMeta extends BaseDatabaseMeta implements DatabaseInter
   /*
   * Fix for BACKLOG-33475 Upgrade bulkload support to include MySQL 8.0
   * Change necessary since the jdbc driver for MySQL 5.7 and 8.0 package name changed from
-  * org.gjt.mm.mysql.Driver to com.mysql.cj.jdbc.Driver
+  * com.mysql.jdbc.Driver to com.mysql.cj.jdbc.Driver
   * */
   @Override public String getDriverClass() {
     String driver = null;
@@ -130,7 +130,7 @@ public class MySQLDatabaseMeta extends BaseDatabaseMeta implements DatabaseInter
         driverClass = "com.mysql.cj.jdbc.Driver";
         Class.forName( driverClass );
       } catch ( ClassNotFoundException e ) {
-        driverClass = "org.gjt.mm.mysql.Driver";
+        driverClass = "com.mysql.jdbc.Driver";
       }
     }
     return driverClass;


### PR DESCRIPTION
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

[BACKLOG-40978]: https://hv-eng.atlassian.net/browse/BACKLOG-40978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ