### PR TITLE
[BACKLOG-40797] - delete old db on rename

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
@@ -91,12 +91,8 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   private static final String DROP_TABLE_STATEMENT = "DROP TABLE IF EXISTS ";
 
   // Comparator for sorting databases alphabetically by name
-  public static final Comparator<DatabaseMeta> comparator = new Comparator<DatabaseMeta>() {
-    @Override
-    public int compare( DatabaseMeta dbm1, DatabaseMeta dbm2 ) {
-      return dbm1.getName().compareToIgnoreCase( dbm2.getName() );
-    }
-  };
+  public static final Comparator<DatabaseMeta> comparator = Comparator.comparing( DatabaseMeta::getName,
+                                                                                  String.CASE_INSENSITIVE_ORDER);
 
   private DatabaseInterface databaseInterface;
 

--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -279,6 +279,12 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
     }
 
     @Override
+    public void removeDatabase( String databaseName ) throws KettleException {
+      super.removeDatabase( databaseName );
+      changedDatabases = true;
+    }
+
+    @Override
     public void clear() throws KettleException {
       super.clear();
       changedDatabases = true;

--- a/engine/src/main/java/org/pentaho/di/shared/DatabaseManagementInterface.java
+++ b/engine/src/main/java/org/pentaho/di/shared/DatabaseManagementInterface.java
@@ -68,6 +68,14 @@ public interface DatabaseManagementInterface {
   void removeDatabase( DatabaseMeta databaseMeta ) throws KettleException;
 
   /**
+   * Remove the provided database
+   *
+   *
+   * @param databasename name of the database to remove
+   */
+  void removeDatabase( String databaseName ) throws KettleException;
+
+  /**
    * Removes all connections
    *
    */

--- a/engine/src/main/java/org/pentaho/di/shared/PassthroughDbConnectionManager.java
+++ b/engine/src/main/java/org/pentaho/di/shared/PassthroughDbConnectionManager.java
@@ -46,7 +46,12 @@ public class PassthroughDbConnectionManager implements DatabaseManagementInterfa
 
   @Override
   public void removeDatabase( DatabaseMeta databaseMeta ) throws KettleException {
-    sharedObjectsIO.delete( DatabaseConnectionManager.DB_TYPE, databaseMeta.getName() );
+    removeDatabase( databaseMeta.getName() );
+  }
+
+  @Override
+  public void removeDatabase( String databaseName ) throws KettleException {
+    sharedObjectsIO.delete( DatabaseConnectionManager.DB_TYPE, databaseName );
   }
 
   @Override

--- a/engine/src/test/java/org/pentaho/di/shared/DatabaseConnectionManagerTest.java
+++ b/engine/src/test/java/org/pentaho/di/shared/DatabaseConnectionManagerTest.java
@@ -1,0 +1,86 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2024 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.shared;
+
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.plugins.DatabasePluginType;
+import org.pentaho.di.core.row.value.ValueMetaPluginType;
+
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+public class DatabaseConnectionManagerTest {
+
+  private MemorySharedObjectsIO sharedObjectsIO;
+  private DatabaseConnectionManager dbManager;
+
+  @BeforeClass
+  public static void setUpOnce() throws Exception {
+    // Register Natives to create a default DatabaseMeta
+    DatabasePluginType.getInstance().searchPlugins();
+    ValueMetaPluginType.getInstance().searchPlugins();
+    KettleClientEnvironment.init();
+  }
+
+  @Before
+  public void setUp() {
+    sharedObjectsIO = new MemorySharedObjectsIO();
+    dbManager = new DatabaseConnectionManager( sharedObjectsIO );
+  }
+
+  @Test
+  public void testAddOne() throws Exception {
+    DatabaseMeta meta = createDatabase( "meta1" );
+    dbManager.addDatabase( meta );
+
+    Assert.assertNotNull( dbManager.getDatabase( "meta1" ) );
+  }
+
+  @Test
+  public void testEdit() throws Exception {
+    DatabaseMeta meta = createDatabase( "meta1" );
+    dbManager.addDatabase( meta );
+
+    Assert.assertNotNull( dbManager.getDatabase( "meta1" ) );
+    meta.setName( "meta2" );
+    dbManager.addDatabase( meta );
+
+    Assert.assertNotNull( dbManager.getDatabase( "meta1" ) );
+    Assert.assertEquals( "meta1", dbManager.getDatabase( "meta1" ).getName() );
+    Assert.assertNotNull( dbManager.getDatabase( "meta2" ) );
+    Assert.assertEquals( "meta2", dbManager.getDatabase( "meta2" ).getName() );
+  }
+
+  protected DatabaseMeta createDatabase( String name ) {
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( name );
+    db.getDatabaseInterface().setDatabaseName( name );
+    return db;
+  }
+
+}

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonDBDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonDBDelegate.java
@@ -102,6 +102,7 @@ public class SpoonDBDelegate extends SpoonDelegate {
         dbManager.addDatabase( databaseMeta );
 
         if ( !newname.equals( originalName ) ) {
+          dbManager.removeDatabase( originalName );
           spoon.refreshDbConnection( newname.trim() );
         }
         spoon.refreshDbConnection( originalName );


### PR DESCRIPTION
- DatabaseConnectionManager makes defensive copies
- added small unit test for this behavior
- changed Comparator in DatabaseMeta to avoid NPEs
- added remove by name method to DatabaseManagementInterface