### PR TITLE
[BACKLOG-40795] Removed the share/unshare menu options from the tree.

### DIFF
--- a/assemblies/static/src/main/resources/ui/menubar.xul
+++ b/assemblies/static/src/main/resources/ui/menubar.xul
@@ -241,7 +241,6 @@
     <menuseparator />
     <menuitem id="database-inst-sql-edit" label="${Spoon.Menu.Popup.CONNECTIONS.SQLEditor}" command="spoon.sqlConnection()" />
     <menuitem id="database-inst-clear-cache" label="${Spoon.Menu.Popup.CONNECTIONS.ClearDBCache}" command="spoon.clearDBCache('database-inst-clear-cache')"/>
-    <menuitem id="database-inst-share" label="${Spoon.Menu.Popup.CONNECTIONS.Share}" command="spoon.shareObject('database-inst-share')" />
     <menuitem id="database-inst-explore" label="${Spoon.Menu.Popup.CONNECTIONS.Explore}" command="spoon.exploreDB()" />
     <menuseparator />
     <menuitem id="database-inst-dependancy" label="${Spoon.Menu.Popup.CONNECTIONS.ShowDependancies}" command="spoon.displayDbDependancies()" />
@@ -251,7 +250,6 @@
     <menuitem id="step-inst-edit" label="${Spoon.Menu.Popup.STEPS.Edit}" command="spoon.editStep()" />
     <menuitem id="step-inst-duplicate" label="${Spoon.Menu.Popup.STEPS.Duplicate}" command="spoon.dupeStep()" />
     <menuitem id="step-inst-delete" label="${Spoon.Menu.Popup.STEPS.Delete}" command="spoon.delStep()" />
-    <menuitem id="step-inst-share" label="${Spoon.Menu.Popup.STEPS.Share}" command="spoon.shareObject('step-inst-share')" />
     <menuseparator id="step-inst-separator-1"/>
     <menuitem id="step-inst-help" label="${Spoon.Menu.Popup.STEPS.Help}" command="spoon.helpStep()" />
 
@@ -274,20 +272,17 @@
   <menupopup id="partition-schema-inst">
     <menuitem id="partition-schema-inst-edit" label="${Spoon.Menu.Popup.STEPS.Edit}" command="spoon.editPartitionSchema()" />
     <menuitem id="partition-schema-inst-delete" label="${Spoon.Menu.Popup.STEPS.Delete}" command="spoon.delPartitionSchema()" />
-    <menuitem id="partition-schema-inst-share" label="${Spoon.Menu.Popup.STEPS.Share}" command="spoon.shareObject('partition-schema-inst-share')" />
   </menupopup>
 
   <menupopup id="cluster-schema-inst">
     <menuitem id="cluster-schema-inst-edit" label="${Spoon.Menu.Popup.STEPS.Edit}" command="spoon.editClusterSchema()" />
     <menuitem id="cluster-schema-inst-delete" label="${Spoon.Menu.Popup.STEPS.Delete}" command="spoon.delClusterSchema()" />
-    <menuitem id="cluster-schema-inst-share" label="${Spoon.Menu.Popup.STEPS.Share}" command="spoon.shareObject('cluster-schema-inst-share')" />
     <menuitem id="cluster-schema-inst-monitor" label="${Spoon.Menu.Popup.CLUSTERS.Monitor}" command="spoon.monitorClusterSchema()" />
   </menupopup>
 
   <menupopup id="slave-server-inst">
     <menuitem id="slave-server-inst-edit" label="${Spoon.Menu.Popup.STEPS.Edit}" command="spoon.editSlaveServer()" />
     <menuitem id="slave-server-inst-delete" label="${Spoon.Menu.Popup.STEPS.Delete}" command="spoon.delSlaveServer()" />
-    <menuitem id="slave-server-inst-share" label="${Spoon.Menu.Popup.STEPS.Share}" command="spoon.shareObject('slave-server-inst-share')" />
     <menuitem id="slave-server-inst-monitor" label="${Spoon.Menu.Popup.SLAVE_SERVER.Monitor}" command="spoon.addSpoonSlave()" />
   </menupopup>
 

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -2615,63 +2615,6 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     previousShowJob = showJob;
   }
 
