### PR TITLE
[CLEANUP] fixing mockito compilation errors relating to upgrade from …

### DIFF
--- a/engine/src/it/java/org/pentaho/di/imp/JobImportIT.java
+++ b/engine/src/it/java/org/pentaho/di/imp/JobImportIT.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.exception.KettleException;

--- a/engine/src/it/java/org/pentaho/di/job/entries/job/JobEntryJobIT.java
+++ b/engine/src/it/java/org/pentaho/di/job/entries/job/JobEntryJobIT.java
@@ -27,41 +27,36 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
+import org.pentaho.di.core.Props;
 import org.pentaho.di.core.Result;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.plugins.StepPluginType;
 import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
-import org.pentaho.di.www.SlaveServerJobStatus;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.stream.Collectors;
-import java.io.IOException;
-
-import org.pentaho.di.core.KettleClientEnvironment;
-import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.Props;
-import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.plugins.PluginRegistry;
-import org.pentaho.di.core.plugins.StepPluginType;
-import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.www.SlaveServerJobStatus;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -125,8 +120,8 @@ public class JobEntryJobIT extends JobEntryJob {
     doReturn( FILE.toString() ).when( job ).environmentSubstitute( LOG_FILE_NAME );
     doReturn( REMOTE_SLAVE_SERVER_NAME ).when( job ).environmentSubstitute( REMOTE_SLAVE_SERVER_NAME );
     doReturn( jobMeta ).when( job ).getJobMeta( any( Repository.class ), any( VariableSpace.class ) );
-    doNothing().when( job ).copyVariablesFrom( anyObject() );
-    doNothing().when( job ).setParentVariableSpace( anyObject() );
+    doNothing().when( job ).copyVariablesFrom( any( VariableSpace.class ) );
+    doNothing().when( job ).setParentVariableSpace( any( VariableSpace.class ) );
 
     job.setLogfile = true;
     job.createParentFolder = false;

--- a/engine/src/it/java/org/pentaho/di/trans/steps/constant/ConstantIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/constant/ConstantIT.java
@@ -26,7 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Props;
@@ -46,7 +46,7 @@ import org.pentaho.di.trans.TransMeta;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith( MockitoJUnitRunner.class )
@@ -60,7 +60,6 @@ public class ConstantIT {
     KettleEnvironment.init();
     KettleLogStore.setLogChannelInterfaceFactory( logChannelFactory );
     when( logChannelFactory.create( any(), any() ) ).thenReturn( logChannel );
-    when( logChannelFactory.create( any() ) ).thenReturn( logChannel );
   }
 
   @BeforeClass

--- a/engine/src/it/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputIT.java
@@ -24,7 +24,7 @@ package org.pentaho.di.trans.steps.fileinput.text;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Props;

--- a/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
@@ -55,7 +55,7 @@ import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
@@ -61,8 +61,11 @@ import java.net.URLDecoder;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * User: Dzmitry Stsiapanau Date: 12/2/13 Time: 4:35 PM

--- a/engine/src/it/java/org/pentaho/di/trans/steps/prioritizestreams/PrioritizeStreamsExecutionIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/prioritizestreams/PrioritizeStreamsExecutionIT.java
@@ -22,7 +22,7 @@
 
 package org.pentaho.di.trans.steps.prioritizestreams;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
… mocktio-core 3.5 to 3.10

The mockito upgrade was done at some point in the past. I did not investigate, the issue was rather easy to find the root cause once I pulled the classes into my IDE.

After my fix, some tests still fail, but there won't be compilation errors now

![engine_it_mockito_cannot_find_symbols](https://github.com/pentaho/pentaho-kettle/assets/2119761/268538a9-655d-4736-8fe7-59bbd88f379e)



Since these are integration tests, the fixes didn't seem like quick fixes. I'm considering them out of scope for this effort.


![engine_it_after_mockito_fixes](https://github.com/pentaho/pentaho-kettle/assets/2119761/02232dc0-50c5-4f42-b631-535fa958c65f)

However, I did fix on test `engine/src/it/java/org/pentaho/di/trans/steps/constant/ConstantIT.java`