### PR TITLE
[BACKLOG-40272] - Bowl Variables in UI

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/bowl/Bowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/Bowl.java
@@ -18,6 +18,7 @@ package org.pentaho.di.core.bowl;
 
 import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.api.IMetaStore;
 
@@ -71,5 +72,14 @@ public interface Bowl {
    * @return Set&lt;Bowl&gt; A set of Parent Bowls. Should not be null.
    */
   Set<Bowl> getParentBowls();
+
+  /**
+   * Get a default variable space using this Bowl's context. Everytime you will get a new instance.
+   * <p>
+   * Implementations may include different sets of Variables depending on what is in context for that Bowl.
+   *
+   * @return a default variable space.
+   */
+  VariableSpace getADefaultVariableSpace();
 
 }

--- a/core/src/main/java/org/pentaho/di/core/bowl/DefaultBowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/DefaultBowl.java
@@ -18,6 +18,8 @@ package org.pentaho.di.core.bowl;
 
 import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.metastore.MetaStoreConst;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.api.IMetaStore;
@@ -57,6 +59,13 @@ public class DefaultBowl extends BaseBowl {
     } else {
       return super.getManager( managerClass );
     }
+  }
+
+  @Override
+  public VariableSpace getADefaultVariableSpace() {
+    VariableSpace space = new Variables();
+    space.initializeVariablesFrom( null );
+    return space;
   }
 
   /**

--- a/core/src/main/java/org/pentaho/di/core/variables/Variables.java
+++ b/core/src/main/java/org/pentaho/di/core/variables/Variables.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -250,6 +250,8 @@ public class Variables implements VariableSpace {
 
   /**
    * Get a default variable space as a placeholder. Everytime you will get a new instance.
+   *
+   * @see org.pentaho.di.core.bowl.Bowl#getADefaultVariableSpace()
    *
    * @return a default variable space.
    */

--- a/core/src/test/java/org/pentaho/di/connections/vfs/provider/ConnectionFileProviderTest.java
+++ b/core/src/test/java/org/pentaho/di/connections/vfs/provider/ConnectionFileProviderTest.java
@@ -23,6 +23,8 @@
 package org.pentaho.di.connections.vfs.provider;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
+import java.util.Set;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.junit.Before;
@@ -36,6 +38,7 @@ import org.pentaho.di.connections.common.domain.TestConnectionWithDomainProvider
 import org.pentaho.di.connections.common.domain.TestFileWithDomainProvider;
 import org.pentaho.di.core.bowl.BaseBowl;
 import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.IKettleVFS;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.metastore.api.IMetaStore;
@@ -95,6 +98,14 @@ public class ConnectionFileProviderTest {
       @Override
       public IMetaStore getMetastore() {
         return memoryMetaStore;
+      }
+      @Override
+      public VariableSpace getADefaultVariableSpace() {
+        return null;
+      }
+      @Override
+      public Set<Bowl> getParentBowls() {
+        return Collections.emptySet();
       }
     };
   }

--- a/engine/src/main/java/org/pentaho/di/ExecutionConfiguration.java
+++ b/engine/src/main/java/org/pentaho/di/ExecutionConfiguration.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,17 +22,23 @@
 
 package org.pentaho.di;
 
