### PR TITLE
[BACKLOG-41331] step and job entry database widget fixes

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/job/entry/JobEntryDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/entry/JobEntryDialog.java
@@ -45,6 +45,7 @@ import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryElementMetaInterface;
+import org.pentaho.di.shared.DatabaseManagementInterface;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.ui.core.PropsUI;
 import org.pentaho.di.ui.core.database.dialog.DatabaseDialog;
@@ -214,13 +215,16 @@ public class JobEntryDialog extends Dialog {
         DatabaseMeta newDBInfo = cdw.createAndRunDatabaseWizard( shell, props, jobMeta.getDatabases() );
         if ( newDBInfo != null ) {
           try {
-            jobMeta.getDatabaseManagementInterface().addDatabase( newDBInfo );
+            DatabaseManagementInterface dbMgr =
+                    spoonSupplier.get().getBowl().getManager( DatabaseManagementInterface.class );
+            dbMgr.addDatabase( newDBInfo );
           } catch ( KettleException exception ) {
             new ErrorDialog( spoonSupplier.get().getShell(),
               BaseMessages.getString( PKG, "Spoon.Dialog.ErrorSavingConnection.Title" ),
               BaseMessages.getString( PKG, "Spoon.Dialog.ErrorSavingConnection.Message", newDBInfo.getName() ), exception );
           }
           reinitConnectionDropDown( wConnection, newDBInfo.getName() );
+          spoonSupplier.get().refreshTree( DBConnectionFolderProvider.STRING_CONNECTIONS );
         }
       }
     } );
@@ -283,7 +287,7 @@ public class JobEntryDialog extends Dialog {
     DatabaseDialog cid = getDatabaseDialog();
     cid.setDatabaseMeta( changing );
     cid.setModalDialog( true );
-    String origname = origin.getName();
+    String origname = origin == null ? null : origin.getName();
 
     String name = null;
     boolean repeat = true;
@@ -373,7 +377,9 @@ public class JobEntryDialog extends Dialog {
       String connectionName = showDbDialogUnlessCancelledOrValid( databaseMeta, null );
       if ( connectionName != null ) {
         try {
-          jobMeta.getDatabaseManagementInterface().addDatabase( databaseMeta );
+          DatabaseManagementInterface dbMgr =
+                  spoonSupplier.get().getBowl().getManager( DatabaseManagementInterface.class );
+          dbMgr.addDatabase( databaseMeta );
         } catch ( KettleException exception ) {
           new ErrorDialog( spoonSupplier.get().getShell(),
             BaseMessages.getString( PKG, "Spoon.Dialog.ErrorSavingConnection.Title" ),

--- a/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
@@ -69,6 +69,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.laf.BasePropertyHandler;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryElementMetaInterface;
+import org.pentaho.di.shared.DatabaseManagementInterface;
 import org.pentaho.di.shared.SharedObjects;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -748,13 +749,16 @@ public class BaseStepDialog extends Dialog {
         DatabaseMeta newDBInfo = cdw.createAndRunDatabaseWizard( shell, props, transMeta.getDatabases() );
         if ( newDBInfo != null ) {
           try {
-            transMeta.getDatabaseManagementInterface().addDatabase( newDBInfo );
+            DatabaseManagementInterface dbMgr =
+                    spoonSupplier.get().getBowl().getManager( DatabaseManagementInterface.class );
+            dbMgr.addDatabase( newDBInfo );
           } catch ( KettleException ex ) {
             new ErrorDialog( wbwConnection.getShell(),
               BaseMessages.getString( PKG, "BaseStepDialog.UnexpectedErrorEditingConnection.DialogTitle" ),
               BaseMessages.getString( PKG, "BaseStepDialog.UnexpectedErrorEditingConnection.DialogMessage" ), ex );
           }
           reinitConnectionDropDown( wConnection, newDBInfo.getName() );
+          spoonSupplier.get().refreshTree( DBConnectionFolderProvider.STRING_CONNECTIONS );
         }
       }
     } );
@@ -817,7 +821,7 @@ public class BaseStepDialog extends Dialog {
     DatabaseDialog cid = getDatabaseDialog( shell );
     cid.setDatabaseMeta( changing );
     cid.setModalDialog( true );
-    String origname = origin.getName();
+    String origname = origin == null ? null : origin.getName();
 
     if ( cid.getDatabaseMeta() == null ) {
       return changing.getName();
@@ -1512,7 +1516,9 @@ public class BaseStepDialog extends Dialog {
       String connectionName = showDbDialogUnlessCancelledOrValid( databaseMeta, null );
       if ( connectionName != null ) {
         try {
-          transMeta.getDatabaseManagementInterface().addDatabase( databaseMeta );
+          DatabaseManagementInterface dbMgr =
+                  spoonSupplier.get().getBowl().getManager( DatabaseManagementInterface.class );
+          dbMgr.addDatabase( databaseMeta );
         } catch ( KettleException ex ) {
           new ErrorDialog( wConnection.getShell(),
             BaseMessages.getString( PKG, "BaseStepDialog.UnexpectedErrorEditingConnection.DialogTitle" ),

--- a/ui/src/test/java/org/pentaho/di/ui/job/entry/JobEntryDialog_ConnectionLine_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/job/entry/JobEntryDialog_ConnectionLine_Test.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
+
 /**
  * @author Andrey Khayrutdinov
  */
@@ -95,6 +96,7 @@ public class JobEntryDialog_ConnectionLine_Test {
     Spoon mockSpoon = mock( Spoon.class );
     Whitebox.setInternalState( dialog, "spoonSupplier", mockSupplier );
     when( mockSupplier.get() ).thenReturn( mockSpoon );
+    when( mockSpoon.getBowl() ).thenReturn( DefaultBowl.getInstance() );
     dialog.jobMeta = jobMeta;
     dialog.new AddConnectionListener( mock( CCombo.class ) ).widgetSelected( null );
     if ( answeredName != null ) {

--- a/ui/src/test/java/org/pentaho/di/ui/trans/step/BaseStepDialog_ConnectionLine_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/trans/step/BaseStepDialog_ConnectionLine_Test.java
@@ -33,7 +33,6 @@ import org.pentaho.di.ui.spoon.Spoon;
 
 import java.util.function.Supplier;
 import org.eclipse.swt.custom.CCombo;
-import org.eclipse.swt.widgets.Shell;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -96,6 +95,7 @@ public class BaseStepDialog_ConnectionLine_Test {
     Spoon mockSpoon = mock( Spoon.class );
     Whitebox.setInternalState( dialog, "spoonSupplier", mockSupplier );
     when( mockSupplier.get() ).thenReturn( mockSpoon );
+    when( mockSpoon.getBowl() ).thenReturn( DefaultBowl.getInstance() );
     dialog.transMeta = transMeta;
     dialog.new AddConnectionListener( mock( CCombo.class ) ).widgetSelected( null );
     if ( answeredName != null ) {


### PR DESCRIPTION
- NPE when clicking New
- Connections created through step or job entry should end up in "project" or "global" context, not local
- Refresh connections list after creating connection via wizard