### PR TITLE
[SP-6551] Backport of PDI-20108 - Memory Leak on org.pentaho.di.core.logging.LoggingObject crashes Pentaho Server (10.1 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -59,7 +59,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.logging.SimpleLoggingObject;
 import org.pentaho.di.core.plugins.PluginTypeListener;
 import org.pentaho.di.core.row.value.ValueMetaPluginType;
 import org.pentaho.di.core.util.Utils;
@@ -161,8 +160,6 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
 
   private LogChannelInterface log;
   private LoggingObjectInterface parentLoggingObject;
-
-  private boolean loggingObjectInUse;
   private static final String[] TABLE_TYPES_TO_GET = { "TABLE", "VIEW" };
   private static final String TABLES_META_DATA_TABLE_NAME = "TABLE_NAME";
 
@@ -363,15 +360,6 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
     return dataSource;
   }
 
-  @Override
-  public boolean isLoggingObjectInUse() {
-    return loggingObjectInUse;
-  }
-
-  public void setLoggingObjectInUse( boolean inUse ) {
-    loggingObjectInUse = inUse;
-  }
-
   /**
    * Open the database connection.
    *
@@ -393,7 +381,7 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
 
   public synchronized void connect( String group, String partitionId ) throws KettleDatabaseException {
     try {
-      setLoggingObjectInUse( true );
+
       log.snap( Metrics.METRIC_DATABASE_CONNECT_START, databaseMeta.getName() );
 
       // Before anything else, let's see if we already have a connection defined
@@ -657,12 +645,9 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
    * Disconnect from the database and close all open prepared statements.
    */
   public synchronized void disconnect() {
-    setLoggingObjectInUse( false );
-
     if ( connection == null ) {
       return; // Nothing to do...
     }
-
     try {
       if ( connection.isClosed() ) {
         return; // Nothing to do...

--- a/core/src/main/java/org/pentaho/di/core/logging/LoggingObject.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/LoggingObject.java
@@ -47,9 +47,6 @@ public class LoggingObject implements LoggingObjectInterface {
 
   private LoggingObjectInterface parent;
 
-  private LoggingObjectInterface loggingObject;
-
-  private boolean loggingObjectInUse;
   private Date registrationDate;
 
   private boolean gatheringMetrics;
@@ -61,7 +58,6 @@ public class LoggingObject implements LoggingObjectInterface {
     } else {
       grabObjectInformation( object );
     }
-    loggingObjectInUse = false;
   }
 
   @Override
@@ -157,7 +153,6 @@ public class LoggingObject implements LoggingObjectInterface {
     containerObjectId = loggingObject.getContainerObjectId();
     forcingSeparateLogging = loggingObject.isForcingSeparateLogging();
     gatheringMetrics = loggingObject.isGatheringMetrics();
-    this.loggingObject = loggingObject;
 
     if ( loggingObject.getParent() != null ) {
       getParentLoggingObject( loggingObject.getParent() );
@@ -169,17 +164,8 @@ public class LoggingObject implements LoggingObjectInterface {
   private void grabObjectInformation( Object object ) {
     objectType = LoggingObjectType.GENERAL;
     objectName = object.toString(); // name of class or name of object..
+
     parent = null;
-    loggingObject = null;
-  }
-
-  @Override
-  public boolean isLoggingObjectInUse() {
-    return loggingObject == null ? loggingObjectInUse : loggingObject.isLoggingObjectInUse() || loggingObjectInUse;
-  }
-
-  public void setLoggingObjectInUse( boolean loggingObjectInUse ) {
-    this.loggingObjectInUse = loggingObjectInUse;
   }
 
   private void getParentLoggingObject( Object parentObject ) {

--- a/core/src/main/java/org/pentaho/di/core/logging/LoggingObject.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/LoggingObject.java
@@ -47,6 +47,7 @@ public class LoggingObject implements LoggingObjectInterface {
 
   private LoggingObjectInterface parent;
 
+  private LoggingObjectInterface loggingObject;
 
   private boolean loggingObjectInUse;
   private Date registrationDate;
@@ -156,6 +157,7 @@ public class LoggingObject implements LoggingObjectInterface {
     containerObjectId = loggingObject.getContainerObjectId();
     forcingSeparateLogging = loggingObject.isForcingSeparateLogging();
     gatheringMetrics = loggingObject.isGatheringMetrics();
+    this.loggingObject = loggingObject;
 
     if ( loggingObject.getParent() != null ) {
       getParentLoggingObject( loggingObject.getParent() );
@@ -168,11 +170,12 @@ public class LoggingObject implements LoggingObjectInterface {
     objectType = LoggingObjectType.GENERAL;
     objectName = object.toString(); // name of class or name of object..
     parent = null;
+    loggingObject = null;
   }
 
   @Override
   public boolean isLoggingObjectInUse() {
-    return loggingObjectInUse || ( parent != null && parent.isLoggingObjectInUse() );
+    return loggingObject == null ? loggingObjectInUse : loggingObject.isLoggingObjectInUse() || loggingObjectInUse;
   }
 
   public void setLoggingObjectInUse( boolean loggingObjectInUse ) {

--- a/core/src/main/java/org/pentaho/di/core/logging/LoggingObjectInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/LoggingObjectInterface.java
@@ -143,7 +143,4 @@ public interface LoggingObjectInterface extends LoggingObjectLifecycleInterface 
    * @return True if the logging is forcibly separated out from even identical objects.
    */
   public boolean isForcingSeparateLogging();
-
-  boolean isLoggingObjectInUse();
-
 }

--- a/core/src/main/java/org/pentaho/di/core/logging/LoggingRegistry.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/LoggingRegistry.java
@@ -544,7 +544,7 @@ public class LoggingRegistry {
       String objId = obj.getLogChannelId();
 
       // Only Objects that are tied to a buffer can be purged.
-      if ( !channelsNotToRemove.contains( objId ) && !map.get(objId).isLoggingObjectInUse() ) {
+      if ( !channelsNotToRemove.contains( objId ) ) {
         // Object is safe to remove, but the counter for purged objects will only be incremented if it is really
         // removed from the map as it's possible for the object to not exist on the map.
         if ( null != map.remove( objId ) ) {

--- a/core/src/main/java/org/pentaho/di/core/logging/SimpleLoggingObject.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/SimpleLoggingObject.java
@@ -33,7 +33,6 @@ public class SimpleLoggingObject implements LoggingObjectInterface {
   private String objectName;
   private LoggingObjectType objectType;
   private LoggingObjectInterface parent;
-  private boolean loggingObjectInUse;
   private LogLevel logLevel = DefaultLogLevel.getLogLevel();
   private String containerObjectId;
   private String logChannelId;
@@ -54,8 +53,8 @@ public class SimpleLoggingObject implements LoggingObjectInterface {
       this.logLevel = parent.getLogLevel();
       this.containerObjectId = parent.getContainerObjectId();
     }
-    setLoggingObjectInUse( false );
   }
+
   /**
    * @return the name
    */
@@ -94,15 +93,6 @@ public class SimpleLoggingObject implements LoggingObjectInterface {
   @Override
   public LoggingObjectInterface getParent() {
     return parent;
-  }
-
-  @Override
-  public boolean isLoggingObjectInUse() {
-    return loggingObjectInUse;
-  }
-
-  public void setLoggingObjectInUse( boolean inUse ) {
-    loggingObjectInUse = inUse;
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -1558,11 +1558,6 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
     this.logLevel = logLevel;
   }
 
-  @Override
-  public boolean isLoggingObjectInUse() {
-    return getParent() == null ? false : getParent().isLoggingObjectInUse();
-  }
-
   public IMetaStore getMetaStore() {
     return metaStore;
   }

--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -132,7 +132,6 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
 
   private LogChannelInterface log;
 
-  private boolean loggingObjectInUse;
   private LogLevel logLevel = DefaultLogLevel.getLogLevel();
 
   private int logBufferStartLine;
@@ -256,17 +255,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
     this.log.setHooks( this );
   }
 
-  @Override
-  public boolean isLoggingObjectInUse() {
-    return loggingObjectInUse;
-  }
-
-  public void setLoggingObjectInUse( boolean inUse ) {
-    loggingObjectInUse = inUse;
-  }
-
   public void init() {
-    setLoggingObjectInUse( true );
     status = new AtomicInteger();
 
     jobListeners = new ArrayList<JobListener>();
@@ -639,7 +628,6 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
    * @see JobListener#jobFinished(Job)
    */
   public void fireJobFinishListeners() throws KettleException {
-    setLoggingObjectInUse( false );
     synchronized ( jobListeners ) {
       for ( JobListener jobListener : jobListeners ) {
         jobListener.jobFinished( this );

--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -114,7 +114,8 @@ import java.util.Set;
  * @since 11-08-2003
  */
 public class JobMeta extends AbstractMeta
-    implements Cloneable, Comparable<JobMeta>, XMLInterface, ResourceExportInterface, RepositoryElementInterface {
+    implements Cloneable, Comparable<JobMeta>, XMLInterface, ResourceExportInterface, RepositoryElementInterface,
+    LoggingObjectInterface {
 
   private static Class<?> PKG = JobMeta.class; // for i18n purposes, needed by Translator2!!
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/checkfilelocked/JobEntryCheckFilesLocked.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/checkfilelocked/JobEntryCheckFilesLocked.java
@@ -237,7 +237,6 @@ public class JobEntryCheckFilesLocked extends JobEntryBase implements Cloneable,
       logError( BaseMessages.getString( PKG, "JobEntryCheckFilesLocked.ErrorRunningJobEntry", e ) );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExist.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExist.java
@@ -292,7 +292,6 @@ public class JobEntryColumnsExist extends JobEntryBase implements Cloneable, Job
       result.setNrErrors( 0 );
       result.setResult( true );
     }
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/copyfiles/JobEntryCopyFiles.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/copyfiles/JobEntryCopyFiles.java
@@ -442,7 +442,6 @@ public class JobEntryCopyFiles extends JobEntryBase implements Cloneable, JobEnt
       result.setNrErrors( NbrFail );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/copymoveresultfilenames/JobEntryCopyMoveResultFilenames.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/copymoveresultfilenames/JobEntryCopyMoveResultFilenames.java
@@ -486,7 +486,6 @@ public class JobEntryCopyMoveResultFilenames extends JobEntryBase implements Clo
       result.setResult( true );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/createfile/JobEntryCreateFile.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/createfile/JobEntryCreateFile.java
@@ -206,7 +206,6 @@ public class JobEntryCreateFile extends JobEntryBase implements Cloneable, JobEn
       logError( "No filename is defined." );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/createfolder/JobEntryCreateFolder.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/createfolder/JobEntryCreateFolder.java
@@ -202,7 +202,6 @@ public class JobEntryCreateFolder extends JobEntryBase implements Cloneable, Job
       logError( "No Foldername is defined." );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/delay/JobEntryDelay.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/delay/JobEntryDelay.java
@@ -214,7 +214,6 @@ public class JobEntryDelay extends JobEntryBase implements Cloneable, JobEntryIn
       }
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/deletefile/JobEntryDeleteFile.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/deletefile/JobEntryDeleteFile.java
@@ -203,7 +203,6 @@ public class JobEntryDeleteFile extends JobEntryBase implements Cloneable, JobEn
       logError( BaseMessages.getString( PKG, "JobEntryDeleteFile.ERROR_0007_No_Filename_Is_Defined" ) );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFiles.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/deletefiles/JobEntryDeleteFiles.java
@@ -248,7 +248,7 @@ public class JobEntryDeleteFiles extends JobEntryBase implements Cloneable, JobE
       result.setNrErrors( numberOfErrFiles );
       result.setResult( false );
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/deletefolders/JobEntryDeleteFolders.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/deletefolders/JobEntryDeleteFolders.java
@@ -283,7 +283,6 @@ public class JobEntryDeleteFolders extends JobEntryBase implements Cloneable, Jo
       result.setResult( true );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/deleteresultfilenames/JobEntryDeleteResultFilenames.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/deleteresultfilenames/JobEntryDeleteResultFilenames.java
@@ -218,7 +218,6 @@ public class JobEntryDeleteResultFilenames extends JobEntryBase implements Clone
         logError( BaseMessages.getString( PKG, "JobEntryDeleteResultFilenames.Error", e.toString() ) );
       }
     }
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/dostounix/JobEntryDosToUnix.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/dostounix/JobEntryDosToUnix.java
@@ -395,7 +395,7 @@ public class JobEntryDosToUnix extends JobEntryBase implements Cloneable, JobEnt
     }
 
     displayResults();
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/empty/JobEntryEmpty.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/empty/JobEntryEmpty.java
@@ -40,7 +40,6 @@ import org.w3c.dom.Node;
 
 public class JobEntryEmpty extends JobEntryBase implements JobEntryInterface {
   public Result execute( Result prev_result, int nr ) throws KettleException {
-    setLoggingObjectInUse( false );
     return null;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/eval/JobEntryEval.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/eval/JobEntryEval.java
@@ -207,7 +207,6 @@ public class JobEntryEval extends JobEntryBase implements Cloneable, JobEntryInt
    */
   public Result execute( Result prev_result, int nr ) {
     prev_result.setResult( evaluate( prev_result, parentJob, prev_result ) );
-    setLoggingObjectInUse( false );
     return prev_result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/evalfilesmetrics/JobEntryEvalFilesMetrics.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/evalfilesmetrics/JobEntryEvalFilesMetrics.java
@@ -517,7 +517,7 @@ public class JobEntryEvalFilesMetrics extends JobEntryBase implements Cloneable,
     result.setResult( isSuccess() );
     result.setNrErrors( getNrError() );
     displayResults();
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/evaluatetablecontent/JobEntryEvalTableContent.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/evaluatetablecontent/JobEntryEvalTableContent.java
@@ -439,7 +439,6 @@ public class JobEntryEvalTableContent extends JobEntryBase implements Cloneable,
     result.setNrLinesRead( rowsCount );
     result.setNrErrors( errCount );
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/filecompare/JobEntryFileCompare.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/filecompare/JobEntryFileCompare.java
@@ -279,7 +279,6 @@ public class JobEntryFileCompare extends JobEntryBase implements Cloneable, JobE
       }
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/fileexists/JobEntryFileExists.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/fileexists/JobEntryFileExists.java
@@ -163,7 +163,7 @@ public class JobEntryFileExists extends JobEntryBase implements Cloneable, JobEn
       result.setNrErrors( 1 );
       logError( BaseMessages.getString( PKG, "JobEntryFileExists.ERROR_0005_No_Filename_Defined" ) );
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/filesexist/JobEntryFilesExist.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/filesexist/JobEntryFilesExist.java
@@ -249,7 +249,6 @@ public class JobEntryFilesExist extends JobEntryBase implements Cloneable, JobEn
       result.setResult( true );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/folderisempty/JobEntryFolderIsEmpty.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/folderisempty/JobEntryFolderIsEmpty.java
@@ -259,7 +259,6 @@ public class JobEntryFolderIsEmpty extends JobEntryBase implements Cloneable, Jo
       result.setNrErrors( 1 );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/folderscompare/JobEntryFoldersCompare.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/folderscompare/JobEntryFoldersCompare.java
@@ -512,7 +512,6 @@ public class JobEntryFoldersCompare extends JobEntryBase implements Cloneable, J
       }
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/http/JobEntryHTTP.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/http/JobEntryHTTP.java
@@ -574,7 +574,6 @@ public class JobEntryHTTP extends JobEntryBase implements Cloneable, JobEntryInt
 
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -1233,7 +1233,6 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
       result.setResult( true );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/movefiles/JobEntryMoveFiles.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/movefiles/JobEntryMoveFiles.java
@@ -533,7 +533,6 @@ public class JobEntryMoveFiles extends JobEntryBase implements Cloneable, JobEnt
 
     displayResults();
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/mssqlbulkload/JobEntryMssqlBulkLoad.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/mssqlbulkload/JobEntryMssqlBulkLoad.java
@@ -624,7 +624,6 @@ public class JobEntryMssqlBulkLoad extends JobEntryBase implements Cloneable, Jo
       result.setNrErrors( 1 );
       logError( BaseMessages.getString( PKG, "JobMssqlBulkLoad.Nofilename.Label" ) );
     }
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/mysqlbulkfile/JobEntryMysqlBulkFile.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/mysqlbulkfile/JobEntryMysqlBulkFile.java
@@ -439,7 +439,6 @@ public class JobEntryMysqlBulkFile extends JobEntryBase implements Cloneable, Jo
       logError( BaseMessages.getString( PKG, "JobMysqlBulkFile.Nofilename.Label" ) );
     }
 
-    setLoggingObjectInUse( false );
     return result;
 
   }

--- a/engine/src/main/java/org/pentaho/di/job/entries/mysqlbulkload/JobEntryMysqlBulkLoad.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/mysqlbulkload/JobEntryMysqlBulkLoad.java
@@ -453,7 +453,6 @@ public class JobEntryMysqlBulkLoad extends JobEntryBase implements Cloneable, Jo
       result.setNrErrors( 1 );
       logError( BaseMessages.getString( PKG, "JobMysqlBulkLoad.Nofilename.Label" ) );
     }
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/pgpdecryptfiles/JobEntryPGPDecryptFiles.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/pgpdecryptfiles/JobEntryPGPDecryptFiles.java
@@ -542,7 +542,6 @@ public class JobEntryPGPDecryptFiles extends JobEntryBase implements Cloneable, 
       if ( destination_filefolder != null ) {
         destination_filefolder = null;
       }
-      setLoggingObjectInUse( false );
     }
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/pgpencryptfiles/JobEntryPGPEncryptFiles.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/pgpencryptfiles/JobEntryPGPEncryptFiles.java
@@ -582,7 +582,7 @@ public class JobEntryPGPEncryptFiles extends JobEntryBase implements Cloneable, 
     }
 
     displayResults();
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/pgpverify/JobEntryPGPVerify.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/pgpverify/JobEntryPGPVerify.java
@@ -220,7 +220,6 @@ public class JobEntryPGPVerify extends JobEntryBase implements Cloneable, JobEnt
       }
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/ping/JobEntryPing.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/ping/JobEntryPing.java
@@ -330,7 +330,6 @@ public class JobEntryPing extends JobEntryBase implements Cloneable, JobEntryInt
     } else {
       logError( BaseMessages.getString( PKG, "JobPing.NOK.Label", hostname ) );
     }
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/sendnagiospassivecheck/JobEntrySendNagiosPassiveCheck.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/sendnagiospassivecheck/JobEntrySendNagiosPassiveCheck.java
@@ -545,8 +545,6 @@ public class JobEntrySendNagiosPassiveCheck extends JobEntryBase implements Clon
       log.logError( BaseMessages.getString( PKG, "JobEntrySendNagiosPassiveCheck.ErrorGetting", e.toString() ) );
     }
 
-    setLoggingObjectInUse( false );
-
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/setvariables/JobEntrySetVariables.java
@@ -372,7 +372,6 @@ public class JobEntrySetVariables extends JobEntryBase implements Cloneable, Job
       logError( BaseMessages.getString( PKG, "JobEntrySetVariables.UnExcpectedError", e.getMessage() ) );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/shell/JobEntryShell.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/shell/JobEntryShell.java
@@ -442,7 +442,7 @@ public class JobEntryShell extends JobEntryBase implements Cloneable, JobEntryIn
         result.getResultFiles().put( resultFile.getFile().toString(), resultFile );
       }
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEval.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEval.java
@@ -974,7 +974,6 @@ public class JobEntrySimpleEval extends JobEntryBase implements Cloneable, JobEn
     result.setResult( success );
     // PDI-6943: this job entry does not set errors upon evaluation, independently of the outcome of the check
     result.setNrErrors( 0 );
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/snmptrap/JobEntrySNMPTrap.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/snmptrap/JobEntrySNMPTrap.java
@@ -514,7 +514,6 @@ public class JobEntrySNMPTrap extends JobEntryBase implements Cloneable, JobEntr
       }
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/special/JobEntrySpecial.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/special/JobEntrySpecial.java
@@ -194,7 +194,6 @@ public class JobEntrySpecial extends JobEntryBase implements Cloneable, JobEntry
     } else if ( isDummy() ) {
       result = previousResult;
     }
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/sql/JobEntrySQL.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/sql/JobEntrySQL.java
@@ -273,8 +273,6 @@ public class JobEntrySQL extends JobEntryBase implements Cloneable, JobEntryInte
     }
 
     result.setResult( result.getNrErrors() == 0 );
-
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/success/JobEntrySuccess.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/success/JobEntrySuccess.java
@@ -101,7 +101,6 @@ public class JobEntrySuccess extends JobEntryBase implements Cloneable, JobEntry
     result.setNrErrors( 0 );
     result.setResult( true );
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/syslog/JobEntrySyslog.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/syslog/JobEntrySyslog.java
@@ -322,7 +322,6 @@ public class JobEntrySyslog extends JobEntryBase implements Cloneable, JobEntryI
       }
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/tableexists/JobEntryTableExists.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/tableexists/JobEntryTableExists.java
@@ -199,7 +199,6 @@ public class JobEntryTableExists extends JobEntryBase implements Cloneable, JobE
       logError( BaseMessages.getString( PKG, "TableExists.Error.NoConnectionDefined" ) );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/talendjobexec/JobEntryTalendJobExec.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/talendjobexec/JobEntryTalendJobExec.java
@@ -169,7 +169,7 @@ public class JobEntryTalendJobExec extends JobEntryBase implements Cloneable, Jo
       result.setNrErrors( 1 );
       logError( BaseMessages.getString( PKG, "JobEntryTalendJobExec.ERROR_0005_No_Filename_Defined" ) );
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/telnet/JobEntryTelnet.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/telnet/JobEntryTelnet.java
@@ -200,7 +200,7 @@ public class JobEntryTelnet extends JobEntryBase implements Cloneable, JobEntryI
       logError( BaseMessages.getString( PKG, "JobTelnet.NOK.Label", hostname, String.valueOf( port ) ) );
       logError( BaseMessages.getString( PKG, "JobTelnet.Error.Label" ) + ex.getMessage() );
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1261,7 +1261,6 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       result.setResult( false );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/truncatetables/JobEntryTruncateTables.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/truncatetables/JobEntryTruncateTables.java
@@ -320,9 +320,6 @@ public class JobEntryTruncateTables extends JobEntryBase implements Cloneable, J
     result.setNrErrors( nrErrors );
     result.setNrLinesDeleted( nrSuccess );
     result.setResult( nrErrors == 0 );
-
-    setLoggingObjectInUse( false );
-
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
@@ -502,7 +502,6 @@ public class JobEntryUnZip extends JobEntryBase implements Cloneable, JobEntryIn
     }
     displayResults();
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/waitforfile/JobEntryWaitForFile.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/waitforfile/JobEntryWaitForFile.java
@@ -358,7 +358,6 @@ public class JobEntryWaitForFile extends JobEntryBase implements Cloneable, JobE
       logError( "No filename is defined." );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/waitforsql/JobEntryWaitForSQL.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/waitforsql/JobEntryWaitForSQL.java
@@ -495,7 +495,7 @@ public class JobEntryWaitForSQL extends JobEntryBase implements Cloneable, JobEn
       // PDI-15437
       result.setNrErrors( 0 );
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/webserviceavailable/JobEntryWebServiceAvailable.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/webserviceavailable/JobEntryWebServiceAvailable.java
@@ -185,7 +185,6 @@ public class JobEntryWebServiceAvailable extends JobEntryBase implements Cloneab
       result.setLogText( message );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/writetofile/JobEntryWriteToFile.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/writetofile/JobEntryWriteToFile.java
@@ -242,7 +242,6 @@ public class JobEntryWriteToFile extends JobEntryBase implements Cloneable, JobE
       logError( BaseMessages.getString( PKG, "JobWriteToFile.Error.MissinfgFile" ) );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/writetolog/JobEntryWriteToLog.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/writetolog/JobEntryWriteToLog.java
@@ -245,11 +245,6 @@ public class JobEntryWriteToLog extends JobEntryBase implements Cloneable, JobEn
     }
 
     @Override