+import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.repository.RepositoriesMeta;
 import org.pentaho.di.repository.Repository;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 public interface ExecutionConfiguration extends Cloneable {
 
@@ -112,4 +118,45 @@ public interface ExecutionConfiguration extends Cloneable {
   String getRunConfiguration();
 
   void setRunConfiguration( String runConfiguration );
+
+  /**
+   * Adds all the used variables from the meta to the Map
+   *
+   *
+   * @param meta The job or transformation to load from
+   * @param variables the Map to add the variables to
+   */
+  static void getUsedVariables( AbstractMeta meta, Map<String, String> variables ) {
+    Properties sp = new Properties();
+    VariableSpace space = meta;
+
+    String[] keys = space.listVariables();
+    for ( int i = 0; i < keys.length; i++ ) {
+      sp.put( keys[i], space.getVariable( keys[i] ) );
+    }
+
+    List<String> vars = meta.getUsedVariables();
+    if ( vars != null && vars.size() > 0 ) {
+      HashMap<String, String> newVariables = new HashMap<String, String>();
+
+      for ( int i = 0; i < vars.size(); i++ ) {
+        String varname = vars.get( i );
+        if ( !varname.startsWith( Const.INTERNAL_VARIABLE_PREFIX ) ) {
+          newVariables.put( varname, Const.NVL( variables.get( varname ), sp.getProperty( varname, "" ) ) );
+        }
+      }
+      // variables.clear();
+      variables.putAll( newVariables );
+    }
+
+    // Also add the internal job variables if these are set...
+    //
+    for ( String variableName : Const.INTERNAL_JOB_VARIABLES ) {
+      String value = meta.getVariable( variableName );
+      if ( !Utils.isEmpty( value ) ) {
+        variables.put( variableName, value );
+      }
+    }
+  }
 }
+

--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -462,6 +462,14 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
   protected abstract void setInternalFilenameKettleVariables( VariableSpace var );
 
   /**
+   * Return a list of the names of all the variables used by this meta or its contents
+   *
+   *
+   * @return List&lt;String&gt; the names of used variables
+   */
+  public abstract List<String> getUsedVariables();
+
+  /**
    * Find a database connection by it's name
    *
    * @param name The database name to look for

--- a/engine/src/main/java/org/pentaho/di/job/JobExecutionConfiguration.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobExecutionConfiguration.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -254,7 +254,7 @@ public class JobExecutionConfiguration implements ExecutionConfiguration {
 
   public void getUsedVariables( JobMeta jobMeta ) {
     Properties sp = new Properties();
-    VariableSpace space = Variables.getADefaultVariableSpace();
+    VariableSpace space = jobMeta;
 
     String[] keys = space.listVariables();
     for ( int i = 0; i < keys.length; i++ ) {

--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -2218,6 +2218,7 @@ public class JobMeta extends AbstractMeta
    *
    * @return the used variables
    */
+  @Override
   public List<String> getUsedVariables() {
     // Get the list of Strings.
     List<StringSearchResult> stringList = getStringList( true, true, false );

--- a/engine/src/main/java/org/pentaho/di/trans/TransExecutionConfiguration.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransExecutionConfiguration.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -359,36 +359,7 @@ public class TransExecutionConfiguration implements ExecutionConfiguration {
   }
 
   public void getUsedVariables( TransMeta transMeta ) {
-    Properties sp = new Properties();
-    VariableSpace space = Variables.getADefaultVariableSpace();
-
-    String[] keys = space.listVariables();
-    for ( int i = 0; i < keys.length; i++ ) {
-      sp.put( keys[i], space.getVariable( keys[i] ) );
-    }
-
-    List<String> vars = transMeta.getUsedVariables();
-    if ( vars != null && vars.size() > 0 ) {
-      HashMap<String, String> newVariables = new HashMap<String, String>();
-
-      for ( int i = 0; i < vars.size(); i++ ) {
-        String varname = vars.get( i );
-        if ( !varname.startsWith( Const.INTERNAL_VARIABLE_PREFIX ) ) {
-          newVariables.put( varname, Const.NVL( variables.get( varname ), sp.getProperty( varname, "" ) ) );
-        }
-      }
-      // variables.clear();
-      variables.putAll( newVariables );
-    }
-
-    // Also add the internal job variables if these are set...
-    //
-    for ( String variableName : Const.INTERNAL_JOB_VARIABLES ) {
-      String value = transMeta.getVariable( variableName );
-      if ( !Utils.isEmpty( value ) ) {
-        variables.put( variableName, value );
-      }
-    }
+    ExecutionConfiguration.getUsedVariables( transMeta, variables );
   }
 
   public void getUsedArguments( TransMeta transMeta, String[] commandLineArguments ) {

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -5317,6 +5317,7 @@ public class TransMeta extends AbstractMeta
    *
    * @return a list of the used variables in this transformation.
    */
+  @Override
   public List<String> getUsedVariables() {
     // Get the list of Strings.
     List<StringSearchResult> stringList = getStringList( true, true, false, true );

--- a/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
@@ -827,6 +827,11 @@ public class AbstractMetaTest {
     }
 
     @Override
+    public List<String> getUsedVariables() {
+      return Collections.emptyList();
+    }
+
+    @Override
     public String getXML() throws KettleException {
       return null;
     }

--- a/engine/src/test/java/org/pentaho/di/job/JobExecutionConfigurationTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/JobExecutionConfigurationTest.java
@@ -252,6 +252,7 @@ public class JobExecutionConfigurationTest {
     List<String> list0 = new ArrayList<>();
     list0.add( "var1" );
     when( jobMeta0.getUsedVariables(  ) ).thenReturn( list0 );
+    when( jobMeta0.listVariables(  ) ).thenReturn( new String[0] );
     // Const.INTERNAL_VARIABLE_PREFIX values
     when( jobMeta0.getVariable( anyString() ) ).thenReturn( "internalDummyValue" );
 
@@ -274,6 +275,7 @@ public class JobExecutionConfigurationTest {
     List<String> list0 = new ArrayList<>();
     list0.add( "var1" );
     when( jobMeta0.getUsedVariables(  ) ).thenReturn( list0 );
+    when( jobMeta0.listVariables(  ) ).thenReturn( new String[0] );
     when( jobMeta0.getVariable( anyString() ) ).thenReturn( "internalDummyValue" );
 
     executionConfiguration.getUsedVariables( jobMeta0 );
@@ -295,6 +297,7 @@ public class JobExecutionConfigurationTest {
     List<String> list0 = new ArrayList<>();
     list0.add( "var1" );
     when( jobMeta0.getUsedVariables(  ) ).thenReturn( list0 );
+    when( jobMeta0.listVariables(  ) ).thenReturn( new String[0] );
     when( jobMeta0.getVariable( anyString() ) ).thenReturn( "internalDummyValue" );
 
     executionConfiguration.getUsedVariables( jobMeta0 );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -6508,9 +6508,18 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     KettlePropertiesFileDialog dialog = new KettlePropertiesFileDialog( shell, SWT.NONE );
     Map<String, String> newProperties = dialog.open();
     if ( newProperties != null ) {
+      VariableSpace bowlSpace;
+      if ( bowl.equals( DefaultBowl.getInstance() ) ) {
+        bowlSpace = new Variables();
+      } else {
+        bowlSpace = bowl.getADefaultVariableSpace();
+      }
       for ( String name : newProperties.keySet() ) {
         String value = newProperties.get( name );
-        applyVariableToAllLoadedObjects( name, value );
+        if ( bowlSpace.getVariable( name ) == null ) {
+          // if the variable is defined in the bowl, that should remain in place.
+          applyVariableToAllLoadedObjects( name, value );
+        }
 
         // Also set as a JVM property
         //

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegate.java
@@ -47,6 +47,7 @@ import org.pentaho.di.core.plugins.StepPluginType;
 import org.pentaho.di.core.undo.TransAction;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.ExecutionConfiguration;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobExecutionConfiguration;
@@ -1334,8 +1335,14 @@ public class SpoonJobDelegate extends SpoonDelegate {
       variableMap.put( fields[idx], data[idx].toString() );
     }
 
+    // apply used variables from all loaded files
+    for ( TransMeta meta : spoon.getLoadedTransformations() ) {
+      ExecutionConfiguration.getUsedVariables( meta, variableMap );
+    }
+    for ( JobMeta meta : spoon.getLoadedJobs() ) {
+      ExecutionConfiguration.getUsedVariables( meta, variableMap );
+    }
     executionConfiguration.setVariables( variableMap );
-    executionConfiguration.getUsedVariables( jobMeta );
     executionConfiguration.setReplayDate( replayDate );
     executionConfiguration.setRepository( spoon.rep );
     executionConfiguration.setSafeModeEnabled( safe );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegate.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -47,7 +47,9 @@ import org.pentaho.di.core.gui.SpoonInterface;
 import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.logging.TransLogTable;
 import org.pentaho.di.core.undo.TransAction;
+import org.pentaho.di.ExecutionConfiguration;
 import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransExecutionConfiguration;
 import org.pentaho.di.trans.TransHopMeta;
@@ -838,7 +840,7 @@ public class SpoonTransformationDelegate extends SpoonDelegate {
     Object[] data = spoon.variables.getData();
     String[] fields = spoon.variables.getRowMeta().getFieldNames();
     Map<String, String> variableMap = new HashMap<String, String>();
-    variableMap.putAll( executionConfiguration.getVariables() ); // the default
+
     for ( int idx = 0; idx < fields.length; idx++ ) {
       String value = executionConfiguration.getVariables().get( fields[idx] );
       if ( Utils.isEmpty( value ) ) {
@@ -847,8 +849,14 @@ public class SpoonTransformationDelegate extends SpoonDelegate {
       variableMap.put( fields[idx], value );
     }
 
+    // apply used variables from all loaded files
+    for ( TransMeta meta : spoon.getLoadedTransformations() ) {
+      ExecutionConfiguration.getUsedVariables( meta, variableMap );
+    }
+    for ( JobMeta meta : spoon.getLoadedJobs() ) {
+      ExecutionConfiguration.getUsedVariables( meta, variableMap );
+    }
     executionConfiguration.setVariables( variableMap );
-    executionConfiguration.getUsedVariables( transMeta );
     executionConfiguration.getUsedArguments( transMeta, spoon.getArguments() );
     executionConfiguration.setReplayDate( replayDate );
 

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegateTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonJobDelegateTest.java
@@ -141,6 +141,8 @@ public class SpoonJobDelegateTest {
     doReturn( jobExecutionConfigurationDialog ).when( delegate )
       .newJobExecutionConfigurationDialog( jobExecutionConfiguration, jobMeta );
     doReturn( activeJobGraph ).when( spoon ).getActiveJobGraph();
+    doReturn( new TransMeta[0] ).when( spoon ).getLoadedTransformations();
+    doReturn( new JobMeta[0] ).when( spoon ).getLoadedJobs();
     doReturn( MAP_WITH_TEST_VARIABLE ).when( jobExecutionConfiguration ).getVariables();
     doReturn( MAP_WITH_TEST_PARAM ).when( jobExecutionConfiguration ).getParams();
     doReturn( TEST_LOG_LEVEL ).when( jobExecutionConfiguration ).getLogLevel();

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegateTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/delegates/SpoonTransformationDelegateTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -38,6 +38,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.logging.TransLogTable;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.trans.TransExecutionConfiguration;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.ui.spoon.Spoon;
@@ -128,6 +129,8 @@ public class SpoonTransformationDelegateTest {
     doReturn( rowMeta ).when( spoon.variables ).getRowMeta();
     doReturn( EMPTY_STRING_ARRAY ).when( rowMeta ).getFieldNames();
     doReturn( transExecutionConfiguration ).when( spoon ).getTransExecutionConfiguration();
+    doReturn( new TransMeta[0] ).when( spoon ).getLoadedTransformations();
+    doReturn( new JobMeta[0] ).when( spoon ).getLoadedJobs();
     doReturn( MAP_WITH_TEST_PARAM ).when( transExecutionConfiguration ).getParams();
     doReturn( activeTransGraph ).when( spoon ).getActiveTransGraph();
     doReturn( TEST_LOG_LEVEL ).when( transExecutionConfiguration ).getLogLevel();


### PR DESCRIPTION
- added getADefaultVariableSpace to Bowl, to enable starting with
  Bowl-specific variables
- Changed ExecutionConfigurations to use the current used variables from
  all open files, rather than used variables from previous executions.
- Changed the "Set Environment Variables" UI to only keep (in Spoon.variables)
  values that were modified by the user.
- Changed "Set Environment Variables" and "Show Used Environment Variables"
  dialogs to include values from the Bowl
- As a result, the Run dialog, and at runtime, project variables are included
  as expected.