### PR TITLE
[PDI-20138] Make SpoonPluginType honor plugins base folder settings

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/plugins/PluginFolder.java
+++ b/core/src/main/java/org/pentaho/di/core/plugins/PluginFolder.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -94,7 +94,7 @@ public class PluginFolder implements PluginFolderInterface {
    */
   public static List<PluginFolderInterface> populateFolders( String xmlSubfolder ) {
     List<PluginFolderInterface> pluginFolders = new ArrayList<>();
-    String folderPaths = EnvUtil.getSystemProperty( "KETTLE_PLUGIN_BASE_FOLDERS" );
+    String folderPaths = EnvUtil.getSystemProperty( Const.PLUGIN_BASE_FOLDERS_PROP );
     if ( folderPaths == null ) {
       folderPaths = Const.DEFAULT_PLUGIN_BASE_FOLDERS;
     }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonPluginType.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonPluginType.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -38,8 +38,7 @@ public class SpoonPluginType extends BasePluginType implements PluginTypeInterfa
 
   private SpoonPluginType() {
     super( SpoonPlugin.class, "SPOONPLUGIN", "Spoon Plugin" );
-
-    pluginFolders.add( new PluginFolder( "plugins", false, true ) );
+    populateFolders( null );
   }
 
   private static SpoonPluginType pluginType;

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonPluginType.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonPluginType.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.plugins.BasePluginType;
 import org.pentaho.di.core.plugins.PluginAnnotationType;
-import org.pentaho.di.core.plugins.PluginFolder;
 import org.pentaho.di.core.plugins.PluginMainClassType;
 import org.pentaho.di.core.plugins.PluginTypeInterface;
 

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonUiExtenderPluginType.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonUiExtenderPluginType.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -43,8 +43,7 @@ public class SpoonUiExtenderPluginType extends BasePluginType implements PluginT
 
   private SpoonUiExtenderPluginType() {
     super( SpoonUiExtenderPlugin.class, "SPOONUIEXTENDERPLUGIN", "Spoon UI Extender Plugin" );
-
-    pluginFolders.add( new PluginFolder( "plugins", false, true ) );
+    populateFolders( null );
   }
 
   private static SpoonUiExtenderPluginType pluginType;

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonUiExtenderPluginType.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/SpoonUiExtenderPluginType.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.plugins.BasePluginType;
 import org.pentaho.di.core.plugins.PluginAnnotationType;
-import org.pentaho.di.core.plugins.PluginFolder;
 import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginMainClassType;
 import org.pentaho.di.core.plugins.PluginRegistry;


### PR DESCRIPTION
This change allows "SpoonPluginType" to be loaded from user specified paths with the **-DKETTLE_PLUGIN_BASE_FOLDERS** option, which also allows this type of plugin to be loaded from ~/.kettle/plugins (user home directory plugins that cross versions).