### PR TITLE
[BACKLOG-41085] add-opens for purge-utility on JDK17

### DIFF
--- a/assemblies/static/src/main/resources-filtered/purge-utility.bat
+++ b/assemblies/static/src/main/resources-filtered/purge-utility.bat
@@ -26,4 +26,11 @@ setlocal
 cd /D %~dp0
 call "%~dp0set-pentaho-env.bat"
 
-"%_PENTAHO_JAVA%" -Xmx2048m -classpath "%~dp0plugins\pdi-pur-plugin\*;%~dp0lib\*;%~dp0classes" com.pentaho.di.purge.RepositoryCleanupUtil %*
+set JAVA_ADD_OPENS=
+set "JAVA_ADD_OPENS=%JAVA_ADD_OPENS% --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"
+set "JAVA_ADD_OPENS=%JAVA_ADD_OPENS% --add-opens=java.base/java.lang=ALL-UNNAMED"
+set "JAVA_ADD_OPENS=%JAVA_ADD_OPENS% --add-opens=java.base/java.net=ALL-UNNAMED"
+set "JAVA_ADD_OPENS=%JAVA_ADD_OPENS% --add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED"
+set "JAVA_ADD_OPENS=%JAVA_ADD_OPENS% --add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED"
+
+"%_PENTAHO_JAVA%" %JAVA_ADD_OPENS% -Xmx2048m -classpath "%~dp0plugins\pdi-pur-plugin\*;%~dp0lib\*;%~dp0classes" com.pentaho.di.purge.RepositoryCleanupUtil %*

--- a/assemblies/static/src/main/resources-filtered/purge-utility.sh
+++ b/assemblies/static/src/main/resources-filtered/purge-utility.sh
@@ -30,6 +30,13 @@ DIR=`pwd`
 . "$DIR/set-pentaho-env.sh"
 setPentahoEnv
 
+JAVA_ADD_OPENS=""
+JAVA_ADD_OPENS="$JAVA_ADD_OPENS --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"
+JAVA_ADD_OPENS="$JAVA_ADD_OPENS --add-opens=java.base/java.lang=ALL-UNNAMED"
+JAVA_ADD_OPENS="$JAVA_ADD_OPENS --add-opens=java.base/java.net=ALL-UNNAMED"
+JAVA_ADD_OPENS="$JAVA_ADD_OPENS --add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED"
+JAVA_ADD_OPENS="$JAVA_ADD_OPENS --add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED"
+
 # uses Java 6 classpath wildcards
 # quotes required around classpath to prevent shell expansion
-"$_PENTAHO_JAVA" -Xmx2048m -classpath "$DIR/plugins/pdi-pur-plugin/*:$DIR/lib/*:$DIR/classes" com.pentaho.di.purge.RepositoryCleanupUtil "$@"
+"$_PENTAHO_JAVA" $JAVA_ADD_OPENS -Xmx2048m -classpath "$DIR/plugins/pdi-pur-plugin/*:$DIR/lib/*:$DIR/classes" com.pentaho.di.purge.RepositoryCleanupUtil "$@"


### PR DESCRIPTION
Needs more than just `sun.net.www.protocol.jar` because OSGI needs to be able to start up if that's there