-  protected void shareObject( SharedObjectInterface sharedObject ) {
-    sharedObject.setShared( true );
-    EngineMetaInterface meta = getActiveMeta();
-    try {
-      if ( meta != null ) {
-        SharedObjects sharedObjects = null;
-        if ( meta instanceof TransMeta ) {
-          sharedObjects = ( (TransMeta) meta ).getSharedObjects();
-        }
-        if ( meta instanceof JobMeta ) {
-          sharedObjects = ( (JobMeta) meta ).getSharedObjects();
-        }
-        if ( sharedObjects != null ) {
-          sharedObjects.storeObject( sharedObject );
-          sharedObjects.saveToFile();
-        }
-      }
-    } catch ( Exception e ) {
-      new ErrorDialog(
-        shell, BaseMessages.getString( PKG, "Spoon.Dialog.ErrorWritingSharedObjects.Title" ), BaseMessages
-          .getString( PKG, "Spoon.Dialog.ErrorWritingSharedObjects.Message" ), e );
-    }
-    refreshTree( selectionTreeManager.getNameByType( sharedObject.getClass() ) );
-  }
-
-  protected void unShareObject( SharedObjectInterface sharedObject ) {
-    MessageBox mb = new MessageBox( shell, SWT.YES | SWT.NO | SWT.ICON_WARNING );
-    // "Are you sure you want to stop sharing?"
-    mb.setMessage( BaseMessages.getString( PKG, "Spoon.Dialog.StopSharing.Message" ) );
-    mb.setText( BaseMessages.getString( PKG, "Spoon.Dialog.StopSharing.Title" ) ); // Warning!
-    int answer = mb.open();
-    if ( answer == SWT.YES ) {
-      sharedObject.setShared( false );
-      EngineMetaInterface meta = getActiveMeta();
-      try {
-        if ( meta != null ) {
-          SharedObjects sharedObjects = null;
-          if ( meta instanceof TransMeta ) {
-            sharedObjects = ( (TransMeta) meta ).getSharedObjects();
-          }
-          if ( meta instanceof JobMeta ) {
-            sharedObjects = ( (JobMeta) meta ).getSharedObjects();
-          }
-          if ( sharedObjects != null ) {
-            sharedObjects.removeObject( sharedObject );
-            sharedObjects.saveToFile();
-          }
-        }
-      } catch ( Exception e ) {
-        new ErrorDialog(
-          shell, BaseMessages.getString( PKG, "Spoon.Dialog.ErrorWritingSharedObjects.Title" ), BaseMessages
-            .getString( PKG, "Spoon.Dialog.ErrorWritingSharedObjects.Message" ), e );
-      }
-      refreshTree( selectionTreeManager.getNameByType( sharedObject.getClass() ) );
-    }
-  }
-
   /**
    * @return The object that is selected in the tree or null if we couldn't figure it out. (titles etc. == null)
    */
@@ -2916,34 +2859,6 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     PluginInterface stepPlugin =
       PluginRegistry.getInstance().findPluginWithId( StepPluginType.class, stepMeta.getStepID() );
     HelpUtils.openHelpDialog( shell, stepPlugin );
-  }
-
-  public void shareObject( String id ) {
-    if ( "database-inst-share".equals( id ) ) {
-      final DatabaseMeta databaseMeta = (DatabaseMeta) selectionObject;
-      if ( databaseMeta.isShared() ) {
-        unShareObject( databaseMeta );
-      } else {
-        shareObject( databaseMeta );
-      }
-    }
-    if ( "step-inst-share".equals( id ) ) {
-      final StepMeta stepMeta = (StepMeta) selectionObject;
-      shareObject( stepMeta );
-    }
-    if ( "partition-schema-inst-share".equals( id ) ) {
-      final PartitionSchema partitionSchema = (PartitionSchema) selectionObject;
-      shareObject( partitionSchema );
-    }
-    if ( "cluster-schema-inst-share".equals( id ) ) {
-      final ClusterSchema clusterSchema = (ClusterSchema) selectionObject;
-      shareObject( clusterSchema );
-    }
-    if ( "slave-server-inst-share".equals( id ) ) {
-      final SlaveServer slaveServer = (SlaveServer) selectionObject;
-      shareObject( slaveServer );
-    }
-    sharedObjectSyncUtil.reloadSharedObjects();
   }
 
   public void editJobEntry() {
@@ -5466,8 +5381,6 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         }
       }
     }
-
-    meta.saveSharedObjects(); // throws Exception in case anything goes wrong
 
     try {
       if ( props.useDBCache() && meta instanceof TransMeta ) {

--- a/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
@@ -1529,12 +1529,7 @@ public class BaseStepDialog extends Dialog {
         clone.setObjectId( databaseMeta.getObjectId() );
         String connectionName = showDbDialogUnlessCancelledOrValid( clone, databaseMeta );
         if ( connectionName != null ) {
-          // need to replace the old connection with a new one
-          if ( databaseMeta.isShared() ) {
-            if ( !replaceSharedConnection( databaseMeta, clone ) ) {
-              return;
-            }
-          }
+          // These changes won't update shared.xml
           transMeta.removeDatabase( transMeta.indexOfDatabase( databaseMeta ) );
           transMeta.addDatabase( clone );
           reinitConnectionDropDown( wConnection, connectionName );

--- a/ui/src/test/java/org/pentaho/di/ui/trans/step/EditConnectionListenerTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/trans/step/EditConnectionListenerTest.java
@@ -88,10 +88,8 @@ public class EditConnectionListenerTest {
 
     editConnectionListener.widgetSelected( null );
 
-    verify( editConnectionListener ).replaceSharedConnection( any( DatabaseMeta.class ), any( DatabaseMeta.class ) );
-    verify( sharedObjects ).removeObject( any( SharedObjectInterface.class ) );
-    verify( sharedObjects ).storeObject( any( SharedObjectInterface.class ) );
-    verify( sharedObjects ).saveToFile();
+    verify( editConnectionListener, never() ).replaceSharedConnection( any( DatabaseMeta.class ), any( DatabaseMeta.class ) );
+
   }
 
   @Test


### PR DESCRIPTION
- Removed the code in Spoon that is related to share/unshare menu items
- Spoon.saveToFile() and Spoon.saveFile() no longer save the shared objects in shared.xml