### PR TITLE
[PDI-20159] - prevent double encoding of spaces

### DIFF
--- a/plugins/rest/core/src/test/java/org/pentaho/di/trans/steps/rest/RestTest.java
+++ b/plugins/rest/core/src/test/java/org/pentaho/di/trans/steps/rest/RestTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith( MockitoJUnitRunner.StrictStubs.class )
@@ -81,6 +82,8 @@ public class RestTest {
 
     Rest rest = mock( Rest.class );
     doCallRealMethod().when( rest ).callRest( any() );
+    doCallRealMethod().when( rest ).getClient( any() );
+    doCallRealMethod().when( rest ).buildRequest( any(), any() );
     doCallRealMethod().when( rest ).searchForHeaders( any() );
 
     ReflectionTestUtils.setField( rest, "meta", meta );
@@ -102,19 +105,9 @@ public class RestTest {
   @Test
   public void testEncodingParams() throws KettleException {
 
-    Object[] params = new Object[1];
+    Object[] params = new Object[2];
     params[0] = "{a:{[val1]}}";
-
-    Invocation.Builder builder = mock( Invocation.Builder.class );
-
-    WebTarget resource = mock( WebTarget.class );
-    lenient().doReturn( builder ).when( resource ).request();
-
-    Client client = mock( Client.class );
-    lenient().doReturn( resource ).when( client ).target( anyString() );
-
-    ClientBuilder clientBuilder = mock( ClientBuilder.class );
-    lenient().when( clientBuilder.build() ).thenReturn( client );
+    params[1] = "string with spaces";
 
     RestMeta meta = mock( RestMeta.class );
     doReturn( false ).when( meta ).isUrlInField();
@@ -122,6 +115,7 @@ public class RestTest {
 
     RowMetaInterface rmi = mock( RowMetaInterface.class );
     doReturn( params[0] ).when( rmi ).getString( params, 0 );
+    doReturn( params[1] ).when( rmi ).getString( params, 1 );
 
     RestData data = mock( RestData.class );
     data.method = RestMeta.HTTP_METHOD_POST;
@@ -132,28 +126,24 @@ public class RestTest {
     data.resultHeaderFieldName = "headers";
     data.realUrl = "http://localhost:8080/pentaho";
     data.useParams = true;
-    data.nrParams = 1;
+    data.nrParams = 2;
     data.mediaType = MediaType.APPLICATION_JSON_TYPE;
 
     // Add one index to this array
-    data.indexOfParamFields = new int[] {0};
-    data.paramNames = new String[] {"param1"};
+    data.indexOfParamFields = new int[] {0, 1};
+    data.paramNames = new String[] {"param1", "param2"};
 
     Rest rest = mock( Rest.class );
-    doCallRealMethod().when( rest ).callRest( any() );
+    doCallRealMethod().when( rest ).getClient( any() );
+    doCallRealMethod().when( rest ).buildRequest( any(), any() );
 
     ReflectionTestUtils.setField( rest, "meta", meta );
     ReflectionTestUtils.setField( rest, "data", data );
 
-    try {
-      Object[] output = rest.callRest( params );
-    } catch ( Exception exception ) {
-      // Ignore the ConnectExcepion which is expected as rest call to localhost:8080 will fail in unit test
-      // IllegalStateException is throws when the parameters are not encoded
-      if ( exception.getCause() instanceof IllegalStateException ) {
-        Assert.fail();
-      }
-    }
+    Client client = rest.getClient( params );
+    WebTarget webResource = rest.buildRequest( client, params );
+    String expected = "http://localhost:8080/pentaho?param1=%7Ba%3A%7B%5Bval1%5D%7D%7D&param2=string%20with%20spaces";
+    assertEquals( expected, webResource.getUri().toString() );
   }
 
   /**
@@ -184,20 +174,24 @@ public class RestTest {
     data.method = RestMeta.HTTP_METHOD_PUT;
     data.config = new ClientConfig();
     data.inputRowMeta = rmi;
-    data.realUrl = "http://localhost:8080/pentaho";
+    // should be non-routable so we can consistetly not connect
+    data.realUrl = "http://192.0.2.1:8080/pentaho";
     data.mediaType = MediaType.TEXT_PLAIN_TYPE;
     data.useBody = true;
     // do not set data.indexOfBodyField
 
     Rest rest = mock( Rest.class );
     doCallRealMethod().when( rest ).callRest( any() );
+    doCallRealMethod().when( rest ).getClient( any() );
+    doCallRealMethod().when( rest ).buildRequest( any(), any() );
 
     ReflectionTestUtils.setField( rest, "meta", meta );
     ReflectionTestUtils.setField( rest, "data", data );
 
     try {
       rest.callRest( new Object[] { 0 } );
-    } catch ( Exception exception ) {
+      Assert.fail( "Expected an exception" );
+    } catch ( KettleException exception ) {
       // Ignore the ConnectException which is expected as rest call to localhost:8080 will fail in unit test
       // IllegalStateException is throws when the body is null
       if ( exception.getCause().getCause() instanceof IllegalStateException ) {


### PR DESCRIPTION
The changes to Rest.java are primarily changing UriComponent.Type.QUERY_PARAM to UriComponent.Type.QUERY_PARAM_SPACE_ENCODED so spaces wouldn't be double-encoded, and splitting `callRest()` into several methods so they could be unit tested. 

Github doesn't seem to handle the change well, despite the only changes being indentation for most lines. 