### PR TITLE
[BACKLOG-40921] Update mockito versions in non-failing plugin tests

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -18,6 +18,7 @@
 
   <properties>
     <pdi.version>10.2.0.0-SNAPSHOT</pdi.version>
+    <mockito-all.version>1.10.19</mockito-all.version>
   </properties>
 
   <dependencies>
@@ -74,6 +75,8 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
+      <version>${mockito-all.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.pentaho.di.plugins</groupId>

--- a/plugins/elasticsearch-bulk-insert/core/pom.xml
+++ b/plugins/elasticsearch-bulk-insert/core/pom.xml
@@ -75,8 +75,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/plugins/engine-configuration/impl/pom.xml
+++ b/plugins/engine-configuration/impl/pom.xml
@@ -15,11 +15,6 @@
 
   <name>PDI Engine Configuration Plugin Implementation</name>
 
-  <properties>
-    <mockito.version>1.10.19</mockito.version>
-    <powermock.version>1.6.3</powermock.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>pentaho-kettle</groupId>
@@ -59,32 +54,14 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-testng</artifactId>
-      <version>${powermock.version}</version>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${spring.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/RunConfigurationManagerTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/RunConfigurationManagerTest.java
@@ -28,13 +28,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
 import org.pentaho.di.engine.configuration.api.RunConfigurationProvider;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfiguration;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationExecutor;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
-import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.stores.memory.MemoryMetaStore;
 
 import java.util.ArrayList;
@@ -49,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Created by bmorrise on 3/15/17.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class RunConfigurationManagerTest {
 
   private RunConfigurationManager executionConfigurationManager;

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPointTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPointTest.java
@@ -3,7 +3,7 @@
  *
  *  Pentaho Data Integration
  *
- *  Copyright (C) 2017-2022 by Hitachi Vantara : http://www.pentaho.com
+ *  Copyright (C) 2017-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *  *******************************************************************************
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
@@ -39,7 +39,6 @@ import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfiguration;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.trans.JobEntryTrans;
 import org.pentaho.di.job.entry.JobEntryCopy;
-
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,7 +53,7 @@ import static org.mockito.Mockito.when;
 /**
  * Created by bmorrise on 5/15/17.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class RunConfigurationImportExtensionPointTest {
 
   private RunConfigurationImportExtensionPoint runConfigurationImportExtensionPoint;
@@ -92,10 +91,6 @@ public class RunConfigurationImportExtensionPointTest {
 
     ArgumentCaptor<DefaultRunConfiguration> rcCaptor =  ArgumentCaptor.forClass( DefaultRunConfiguration.class );
     when( jobMeta.getEmbeddedMetaStore() ).thenReturn( embeddedMetaStore );
-    when( jobMeta.getSlaveServers() ).thenReturn( Arrays.asList(
-            new SlaveServer( "carte1", "host1", "1234", "user", "passw" ),
-            new SlaveServer( "carte2", "host2", "1234", "user", "passw" )
-            ) );
     when( jobMeta.getJobCopies() ).thenReturn( Arrays.asList( jobEntryCopy1, jobEntryCopy2, jobEntryCopy3 ) );
     when( jobEntryCopy1.getEntry() ).thenReturn( trans1 );
     when( jobEntryCopy2.getEntry() ).thenReturn( trans2 );

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationInjectExtensionPointTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationInjectExtensionPointTest.java
@@ -3,7 +3,7 @@
  *
  *  Pentaho Data Integration
  *
- *  Copyright (C) 2018-2022 by Hitachi Vantara : http://www.pentaho.com
+ *  Copyright (C) 2018-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *  *******************************************************************************
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
@@ -43,19 +43,19 @@ import org.pentaho.di.job.entries.trans.JobEntryTrans;
 import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.trans.TransExecutionConfiguration;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.times;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.anyString;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by bmorrise on 5/4/17.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class RunConfigurationInjectExtensionPointTest {
 
   RunConfigurationInjectExtensionPoint runConfigurationInjectExtensionPoint;
@@ -87,8 +87,6 @@ public class RunConfigurationInjectExtensionPointTest {
     runConfigurationInjectExtensionPoint.setRunConfigurationManager( runConfigurationManager );
     executionExt = new JobExecutionExtension( job, result, jobEntryCopy, false );
 
-    when( abstractMeta.getEmbeddedMetaStore() ).thenReturn( embeddedMetaStore );
-    when( transExecutionConfiguration.getRunConfiguration() ).thenReturn( runConfName );
     when( runConfigurationManager.load( runConfName ) ).thenReturn( runConfiguration );
 
     when( job.getJobMeta() ).thenReturn( jobMeta );

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationRunExtensionPointTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationRunExtensionPointTest.java
@@ -3,7 +3,7 @@
  *
  *  Pentaho Data Integration
  *
- *  Copyright (C) 2017-2022 by Hitachi Vantara : http://www.pentaho.com
+ *  Copyright (C) 2017-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *  *******************************************************************************
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 /**
  * Created by bmorrise on 5/4/17.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class RunConfigurationRunExtensionPointTest {
 
   RunConfigurationRunExtensionPoint runConfigurationRunExtensionPoint;
@@ -84,9 +84,6 @@ public class RunConfigurationRunExtensionPointTest {
 
   @Test
   public void testCallExtensionPointEmbedded() throws Exception {
-
-    when( runConfigurationManager.load( "RUN_CONF" ) ).thenReturn( null );
-
     try {
       runConfigurationRunExtensionPoint.callExtensionPoint( log, new Object[] {
         transExecutionConfiguration, abstractMeta, variableSpace

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationSaveExtensionPointTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationSaveExtensionPointTest.java
@@ -3,7 +3,7 @@
  *
  *  Pentaho Data Integration
  *
- *  Copyright (C) 2020-2022 by Hitachi Vantara : http://www.pentaho.com
+ *  Copyright (C) 2020-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *  *******************************************************************************
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
@@ -43,13 +43,14 @@ import org.pentaho.di.job.entry.JobEntryRunConfigurableInterface;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class RunConfigurationSaveExtensionPointTest {
 
   private static final int JOB_ENTRY_COUNT = 10;
@@ -67,8 +68,8 @@ public class RunConfigurationSaveExtensionPointTest {
     for ( int i = 0; i < JOB_ENTRY_COUNT; i++ ) {
       String configurationName = RUN_CONFIGURATION + i;
       RunConfiguration runConfiguration = mock( RunConfiguration.class );
-      when( runConfiguration.getName() ).thenReturn( configurationName );
-      when( runConfigurationManager.load( configurationName ) ).thenReturn( runConfiguration );
+      lenient().when( runConfiguration.getName() ).thenReturn( configurationName );
+      lenient().when( runConfigurationManager.load( configurationName ) ).thenReturn( runConfiguration );
     }
   }
 

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationExecutorTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationExecutorTest.java
@@ -3,7 +3,7 @@
  *
  *  Pentaho Data Integration
  *
- *  Copyright (C) 2017-2018 by Hitachi Vantara : http://www.pentaho.com
+ *  Copyright (C) 2017-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *  *******************************************************************************
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.exception.KettleException;
@@ -41,12 +41,13 @@ import org.pentaho.di.ui.spoon.Spoon;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 /**
  * Created by bmorrise on 3/22/17.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class DefaultRunConfigurationExecutorTest {
 
   private DefaultRunConfigurationExecutor defaultRunConfigurationExecutor;
@@ -74,14 +75,14 @@ public class DefaultRunConfigurationExecutorTest {
 
   @Before
   public void setup() {
-    when( spoon.getRepository() ).thenReturn( repository );
-    when( repository.getUserInfo() ).thenReturn( userInfo );
-    when( userInfo.getName() ).thenReturn( "admin" );
-    when( userInfo.getUsername() ).thenReturn( "password" );
-    when( abstractMeta.getRepositoryDirectory() ).thenReturn( repositoryDirectory );
-    when( repositoryDirectory.getPath() ).thenReturn( "/admin" );
-    when( abstractMeta.getName() ).thenReturn( "file" );
-    when( abstractMeta.getDefaultExtension() ).thenReturn( "ktr" );
+    lenient().when( spoon.getRepository() ).thenReturn( repository );
+    lenient().when( repository.getUserInfo() ).thenReturn( userInfo );
+    lenient().when( userInfo.getName() ).thenReturn( "admin" );
+    lenient().when( userInfo.getUsername() ).thenReturn( "password" );
+    lenient().when( abstractMeta.getRepositoryDirectory() ).thenReturn( repositoryDirectory );
+    lenient().when( repositoryDirectory.getPath() ).thenReturn( "/admin" );
+    lenient().when( abstractMeta.getName() ).thenReturn( "file" );
+    lenient().when( abstractMeta.getDefaultExtension() ).thenReturn( "ktr" );
 
     defaultRunConfigurationExecutor = new DefaultRunConfigurationExecutor();
   }
@@ -175,7 +176,7 @@ public class DefaultRunConfigurationExecutorTest {
     defaultRunConfiguration.setServer( "Test Server" );
 
     TransExecutionConfiguration transExecutionConfiguration = new TransExecutionConfiguration();
-    doReturn( slaveServer ).when( abstractMeta ).findSlaveServer( null );
+    lenient().doReturn( slaveServer ).when( abstractMeta ).findSlaveServer( null );
 
     try {
       defaultRunConfigurationExecutor
@@ -228,7 +229,7 @@ public class DefaultRunConfigurationExecutorTest {
     defaultRunConfiguration.setServer( "Test Server" );
 
     JobExecutionConfiguration jobExecutionConfiguration = new JobExecutionConfiguration();
-    doReturn( slaveServer ).when( abstractMeta ).findSlaveServer( null );
+    lenient().doReturn( slaveServer ).when( abstractMeta ).findSlaveServer( null );
 
     try {
       defaultRunConfigurationExecutor

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationProviderTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationProviderTest.java
@@ -28,17 +28,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
 import org.pentaho.di.engine.configuration.impl.CheckedMetaStoreSupplier;
-import org.pentaho.metastore.api.IMetaStore;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * Created by bmorrise on 4/4/17.
  */
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class DefaultRunConfigurationProviderTest {
 
   private DefaultRunConfigurationProvider defaultRunConfigurationProvider;

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/JobScheduleParamTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/JobScheduleParamTest.java
@@ -1,17 +1,40 @@
+/*
+ * *****************************************************************************
+ *
+ *  Pentaho Data Integration
+ *
+ *  Copyright (C) 2019-2024 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *  *******************************************************************************
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  this file except in compliance with the License. You may obtain a copy of the
+ *  License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * *****************************************************************************
+ *
+ */
+
 package org.pentaho.di.engine.configuration.impl.pentaho.scheduler;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.internal.util.reflection.Whitebox.getInternalState;
-import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
 
 public class JobScheduleParamTest {
 
@@ -21,7 +44,7 @@ public class JobScheduleParamTest {
     JobScheduleParam jobScheduleParam = mock( JobScheduleParam.class );
     when( jobScheduleParam.getName() ).thenCallRealMethod();
     String name = "hitachi";
-    setInternalState( jobScheduleParam, "name", name );
+    ReflectionTestUtils.setField( jobScheduleParam, "name", name );
     Assert.assertEquals( name, jobScheduleParam.getName() );
   }
 
@@ -31,7 +54,7 @@ public class JobScheduleParamTest {
     doCallRealMethod().when( jobScheduleParam ).setName( any() );
     String name = "hitachi";
     jobScheduleParam.setName( name );
-    Assert.assertEquals( name, getInternalState( jobScheduleParam, "name" ) );
+    Assert.assertEquals( name, ReflectionTestUtils.getField( jobScheduleParam, "name" ) );
   }
 
   @Test
@@ -39,7 +62,7 @@ public class JobScheduleParamTest {
     JobScheduleParam jobScheduleParam = mock( JobScheduleParam.class );
     when( jobScheduleParam.getType() ).thenCallRealMethod();
     String type = "hitachi";
-    setInternalState( jobScheduleParam, "type", type );
+    ReflectionTestUtils.setField( jobScheduleParam, "type", type );
     Assert.assertEquals( type, jobScheduleParam.getType() );
   }
 
@@ -49,7 +72,7 @@ public class JobScheduleParamTest {
     doCallRealMethod().when( jobScheduleParam ).setType( any() );
     String type = "hitachi";
     jobScheduleParam.setType( type );
-    Assert.assertEquals( type, getInternalState( jobScheduleParam, "type" ) );
+    Assert.assertEquals( type, ReflectionTestUtils.getField( jobScheduleParam, "type" ) );
   }
 
   @Test
@@ -58,7 +81,7 @@ public class JobScheduleParamTest {
     when( jobScheduleParam.getStringValue() ).thenCallRealMethod();
     List<String> stringValue = new ArrayList<>();
     stringValue.add( "hitachi" );
-    setInternalState( jobScheduleParam, "stringValue", stringValue );
+    ReflectionTestUtils.setField( jobScheduleParam, "stringValue", stringValue );
     Assert.assertEquals( stringValue, jobScheduleParam.getStringValue() );
   }
 
@@ -69,6 +92,6 @@ public class JobScheduleParamTest {
     List<String> stringValue = new ArrayList<>();
     stringValue.add( "hitachi" );
     jobScheduleParam.setStringValue( stringValue );
-    Assert.assertEquals( stringValue, getInternalState( jobScheduleParam, "stringValue" ) );
+    Assert.assertEquals( stringValue, ReflectionTestUtils.getField( jobScheduleParam, "stringValue" ) );
   }
 }

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/JobScheduleRequestTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/pentaho/scheduler/JobScheduleRequestTest.java
@@ -1,19 +1,42 @@
+/*
+ * *****************************************************************************
+ *
+ *  Pentaho Data Integration
+ *
+ *  Copyright (C) 2019-2024 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *  *******************************************************************************
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  this file except in compliance with the License. You may obtain a copy of the
+ *  License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * *****************************************************************************
+ *
+ */
+
 package org.pentaho.di.engine.configuration.impl.pentaho.scheduler;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.internal.util.reflection.Whitebox.getInternalState;
-import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
 
 public class JobScheduleRequestTest {
 
@@ -22,7 +45,7 @@ public class JobScheduleRequestTest {
     JobScheduleRequest jobScheduleRequest = mock( JobScheduleRequest.class );
     when( jobScheduleRequest.getInputFile() ).thenCallRealMethod();
     String inputFile = "hitachi";
-    setInternalState( jobScheduleRequest, "inputFile", inputFile );
+    ReflectionTestUtils.setField( jobScheduleRequest, "inputFile", inputFile );
     Assert.assertEquals( inputFile, jobScheduleRequest.getInputFile() );
   }
 
@@ -32,7 +55,7 @@ public class JobScheduleRequestTest {
     doCallRealMethod().when( jobScheduleRequest ).setInputFile( any() );
     String inputFile = "hitachi";
     jobScheduleRequest.setInputFile( inputFile );
-    Assert.assertEquals( inputFile, getInternalState( jobScheduleRequest, "inputFile" ) );
+    Assert.assertEquals( inputFile, ReflectionTestUtils.getField( jobScheduleRequest, "inputFile" ) );
   }
 
   @Test
@@ -41,7 +64,7 @@ public class JobScheduleRequestTest {
     when( jobScheduleRequest.getJobParameters() ).thenCallRealMethod();
     List<String> jobParameters = new ArrayList<>();
     jobParameters.add( "hitachi" );
-    setInternalState( jobScheduleRequest, "jobParameters", jobParameters );
+    ReflectionTestUtils.setField( jobScheduleRequest, "jobParameters", jobParameters );
     Assert.assertEquals( jobParameters, jobScheduleRequest.getJobParameters() );
   }
 
@@ -53,7 +76,7 @@ public class JobScheduleRequestTest {
     JobScheduleParam jobScheduleParam = new JobScheduleParam();
     jobParameters.add( jobScheduleParam );
     jobScheduleRequest.setJobParameters( jobParameters );
-    Assert.assertEquals( jobParameters, getInternalState( jobScheduleRequest, "jobParameters" ) );
+    Assert.assertEquals( jobParameters, ReflectionTestUtils.getField( jobScheduleRequest, "jobParameters" ) );
   }
 
   @Test
@@ -62,7 +85,7 @@ public class JobScheduleRequestTest {
     when( jobScheduleRequest.getPdiParameters() ).thenCallRealMethod();
     Map<String, String> pdiParameters = new HashMap<>();
     pdiParameters.put( "hitachi", "vantara" );
-    setInternalState( jobScheduleRequest, "pdiParameters", pdiParameters );
+    ReflectionTestUtils.setField( jobScheduleRequest, "pdiParameters", pdiParameters );
     Assert.assertEquals( pdiParameters, jobScheduleRequest.getPdiParameters() );
   }
 
@@ -73,6 +96,6 @@ public class JobScheduleRequestTest {
     Map<String, String> pdiParameters = new HashMap<>();
     pdiParameters.put( "hitachi", "vantara" );
     jobScheduleRequest.setPdiParameters( pdiParameters );
-    Assert.assertEquals( pdiParameters, getInternalState( jobScheduleRequest, "pdiParameters" ) );
+    Assert.assertEquals( pdiParameters, ReflectionTestUtils.getField( jobScheduleRequest, "pdiParameters" ) );
   }
 }

--- a/plugins/streaming/impls/jms/pom.xml
+++ b/plugins/streaming/impls/jms/pom.xml
@@ -152,8 +152,8 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-all.version}</version>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/JmsProducerTest.java
+++ b/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/JmsProducerTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2018-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2018-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -30,7 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
@@ -64,15 +64,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith ( MockitoJUnitRunner.class )
+@RunWith ( MockitoJUnitRunner.StrictStubs.class )
 public class JmsProducerTest {
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
   @Mock LogChannelInterfaceFactory logChannelFactory;
@@ -102,7 +103,7 @@ public class JmsProducerTest {
   public void setUp() throws KettleException {
     KettleLogStore.setLogChannelInterfaceFactory( logChannelFactory );
     when( logChannelFactory.create( any(), any() ) ).thenReturn( logChannel );
-    when( logChannelFactory.create( any() ) ).thenReturn( logChannel );
+    lenient().when( logChannelFactory.create( any() ) ).thenReturn( logChannel );
 
     List<JmsProvider> jmsProviders = new ArrayList<>();
     ActiveMQProvider activeMQProvider = spy( new ActiveMQProvider() );
@@ -136,9 +137,9 @@ public class JmsProducerTest {
     //Mock inputRowMeta into the step
     String[] fieldNames = new String[] { "one", "two" };
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
-    when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( inputRowMeta.size() ).thenReturn( 2 );
-    when( inputRowMeta.getFieldNames() ).thenReturn( fieldNames );
+    lenient().when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
+    lenient().when( inputRowMeta.size() ).thenReturn( 2 );
+    lenient().when( inputRowMeta.getFieldNames() ).thenReturn( fieldNames );
     when( inputRowMeta.indexOfValue( any() ) ).thenReturn( 0 );
     step.setInputRowMeta( inputRowMeta );
   }

--- a/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/JmsStreamSourceTest.java
+++ b/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/JmsStreamSourceTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.SubtransExecutor;
 
 import javax.jms.Destination;
@@ -45,10 +45,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith ( MockitoJUnitRunner.class )
+@RunWith ( MockitoJUnitRunner.StrictStubs.class )
 public class JmsStreamSourceTest {
 
   @Mock private JmsContext context;
@@ -63,7 +64,7 @@ public class JmsStreamSourceTest {
 
   @Before
   public void before() throws JMSException {
-    when( subtransExecutor.getPrefetchCount() ).thenReturn( 1000 );
+    lenient().when( subtransExecutor.getPrefetchCount() ).thenReturn( 1000 );
     when( consumerStep.getSubtransExecutor() ).thenReturn( subtransExecutor );
     source = new JmsStreamSource( consumerStep, delegate, 0 );
     when( delegate.getJmsContext() ).thenReturn( context );

--- a/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/context/ActiveMQProviderTest.java
+++ b/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/context/ActiveMQProviderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -29,7 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
@@ -56,11 +56,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class ActiveMQProviderTest {
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
   @Mock LogChannelInterfaceFactory logChannelFactory;
@@ -99,8 +100,8 @@ public class ActiveMQProviderTest {
   public void setUp() {
     KettleLogStore.setLogChannelInterfaceFactory( logChannelFactory );
     doReturn( LogLevel.BASIC ).when( logChannel ).getLogLevel();
-    when( logChannelFactory.create( any(), any() ) ).thenReturn( logChannel );
-    when( logChannelFactory.create( any() ) ).thenReturn( logChannel );
+    lenient().when( logChannelFactory.create( any(), any() ) ).thenReturn( logChannel );
+    lenient().when( logChannelFactory.create( any() ) ).thenReturn( logChannel );
   }
 
   @Test public void testFullCircle() throws KettleException, InterruptedException, TimeoutException,

--- a/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/context/WebsphereMQProviderTest.java
+++ b/plugins/streaming/impls/jms/src/test/java/org/pentaho/di/trans/step/jms/context/WebsphereMQProviderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,7 +26,7 @@ package org.pentaho.di.trans.step.jms.context;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.trans.step.jms.JmsDelegate;
 
 import javax.jms.Destination;
@@ -41,7 +41,7 @@ import static org.pentaho.di.trans.step.jms.context.JmsProvider.ConnectionType.W
 import static org.pentaho.di.trans.step.jms.context.JmsProvider.DestinationType.QUEUE;
 import static org.pentaho.di.trans.step.jms.context.JmsProvider.DestinationType.TOPIC;
 
-@RunWith ( MockitoJUnitRunner.class )
+@RunWith ( MockitoJUnitRunner.StrictStubs.class )
 public class WebsphereMQProviderTest {
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
     <jface.version>3.3.0-I20070606-0010</jface.version>
 
     <!-- Test dependencies -->
-    <mockito-all.version>1.10.19</mockito-all.version>
     <mockito.version>5.10.0</mockito.version>
 
     <powermock-module-junit4.version>1.7.3</powermock-module-junit4.version>
@@ -201,18 +200,6 @@
       </dependency>
 
       <!-- Test dependencies -->
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>${mockito-all.version}</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>java-hamcrest</artifactId>


### PR DESCRIPTION
This also removes `mockito-all` from the root pom, leaving it only in the integration tests (which we should probably address in a separate ticket)

We had marked `plugins/file-stream` for update as well, but I wound up skipping that -- this module is not included in the plugins pom, and both the tests and implementation haven't compiled since sometime in 2018 (due to changes in the `StreamSource` class). We should probably remove this instead, but that seemed out of scope for these updates.