### PR TITLE
[BACKLOG-40519] Display the database connection in the UI based on th…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/bowl/Bowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/Bowl.java
@@ -18,6 +18,8 @@ package org.pentaho.di.core.bowl;
 
 import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.shared.SharedObjectsIO;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.api.IMetaStore;
@@ -72,6 +74,14 @@ public interface Bowl {
    * @return Set&lt;Bowl&gt; A set of Parent Bowls. Should not be null.
    */
   Set<Bowl> getParentBowls();
+
+  /**
+   * Get the SharedObjectIO instance that is responsible for reading/writing of
+   *  Shared Objects
+   * @return
+   *
+   */
+  SharedObjectsIO getSharedObjectsIO() ;
 
   /**
    * Get a default variable space using this Bowl's context. Everytime you will get a new instance.

--- a/core/src/main/java/org/pentaho/di/core/bowl/DefaultBowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/DefaultBowl.java
@@ -18,9 +18,12 @@ package org.pentaho.di.core.bowl;
 
 import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.metastore.MetaStoreConst;
+import org.pentaho.di.shared.SharedObjectsIO;
+import org.pentaho.di.shared.VfsSharedObjectsIO;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.api.IMetaStore;
 
@@ -37,6 +40,8 @@ public class DefaultBowl extends BaseBowl {
   // for testing
   private Supplier<IMetaStore> metastoreSupplier = MetaStoreConst.getDefaultMetastoreSupplier();
   private boolean customSupplier = false;
+
+  private SharedObjectsIO sharedObjectsIO;
 
   private DefaultBowl() {
   }
@@ -78,5 +83,16 @@ public class DefaultBowl extends BaseBowl {
     this.customSupplier = true;
   }
 
+  /**
+   * Creates and return an instance of SharedObjectsIO using the default shared objects file location
+   * @return SharedObjectsIO
+   */
+  @Override
+  public SharedObjectsIO getSharedObjectsIO()  {
+    if ( sharedObjectsIO == null ) {
+      sharedObjectsIO = new VfsSharedObjectsIO();
+    }
+    return sharedObjectsIO;
+  }
 
 }

--- a/core/src/main/java/org/pentaho/di/shared/SharedObjectsIO.java
+++ b/core/src/main/java/org/pentaho/di/shared/SharedObjectsIO.java
@@ -1,0 +1,86 @@
+/*!
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.pentaho.di.shared;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.w3c.dom.Node;
+
+/**
+ * This interface provide methods to retrieve and save the shared objects defined in shared.xml irrespective of
+ * where the shared objects are persisted.
+ */
+public interface SharedObjectsIO {
+
+  public enum SharedObjectType {
+    CONNECTION( "connection" ),
+    SLAVESERVER( "slaveserver" ),
+    PARTITIONSCHEMA( "partitionschema" ),
+    CLUSTERSCHEMA( "clusterschema" );
+
+    private final String name;
+
+    SharedObjectType( String name ) {
+      this.name = name;
+    }
+    public String getName() {
+      return name;
+    }
+  }
+
+  /**
+   * Get the collection of SharedObjects of the given type
+   * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
+   * @return Map<String,Node>  The collection of name of sharedObject and the Xml Node containing the details. For example,
+   *                            {"my-postgres", node} where  my-postgres is the name of
+   *                            the type - database connection and the Node is xml node containing the details of the db connection.
+   * @throws KettleXMLException
+   */
+  Map<String, Node> getSharedObjects( String type ) throws KettleXMLException;
+
+  /**
+   * Save the SharedObject node for the type and name.
+   * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
+   * @param name The name is the name of the sharedObject
+   * @param node The Xml node containing the details of the shared object
+   * @throws IOException
+   * @throws KettleException
+   */
+  void saveSharedObject( String type, String name, Node node ) throws IOException, KettleException;
+
+  /**
+   * Return the Shared Object Node for the given type and name
+   * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
+   * @param name The name is the name of the sharedObject
+   * @return Xml node
+   * @throws KettleXMLException
+   */
+  Node getSharedObject( String type, String name ) throws KettleXMLException;
+
+  /**
+   * Delete the SharedObject for the given type and name
+   * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
+   * @param name The name is the name of the sharedObject
+   * @throws KettleXMLException
+   */
+  void delete( String type, String name ) throws KettleXMLException;
+
+}