-    public boolean isLoggingObjectInUse() {
-      return parent == null ? false : parent.isLoggingObjectInUse();
-    }
-
-    @Override
     public void setForcingSeparateLogging( boolean forcingSeparateLogging ) {
       log.setForcingSeparateLogging( forcingSeparateLogging );
     }
@@ -318,7 +313,6 @@ public class JobEntryWriteToLog extends JobEntryBase implements Cloneable, JobEn
   @Override
   public Result execute( Result prev_result, int nr ) {
     prev_result.setResult( evaluate( prev_result ) );
-    setLoggingObjectInUse( false );
     return prev_result;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
@@ -927,7 +927,6 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
       }
     }
 
-    setLoggingObjectInUse( false );
     // End
     return result;
   }

--- a/engine/src/main/java/org/pentaho/di/job/entry/JobEntryBase.java
+++ b/engine/src/main/java/org/pentaho/di/job/entry/JobEntryBase.java
@@ -118,8 +118,6 @@ public class JobEntryBase implements Cloneable, VariableSpace, CheckResultSource
   /** The log channel interface object, used for logging */
   protected LogChannelInterface log;
 
-  private boolean loggingObjectInUse;
-
   /** The log level */
   private LogLevel logLevel = DefaultLogLevel.getLogLevel();
 
