### PR TITLE
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -546,7 +546,7 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
   /**
    * Connect using the correct classname
    *
-   * @param classname for example "org.gjt.mm.mysql.Driver"
+   * @param classname for example "com.mysql.jdbc.Driver"
    * @return true if the connect was successful, false if something went wrong.
    */
   private void connectUsingClass( String classname, String partitionId ) throws KettleDatabaseException {

--- a/core/src/main/java/org/pentaho/di/core/database/MySQLDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/MySQLDatabaseMeta.java
@@ -130,7 +130,7 @@ public class MySQLDatabaseMeta extends BaseDatabaseMeta implements DatabaseInter
         driverClass = "com.mysql.cj.jdbc.Driver";
         Class.forName( driverClass );
       } catch ( ClassNotFoundException e ) {
-        driverClass = "org.gjt.mm.mysql.Driver";
+        driverClass = "com.mysql.jdbc.Driver";
       }
     }
     return driverClass;

--- a/core/src/test/java/org/pentaho/di/core/xml/XMLHandlerUnitTest.java
+++ b/core/src/test/java/org/pentaho/di/core/xml/XMLHandlerUnitTest.java
@@ -200,7 +200,7 @@ public class XMLHandlerUnitTest {
   @Test
   public void addTagValueBinary() throws IOException {
     byte[] input = "Test Data".getBytes();
-    String result = "H4sIAAAAAAAA/wtJLS5RcEksSQQAL4PL8QkAAAA=";
+    String result = "H4sIAAAAAAAAAAtJLS5RcEksSQQAL4PL8QkAAAA=";
 
     assertEquals( "<bytedata>" + result + "</bytedata>" + cr, XMLHandler.addTagValue( "bytedata", input ) );
     assertEquals( "<bytedata>" + result + "</bytedata>" + cr, XMLHandler.addTagValue( "bytedata", input, true ) );


### PR DESCRIPTION
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

[BACKLOG-40978]: https://hv-eng.atlassian.net/browse/BACKLOG-40978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