### PR TITLE
[BACKLOG-40519] - Refactor Bowl, add manager registry

### DIFF
--- a/core/src/main/java/org/pentaho/di/connections/ConnectionUpdateSubscriber.java
+++ b/core/src/main/java/org/pentaho/di/connections/ConnectionUpdateSubscriber.java
@@ -1,0 +1,38 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2024 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.connections;
+
+/**
+ * Interface to be notified by ConnectionManager when changes are made.
+ *
+ */
+@FunctionalInterface
+public interface ConnectionUpdateSubscriber {
+
+  /**
+   * Notify that any write operation was performed (create/update/delete)
+   *
+   */
+  void notifyChanged();
+
+}

--- a/core/src/main/java/org/pentaho/di/connections/vfs/VFSHelper.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/VFSHelper.java
@@ -26,6 +26,7 @@ import org.apache.commons.vfs2.FileSystemOptions;
 import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.vfs.configuration.KettleGenericFileSystemConfigBuilder;
@@ -45,19 +46,20 @@ public class VFSHelper {
   public static FileSystemOptions getOpts( String file, String connection, VariableSpace space ) {
     try {
       return getOpts( DefaultBowl.getInstance(), file, connection, space );
-    } catch ( MetaStoreException ex ) {
+    } catch ( KettleException ex ) {
       // deprecated behavior was to ignore failures and return nulls.
       return null;
     }
   }
 
   public static FileSystemOptions getOpts( Bowl bowl, String file, String connection, VariableSpace space )
-    throws MetaStoreException {
+    throws KettleException {
     if ( connection != null ) {
+      ConnectionManager connectionManager = bowl.getManager( ConnectionManager.class );
       VFSConnectionDetails vfsConnectionDetails =
-        (VFSConnectionDetails) bowl.getConnectionManager().getConnectionDetails( file, connection );
+        (VFSConnectionDetails) connectionManager.getConnectionDetails( file, connection );
       VFSConnectionProvider<VFSConnectionDetails> vfsConnectionProvider =
-        (VFSConnectionProvider<VFSConnectionDetails>) bowl.getConnectionManager().getConnectionProvider( file );
+        (VFSConnectionProvider<VFSConnectionDetails>) connectionManager.getConnectionProvider( file );
       if ( vfsConnectionDetails != null && vfsConnectionProvider != null ) {
         vfsConnectionDetails.setSpace( space );
         FileSystemOptions opts = vfsConnectionProvider.getOpts( vfsConnectionDetails );

--- a/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileSystem.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileSystem.java
@@ -85,7 +85,7 @@ public class ConnectionFileSystem extends AbstractFileSystem implements FileSyst
     String connectionName = ( (ConnectionFileName) abstractFileName ).getConnection();
     Bowl bowl = KettleGenericFileSystemConfigBuilder.getInstance().getBowl( getFileSystemOptions() );
     VFSConnectionDetails connectionDetails =
-      (VFSConnectionDetails) bowl.getConnectionManager().getConnectionDetails( connectionName );
+      (VFSConnectionDetails) bowl.getManager( ConnectionManager.class ).getConnectionDetails( connectionName );
     FileSystemOptions opts = super.getFileSystemOptions();
     IKettleFileSystemConfigBuilder configBuilder = KettleFileSystemConfigBuilderFactory.getConfigBuilder
       ( new Variables(), ConnectionFileProvider.SCHEME );

--- a/core/src/main/java/org/pentaho/di/core/bowl/BaseBowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/BaseBowl.java
@@ -16,43 +16,48 @@
  */
 package org.pentaho.di.core.bowl;
 
-import org.pentaho.di.connections.ConnectionManager;
-import org.pentaho.metastore.api.IMetaStore;
-import org.pentaho.metastore.api.exceptions.MetaStoreException;
+import org.pentaho.di.core.exception.KettleException;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class BaseBowl implements Bowl {
 
-  private volatile ConnectionManager connectionManager;
-  private volatile ConnectionManager explicitConnectionManager;
+  private final Map<Class<?>, Object> managerInstances = new ConcurrentHashMap();
+  private final Set<Bowl> parentBowls = ConcurrentHashMap.newKeySet();
 
   @Override
-  public ConnectionManager getConnectionManager() throws MetaStoreException {
-    ConnectionManager result = connectionManager;
+  public <T> T getManager( Class<T> managerClass ) throws KettleException {
+    // can't use computeIfAbsent here because we want exceptions to propagate. :(
+    T result = managerClass.cast( managerInstances.get( managerClass ) );
     if ( result != null ) {
       return result;
     }
-    synchronized( this ) {
-      if ( connectionManager == null ) {
-        IMetaStore metastore = getMetastore();
-        connectionManager = ConnectionManager.getInstance( () -> metastore, this );
+    synchronized ( this ) {
+      result = managerClass.cast( managerInstances.get( managerClass ) );
+      if ( result == null ) {
+        ManagerFactory<T> factory = BowlManagerFactoryRegistry.getInstance().getManagerFactory( managerClass );
+        if ( factory == null ) {
+          throw new KettleException( "No Factory found for " + managerClass );
+        }
+        result = factory.apply( this );
+        if ( result == null ) {
+          throw new KettleException( "Unable to create manager for " + managerClass );
+        }
+        managerInstances.put( managerClass, result );
       }
-      return connectionManager;
+      return result;
     }
   }
 
   @Override
-  public ConnectionManager getExplicitConnectionManager() throws MetaStoreException {
-    ConnectionManager result = explicitConnectionManager;
-    if ( result != null ) {
-      return result;
-    }
-    synchronized( this ) {
-      if ( explicitConnectionManager == null ) {
-        IMetaStore metastore = getExplicitMetastore();
-        explicitConnectionManager = ConnectionManager.getInstance( () -> metastore, this );
-      }
-      return explicitConnectionManager;
-    }
+  public Set<Bowl> getParentBowls() {
+    return parentBowls;
   }
 
+  public void addParentBowl( Bowl parent ) {
+    parentBowls.add( parent );
+  }
 }
+

--- a/core/src/main/java/org/pentaho/di/core/bowl/Bowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/Bowl.java
@@ -17,15 +17,27 @@
 package org.pentaho.di.core.bowl;
 
 import org.pentaho.di.connections.ConnectionManager;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.api.IMetaStore;
+
+import java.util.Set;
 
 
 /**
  * A Bowl is a generic container/context/workspace concept. Different plugin implementations may implement this for
  * additional features.
- *
- * All implementations of Bowl should implement equals() and hashcode()
+ * <p>
+ * Bowls provide access to various "Manager" classes that in turn provide access to specific types of stored objects
+ * that may be specificially grouped in the Bowl. As much as possible, Managers should generally not depend on
+ * Bowl-specific features *except* common underlying storage mechanisms that are defined as APIs on Bowl itself (this
+ * interface). For example, ConnectionManager does not directly depend on Bowl-specific attributes, except for the
+ * MetaStore.
+ * <p>
+ * Specific subclasses for contexts should implement their custom logic to get a MetaStore or other underlying storage,
+ * and the managers should just build on that and not have any other Bowl-specific code.
+ * <p>
+ * All implementations of Bowl should implement equals() and hashcode().
  *
  */
 public interface Bowl {
@@ -39,34 +51,25 @@ public interface Bowl {
   IMetaStore getMetastore() throws MetaStoreException;
 
   /**
-   * Gets a Metastore only for accessing any bowl-specific objects.
+   * Gets a Manager for some type of object specifically in the context of this Bowl.
+   * <p>
+   * Since constructing and initializing Managers can be expensive, and instances may share state or have other
+   * limitations, callers with a Bowl should use this method in favor of directly using the manager type.
+   * <p>
+   * @see BowlManagerFactoryRegistry for how Managers should be registered.
    *
-   *
-   * @return IMetaStore A metastore for the specified Bowl. Never null.
+   * @return a manager instance, never null.
+   * @throws NotFoundException if the manager type is unknown
+   * @throws KettleException for other errors.
    */
-  IMetaStore getExplicitMetastore() throws MetaStoreException;
+  <T> T getManager( Class<T> managerClazz ) throws KettleException;
 
   /**
-   * Gets a ConnectionManager for this Bowl. Uses a metastore from getMetastore(), so global connections will be
-   * returned as well. This ConnectionManager is effectively read-only.
+   * Parent Bowls are any Bowls that a particular Bowl inherits from.
    *
-   * Since constructing and initializing ConnectionManagers can be expensive, and ConnectionManager instances don't
-   * share state, consumers should always use this method instead of ConnectionManager.getInstance()
    *
-   * @return ConnectionManager, never null.
+   * @return Set&lt;Bowl&gt; A set of Parent Bowls. Should not be null.
    */
-  ConnectionManager getConnectionManager() throws MetaStoreException;
-
-  /**
-   * Gets a ConnectionManager for this Bowl. Uses a metastore from getExplicitMetastore(). This ConnectionManager
-   * allows writes.
-   *
-   * Since constructing and initializing ConnectionManagers can be expensive, and ConnectionManager instances don't
-   * share state, consumers should always use this method instead of ConnectionManager.getInstance()
-   *
-   * @return ConnectionManager, never null.
-   */
-  ConnectionManager getExplicitConnectionManager() throws MetaStoreException;
-
+  Set<Bowl> getParentBowls();
 
 }

--- a/core/src/main/java/org/pentaho/di/core/bowl/BowlManagerFactoryRegistry.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/BowlManagerFactoryRegistry.java
@@ -1,0 +1,77 @@
+/*!
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.pentaho.di.core.bowl;
+
+import org.pentaho.di.connections.ConnectionManager;
+import org.pentaho.di.connections.ConnectionUpdateSubscriber;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+import org.pentaho.metastore.api.IMetaStore;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+
+/**
+ * A Registry that holds Factories that generate Manager classes from a Bowl.
+ * <p>
+ * Used by BaseBowl to create single-instance-per-bowl manager instances from the factory method here.
+ *
+ */
+public class BowlManagerFactoryRegistry {
+  private static final BowlManagerFactoryRegistry instance = new BowlManagerFactoryRegistry();
+
+  private final Map<Class<?>, ManagerFactory<?>> factories = new HashMap<>();
+
+  private static class ConnectionManagerFactory implements ManagerFactory<ConnectionManager> {
+    // need to hang onto the subscriber as long as the Bowl exists
+    private final WeakHashMap<Bowl, ConnectionUpdateSubscriber> subscribers = new WeakHashMap<>();
+
+    public ConnectionManager apply( Bowl bowl ) throws KettleException {
+      ConnectionManager connectionManager = ConnectionManager.getInstance( bowl );
+      if ( !bowl.getParentBowls().isEmpty() ) {
+        ConnectionUpdateSubscriber subscriber = () -> connectionManager.reset();
+        for ( Bowl parentBowl : bowl.getParentBowls() ) {
+          parentBowl.getManager( ConnectionManager.class ).addSubscriber( subscriber );
+        }
+        subscribers.put( bowl, subscriber );
+      }
+      return connectionManager;
+    }
+  }
+
+  private BowlManagerFactoryRegistry() {
+    // initialize manager factories from core
+    registerManagerFactory( ConnectionManager.class, new ConnectionManagerFactory() );
+  }
+
+  public static BowlManagerFactoryRegistry getInstance() {
+    return instance;
+  }
+
+  public synchronized <T> void registerManagerFactory( Class<T> managerClass, ManagerFactory<T> factoryMethod ) {
+    factories.put( managerClass, factoryMethod );
+  }
+
+  public synchronized <T> ManagerFactory<T> getManagerFactory( Class<T> managerClass ) {
+    @SuppressWarnings( "unchecked" )
+    ManagerFactory<T> factory = (ManagerFactory<T>) factories.get( managerClass );
+    return factory;
+  }
+
+}

--- a/core/src/main/java/org/pentaho/di/core/bowl/DefaultBowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/DefaultBowl.java
@@ -17,6 +17,7 @@
 package org.pentaho.di.core.bowl;
 
 import org.pentaho.di.connections.ConnectionManager;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.metastore.MetaStoreConst;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.api.IMetaStore;
@@ -42,35 +43,26 @@ public class DefaultBowl extends BaseBowl {
     return INSTANCE;
   }
 
-
-  @Override
-  public IMetaStore getExplicitMetastore() throws MetaStoreException {
-    return metastoreSupplier.get();
-  }
-
   @Override
   public IMetaStore getMetastore() throws MetaStoreException {
     return metastoreSupplier.get();
   }
 
-
   @Override
-  public ConnectionManager getConnectionManager() throws MetaStoreException {
-    // need to override getConnectionManager so this instance of DefaultBowl shares the same ConnectionManager
+  public <T> T getManager( Class<T> managerClass) throws KettleException {
+    // need to override getManager so this instance of DefaultBowl shares the same ConnectionManager
     // instance with ConnectionManager.getInstance()
-    if ( customSupplier ) {
-      return super.getConnectionManager();
+    if ( managerClass == ConnectionManager.class && !customSupplier ) {
+      return managerClass.cast( ConnectionManager.getInstance() );
     } else {
-      return ConnectionManager.getInstance();
+      return super.getManager( managerClass );
     }
   }
 
-  @Override
-  public ConnectionManager getExplicitConnectionManager() throws MetaStoreException {
-    return getConnectionManager();
-  }
-
-
+  /**
+   * Set a specific metastore supplier for use by later calls to this class. Note that this will cause the
+   * ConnectionManager from this class and from ConnectionManager.getInstance() to return different instances.
+   */
   @VisibleForTesting
   public void setMetastoreSupplier( Supplier<IMetaStore> metastoreSupplier ) {
     this.metastoreSupplier = metastoreSupplier;

--- a/core/src/main/java/org/pentaho/di/core/bowl/ManagerFactory.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/ManagerFactory.java
@@ -1,0 +1,34 @@
+/*!
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.pentaho.di.core.bowl;
+
+import org.pentaho.di.core.exception.KettleException;
+
+@FunctionalInterface
+public interface ManagerFactory<T> {
+  /**
+     * Should not return null
+     *
+     *
+     * @param bowl Bowl this manager should belong to.
+     *
+     * @return T Manager for this bowl.
+     * @throw KettleException if a manager cannot be created
+     */
+  T apply( Bowl bowl ) throws KettleException;
+}
+

--- a/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/KettleVFS.java
@@ -123,8 +123,8 @@ public class KettleVFS {
    * hashcode() to make this work.
    *
    * It is also critical that there is only one ConnectionManager for a given Bowl. Anything that needs a
-   * ConnectionManager (especially including VFS code) should only use Bowl.getConnectionManager() to ensure there is a
-   * single instance per bowl.
+   * ConnectionManager (especially including VFS code) should only Bowl.getManager( ConnectionManager.class ) to ensure
+   * there is a single instance per bowl.
    *
    * @param bowl the bowl for the current context
    * @return IKettleVFS The API for file operations.

--- a/core/src/main/java/org/pentaho/di/core/vfs/KettleVFSImpl.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/KettleVFSImpl.java
@@ -24,6 +24,7 @@ package org.pentaho.di.core.vfs;
 
 import org.pentaho.di.connections.vfs.VFSHelper;
 import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.util.UUIDUtil;
 import org.pentaho.di.core.variables.Variables;
@@ -32,7 +33,6 @@ import org.pentaho.di.core.vfs.configuration.IKettleFileSystemConfigBuilder;
 import org.pentaho.di.core.vfs.configuration.KettleFileSystemConfigBuilderFactory;
 import org.pentaho.di.core.vfs.configuration.KettleGenericFileSystemConfigBuilder;
 import org.pentaho.di.i18n.BaseMessages;
-import org.pentaho.metastore.api.exceptions.MetaStoreException;
 
 import com.google.common.base.Preconditions;
 
@@ -210,7 +210,7 @@ public class KettleVFSImpl implements IKettleVFS {
       if ( scheme.equals( "pvfs" ) ) {
         configBuilder.setParameter( fsOptions, "VariableSpace", varSpace, vfsFilename );
       }
-    } catch ( MetaStoreException ex ) {
+    } catch ( KettleException ex ) {
       // keep backward compatible API in KettleVFS
       throw new IOException( ex );
     }

--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -404,10 +404,19 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
     setInternalKettleVariables();
   }
 
+  /**
+   * Retrieves the Bowl for the execution context. This Bowl should not be used for write operations.
+   *
+   * @return Bowl The Bowl that should be used during execution.
+   */
   public Bowl getBowl() {
     return bowl;
   }
 
+  /**
+   * Set the Bowl for the execution context. This Bowl should not be used for write operations.
+   *
+   */
   public void setBowl( Bowl bowl ) {
     this.bowl = bowl;
   }

--- a/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/tree/ConnectionFolderProvider.java
+++ b/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/tree/ConnectionFolderProvider.java
@@ -27,6 +27,7 @@ import org.pentaho.di.connections.ConnectionDetails;
 import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.ui.core.dialog.ErrorDialog;
@@ -35,7 +36,6 @@ import org.pentaho.di.ui.core.widget.tree.LeveledTreeNode;
 import org.pentaho.di.ui.core.widget.tree.TreeNode;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.spoon.tree.TreeFolderProvider;
-import org.pentaho.metastore.api.exceptions.MetaStoreException;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -61,7 +61,7 @@ public class ConnectionFolderProvider extends TreeFolderProvider {
       Set<String> bowlNames = new HashSet<>();
       Bowl currentBowl = Spoon.getInstance().getBowl();
       if ( !currentBowl.equals( DefaultBowl.getInstance() ) ) {
-        ConnectionManager bowlCM = currentBowl.getExplicitConnectionManager();
+        ConnectionManager bowlCM = currentBowl.getManager( ConnectionManager.class );
         for ( String name : bowlCM.getNames() ) {
           if ( !filterMatch( name, filter ) ) {
             continue;
@@ -72,7 +72,7 @@ public class ConnectionFolderProvider extends TreeFolderProvider {
         }
       }
 
-      ConnectionManager globalCM = DefaultBowl.getInstance().getExplicitConnectionManager();
+      ConnectionManager globalCM = DefaultBowl.getInstance().getManager( ConnectionManager.class );
       for ( String name : globalCM.getNames() ) {
         if ( !filterMatch( name, filter ) ) {
           continue;
@@ -80,7 +80,7 @@ public class ConnectionFolderProvider extends TreeFolderProvider {
         createTreeNode( treeNode, name, GUIResource.getInstance().getImageSlaveTree(), LeveledTreeNode.LEVEL.GLOBAL,
                         bowlNames.contains( name ) );
       }
-    } catch ( MetaStoreException e ) {
+    } catch ( KettleException e ) {
       new ErrorDialog( Spoon.getInstance().getShell(),
               BaseMessages.getString( PKG, "Spoon.ErrorDialog.Title" ),
               BaseMessages.getString( PKG, "Spoon.ErrorDialog.ErrorFetchingVFSConnections" ),

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
@@ -61,7 +61,7 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
     Bowl currentBowl = Spoon.getInstance().getBowl();
     if ( !currentBowl.equals( DefaultBowl.getInstance() ) ) {
       RunConfigurationDelegate bowlDelegate =
-        RunConfigurationDelegate.getInstance( () -> currentBowl.getExplicitMetastore() );
+        RunConfigurationDelegate.getInstance( () -> currentBowl.getMetastore() );
       for ( RunConfiguration runConfiguration : bowlDelegate.load() ) {
         if ( !filterMatch( runConfiguration.getName(), filter ) ) {
           continue;
@@ -80,7 +80,7 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
     }
 
     RunConfigurationDelegate globalDelegate =
-      RunConfigurationDelegate.getInstance( () -> DefaultBowl.getInstance().getExplicitMetastore() );
+      RunConfigurationDelegate.getInstance( () -> DefaultBowl.getInstance().getMetastore() );
 
     for ( RunConfiguration runConfiguration : globalDelegate.load() ) {
       if ( !filterMatch( runConfiguration.getName(), filter ) ) {

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationPopupMenuExtension.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationPopupMenuExtension.java
@@ -99,7 +99,7 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
         public void widgetSelected( SelectionEvent selectionEvent ) {
           // new goes to the Spoon's current bowl
           Bowl bowl = Spoon.getInstance().getBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getExplicitMetastore();
+          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
           RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
           runConfigurationDelegate.create();
         }
@@ -116,7 +116,7 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       editMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
           Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getExplicitMetastore();
+          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
           RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
           RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
           runConfigurationDelegate.edit( runConfigurationManager.load( runConfigurationTreeItem.getName() ) );
@@ -128,7 +128,7 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       deleteMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
           Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getExplicitMetastore();
+          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
           RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
           RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
           runConfigurationDelegate.delete( runConfigurationManager.load( runConfigurationTreeItem.getName() ) );

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationViewTreeExtension.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationViewTreeExtension.java
@@ -66,7 +66,7 @@ public class RunConfigurationViewTreeExtension implements ExtensionPointInterfac
           bowl = Spoon.getInstance().getBowl();
         }
         RunConfigurationDelegate runConfigurationDelegate =
-          RunConfigurationDelegate.getInstance( () -> bowl.getExplicitMetastore() );
+          RunConfigurationDelegate.getInstance( () -> bowl.getMetastore() );
 
         runConfigurationDelegate.edit( runConfigurationDelegate.load( name ) );
       }

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/ui/RunConfigurationDelegateTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/ui/RunConfigurationDelegateTest.java
@@ -84,7 +84,7 @@ public class RunConfigurationDelegateTest {
     PowerMockito.mockStatic( Spoon.class );
     when( Spoon.getInstance() ).thenReturn( spoon );
 
-    delegate = spy( RunConfigurationDelegate.getInstance( () -> DefaultBowl.getInstance().getExplicitMetastore() ) );
+    delegate = spy( RunConfigurationDelegate.getInstance( () -> DefaultBowl.getInstance().getMetastore() ) );
     service = mock( RunConfigurationManager.class );
     delegate.setRunConfigurationManager( service );
   }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -9546,10 +9546,21 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     this.metaStoreSupplier = metaStoreSupplier;
   }
 
+  /**
+   * Retrieves the Bowl for the Management context. This Bowl should be used for write operations. This Bowl will only
+   * return objects directly owned by the particular context. It will not include objects owned by the global context.
+   * Use DefaultBowl to access the global context.
+   *
+   * @return Bowl The Bowl that should be used during execution.
+   */
   public Bowl getBowl() {
     return bowl;
   }
 
+  /**
+   * Sets the Bowl for the management context. This Bowl should be used for write operations.
+   *
+   */
   public void setBowl( Bowl bowl ) {
     this.bowl = Objects.requireNonNull( bowl );
     forceRefreshTree();


### PR DESCRIPTION
- one of each manager per Bowl
- separate bowls for "execution" vs "management" (see also PR for pdi-plugins-ee) Spoon will have "Management" Bowl, each Meta will have "Execution" bowl.
- BowlManagerFactoryRegistry to register new types of managers
- switch ConnectionManager to new APIs