@@ -138,13 +136,11 @@ public class JobEntryBase implements Cloneable, VariableSpace, CheckResultSource
    * Instantiates a new job entry base object.
    */
   public JobEntryBase() {
-    setLoggingObjectInUse( true );
     name = null;
     description = null;
     log = new LogChannel( this );
     attributesMap = new HashMap<>();
     extensionDataMap = new HashMap<>();
-
   }
 
   /**
@@ -156,7 +152,6 @@ public class JobEntryBase implements Cloneable, VariableSpace, CheckResultSource
    *          the description of the job entry
    */
   public JobEntryBase( String name, String description ) {
-    setLoggingObjectInUse( true );
     setName( name );
     setDescription( description );
     setObjectId( null );
@@ -1052,15 +1047,6 @@ public class JobEntryBase implements Cloneable, VariableSpace, CheckResultSource
    */
   public Job getParentJob() {
     return parentJob;
-  }
-
-  @Override
-  public boolean isLoggingObjectInUse() {
-    return loggingObjectInUse;
-  }
-
-  public void setLoggingObjectInUse( boolean inUse ) {
-    loggingObjectInUse = inUse;
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -188,8 +188,6 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
    */
   protected LogChannelInterface log;
 
-  protected boolean loggingObjectInUse;
-
   /**
    * The log level.
    */
@@ -571,7 +569,6 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
    * Instantiates a new transformation.
    */
   public Trans() {
-    setLoggingObjectInUse(true);
     status = new AtomicInteger();
 
     transListeners = Collections.synchronizedList( new ArrayList<TransListener>() );
@@ -654,15 +651,6 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
         String.valueOf( transMeta.nrTransHops() ) ) );
     }
 
