### PR TITLE
[PPP-4899] Vulnerable Component: commons-io

### DIFF
--- a/plugins/file-open-save-new/core/pom.xml
+++ b/plugins/file-open-save-new/core/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.ui.workbench</artifactId>
-      <version>3.127.0</version>
+      <version>3.132.0</version>
       <exclusions>
         <exclusion>
           <artifactId>javax.annotation-api</artifactId>


### PR DESCRIPTION
Jira: https://hv-eng.atlassian.net/browse/PPP-4899

- upgrade eclipse ui workbench version 3.127.0 -> 3.132.0 -- This gets us to commons-io 2.11.0, which is 2.7+, addressing CVE-2021-29425
- libloader case handled in https://github.com/pentaho/pentaho-reporting/pull/1678

```
[INFO] |  +- org.eclipse.platform:org.eclipse.ui.workbench:jar:3.132.0:compile
...
[INFO] |  |  +- org.eclipse.platform:org.eclipse.e4.ui.workbench.swt:jar:0.17.400:compile
...
[INFO] |  |  |  +- org.eclipse.platform:org.eclipse.e4.ui.css.core:jar:0.14.400:compile
[INFO] |  |  |  |  \- org.apache.xmlgraphics:batik-css:jar:1.17:compile
...
[INFO] |  |  |  |     \- org.apache.xmlgraphics:xmlgraphics-commons:jar:2.9:compile
[INFO] |  |  |  |        +- commons-io:commons-io:jar:2.11.0:compile
```

Related PRs:
https://github.com/pentaho/pentaho-reporting/pull/1678
https://github.com/pentaho/maven-parent-poms/pull/588