--- a/core/src/main/java/org/pentaho/di/shared/VfsSharedObjectsIO.java
+++ b/core/src/main/java/org/pentaho/di/shared/VfsSharedObjectsIO.java
@@ -1,0 +1,323 @@
+/*!
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.pentaho.di.shared;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.util.Utils;
+import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.i18n.BaseMessages;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Provide methods to retrieve and save the shared objects defined in shared.xml that is stored in file system.
+ *
+ */
+public class VfsSharedObjectsIO implements SharedObjectsIO {
+  private static Class<?> PKG = VfsSharedObjectsIO.class; // for i18n purposes, needed by Translator2!!
+  private static final Logger log = LoggerFactory.getLogger( VfsSharedObjectsIO.class );
+
+  String sharedObjectFile;
+  String rootFolder;
+  private static final String XML_TAG = "sharedobjects";
+  // Type specific map.
+  private Map<String, Node> connectionsNodes = new HashMap<>();
+  private Map<String, Node> slaveServersNodes = new HashMap<>();
+  private Map<String, Node> partitionSchemaNodes = new HashMap<>();
+  private Map<String, Node> clusterSchemaNodes = new HashMap<>();
+
+  private boolean isInitialized = false;
+
+  /**
+   * Creates the instance of VfsSharedObjectsIO using the default location of the shared file.
+   *
+   */
+  public VfsSharedObjectsIO() {
+    this( getDefaultSharedObjectFileLocation() );
+  }
+
+  /**
+   * Creates the instance of VfsSharedObjectsIO using the rootFolder.
+   *
+   * @param rootFolder the root folder containing the shared object file.
+   */
+  public VfsSharedObjectsIO( String rootFolder ) {
+    this.rootFolder = rootFolder;
+  }
+
+
+  /**
+   * Return the Map of names and the corresponding nodes for the given shared object type.
+   * The parsing of shared.xml happens when this method is called.
+   * @param type
+   * @return Map<String, Node>
+   * @throws KettleXMLException
+   */
+  public synchronized Map<String, Node> getSharedObjects( String type ) throws KettleXMLException {
+    if ( !isInitialized ) {
+      // Load the shared.xml file
+      loadSharedObjectNodeMap( rootFolder );
+      isInitialized = true;
+    }
+    return getNodesMapForType( type );
+  }
+
+  /**
+   * Loads the shared objects in the map. The map will be of the form <String, Node>
+   * where key can be {"connection", "slaveserver", "partitionschema" or  clusterschema"} and
+   * value will be xml Node.
+   *
+   * @param rootFolder The path to the shared object file
+   * @throws KettleXMLException
+   */
+  private void loadSharedObjectNodeMap( String rootFolder ) throws KettleXMLException {
+    // Get the complete path to shared.xml
+    this.sharedObjectFile = getSharedObjectFilePath( rootFolder );
+
+    try {
+      // Get the FileObject
+      FileObject file = KettleVFS.getFileObject( sharedObjectFile );
+
+      // If we have a shared file, load the content, otherwise, just keep this one empty
+      if ( file.exists() ) {
+        Document document = XMLHandler.loadXMLFile( file );
+        Node sharedObjectsNode = XMLHandler.getSubNode( document, XML_TAG );
+        if ( sharedObjectsNode != null ) {
+          NodeList childNodes = sharedObjectsNode.getChildNodes();
+          for ( int i = 0; i < childNodes.getLength(); i++ ) {
+            Node node = childNodes.item( i );
+
+            String nodeName = node.getNodeName();
+            // add the node to the map
+            addNodeToMap( nodeName, node );
+
+          }
+        }
+      }
+    } catch ( Exception e ) {
+      throw new KettleXMLException( BaseMessages.getString( PKG, "SharedOjects.ReadingError",
+        sharedObjectFile ), e );
+    }
+
+  }
+
+  private void addNodeToMap( String type, Node node ) throws KettleXMLException {
+    String tagName = XMLHandler.getTagValue( node, "name" );
+    if ( !Utils.isEmpty( tagName ) ) {
+      log.info( " Checking if connection exist  " + SharedObjectType.valueOf( type.toUpperCase() ) );
+      getNodesMapForType( type ).put( tagName, node );
+    }
+  }
+
+  /**
+   * Return the complete path to the shared.xml. If the given path is blank,
+   * it returns the default location of file.
+   * @param path the root folder for shared object file
+   * @return
+   */
+  private static final String getSharedObjectFilePath( String path ) {
+    String filename = path;
+    if ( Utils.isEmpty( path ) ) {
+      filename = getDefaultSharedObjectFileLocation();
+    } else if ( !path.endsWith( Const.SHARED_DATA_FILE ) ) {
+      filename = path + File.separator + Const.SHARED_DATA_FILE;
+    }
+    return filename;
+  }
+
+  /**
+   * Returns the default location of shared.xml. If checks the kettle environment varibale and if that is not set
+   * retruns the location in user's home folder.
+   * @return String
+   */
+  private static String  getDefaultSharedObjectFileLocation() {
+    // First fallback is the environment/kettle variable ${KETTLE_SHARED_OBJECTS}
+    // This points to the file
+    String filename = Variables.getADefaultVariableSpace().getVariable( Const.KETTLE_SHARED_OBJECTS );
+
+    // Last line of defence...
+    if ( Utils.isEmpty( filename ) ) {
+      filename = Const.getSharedObjectsFile();
+    }
+    return filename;
+  }
+  /**
+   * Save the name and the node for the given Shared Object Type in the file
+   * @param type The SharedObject type
+   * @param name The name of the SharedObject for a given type
+   * @param node The xml node that containing the details of the SharedObject
+   * @throws IOException
+   * @throws KettleException
+   */
+  public void saveSharedObject( String type, String name, Node node ) throws IOException, KettleException {
+    // Find the map for the type
+    Map<String, Node> nodeMap = getNodesMapForType( type );
+    if ( nodeMap.containsKey( name ) ) {
+      // Update the map entry for this name
+      nodeMap.put( name, node );
+
+      FileObject fileObject = KettleVFS.getFileObject( sharedObjectFile );
+      Optional<String> backupFileName = createOrGetFileBackup( fileObject );
+      writeToFile( fileObject, backupFileName );
+      isInitialized = false;
+    }
+    // TODO need to handle the case when the new shared object is being added
+  }
+
+  protected void writeToFile( FileObject fileObject, Optional<String> backupFileName ) throws IOException, KettleException {
+    try ( OutputStream outputStream = KettleVFS.getOutputStream( fileObject, false );
+         PrintStream out = new PrintStream( outputStream ) ) {
+
+      out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
+      out.println( "<" + XML_TAG + ">" );
+
+      // Write the different SharedObject Types nodes to string
+      out.println( toString( connectionsNodes ) );
+      out.println( toString( slaveServersNodes ) );
+      out.println( toString( partitionSchemaNodes ) );
+      out.println( toString( clusterSchemaNodes ) );
+
+      out.println( "</" + XML_TAG + ">" );
+    } catch ( Exception e ) {
+      // restore file if something wrong
+      boolean isRestored = false;
+      if ( backupFileName.isPresent() ) {
+        restoreFileFromBackup( backupFileName.get() );
+        isRestored = true;
+      }
+      throw new KettleException( BaseMessages.getString( PKG, "SharedOjects.ErrorWritingFile", isRestored ), e );
+    }
+  }
+
+  private Optional<String> createOrGetFileBackup( FileObject fileObject ) throws IOException, KettleException {
+    String backupFileName = sharedObjectFile + ".backup";
+    boolean isBackupFileExist;
+    if ( fileObject.exists() ) {
+      isBackupFileExist = createFileBackup( backupFileName );
+    } else {
+      isBackupFileExist = getBackupFileFromFileSystem( backupFileName );
+    }
+    return isBackupFileExist ? Optional.ofNullable( backupFileName ) : Optional.empty();
+  }
+
+  private boolean createFileBackup( String backupFileName ) throws IOException, KettleFileException {
+    return copyFile( sharedObjectFile, backupFileName );
+  }
+
+  protected void restoreFileFromBackup( String backupFileName ) throws IOException, KettleFileException {
+    copyFile( backupFileName, sharedObjectFile );
+  }
+
+  private boolean getBackupFileFromFileSystem( String backupFileName ) throws KettleException {
+    FileObject fileObject = KettleVFS.getFileObject( backupFileName );
+    try {
+      return fileObject.exists();
+    } catch ( FileSystemException e ) {
+      return false;
+    }
+  }
+
+  private boolean copyFile( String src, String dest ) throws KettleFileException, IOException {
+    FileObject srcFile = KettleVFS.getFileObject( src );
+    FileObject destFile = KettleVFS.getFileObject( dest );
+    try ( InputStream in = KettleVFS.getInputStream( srcFile );
+         OutputStream out = KettleVFS.getOutputStream( destFile, false ) ) {
+      IOUtils.copy( in, out );
+    }
+    return true;
+  }
+
+  /**
+   * Return the node for the given SharedObject type and name.
+   * @param type
+   * @param name
+   * @return
+   * @throws KettleXMLException
+   */
+  public Node getSharedObject( String type, String name ) throws KettleXMLException {
+    // Get the Map using the type
+    Map<String, Node> nodeMap = getNodesMapForType( type );
+    return nodeMap.get( name );
+  }
+
+  public void delete( String type, String name ) throws KettleXMLException {
+    // Get the nodeMap for the type
+    Map<String, Node> nodeTypeMap = getNodesMapForType( type );
+    Node removedNode = nodeTypeMap.remove( name );
+  }
+
+  private Map<String, Node> getNodesMapForType( String type ) throws KettleXMLException {
+    // change the type to uppercase so we can convert it to SharedObjectType
+    return getNodesMapForType( SharedObjectType.valueOf( type.toUpperCase() ) );
+  }
+
+  private Map<String, Node> getNodesMapForType( SharedObjectType type ) throws KettleXMLException {
+    Map<String, Node> nodeMap = new HashMap();
+    switch ( type ) {
+      case CONNECTION:
+        nodeMap = connectionsNodes;
+        break;
+      case SLAVESERVER:
+        nodeMap = slaveServersNodes;
+        break;
+      case PARTITIONSCHEMA:
+        nodeMap = partitionSchemaNodes;
+        break;
+      case CLUSTERSCHEMA:
+        nodeMap = clusterSchemaNodes;
+        break;
+      default:
+        // unsupported type
+        log.error( " Invalid Shared Object type " + type );
+        throw new KettleXMLException( "Invalid shared object type " + type );
+    }
+    return nodeMap;
+  }
+
+  protected String toString( Map<String, Node> nodesMap ) throws KettleXMLException {
+    StringBuilder xml = new StringBuilder();
+    // Loop through the nodes objects from the map
+    Collection<Node> collection = nodesMap.values();
+    for ( Node node : collection ) {
+      xml.append( XMLHandler.formatNode( node ) );
+    }
+    return xml.toString();
+  }
+
+}