-  }
-
-  @Override
-  public boolean isLoggingObjectInUse() {
-    return loggingObjectInUse;
-  }
-
-  public void setLoggingObjectInUse( boolean inUse ) {
-    loggingObjectInUse = inUse;
   }
 
   /**
@@ -1654,7 +1642,6 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
    * @throws KettleException if any errors occur during notification
    */
   protected void fireTransFinishedListeners() throws KettleException {
-    setLoggingObjectInUse( false );
     // PDI-5229 sync added
     synchronized ( transListeners ) {
       if ( transListeners.size() == 0 ) {

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -140,7 +140,7 @@ import java.util.stream.Collectors;
  */
 public class TransMeta extends AbstractMeta
     implements XMLInterface, Comparator<TransMeta>, Comparable<TransMeta>, Cloneable, ResourceExportInterface,
-    RepositoryElementInterface {
+    RepositoryElementInterface, LoggingObjectInterface {
 
   /** The package name, used for internationalization of messages. */
   private static Class<?> PKG = Trans.class; // for i18n purposes, needed by Translator2!!

--- a/engine/src/main/java/org/pentaho/di/trans/step/BaseStep.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/BaseStep.java
@@ -161,8 +161,6 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
 
   protected LogChannelInterface log;
 
-  protected boolean loggingObjectInUse;
-
   private String containerObjectId;
 
   private Trans trans;
@@ -577,8 +575,6 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     sdi.setStatus( StepExecutionStatus.STATUS_INIT );
 
-    setLoggingObjectInUse(true);
-
     String slaveNr = transMeta.getVariable( Const.INTERNAL_VARIABLE_SLAVE_SERVER_NUMBER );
     String clusterSize = transMeta.getVariable( Const.INTERNAL_VARIABLE_CLUSTER_SIZE );
     boolean master = "Y".equalsIgnoreCase( transMeta.getVariable( Const.INTERNAL_VARIABLE_CLUSTER_MASTER ) );
@@ -822,7 +818,6 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
    */
   @Override
   public void dispose( StepMetaInterface smi, StepDataInterface sdi ) {
-    setLoggingObjectInUse(false);
     sdi.setStatus( StepExecutionStatus.STATUS_DISPOSED );
   }
 
@@ -4344,15 +4339,6 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
   @Override
   public boolean isForcingSeparateLogging() {
     return log != null && log.isForcingSeparateLogging();
-  }
-
-  @Override
-  public boolean isLoggingObjectInUse() {
-    return loggingObjectInUse;
-  }
-
-  public void setLoggingObjectInUse( boolean inUse ) {
-    loggingObjectInUse = inUse;
   }
 
   @Override

--- a/plugins/connected-to-repository/impl/src/main/java/org/pentaho/di/job/entries/connectedtorepository/JobEntryConnectedToRepository.java
+++ b/plugins/connected-to-repository/impl/src/main/java/org/pentaho/di/job/entries/connectedtorepository/JobEntryConnectedToRepository.java
@@ -218,7 +218,6 @@ public class JobEntryConnectedToRepository extends JobEntryBase implements Clone
     result.setResult( true );
     result.setNrErrors( 0 );
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/core/impl/src/main/java/org/pentaho/di/job/entries/abort/JobEntryAbort.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/job/entries/abort/JobEntryAbort.java
@@ -151,7 +151,6 @@ public class JobEntryAbort extends JobEntryBase implements Cloneable, JobEntryIn
     // we fail so stop
     // job execution
     parentJob.stopAll();
-    setLoggingObjectInUse( false );
     return previousResult;
   }
 

--- a/plugins/core/impl/src/main/java/org/pentaho/di/job/entries/addresultfilenames/JobEntryAddResultFilenames.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/job/entries/addresultfilenames/JobEntryAddResultFilenames.java
@@ -266,7 +266,6 @@ public class JobEntryAddResultFilenames extends JobEntryBase implements Cloneabl
       result.setNrErrors( nrErrFiles );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/core/impl/src/main/java/org/pentaho/di/job/entries/checkdbconnection/JobEntryCheckDbConnections.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/job/entries/checkdbconnection/JobEntryCheckDbConnections.java
@@ -387,7 +387,6 @@ public class JobEntryCheckDbConnections extends JobEntryBase implements Cloneabl
       logDetailed( "=======================================" );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/dummy/core/src/main/java/org/pentaho/di/pdi/jobentry/dummy/JobEntryDummy.java
+++ b/plugins/dummy/core/src/main/java/org/pentaho/di/pdi/jobentry/dummy/JobEntryDummy.java
@@ -193,7 +193,6 @@ public class JobEntryDummy extends JobEntryBase implements Cloneable, JobEntryIn
       logError( toString(), "Error processing DummyJob : " + e.getMessage() );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/email-messages/impl/src/main/java/org/pentaho/di/job/entries/getpop/JobEntryGetPOP.java
+++ b/plugins/email-messages/impl/src/main/java/org/pentaho/di/job/entries/getpop/JobEntryGetPOP.java
@@ -1072,7 +1072,6 @@ public class JobEntryGetPOP extends JobEntryBase implements Cloneable, JobEntryI
       }
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/export-repository/impl/src/main/java/org/pentaho/di/job/entries/exportrepository/JobEntryExportRepository.java
+++ b/plugins/export-repository/impl/src/main/java/org/pentaho/di/job/entries/exportrepository/JobEntryExportRepository.java
@@ -664,7 +664,6 @@ public class JobEntryExportRepository extends JobEntryBase implements Cloneable,
       result.setResult( true );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/ftp-delete/impl/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
+++ b/plugins/ftp-delete/impl/src/main/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDelete.java
@@ -919,7 +919,6 @@ public class JobEntryFTPDelete extends JobEntryBase implements Cloneable, JobEnt
     result.setNrFilesRetrieved( NrfilesDeleted );
     result.setNrErrors( NrErrors );
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/ftps/impl/src/main/java/org/pentaho/di/job/entries/ftpsget/JobEntryFTPSGet.java
+++ b/plugins/ftps/impl/src/main/java/org/pentaho/di/job/entries/ftpsget/JobEntryFTPSGet.java
@@ -830,7 +830,6 @@ public class JobEntryFTPSGet extends JobEntryBase implements Cloneable, JobEntry
 
     displayResults();
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/ftps/impl/src/main/java/org/pentaho/di/job/entries/ftpsput/JobEntryFTPSPUT.java
+++ b/plugins/ftps/impl/src/main/java/org/pentaho/di/job/entries/ftpsput/JobEntryFTPSPUT.java
@@ -611,7 +611,7 @@ public class JobEntryFTPSPUT extends JobEntryBase implements Cloneable, JobEntry
         }
       }
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/plugins/get-file-sftp/impl/src/main/java/org/pentaho/di/job/entries/sftp/JobEntrySFTP.java
+++ b/plugins/get-file-sftp/impl/src/main/java/org/pentaho/di/job/entries/sftp/JobEntrySFTP.java
@@ -768,7 +768,7 @@ public class JobEntrySFTP extends JobEntryBase implements Cloneable, JobEntryInt
       }
 
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/plugins/get-file-with-ftp/impl/src/main/java/org/pentaho/di/job/entries/ftp/JobEntryFTP.java
+++ b/plugins/get-file-with-ftp/impl/src/main/java/org/pentaho/di/job/entries/ftp/JobEntryFTP.java
@@ -1168,7 +1168,6 @@ public class JobEntryFTP extends JobEntryBase implements Cloneable, JobEntryInte
       result.setResult( false );
     }
     displayResults();
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/hl7/core/src/main/java/org/pentaho/di/job/entries/hl7mllpack/HL7MLLPAcknowledge.java
+++ b/plugins/hl7/core/src/main/java/org/pentaho/di/job/entries/hl7mllpack/HL7MLLPAcknowledge.java
@@ -216,7 +216,6 @@ public class HL7MLLPAcknowledge extends JobEntryBase implements Cloneable, JobEn
       result.setResult( false );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/hl7/core/src/main/java/org/pentaho/di/job/entries/hl7mllpin/HL7MLLPInput.java
