### PR TITLE
[BACKLOG-41283]-Upgrading Pentaho kettle from Java EE 9 to Jakarta EE 10

### DIFF
--- a/core/src/test/java/org/pentaho/di/core/variables/VariablesTest.java
+++ b/core/src/test/java/org/pentaho/di/core/variables/VariablesTest.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.di.core.variables;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -65,7 +64,6 @@ public class VariablesTest {
    * Test for PDI-12893 issue.  Checks if an ConcurrentModificationException while iterating over the System properties
    * is occurred.
    */
-  @Ignore
   @Test
   public void testInitializeVariablesFrom() {
     final Variables variablesMock = mock( Variables.class );

--- a/dbdialog/src/test/java/org/pentaho/ui/database/event/FragmentHandlerTest.java
+++ b/dbdialog/src/test/java/org/pentaho/ui/database/event/FragmentHandlerTest.java
@@ -23,7 +23,6 @@ package org.pentaho.ui.database.event;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.logging.KettleLogStore;
@@ -47,7 +46,6 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for FragmentHandler.
  */
-@Ignore
 public class FragmentHandlerTest {
 
   FragmentHandler fragmentHandler;

--- a/engine/src/test/java/org/pentaho/di/core/util/AsyncDatabaseActionTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/util/AsyncDatabaseActionTest.java
@@ -22,7 +22,6 @@ package org.pentaho.di.core.util;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.database.DatabaseMeta;
@@ -89,7 +88,6 @@ public class AsyncDatabaseActionTest {
     KettleLogStore.getAppender().addLoggingEventListener( errorLogListener );
   }
 
-  @Ignore
   @Test
   public void getTables() throws InterruptedException, ExecutionException, TimeoutException {
     AsyncDatabaseAction.getTables( dbMeta, "PUBLIC", completion::complete );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputContentParsingTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/csvinput/CsvInputContentParsingTest.java
@@ -23,7 +23,6 @@
 package org.pentaho.di.trans.steps.csvinput;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
@@ -204,7 +203,6 @@ public class CsvInputContentParsingTest extends BaseCsvParsingTest {
     );
   }
 
-  @Ignore
   @Test
   public void testEnclosures() throws Exception {
     meta.setDelimiter( ";" );

--- a/engine/src/test/java/org/pentaho/di/www/ExecuteJobServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/ExecuteJobServletTest.java
@@ -24,7 +24,6 @@ package org.pentaho.di.www;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
@@ -182,7 +181,6 @@ public class ExecuteJobServletTest {
       assertTrue( out.toString().contains( Encode.forHtml( message ) ) );
     }
   }
-  @Ignore
   @Test
   public void testExecuteJobServletTestCantFindRepository() throws ServletException, IOException {
     try ( MockedStatic<Encr> encrMockedStatic = mockStatic( Encr.class ) ) {

--- a/plugins/ivw-bulk-loader/impl/src/test/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseTest.java
+++ b/plugins/ivw-bulk-loader/impl/src/test/java/org/pentaho/di/trans/steps/ivwloader/IngresVectorwiseTest.java
@@ -62,7 +62,6 @@ import org.pentaho.di.trans.steps.mock.StepMockHelper;
 /**
  * User: Dzmitry Stsiapanau Date: 11/20/13 Time: 12:41 PM
  */
-@Ignore
 public class IngresVectorwiseTest {
 
   private class IngresVectorwiseLoaderTest extends IngresVectorwiseLoader {

--- a/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsoninput/analyzer/JsonInputAnalyzerTest.java
+++ b/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsoninput/analyzer/JsonInputAnalyzerTest.java
@@ -24,7 +24,6 @@ package org.pentaho.di.trans.steps.jsoninput.analyzer;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -61,7 +60,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-@Ignore
 @RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class JsonInputAnalyzerTest {
 
@@ -165,7 +163,6 @@ public class JsonInputAnalyzerTest {
     assertTrue( types.contains( JsonInputMeta.class ) );
   }
 
-  @Ignore
   @Test
   public void testJsonInputExternalResourceConsumer() throws Exception {
     JsonInputExternalResourceConsumer consumer = new JsonInputExternalResourceConsumer();

--- a/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsonoutput/analyzer/JsonOutputAnalyzerTest.java
+++ b/plugins/json/core/src/test/java/org/pentaho/di/trans/steps/jsonoutput/analyzer/JsonOutputAnalyzerTest.java
@@ -24,7 +24,6 @@ package org.pentaho.di.trans.steps.jsonoutput.analyzer;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -129,7 +128,6 @@ public class JsonOutputAnalyzerTest {
     assertTrue( types.contains( JsonOutputMeta.class ) );
   }
 
-  @Ignore
   @Test
   public void testJsonOutputExternalResourceConsumer() throws Exception {
     JsonOutputExternalResourceConsumer consumer = new JsonOutputExternalResourceConsumer();


### PR DESCRIPTION
[BACKLOG-41283]-Upgrading Pentaho kettle from Java EE 9 to Jakarta EE 10

[BACKLOG-41283]: https://hv-eng.atlassian.net/browse/BACKLOG-41283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