--- a/core/src/test/java/org/pentaho/di/connections/vfs/provider/ConnectionFileProviderTest.java
+++ b/core/src/test/java/org/pentaho/di/connections/vfs/provider/ConnectionFileProviderTest.java
@@ -41,6 +41,7 @@ import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.IKettleVFS;
 import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.shared.SharedObjectsIO;
 import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.stores.memory.MemoryMetaStore;
 
@@ -102,10 +103,16 @@ public class ConnectionFileProviderTest {
       @Override
       public VariableSpace getADefaultVariableSpace() {
         return null;
+
       }
       @Override
       public Set<Bowl> getParentBowls() {
         return Collections.emptySet();
+      }
+
+      @Override
+      public SharedObjectsIO getSharedObjectsIO() {
+        return null;
       }
     };
   }

--- a/core/src/test/java/org/pentaho/di/shared/VfsSharedObjectsIOTest.java
+++ b/core/src/test/java/org/pentaho/di/shared/VfsSharedObjectsIOTest.java
@@ -1,0 +1,57 @@
+package org.pentaho.di.shared;
+
+import org.apache.commons.vfs2.FileObject;
+import org.junit.Test;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.w3c.dom.Node;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class VfsSharedObjectsIOTest {
+  private static final String ROOT_FILE_PATH = "ram:///config";
+  private static final String SHARED_FILE = "shared.xml";
+  private static final String CONN_STR = "<?xml version=\"1.0\" encoding=\"UTF-8\"?> <sharedobjects> "
+                  + " <connection> <name>postgres-docker</name> <server>localhost</server> <type>POSTGRESQL</type> "
+                  +  " <access>Native</access> <database>sampledata</database> <port>5435</port> <username>postgres</username> "
+                  +  " </connection> </sharedobjects>";
+
+  @Test
+  public void testGetSharedObjects()  throws Exception {
+    // Prepare the test shared.xml
+    FileObject projectDirectory = KettleVFS.getFileObject( ROOT_FILE_PATH );
+    projectDirectory.createFolder();
+
+    FileObject sharedFile = projectDirectory.resolveFile( SHARED_FILE );
+
+    try ( OutputStream outputStream = sharedFile.getContent().getOutputStream() ) {
+      outputStream.write( CONN_STR.getBytes( StandardCharsets.UTF_8 ) );
+    }
+
+    SharedObjectsIO sharedObjectsIO = new VfsSharedObjectsIO( ROOT_FILE_PATH );
+    Map<String, Node> nodesMap = sharedObjectsIO.getSharedObjects( "connection" );
+    assertEquals( 1, nodesMap.size() );
+
+    //Get the key
+    Map.Entry<String, Node> entry = nodesMap.entrySet().iterator().next();
+    String key = entry.getKey();
+    Node node = entry.getValue();
+    assertEquals( "postgres-docker", key );
+    validateNode( node );
+
+    // close the file
+    sharedFile.close();
+  }
+  private void validateNode( Node node ) {
+    assertEquals( "localhost", XMLHandler.getTagValue( node, "server" ) );
+    assertEquals( "POSTGRESQL", XMLHandler.getTagValue( node, "type" ) );
+    assertEquals( "Native", XMLHandler.getTagValue( node, "access" ) );
+    assertEquals( "5435", XMLHandler.getTagValue( node, "port" ) );
+    assertEquals( "postgres", XMLHandler.getTagValue( node, "username" ) );
+  }
+}