+++ b/plugins/hl7/core/src/main/java/org/pentaho/di/job/entries/hl7mllpin/HL7MLLPInput.java
@@ -222,7 +222,6 @@ public class HL7MLLPInput extends JobEntryBase implements Cloneable, JobEntryInt
       result.setResult( false );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/mail-job/impl/src/main/java/org/pentaho/di/job/entries/mail/JobEntryMail.java
+++ b/plugins/mail-job/impl/src/main/java/org/pentaho/di/job/entries/mail/JobEntryMail.java
@@ -1248,7 +1248,6 @@ public class JobEntryMail extends JobEntryBase implements Cloneable, JobEntryInt
       result.setResult( true );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/mail-validator/impl/src/main/java/org/pentaho/di/job/entries/mailvalidator/JobEntryMailValidator.java
+++ b/plugins/mail-validator/impl/src/main/java/org/pentaho/di/job/entries/mailvalidator/JobEntryMailValidator.java
@@ -278,7 +278,6 @@ public class JobEntryMailValidator extends JobEntryBase implements Cloneable, Jo
 
     // return result
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/ms-access/impl/src/main/java/org/pentaho/di/job/entries/msaccessbulkload/JobEntryMSAccessBulkLoad.java
+++ b/plugins/ms-access/impl/src/main/java/org/pentaho/di/job/entries/msaccessbulkload/JobEntryMSAccessBulkLoad.java
@@ -537,7 +537,6 @@ public class JobEntryMSAccessBulkLoad extends JobEntryBase implements Cloneable,
     }
 
     displayResults();
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/msg-box-info/impl/src/main/java/org/pentaho/di/job/entries/msgboxinfo/JobEntryMsgBoxInfo.java
+++ b/plugins/msg-box-info/impl/src/main/java/org/pentaho/di/job/entries/msgboxinfo/JobEntryMsgBoxInfo.java
@@ -158,7 +158,6 @@ public class JobEntryMsgBoxInfo extends JobEntryBase implements Cloneable, JobEn
    */
   public Result execute( Result prev_result, int nr ) {
     prev_result.setResult( evaluate( prev_result ) );
-    setLoggingObjectInUse( false );
     return prev_result;
   }
 

