### PR TITLE
[PDI-20195] - inconsistent variable names recently created

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1688,6 +1688,21 @@ public class Const {
   public static final String COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW = "COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW";
 
   /**
+   Value to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as job input mode.
+   */
+  public static final String KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT = "KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT";
+
+  /**
+   Value to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as trans input mode.
+   */
+  public static final String KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT = "KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT";
+
+  /**
+   Value to show/not show the Warning messages regarding the configured behaviour of the flag "Execute every Input Row"
+   */
+  public static final String KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW = "KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW";
+
+  /**
    Value to Configure if we want to export only the used connections to the XML file
    */
   public static final String STRING_ONLY_USED_DB_TO_XML = "STRING_ONLY_USED_DB_TO_XML";

--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -1238,16 +1238,36 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
   }
 
   private boolean shouldConsiderOldBehaviourForEveryInputRow( ) {
-    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
-    if ( "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "N" ) ) ) {
+    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
+    String shouldExecuteWithZeroRowsCompat = System.getProperty( Const.COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT );
+    if ( !Utils.isEmpty( shouldExecuteWithZeroRowsCompat ) && "Y".equalsIgnoreCase( shouldExecuteWithZeroRowsCompat ) != shouldExecuteWithZeroRows ) {
+      log.logError(
+        "COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT property is deprecated, please use KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT and remove the old one."
+      );
+      //Assumes the old variable setting until it is deleted
+      shouldExecuteWithZeroRows = !shouldExecuteWithZeroRows;
+    }
+
+    boolean showWarnings = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "Y" ) );
+    String showWarningsCompat = System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW );
+    if ( !Utils.isEmpty( showWarningsCompat ) && "Y".equalsIgnoreCase( showWarningsCompat ) != showWarnings  ) {
+      log.logError(
+        "COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW property is deprecated, please use KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW."
+      );
+      //Assumes the old variable setting until it is deleted
+      showWarnings = !showWarnings;
+    }
+
+    if (  showWarnings  ) {
       if ( shouldExecuteWithZeroRows ) {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       } else {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       }
     }
+
     return shouldExecuteWithZeroRows;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1264,16 +1264,36 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
   }
 
   private boolean shouldConsiderOldBehaviourForEveryInputRow() {
-    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
-    if ( "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "N" ) ) ) {
+    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
+    String shouldExecuteWithZeroRowsCompat = System.getProperty( Const.COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT );
+    if ( !Utils.isEmpty( shouldExecuteWithZeroRowsCompat ) && "Y".equalsIgnoreCase( shouldExecuteWithZeroRowsCompat ) != shouldExecuteWithZeroRows ) {
+      log.logError(
+        "COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT property is deprecated, please use KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT and remove the old one."
+      );
+      //Assumes the old variable setting until it is deleted
+      shouldExecuteWithZeroRows = !shouldExecuteWithZeroRows;
+    }
+
+    boolean showWarnings = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "Y" ) );
+    String showWarningsCompat = System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW );
+    if ( !Utils.isEmpty( showWarningsCompat ) && "Y".equalsIgnoreCase( showWarningsCompat ) != showWarnings  ) {
+      log.logError(
+        "COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW property is deprecated, please use KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW."
+      );
+      //Assumes the old variable setting until it is deleted
+      showWarnings = !showWarnings;
+    }
+
+    if (  showWarnings  ) {
       if ( shouldExecuteWithZeroRows ) {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       } else {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       }
     }
+
     return shouldExecuteWithZeroRows;
   }
 

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -644,7 +644,7 @@
     <description>Set this variable to Y to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as job input mode.
       See Jira issue PPP-20033 for details.
     </description>
-    <variable>COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
+    <variable>KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
     <default-value>N</default-value>
   </kettle-variable>
 
@@ -652,7 +652,7 @@
     <description>Set this variable to Y to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as trans input mode.
       See Jira issue PPP-20033 for details.
     </description>
-    <variable>COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
+    <variable>KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
     <default-value>N</default-value>
   </kettle-variable>
 
@@ -660,7 +660,7 @@
     <description>Set this variable to Y/N to show/not show the Warning messages regarding the configured behaviour of the flag "Execute every Input Row".
       See Jira issue PPP-20033 for details.
     </description>
-    <variable>COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW</variable>
+    <variable>KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW</variable>
     <default-value>Y</default-value>
   </kettle-variable>
 </kettle-variables>


### PR DESCRIPTION
1. Created the NEW variables names compliant with the standard
2. Added a fallback on the OLD name, and give a ERROR message to the Logs saying that that name is deprecated, and upgrade to the new name

@pentaho/tatooine_dev 