### PR TITLE
[SP-6608] Backport of [PPP-4582] - Use of Vulnerable Component: Components/oauth_client_library_for_java (10.2 Suite)

### DIFF
--- a/assemblies/plugins/pom.xml
+++ b/assemblies/plugins/pom.xml
@@ -24,7 +24,6 @@
     <kettle-gpload-plugin.version>${project.version}</kettle-gpload-plugin.version>
     <kettle-hl7-plugin.version>${project.version}</kettle-hl7-plugin.version>
     <mail-job-plugin.version>${project.version}</mail-job-plugin.version>
-    <pdi-google-analytics-plugin.version>10.2.0.0-SNAPSHOT</pdi-google-analytics-plugin.version>
     <pdi-salesforce-plugin.version>10.2.0.0-SNAPSHOT</pdi-salesforce-plugin.version>
     <monet-db-bulk-loader-plugin.version>${project.version}</monet-db-bulk-loader-plugin.version>
     <yaml-input-plugin.version>${project.version}</yaml-input-plugin.version>
@@ -48,7 +47,6 @@
     <mondrianinput-plugin.version>${project.version}</mondrianinput-plugin.version>
     <pdi-sap-plugin.version>10.2.0.0-SNAPSHOT</pdi-sap-plugin.version>
     <jms-streaming-plugin.version>${project.version}</jms-streaming-plugin.version>
-    <pentaho-googledrive-vfs-plugin.version>${project.version}</pentaho-googledrive-vfs-plugin.version>
     <pdi-teradata-tpt-plugin-package.version>${project.version}</pdi-teradata-tpt-plugin-package.version>
     <pdi-platform-utils-plugin.version>10.2.0.0-SNAPSHOT</pdi-platform-utils-plugin.version>
     <vertica-bulkloader-plugin.version>10.2.0.0-SNAPSHOT</vertica-bulkloader-plugin.version>
@@ -182,18 +180,6 @@
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>kettle-hl7-plugin</artifactId>
       <version>${kettle-hl7-plugin.version}</version>
-      <type>zip</type>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho.di.plugins</groupId>
-      <artifactId>pdi-google-analytics-plugin</artifactId>
-      <version>${pdi-google-analytics-plugin.version}</version>
       <type>zip</type>
       <exclusions>
         <exclusion>
@@ -446,18 +432,6 @@
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>ivw-bulk-loader-plugins</artifactId>
       <version>${ivw-bulk-loader-plugin.version}</version>
-      <type>zip</type>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho.di.plugins</groupId>
-      <artifactId>pentaho-googledrive-vfs-plugin</artifactId>
-      <version>${pentaho-googledrive-vfs-plugin.version}</version>
       <type>zip</type>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Remove pdi-google-analytics-plugin and pentaho-googledrive-vfs-plugin from plugin assemblies