--- a/plugins/palo/core/src/main/java/org/pentaho/di/job/entries/palo/JobEntryCubeCreate/PaloCubeCreate.java
+++ b/plugins/palo/core/src/main/java/org/pentaho/di/job/entries/palo/JobEntryCubeCreate/PaloCubeCreate.java
@@ -170,7 +170,7 @@ public class PaloCubeCreate extends JobEntryBase implements Cloneable, JobEntryI
     } finally {
       database.disconnect();
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/plugins/palo/core/src/main/java/org/pentaho/di/job/entries/palo/JobEntryCubeDelete/PaloCubeDelete.java
+++ b/plugins/palo/core/src/main/java/org/pentaho/di/job/entries/palo/JobEntryCubeDelete/PaloCubeDelete.java
@@ -141,7 +141,7 @@ public class PaloCubeDelete extends JobEntryBase implements Cloneable, JobEntryI
     } finally {
       database.disconnect();
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/plugins/put-a-file-with-ftp/impl/src/main/java/org/pentaho/di/job/entries/ftpput/JobEntryFTPPUT.java
+++ b/plugins/put-a-file-with-ftp/impl/src/main/java/org/pentaho/di/job/entries/ftpput/JobEntryFTPPUT.java
@@ -738,7 +738,7 @@ public class JobEntryFTPPUT extends JobEntryBase implements Cloneable, JobEntryI
 
       FTPClient.clearSOCKS();
     }
