### PR TITLE
[BACKLOG-42335] - fix calling carte

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -260,8 +260,17 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
   protected MemorySharedObjectsIO localSharedObjects = new MemorySharedObjectsIO();
   // important, these need to be updated if the bowl is changed.
   private SharedObjectsIO combinedSharedObjects =
-    new DelegatingSharedObjectsIO( bowl.getSharedObjectsIO(), localSharedObjects );
+      new DelegatingSharedObjectsIO( bowl.getSharedObjectsIO(), localSharedObjects );
   protected DatabaseManagementInterface readDbManager = new PassthroughDbConnectionManager( combinedSharedObjects );
+
+  protected void initializeLocalDatabases() {
+    // NOTE: this has to assign new objects, not just clear existing ones, because it is used in clone(), and
+    // updating the original objects will update the source of the clone.
+    localSharedObjects = new MemorySharedObjectsIO();
+    combinedSharedObjects =
+      new DelegatingSharedObjectsIO( bowl.getSharedObjectsIO(), localSharedObjects );
+    readDbManager = new PassthroughDbConnectionManager( combinedSharedObjects );
+  }
 
   private class MetaDatabaseManager extends PassthroughDbConnectionManager {
     // TODO: repository logic should be in this local class. Caller should not need to know whether or not a

--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -416,7 +416,7 @@ public class JobMeta extends AbstractMeta
         jobMeta.jobcopies = new ArrayList<JobEntryCopy>();
         jobMeta.jobhops = new ArrayList<JobHopMeta>();
         jobMeta.notes = new ArrayList<NotePadMeta>();
-        jobMeta.localSharedObjects.clear();
+        jobMeta.initializeLocalDatabases();
         jobMeta.slaveServers = new ArrayList<SlaveServer>();
         jobMeta.namedParams = new NamedParamsDefault();
       }
@@ -2608,7 +2608,8 @@ public class JobMeta extends AbstractMeta
       } else {
         // Assume file
         //
-        FileObject fileObject = KettleVFS.getInstance( bowl ).getFileObject( space.environmentSubstitute( getFilename() ), space );
+        FileObject fileObject = KettleVFS.getInstance( bowl ).
+          getFileObject( space.environmentSubstitute( getFilename() ), space );
         originalPath = fileObject.getParent().getName().getPath();
         baseName = fileObject.getName().getBaseName();
         fullname = fileObject.getName().getPath();
@@ -2636,8 +2637,9 @@ public class JobMeta extends AbstractMeta
         // loop over steps, databases will be exported to XML anyway.
         //
         for ( JobEntryCopy jobEntry : jobMeta.jobcopies ) {
-          compatibleJobEntryExportResources( jobEntry.getEntry(), jobMeta, definitions, namingInterface, repository );
-          jobEntry.getEntry().exportResources( jobMeta, definitions, namingInterface, repository, metaStore );
+          compatibleJobEntryExportResources( jobEntry.getEntry(), jobMeta, definitions, namingInterface, repository,
+                                             metaStore );
+          jobEntry.getEntry().exportResources( bowl, jobMeta, definitions, namingInterface, repository, metaStore );
         }
 
         // Set a number of parameters for all the data files referenced so far...
@@ -2676,11 +2678,13 @@ public class JobMeta extends AbstractMeta
     return resourceName;
   }
 
+  // calls deprecated APIs for old JobEntries that haven't updated
   @SuppressWarnings( "deprecation" )
   private void compatibleJobEntryExportResources( JobEntryInterface entry, JobMeta jobMeta,
-      Map<String, ResourceDefinition> definitions, ResourceNamingInterface namingInterface, Repository repository2 )
-      throws KettleException {
-    entry.exportResources( jobMeta, definitions, namingInterface, repository );
+      Map<String, ResourceDefinition> definitions, ResourceNamingInterface namingInterface, Repository repository2,
+      IMetaStore metaStore ) throws KettleException {
+    entry.exportResources( jobMeta, definitions, namingInterface, repository2 );
+    entry.exportResources( jobMeta, definitions, namingInterface, repository2, metaStore );
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/job/entry/JobEntryInterface.java
+++ b/engine/src/main/java/org/pentaho/di/job/entry/JobEntryInterface.java
@@ -666,8 +666,35 @@ public interface JobEntryInterface {
    * @return The filename for this object. (also contained in the definitions map)
    * @throws KettleException
    *           in case something goes wrong during the export
+   * @deprecated Use the version with the Bowl
    */
+  @Deprecated
   String exportResources( VariableSpace space, Map<String, ResourceDefinition> definitions,
+    ResourceNamingInterface namingInterface, Repository repository, IMetaStore metaStore ) throws KettleException;
+
+  /**
+   * Exports the object to a flat-file system, adding content with filename keys to a set of definitions. The supplied
+   * resource naming interface allows the object to name appropriately without worrying about those parts of the
+   * implementation specific details.
+   *
+   * @param Bowl
+   *          Context for file operations
+   * @param space
+   *          The variable space to resolve (environment) variables with.
+   * @param definitions
+   *          The map containing the filenames and content
+   * @param namingInterface
+   *          The resource naming interface allows the object to be named appropriately
+   * @param repository
+   *          The repository to load resources from
+   * @param metaStore
+   *          the metaStore to load external metadata from
+   *
+   * @return The filename for this object. (also contained in the definitions map)
+   * @throws KettleException
+   *           in case something goes wrong during the export
+   */
+  String exportResources( Bowl bowl, VariableSpace space, Map<String, ResourceDefinition> definitions,
     ResourceNamingInterface namingInterface, Repository repository, IMetaStore metaStore ) throws KettleException;
 
   /**

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -577,7 +577,7 @@ public class TransMeta extends AbstractMeta
         transMeta.clear();
       } else {
         // Clear out the things we're replacing below
-        transMeta.localSharedObjects.clear();
+        transMeta.initializeLocalDatabases();
         transMeta.steps = new ArrayList<>();
         transMeta.hops = new ArrayList<>();
         transMeta.notes = new ArrayList<>();


### PR DESCRIPTION
Fixed clone, which had resulted in the local shared objects being wiped out on both the source and the target

Fixed a call to exportResources that hadn't been updated with a Bowl, resulting in the wrong method being called.