### PR TITLE
[PDI-17310/PDI-17311] - Currency sign, replaced by currency symbol (¤) specified in Generate Rows/Regex Evaluation step errors out.

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -1033,7 +1033,7 @@ public class ValueMetaBase implements ValueMetaInterface {
 
         if ( parsePosition.getIndex() < string.length() ) {
           throw new KettleValueException( toString()
-              + " : couldn't convert String to number with " + ( ( getFormatMask() == null ) ? "empty format" : "format " + getFormatMask() ) +  ": unexpected character found at position "
+              + " : couldn't convert String to number with " + ( ( getFormatMask() == null ) ? "empty format" : "format [" + getFormatMask() + "]" ) +  ": unexpected character found at position "
               + ( parsePosition.getErrorIndex() + 1 ) + " for value [" + string + "]" );
         }
 

--- a/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/pentaho/di/core/row/value/ValueMetaBase.java
@@ -1033,8 +1033,8 @@ public class ValueMetaBase implements ValueMetaInterface {
 
         if ( parsePosition.getIndex() < string.length() ) {
           throw new KettleValueException( toString()
-              + " : couldn't convert String to number : non-numeric character found at position "
-              + ( parsePosition.getIndex() + 1 ) + " for value [" + string + "]" );
+              + " : couldn't convert String to number with " + ( ( getFormatMask() == null ) ? "empty format" : "format " + getFormatMask() ) +  ": unexpected character found at position "
+              + ( parsePosition.getErrorIndex() + 1 ) + " for value [" + string + "]" );
         }
 
       }


### PR DESCRIPTION
@pentaho/tatooine_dev 