-    setLoggingObjectInUse( false );
+
     return result;
   }
 

--- a/plugins/put-file-sftp/impl/src/main/java/org/pentaho/di/job/entries/sftpput/JobEntrySFTPPUT.java
+++ b/plugins/put-file-sftp/impl/src/main/java/org/pentaho/di/job/entries/sftpput/JobEntrySFTPPUT.java
@@ -969,7 +969,6 @@ public class JobEntrySFTPPUT extends JobEntryBase implements Cloneable, JobEntry
       myFileList = null;
     } // end finally
 
-    setLoggingObjectInUse( false );
     return result;
   } // JKU: end function execute()
 

--- a/plugins/xml/core/src/main/java/org/pentaho/di/job/entries/dtdvalidator/JobEntryDTDValidator.java
+++ b/plugins/xml/core/src/main/java/org/pentaho/di/job/entries/dtdvalidator/JobEntryDTDValidator.java
@@ -171,7 +171,6 @@ public class JobEntryDTDValidator extends JobEntryBase implements Cloneable, Job
       result.setLogText( validator.getErrorMessage() );
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/xml/core/src/main/java/org/pentaho/di/job/entries/xmlwellformed/JobEntryXMLWellFormed.java
+++ b/plugins/xml/core/src/main/java/org/pentaho/di/job/entries/xmlwellformed/JobEntryXMLWellFormed.java
@@ -320,7 +320,6 @@ public class JobEntryXMLWellFormed extends JobEntryBase implements Cloneable, Jo
 
     displayResults();
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/xml/core/src/main/java/org/pentaho/di/job/entries/xsdvalidator/JobEntryXSDValidator.java
+++ b/plugins/xml/core/src/main/java/org/pentaho/di/job/entries/xsdvalidator/JobEntryXSDValidator.java
@@ -256,7 +256,6 @@ public class JobEntryXSDValidator extends JobEntryBase implements Cloneable, Job
       }
     }
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/plugins/xml/core/src/main/java/org/pentaho/di/job/entries/xslt/JobEntryXSLT.java
+++ b/plugins/xml/core/src/main/java/org/pentaho/di/job/entries/xslt/JobEntryXSLT.java
@@ -413,7 +413,6 @@ public class JobEntryXSLT extends JobEntryBase implements Cloneable, JobEntryInt
     result.setNrErrors( NrErrors );
     result.setNrLinesWritten( NrSuccess );
 