--- a/core/src/test/resources/org/pentaho/di/shared/messages_en_US.properties
+++ b/core/src/test/resources/org/pentaho/di/shared/messages_en_US.properties
@@ -1,0 +1,2 @@
+SharedOjects.ErrorWritingFile=Can\u2019t write shared.xml file. Is file restored from backup: {0}
+SharedOjects.ReadingError=Unexpected problem reading shared objects from XML file \: {0}

--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -39,6 +39,7 @@ import org.pentaho.di.core.bowl.HasBowlInterface;
 import org.pentaho.di.core.changed.ChangedFlag;
 import org.pentaho.di.core.changed.ChangedFlagInterface;
 import org.pentaho.di.core.changed.PDIObserver;
+import org.pentaho.di.core.database.Database;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettlePluginException;
@@ -251,11 +252,9 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
    **/
   protected Set<String> privateDatabases;
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see org.pentaho.di.repository.RepositoryElementInterface#getObjectId()
-   */
+  /** Needed to display the local Database connections in configuration pane in UI*/
+  protected Map<String, DatabaseMeta> localDbMetas = new HashMap();
+
   @Override
   public ObjectId getObjectId() {
     return objectId;
@@ -2178,4 +2177,7 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
     this.metaFileCache = metaFileCache;
   }
 
