### PR TITLE
[BACKLOG-40356] Fixed normalization and encoding issues in PVFS to Provider File Name transformation

### DIFF
--- a/core/src/main/java/org/pentaho/di/connections/vfs/DefaultVFSConnectionFileNameTransformer.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/DefaultVFSConnectionFileNameTransformer.java
@@ -22,11 +22,21 @@
 
 package org.pentaho.di.connections.vfs;
 
+import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.NameScope;
+import org.apache.commons.vfs2.provider.FileNameParser;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.connections.vfs.provider.ConnectionFileName;
 import org.pentaho.di.connections.vfs.provider.ConnectionFileNameUtils;
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.vfs.IKettleVFS;
+import org.pentaho.di.core.vfs.KettleVFS;
 
 import java.util.Objects;
 
@@ -39,19 +49,29 @@ public class DefaultVFSConnectionFileNameTransformer<T extends VFSConnectionDeta
   private static final String SCHEME_SUFFIX = ":" + SEPARATOR + SEPARATOR;
 
   @NonNull
+  private final ConnectionManager connectionManager;
+
+  @NonNull
   private final VFSConnectionManagerHelper vfsConnectionManagerHelper;
 
   @NonNull
   private final ConnectionFileNameUtils connectionFileNameUtils;
 
-  public DefaultVFSConnectionFileNameTransformer() {
-    this( VFSConnectionManagerHelper.getInstance(), ConnectionFileNameUtils.getInstance() );
+  public DefaultVFSConnectionFileNameTransformer( @NonNull ConnectionManager connectionManager ) {
+    this( connectionManager, VFSConnectionManagerHelper.getInstance(), ConnectionFileNameUtils.getInstance() );
   }
 
-  public DefaultVFSConnectionFileNameTransformer( @NonNull VFSConnectionManagerHelper vfsConnectionManagerHelper,
+  public DefaultVFSConnectionFileNameTransformer( @NonNull ConnectionManager connectionManager,
+                                                  @NonNull VFSConnectionManagerHelper vfsConnectionManagerHelper,
                                                   @NonNull ConnectionFileNameUtils connectionFileNameUtils ) {
+    this.connectionManager = Objects.requireNonNull( connectionManager );
     this.vfsConnectionManagerHelper = Objects.requireNonNull( vfsConnectionManagerHelper );
     this.connectionFileNameUtils = Objects.requireNonNull( connectionFileNameUtils );
+  }
+
+  @NonNull
+  protected ConnectionManager getConnectionManager() {
+    return connectionManager;
   }
 
   @NonNull
@@ -64,10 +84,10 @@ public class DefaultVFSConnectionFileNameTransformer<T extends VFSConnectionDeta
     return connectionFileNameUtils;
   }
 
-  // region toProviderUri
+  // region toProviderFileName
   @NonNull
   @Override
-  public String toProviderUri( @NonNull ConnectionFileName pvfsFileName, @NonNull T details )
+  public FileName toProviderFileName( @NonNull ConnectionFileName pvfsFileName, @NonNull T details )
     throws KettleException {
 
     StringBuilder providerUriBuilder = new StringBuilder();
@@ -82,7 +102,7 @@ public class DefaultVFSConnectionFileNameTransformer<T extends VFSConnectionDeta
 
     // Examples: "hcp://domain.my:443/root/path/folder/sub-folder" | "s3://folder/sub-folder"
 
-    return providerUriBuilder.toString();
+    return parseUri( providerUriBuilder.toString() );
   }
 
   // IMPROVEMENT: The connection root provider URI is being repeatedly determined, but is actually constant as long as
@@ -91,10 +111,22 @@ public class DefaultVFSConnectionFileNameTransformer<T extends VFSConnectionDeta
   // changed. These don't even implement hashCode, atm. Could use the connection manager to store and manage this
   // cache, by name, invalidating it whenever a connection is loaded/saved. Would still need to deal with in-memory
   // connections used by test(..) somehow.
+  // See also, related note in #getConnectionRootProviderUriPrefix(.).
+
+  /**
+   * Appends to the provider URI builder the root of the connection, which includes the scheme, the domain and
+   * the root path.
+   * <p>
+   * The components appended to the builder may not be normalized. It is expected that an overall normalization step
+   * follows on the entirety of the provider URI string.
+   *
+   * @param providerUriBuilder The provider URI builder.
+   * @param details            The details of the connection.
+   */
   protected void appendProviderUriConnectionRoot( @NonNull StringBuilder providerUriBuilder, @NonNull T details )
     throws KettleException {
 
-    appendProviderRootPrefix( providerUriBuilder, details );
+    appendProviderUriSchemePrefix( providerUriBuilder, details );
 
     // Examples: "hcp://" | "s3://"  | "local:///"
 
@@ -107,7 +139,7 @@ public class DefaultVFSConnectionFileNameTransformer<T extends VFSConnectionDeta
     // Examples: "hcp://domain.my:443/root/path" | "local:///C:/root/path"
   }
 
-  protected void appendProviderRootPrefix( @NonNull StringBuilder providerUriBuilder, @NonNull T details )
+  protected void appendProviderUriSchemePrefix( @NonNull StringBuilder providerUriBuilder, @NonNull T details )
     throws KettleException {
 
     providerUriBuilder
@@ -155,38 +187,177 @@ public class DefaultVFSConnectionFileNameTransformer<T extends VFSConnectionDeta
     throws KettleException {
     // Determine the part of provider file name following the connection "root".
     // Use the transformer to generate the connection root provider uri.
-    // Both uris are assumed to be in canonical form.
-    // Need to add/ensure trailing slashes in both to avoid matching segments which share a prefix.
+    // Both uris are assumed to be normalized.
     // Examples:
-    // - rootPathProviderUri: "hcp://domain.my:443/root/path/"           |  "s3://" |  "local://"
-    // - providerUri:         "hcp://domain.my:443/root/path/rest/path"  |  "s3://rest/path"
-    String rootPathProviderUri = connectionFileNameUtils.ensureTrailingSeparator(
-      vfsConnectionManagerHelper.getConnectionRootProviderUri( this, details ) );
+    // - connectionRootProviderUri: "hcp://domain.my:443/root/path/"           |  "s3://" |  "local://"
+    // - providerUri:               "hcp://domain.my:443/root/path/rest/path"  |  "s3://rest/path"
+    // Example: "pvfs://my-connection"
 
-    String providerUri = connectionFileNameUtils.ensureTrailingSeparator( providerFileName.getURI() );
-    if ( !providerUri.startsWith( rootPathProviderUri ) ) {
-      throw new IllegalStateException( "Provider URI does not start with the provider root URI." );
+    String connectionRootProviderUri = getConnectionRootProviderUriPrefix( details );
+    String providerUri = providerFileName.getURI();
+
+    if ( !connectionFileNameUtils.isDescendent( providerUri, connectionRootProviderUri ) ) {
+      throw new IllegalStateException( "Provider URI does not start with the provider's connection root URI." );
     }
 
-    String restPath = providerUri.substring( rootPathProviderUri.length() );
+    String restUriPath = providerUri.substring( connectionRootProviderUri.length() );
 
-    // Examples: restPath: "/rest/path/" | "rest/path/"
+    // Examples: "/rest/path" or "rest/path"
 
-    // According to FileName#getPath(), the path must always start with a / (even if it would be empty).
-    // Also, the trailing slash is removed by the AbstractFileName constructor.
-    restPath = connectionFileNameUtils.ensureLeadingSeparator( restPath );
+    return buildPvfsFileName( details, restUriPath, providerFileName.getType() );
+  }
 
-    // Examples:
-    // restPath: "/rest/path/"
-    // connection root file name uri: "pvfs://my-connection/"
-    // connection file name uri:      "pvfs://my-connection/rest/path"
-    // NOTE:
-    //  The way ConnectionFileName is implemented, connection is included as part of the root URI.
-    //  There is one ConnectionFileSystem instance per root URI, i.e., per connection.
-    //  Also, a root fs uri always has a / at the end, given that getPath() always starts with a /.
-    return vfsConnectionManagerHelper
-      .getConnectionRootFileName( details )
-      .createName( restPath, providerFileName.getType() );
+  /**
+   * Builds a PVFS file name for a connection given the URI path and the file type.
+   * <h3>Implementation Notes</h3>
+   * <p>
+   * {@code nonNormalizedRestPath} may be using the URI encoding, resulting from {@link FileName#getURI()} (which is
+   * ensured by <pre>AbstractFileName#handleURISpecialCharacters(..)</pre>), which additionally encodes {@code " "} and
+   * {@code "#"} on the URI path section, compared to only {@code "%"} in the path section of a
+   * {@link ConnectionFileName}.
+   *
+   * <p>
+   * If the PVFS file name were built using <pre>connectionRootFileName#createName(nonNormalizedRestPath ..)</pre>, it
+   * could get a non-normalized path, which should not happen and is usually assured by the file name parser.
+   *
+   * <p>
+   * The encoding of {@code nonNormalizedRestPath} could be normalized beforehand, by explicitly calling
+   * {@link UriParser#canonicalizePath(StringBuilder, int, int, FileNameParser)}. However, that would be duplicating
+   * logic that only the file name parser should have.
+   *
+   * <p>
+   * Opting instead to take the slower route of giving the URI to the parser for full parsing, normalization, and later
+   * re-considering if a performance bottleneck is found.
+   *
+   * @param details               The details of the connection.
+   * @param nonNormalizedRestPath The possibly non-normalized file name path.
+   * @param fileType              The file type.
+   * @return The PVFS file name.
+   */
+  @NonNull
+  protected ConnectionFileName buildPvfsFileName( @NonNull T details,
+                                                  @NonNull String nonNormalizedRestPath,
+                                                  @NonNull FileType fileType ) throws KettleException {
+    // Always ends with a /. Why:
+    //  The way ConnectionFileName is implemented, the connection name is included as part of the root URI.
+    //  There is one FileSystem instance per root URI, and thus per connection.
+    //  Finally, root FS URIs always have a trailing "/" (because getPath() always starts with a /).
+    String pvfsConnectionRootUri = vfsConnectionManagerHelper.getConnectionRootFileName( details ).getURI();
+
+    String folderSeparator = ( fileType.hasChildren() ? SEPARATOR : "" );
+
+    // Any double // in the path section are normalized by the parser.
+    return parseUri( pvfsConnectionRootUri + nonNormalizedRestPath + folderSeparator );
+  }
+
+  // IMPROVEMENT: Just like with appendProviderUriConnectionRoot, the results of this function could be cached
+  // to avoid constant parsing/normalization of the result of appendProviderUriConnectionRoot.
+
+  /**
+   * Gets the normalized URI prefix of a connection's root folder.
+   *
+   * <p>
+   * Builds the URI prefix by using {@link #appendProviderUriConnectionRoot(StringBuilder, VFSConnectionDetails)} and
+   * then normalizes the result using {@link #normalizeConnectionRootProviderUriPrefix(String, VFSConnectionDetails)}.
+   *
+   * <p>
+   * Normalization is important for being able to perform the relative URI operations using basic string comparison, as is
+   * done in {@link #toPvfsFileName(FileName, VFSConnectionDetails)}. This is crucial for at least the Local provider,
+   * in a Windows OS, where the normalized format uses a variable number of separator characters after the scheme,
+   * depending on whether the path refers to a drive letter or UNC path. In general, for all providers, it is crucial to
+   * ensure that the URI prefix is normalized, given it may include non-normalized components such as the domain and the
+   * root folder path.
+   *
+   * <p>
+   * Ideally, a provider file name representing the connection root would be built, avoiding explicit string
+   * manipulation, however, that's not possible in general for connections using buckets and which have no domain.
+   * If it were possible, then {@code toPvfsFileName} would not need to use basic string comparison operations and could
+   * instead use the file name methods: {@link FileName#isDescendent(FileName, NameScope)} and
+   * {@link FileName#getRelativeName(FileName)}.
+   *
+   * @param details The details of the connection.
+   * @return The normalized URI prefix.
+   */
+  private String getConnectionRootProviderUriPrefix( @NonNull T details ) throws KettleException {
+    StringBuilder providerUriBuilder = new StringBuilder();
+
+    appendProviderUriConnectionRoot( providerUriBuilder, details );
+
+    String providerUriPrefix = providerUriBuilder.toString();
+
+    return normalizeConnectionRootProviderUriPrefix( providerUriPrefix, details );
+  }
+
+  /**
+   * Normalizes the connection root provider URI prefix.
+   *
+   * <p>
+   * This method is used by the default implementation of {@link #toPvfsFileName(FileName, VFSConnectionDetails)}
+   *
+   * <p>
+   * This implementation normalizes the given URI prefixes by calling {@link #normalizeUri(String)}.
+   * However, the normalization is skipped for connections using buckets, according to
+   * {@link VFSConnectionManagerHelper#usesBuckets(VFSConnectionDetails)}, and with no
+   * {@link VFSConnectionDetails#getDomain() domain}, given in general these URI prefixes cannot be normalized.
+   * If, for a specific connection type, special normalization is needed in this situation, define a custom transformer
+   * class and override this method.
+   *
+   * @param providerUriPrefix The connection root provider URI prefix.
+   * @param details           The details of the connection.
+   * @return A normalized connection root provider URI prefix.
+   */
+  @NonNull
+  protected String normalizeConnectionRootProviderUriPrefix( @NonNull String providerUriPrefix, @NonNull T details )
+    throws KettleException {
+
+    if ( StringUtils.isEmpty( details.getDomain() ) && vfsConnectionManagerHelper.usesBuckets( details ) ) {
+      // Parsing would likely fail, due to degenerate URIs which cannot be represented as FileName (e.g. s3://).
+      // Return the original uri prefix. Override in specific bucketed providers if any normalization is really needed.
+      return providerUriPrefix;
+    }
+
+    return normalizeUri( providerUriPrefix );
+  }
+
+  // endregion
+
+  // region Helpers
+
+  /**
+   * Normalizes a URI by parsing it into a file name and then obtaining its URI string.
+   *
+   * @param nonNormalizedUri The URI to normalize.
+   * @return The normalized URI.
+   * @throws KettleException If the given URI has an invalid syntax, including when it is a degenerate connection root
+   *                         provider URI prefix.
+   * @see #parseUri(String)
+   * @see FileName#getURI()
+   */
+  @NonNull
+  protected String normalizeUri( @NonNull String nonNormalizedUri ) throws KettleException {
+    return parseUri( nonNormalizedUri ).getURI();
+  }
+
+  /**
+   * Parses a given PVFS or Provider URI string, which may not be in canonical form
+   * (w.r.t., for example, to separators, percent-encoding).
+   * <p>
+   * The resulting file name can then be used to get a normalized path, via {@link FileName#getPath()},
+   * or the URI, via {@link FileName#getURI()}.
+   *
+   * @param nonNormalizedUri A URI string.
+   * @return The file name.
+   */
+  @SuppressWarnings( "unchecked" )
+  @NonNull
+  protected <F extends FileName> F parseUri( @NonNull String nonNormalizedUri ) throws KettleException {
+    return (F) getKettleVFS( connectionManager.getBowl() ).resolveURI( nonNormalizedUri );
+  }
+
+  @VisibleForTesting
+  @NonNull
+  IKettleVFS getKettleVFS( @NonNull Bowl bowl ) {
+    return KettleVFS.getInstance( bowl );
   }
   // endregion
 }

--- a/core/src/main/java/org/pentaho/di/connections/vfs/VFSConnectionFileNameTransformer.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/VFSConnectionFileNameTransformer.java
@@ -33,18 +33,14 @@ import org.pentaho.di.core.exception.KettleException;
  */
 public interface VFSConnectionFileNameTransformer<T extends VFSConnectionDetails> {
   /**
-   * Transforms a <i>PVFS</i> file name to a provider URI string.
-   * <p>
-   * This method accepts a connection file name and returns a provider URI string. To obtain an actual provider
-   * {@link org.apache.commons.vfs2.FileName}, the result needs to be further transformed by the provider's
-   * {@link org.apache.commons.vfs2.provider.FileNameParser}.
+   * Transforms a <i>PVFS</i> file name to a provider file name.
    *
    * @param pvfsFileName The <i>PVFS</i> file name.
    * @param details      The connection details of the connection referenced by {@code pvfsFileName}.
-   * @return The provider URI string.
+   * @return The provider file name.
    */
   @NonNull
-  String toProviderUri( @NonNull ConnectionFileName pvfsFileName, @NonNull T details ) throws KettleException;
+  FileName toProviderFileName( @NonNull ConnectionFileName pvfsFileName, @NonNull T details ) throws KettleException;
 
   /**
    * Transforms a provider file name to a <i>PVFS</i> file name.

--- a/core/src/main/java/org/pentaho/di/connections/vfs/VFSConnectionManagerHelper.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/VFSConnectionManagerHelper.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.provider.UriParser;
@@ -200,8 +201,8 @@ public class VFSConnectionManagerHelper {
     return new ConnectionFileName( connectionName );
   }
 
-  @NonNull
-  public <T extends VFSConnectionDetails> String getConnectionRootProviderUri(
+  @VisibleForTesting
+  @NonNull <T extends VFSConnectionDetails> FileName getConnectionRootProviderFileName(
     @NonNull VFSConnectionFileNameTransformer<T> fileNameTransformer,
     @NonNull T details )
     throws KettleException {
@@ -209,21 +210,32 @@ public class VFSConnectionManagerHelper {
     // Example: "pvfs://my-connection"
     ConnectionFileName rootPvfsFileName = getConnectionRootFileName( details );
 
-
-    // Example: "s3://root-bucket/root-path-subfolder"
-    return fileNameTransformer.toProviderUri( rootPvfsFileName, details );
+    // Example: "s3://root-path-bucket"
+    // Would fail if only "s3://"
+    return fileNameTransformer.toProviderFileName( rootPvfsFileName, details );
   }
 
+  // For bucketed connections with no domain, a provider file object / file name corresponding to the connection root
+  // can only be obtained if there is a root path. Otherwise, we'd need to be able to build degenerate file name, such
+  // as `s3://`, which is not a valid URI and is not supported by URLFileName, used by many of these connections.
+  // The single caller of this method is the test method, and only calls this when there is a resolved root path,
+  // for which the restriction necessarily does not apply.
   @NonNull
   private <T extends VFSConnectionDetails> FileObject getConnectionRootProviderFileObject(
-    @NonNull IKettleVFS kettleVFS,
-    @NonNull T details,
-    @NonNull VFSConnectionProvider<T> provider )
+    @NonNull ConnectionManager manager,
+    @NonNull VFSConnectionProvider<T> provider,
+    @NonNull T details )
     throws KettleException {
 
-    String rootPathProviderUri = getConnectionRootProviderUri( provider.getFileNameTransformer(), details );
+    FileName rootProviderFileName =
+      getConnectionRootProviderFileName( provider.getFileNameTransformer( manager ), details );
 
-    return kettleVFS.getFileObject( rootPathProviderUri, new Variables(), provider.getOpts( details ) );
+    IKettleVFS kettleVFS = getKettleVFS( manager.getBowl() );
+
+    return kettleVFS.getFileObject(
+      rootProviderFileName.getURI(),
+      new Variables(),
+      provider.getOpts( details ) );
   }
   // endregion
 
@@ -349,7 +361,7 @@ public class VFSConnectionManagerHelper {
     }
 
     // Ensure that root path exists and is a folder.
-    return isFolder( getConnectionRootProviderFileObject( getKettleVFS( manager.getBowl() ), details, provider ) );
+    return isFolder( getConnectionRootProviderFileObject( manager, provider, details ) );
   }
   // endregion
 

--- a/core/src/main/java/org/pentaho/di/connections/vfs/VFSConnectionProvider.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/VFSConnectionProvider.java
@@ -25,6 +25,7 @@ package org.pentaho.di.connections.vfs;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.connections.ConnectionProvider;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.variables.Variables;
@@ -58,8 +59,13 @@ public interface VFSConnectionProvider<T extends VFSConnectionDetails> extends C
     return KettleVFS.getFileObject( pvfsUrl, new Variables(), getOpts( connectionDetails ) );
   }
 
+  /**
+   * Gets a file name transformer for transforming file names in the context of a given connection manager.
+   * @param connectionManager The connection manager.
+   * @return The file name transformer.
+   */
   @NonNull
-  default VFSConnectionFileNameTransformer<T> getFileNameTransformer() {
-    return new DefaultVFSConnectionFileNameTransformer<>();
+  default VFSConnectionFileNameTransformer<T> getFileNameTransformer( @NonNull ConnectionManager connectionManager ) {
+    return new DefaultVFSConnectionFileNameTransformer<>( connectionManager );
   }
 }

--- a/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileNameParser.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileNameParser.java
@@ -69,7 +69,7 @@ import static org.apache.commons.vfs2.provider.UriParser.TRANS_SEPARATOR;
  *   <li>"." path segments are removed</li>
  *   <li>".." path segments are validated and resolved</li>
  *   <li>a path with a trailing slash is recognized as a folder</li>
- *   <li>any percent-encoded characters in path segments which are not {@link #encodeCharacter(char)}  reserved} are
+ *   <li>any percent-encoded characters in path segments which are not {@link #encodeCharacter(char)} reserved} are
  *       decoded</li>
  * </ul>
  *
@@ -241,9 +241,8 @@ public class ConnectionFileNameParser extends AbstractFileNameParser {
     // May be null/empty, in case pvfsUri = "pvfs://".
     @Nullable
     String connectionName = UriParser.extractFirstElement( name );
-
-    // A connection with a percent (as %25) would throw here.
     if ( StringUtils.isNotEmpty( connectionName )) {
+      // A connection with a percent (as %25) would throw here.
       validateConnectionName( connectionName );
     }
 

--- a/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileNameUtils.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileNameUtils.java
@@ -60,6 +60,10 @@ public class ConnectionFileNameUtils {
     urlBuilder.append( path );
   }
 
+  public boolean isDescendent( @NonNull String descendantPath, @NonNull String basePath ) {
+    return ensureTrailingSeparator( descendantPath ).startsWith( ensureTrailingSeparator( basePath ) );
+  }
+
   @NonNull
   public String trimLeadingSeparator( @NonNull String path ) {
     return path.startsWith( SEPARATOR )

--- a/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileSystem.java
+++ b/core/src/main/java/org/pentaho/di/connections/vfs/provider/ConnectionFileSystem.java
@@ -94,13 +94,14 @@ public class ConnectionFileSystem extends AbstractFileSystem implements FileSyst
     }
 
     // 4. Normal case, for which there is an associated provider file object.
-    String providerUri = vfsConnectionManagerHelper
+    FileName providerFileName = vfsConnectionManagerHelper
       .getExistingProvider( connectionManager, details )
-      .getFileNameTransformer()
-      .toProviderUri( pvfsFileName, details );
+      .getFileNameTransformer( connectionManager )
+      .toProviderFileName( pvfsFileName, details );
 
     AbstractFileObject<?> providerFileObject =
-      (AbstractFileObject<?>) getKettleVFS().getFileObject( providerUri, initializeVariableSpace( details ) );
+      (AbstractFileObject<?>) getKettleVFS()
+        .getFileObject( providerFileName.getURI(), initializeVariableSpace( details ) );
 
     return new ResolvedConnectionFileObject( pvfsFileName, this, providerFileObject );
   }
@@ -140,7 +141,7 @@ public class ConnectionFileSystem extends AbstractFileSystem implements FileSyst
     try {
       return vfsConnectionManagerHelper
         .getExistingProvider( connectionManager, details )
-        .getFileNameTransformer()
+        .getFileNameTransformer( connectionManager )
         .toPvfsFileName( providerFileName, details );
     } catch ( KettleException e ) {
       throw new KettleVFSFileSystemException(

--- a/core/src/main/java/org/pentaho/di/core/vfs/IKettleVFS.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/IKettleVFS.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.di.core.vfs;
 
+import org.apache.commons.vfs2.FileName;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.variables.VariableSpace;
 
@@ -49,6 +50,15 @@ public interface IKettleVFS {
 
   FileObject getFileObject( String vfsFilename, VariableSpace space, FileSystemOptions fsOptions )
     throws KettleFileException;
+
+  /**
+   * Resolves the given URI to a file name.
+   *
+   * @param uri The URI to resolve.
+   * @return A {@link FileName} that matches the URI; never {@code null}.
+   * @throws KettleFileException if this is not possible.
+   */
+  FileName resolveURI( String uri ) throws KettleFileException;
 
   // warning, was not public
   FileSystemOptions getFileSystemOptions( String scheme, String vfsFilename, VariableSpace space,


### PR DESCRIPTION
To be merged with:
- TBD

/cc @pentaho/hoth

- Fixed non-normalized `ConnectionFileName` instances resulting from `DefaultVFSConnectionFileNameTransformer#toPvfsFileName(.)`. This would cause equality tests to fail between two instances having the same path with different normalization.

- More visibly, this issue was causing the `$` and ` ` (beyond `%` which remains) to be percent encoded in folder/file names in the UIs (PUC Browse Files perspective, Select Folder dialog and PDI File Open Save dialog). Now back to only `%` being percent encoded, as before.

- Finally, still related with normalization of transformed file names, lack of normalization of the connection root provider URI prefix would cause `DefaultVFSConnectionFileNameTransformer#toProviderFileName(.)` to fail. This was experienced specifically with a Windows/UNC provider file name of the Local connection type, due to differences in the number of separators expected after the scheme for UNC paths in Windows (4 instead of 3). However, lack of provider-specific normalization of the provider root path section could cause this on other providers.

- As part of ensuring normalization for file name transformations, the `VFSConnectionFileNameTransformer#toProviderUri(.)` was modified to return a `FileName`, and accordingly renamed to `VFSConnectionFileName#toProviderFileName(.)`, thus achieving symmetry with `VFSConnectionFileNameTransformer#toPvfsFileName(.)`. Not all `ConnectionFileName` have a corresponding Provider `FileName` and the operation may throw (the case of degenerate provider URIs and bucketed connections).

- The changes to `DefaultVFSConnectionFileNameTransformer` require access to the `ConnectionManager`. As such, the `VFSConnectionProvider#getFileNameTransformer()` factory method was modified to receive a connection manager as argument.