-    setLoggingObjectInUse( false );
     return result;
   }
 

--- a/ui/src/main/java/org/pentaho/di/ui/core/dialog/Splash.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/dialog/Splash.java
@@ -85,7 +85,7 @@ public class Splash {
   }
 
   protected Splash( Display display, Shell splashShell ) {
-    log = new LogChannel( Spoon.APP_NAME, false, false );
+    log = new LogChannel( Spoon.APP_NAME );
 
     Rectangle displayBounds = display.getPrimaryMonitor().getBounds();
 

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -771,7 +771,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   public Spoon( Repository rep ) {
     super( null );
     this.addMenuBar();
-    log = new LogChannel( APP_NAME, false, false );
+    log = new LogChannel( APP_NAME );
     SpoonFactory.setSpoonInstance( this );
 
     props = PropsUI.getInstance();
@@ -8238,7 +8238,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
 
     // start with the default logger until we find out otherwise
     //
-    log = new LogChannel( APP_NAME, false, false );
+    log = new LogChannel( APP_NAME );
 
     // Parse the options...
     if ( !CommandLineOption.parseArguments( args, clOptions, log ) ) {


### PR DESCRIPTION
Backport of [pentaho-kettle#9413](https://github.com/pentaho/pentaho-kettle/pull/9413)

Please note that PDI-20056 did not enter 10.1 GA, as so, the backport is only for the development under PDI-20038 and PDI-19712!

@pentaho/tatooine_dev @rmansoor @peterrinehart 