+  public List<DatabaseMeta> getLocalDbMetas() {
+    return new ArrayList<>( localDbMetas.values());
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/core/KettleEnvironment.java
+++ b/engine/src/main/java/org/pentaho/di/core/KettleEnvironment.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2024 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -25,6 +25,7 @@ package org.pentaho.di.core;
 import com.google.common.util.concurrent.SettableFuture;
 import org.pentaho.di.core.auth.AuthenticationConsumerPluginType;
 import org.pentaho.di.core.auth.AuthenticationProviderPluginType;
+import org.pentaho.di.core.bowl.BowlManagerFactoryRegistry;
 import org.pentaho.di.core.compress.CompressionPluginType;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettlePluginException;
@@ -47,6 +48,7 @@ import org.pentaho.di.core.plugins.StepPluginType;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.IUser;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.shared.DatabaseConnectionManager;
 import org.pentaho.di.trans.step.RowDistributionPluginType;
 
 import java.util.Arrays;
@@ -152,6 +154,9 @@ public class KettleEnvironment {
         // Update Variables for LoggingRegistry
         LoggingRegistry.getInstance().updateFromProperties();
 
+        // Registering the Shared Objects Managers to Bowl
+        registerSharedObjectManagersWithBowl();
+
         // Schedule the purge timer task
         LoggingRegistry.getInstance().schedulePurgeTimer();
 
@@ -255,5 +260,13 @@ public class KettleEnvironment {
     KettleClientEnvironment.reset();
     LoggingRegistry.getInstance().reset();
     initialized.set( null );
+  }
+
+  /**
+   * Registers the SharedObject type specific factory with the Bowl factory registry.
+   */
+  private static void registerSharedObjectManagersWithBowl(){
+    BowlManagerFactoryRegistry.getInstance().registerManagerFactory( DatabaseConnectionManager.class,
+                        new DatabaseConnectionManager.DbConnectionManagerFactory() );
   }
 }

--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -1013,6 +1013,7 @@ public class JobMeta extends AbstractMeta
         dbcon.shareVariablesWith( this );
         if ( !dbcon.isShared() ) {
           privateDatabases.add( dbcon.getName() );
+          localDbMetas.put( dbcon.getName(), dbcon );
         }
 
         DatabaseMeta exist = findDatabase( dbcon.getName() );

--- a/engine/src/main/java/org/pentaho/di/shared/DatabaseConnectionManager.java
+++ b/engine/src/main/java/org/pentaho/di/shared/DatabaseConnectionManager.java
@@ -1,0 +1,81 @@
+/*!
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.pentaho.di.shared;
+
+import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.bowl.ManagerFactory;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class uses the SharedObjectIO to retrieve and save shared objects. This is used by the UI.
+ */
+public class DatabaseConnectionManager {
+
+  private SharedObjectsIO sharedObjectIO;
+  private Map<String, DatabaseMeta> dbMetas = new HashMap<>();
+
+  private Bowl bowl;
+
+  public static DatabaseConnectionManager getInstance( Bowl bowl ) throws KettleXMLException {
+    return new DatabaseConnectionManager( bowl );
+  }
+  private DatabaseConnectionManager( Bowl bowl ) throws KettleXMLException {
+    this.bowl = bowl;
+    this.sharedObjectIO = bowl.getSharedObjectsIO();
+  }
+
+
+  public List<DatabaseMeta> getDatabases() throws KettleXMLException {
+    Map<String, Node> nodeMap = sharedObjectIO.getSharedObjects( String.valueOf( SharedObjectsIO.SharedObjectType.CONNECTION ) );
+    populateDbMetaMap( nodeMap );
+
+    return new ArrayList<>( dbMetas.values() );
+
+  }
+
+  private void populateDbMetaMap( Map<String, Node> nodesMap ) throws KettleXMLException {
+    Map<String, DatabaseMeta> metaMap = new HashMap<>();
+    for ( String name : nodesMap.keySet() ) {
+      DatabaseMeta dbMeta = new DatabaseMeta( nodesMap.get( name ) );
+      if ( !metaMap.containsKey( name ) ) {
+        metaMap.put( name, dbMeta );
+      }
+    }
+    this.dbMetas = metaMap;
+
+  }
+
+  /**
+   * Factory for the DatabaseConnectionManager. This factory class is registered with BowlFactory registry
+   * during the initialization in KettleEnvironment
+   */
+  public static class DbConnectionManagerFactory implements ManagerFactory<DatabaseConnectionManager> {
+    public DatabaseConnectionManager apply( Bowl bowl ) throws KettleException {
+      return DatabaseConnectionManager.getInstance( bowl );
+    }
+  }
+
+}

--- a/engine/src/main/java/org/pentaho/di/shared/DelegatingShareObjectsIO.java
+++ b/engine/src/main/java/org/pentaho/di/shared/DelegatingShareObjectsIO.java
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.pentaho.di.shared;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.w3c.dom.Node;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DelegatingShareObjectsIO implements SharedObjectsIO {
+
+  List<SharedObjectsIO> sharedObjectsIOList;
+  public DelegatingShareObjectsIO( SharedObjectsIO... sharedObjectsIOs ) {
+    this.sharedObjectsIOList = new ArrayList<>( Arrays.asList( sharedObjectsIOs ) );
+  }
+
+  @Override
+  public Map<String, Node> getSharedObjects( String type ) throws KettleXMLException {
+    Map<String, Node> sharedObjectNodes = new HashMap<>();
+    for ( SharedObjectsIO sharedObjectIO : sharedObjectsIOList ) {
+      Map<String, Node> localSharedObjectNodes = sharedObjectIO.getSharedObjects( type );
+      for ( String key: localSharedObjectNodes.keySet() ) {
+        // Add only the keys that was not previously added
+        if ( !sharedObjectNodes.containsKey( key ) ) {
+          sharedObjectNodes.put( key, localSharedObjectNodes.get( key ) );
+        }
+      }
+    }
+    return sharedObjectNodes;
+  }
+
+  @Override
+  public void saveSharedObject( String type, String name, Node node ) throws IOException, KettleException {
+    // read-only operation
+  }
+
+  @Override
+  public Node getSharedObject( String type, String name ) throws KettleXMLException {
+    Map<String, Node> sharedObjectsNodes = getSharedObjects( type );
+    return sharedObjectsNodes.get( name );
+  }
+
+  @Override
+  public void delete( String type, String name ) throws KettleXMLException {
+    // read-only operation
+  }
+}

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -3044,6 +3044,7 @@ public class TransMeta extends AbstractMeta
           dbcon.shareVariablesWith( this );
           if ( !dbcon.isShared() ) {
             privateTransformationDatabases.add( dbcon.getName() );
+            localDbMetas.put(dbcon.getName(), dbcon );
           }
 
           DatabaseMeta exist = findDatabase( dbcon.getName() );

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshDbConnectionsSubtreeTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshDbConnectionsSubtreeTest.java
@@ -22,21 +22,27 @@
 
 package org.pentaho.di.ui.spoon;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.pentaho.di.base.AbstractMeta;
+import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.shared.DatabaseConnectionManager;
 import org.pentaho.di.ui.core.gui.GUIResource;
 import org.pentaho.di.ui.core.widget.tree.TreeNode;
 import org.pentaho.di.ui.spoon.tree.provider.DBConnectionFolderProvider;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 /**
@@ -46,17 +52,49 @@ public class SpoonRefreshDbConnectionsSubtreeTest {
 
   private DBConnectionFolderProvider dbConnectionFolderProvider;
   private TreeNode treeNode;
+  private Spoon mockSpoon;
+  private GUIResource mockGuiResource;
+  private DatabaseConnectionManager mockDbManager;
+  private DefaultBowl mockDefaultBowl;
+  private MockedStatic<Spoon> spoonMockedStatic;
+  private MockedStatic<GUIResource> guiResourceMockedStatic;
+  private MockedStatic<DefaultBowl> defaultBowlMockedStatic;
 
   @Before
   public void setUp() throws Exception {
-    GUIResource guiResource = mock( GUIResource.class );
-    Spoon spoon = mock( Spoon.class );
-    dbConnectionFolderProvider = new DBConnectionFolderProvider( guiResource, spoon );
+    mockGuiResource = mock( GUIResource.class );
+    mockSpoon = mock( Spoon.class );
+    mockDefaultBowl = mock( DefaultBowl.class );
+
+    spoonMockedStatic = mockStatic( Spoon.class );
+    guiResourceMockedStatic = mockStatic( GUIResource.class );
+    defaultBowlMockedStatic = mockStatic( DefaultBowl.class );
+
+    when( Spoon.getInstance() ).thenReturn( mockSpoon );
+    when( GUIResource.getInstance() ).thenReturn( mockGuiResource );
+    when( DefaultBowl.getInstance() ).thenReturn( mockDefaultBowl );
+
+    mockDbManager = mock( DatabaseConnectionManager.class );
+    dbConnectionFolderProvider = new DBConnectionFolderProvider( mockGuiResource, mockSpoon );
+
     treeNode = new TreeNode();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    when( mockDefaultBowl.getManager( DatabaseConnectionManager.class ) ).thenReturn( mockDbManager );
   }
 
-  private void callRefreshWith( AbstractMeta meta, String filter ) {
-    dbConnectionFolderProvider.refresh( Optional.of( meta ), treeNode, filter );
+  @After
+  public void tearDown() {
+    spoonMockedStatic.close();
+    guiResourceMockedStatic.close();
+    defaultBowlMockedStatic.close();
+  }
+
+  private void callRefreshWith( AbstractMeta meta, String filter ) throws Exception {
+    if ( meta == null ) {
+      dbConnectionFolderProvider.refresh( Optional.empty(), treeNode, filter );
+    } else {
+      dbConnectionFolderProvider.refresh( Optional.of( meta ), treeNode, filter );
+    }
   }
 
   private void verifyNumberOfNodesCreated( int times ) {
@@ -64,27 +102,29 @@ public class SpoonRefreshDbConnectionsSubtreeTest {
   }
 
   @Test
-  public void noConnectionsExist() {
-    AbstractMeta meta = mock( AbstractMeta.class );
-    when( meta.getDatabases() ).thenReturn( Collections.<DatabaseMeta>emptyList() );
-
-    callRefreshWith( meta, null );
+  public void noConnectionsExist() throws Exception {
+    DatabasesCollector dbCollector = new DatabasesCollector( prepareDbManager( null ), prepareMeta( null ), null );
+    Assert.assertEquals( 0, dbCollector.getDatabaseNames().size() );
+    callRefreshWith( null, null );
     // one call - to create a parent tree node
     verifyNumberOfNodesCreated( 0 );
   }
 
   @Test
-  public void severalConnectionsExist() {
+  public void severalConnectionsExist() throws Exception {
     AbstractMeta meta = prepareMetaWithThreeDbs();
-
+    DatabaseConnectionManager mgr = prepareDbManager( mockDatabaseMeta( "mysql" ), mockDatabaseMeta( "oracle" ) );
+    DatabasesCollector dbCollector = new DatabasesCollector( mgr, meta, null );
+    Assert.assertEquals( 5, dbCollector.getDatabaseNames().size() );
     callRefreshWith( meta, null );
-    verifyNumberOfNodesCreated( 3 );
+    verifyNumberOfNodesCreated( 5 );
   }
 
   @Test
-  public void onlyOneMatchesFiltering() {
+  public void onlyOneMatchesFiltering() throws Exception {
     AbstractMeta meta = prepareMetaWithThreeDbs();
-
+    DatabasesCollector dbCollector = new DatabasesCollector( prepareDbManager( null ), meta, null );
+    Assert.assertEquals( 3, dbCollector.getDatabaseNames().size() );
     callRefreshWith( meta, "2" );
     verifyNumberOfNodesCreated( 1 );
   }
@@ -94,7 +134,7 @@ public class SpoonRefreshDbConnectionsSubtreeTest {
     AbstractMeta meta = mock( AbstractMeta.class );
     List<DatabaseMeta> dbs =
             asList( mockDatabaseMeta( "1" ), mockDatabaseMeta( "2" ), mockDatabaseMeta( "3" ) );
-    when( meta.getDatabases() ).thenReturn( dbs );
+    when( meta.getLocalDbMetas() ).thenReturn( dbs );
     return meta;
   }
 
@@ -103,5 +143,25 @@ public class SpoonRefreshDbConnectionsSubtreeTest {
     when( mock.getName() ).thenReturn( name );
     when( mock.getDisplayName() ).thenReturn( name );
     return mock;
+  }
+  private DatabaseConnectionManager prepareDbManager( DatabaseMeta... metas ) throws KettleException {
+    if ( metas == null ) {
+      metas = new DatabaseMeta[ 0 ];
+    }
+
+    List<DatabaseMeta> dbs = asList( metas );
+    when( mockDbManager.getDatabases() ).thenReturn( dbs );
+    return mockDbManager;
+  }
+
+  private static AbstractMeta prepareMeta( DatabaseMeta... metas ) {
+    if ( metas == null ) {
+      metas = new DatabaseMeta[ 0 ];
+    }
+
+    AbstractMeta meta = mock( AbstractMeta.class );
+    List<DatabaseMeta> dbs = asList( metas );
+    when( meta.getLocalDbMetas() ).thenReturn( dbs );
+    return meta;
   }
 }


### PR DESCRIPTION
…e level - Glabal, project and local. Changes include

 - Added SharedObjectIO that is responsible for reading/writing shared objects
 - Added the accessor method to get SharedObjectIO in Bowl. DefaultBowl provides the SharedOjectsIO for accessing global Shared objects.
 - Added DatabaseConnectionManager that uses the SharedObjectsIO to retrieve the shared objects
 - Updated DBConnectionFolderProvider to display the database connection based on the category - Project, Global and local.
 - Added a new method in  AbstractMeta to get the list of local datbase connection (that is defined n ktr/kjb)
 - Updated the unit tests