### PR TITLE
[SP-6595][BACKLOG-41795] Job is adding already-added log records on p…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -909,13 +909,6 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
       throw threadExceptions.poll();
     }
 
-    // In parallel execution, we aggregate all the results, simply add them to
-    // the previous result...
-    //
-    for ( Result threadResult : threadResults ) {
-      res.add( threadResult );
-    }
-
     // If there have been errors, logically, we need to set the result to
     // "false"...
     //


### PR DESCRIPTION
…arallel runs causing exponential memory leak - Backport of PDI-20199 - Spoon running out of memory while running a job (10.2 Suite)