### PR TITLE
[BACKLOG-40920] - Correctly initalize project variables in carte

### DIFF
--- a/engine/src/main/java/org/pentaho/di/www/AddJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/AddJobServlet.java
@@ -213,7 +213,7 @@ public class AddJobServlet extends BaseHttpServlet implements CartePluginInterfa
 
       // Setting variables
       //
-      job.initializeVariablesFrom( null );
+      job.initializeVariablesFrom( jobMeta.getBowl().getADefaultVariableSpace() );
       job.getJobMeta().setInternalKettleVariables( job );
       job.injectVariables( jobConfiguration.getJobExecutionConfiguration().getVariables() );
       job.setArguments( jobExecutionConfiguration.getArgumentStrings() );

--- a/engine/src/main/java/org/pentaho/di/www/RunJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RunJobServlet.java
@@ -249,7 +249,7 @@ public class RunJobServlet extends BaseHttpServlet implements CartePluginInterfa
 
       // Setting variables
       //
-      job.initializeVariablesFrom( null );
+      job.initializeVariablesFrom( jobMeta.getBowl().getADefaultVariableSpace() );
       job.getJobMeta().setInternalKettleVariables( job );
       job.injectVariables( jobConfiguration.getJobExecutionConfiguration().getVariables() );
 

--- a/engine/src/main/java/org/pentaho/di/www/RunTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RunTransServlet.java
@@ -221,7 +221,7 @@ public class RunTransServlet extends BaseHttpServlet implements CartePluginInter
 
       // Setting variables
       //
-      trans.initializeVariablesFrom( null );
+      trans.initializeVariablesFrom( transMeta.getBowl().getADefaultVariableSpace() );
       trans.getTransMeta().setInternalKettleVariables( trans );
       trans.injectVariables( transConfiguration.getTransExecutionConfiguration().getVariables() );
 

--- a/engine/src/main/java/org/pentaho/di/www/StartJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StartJobServlet.java
@@ -278,11 +278,7 @@ public class StartJobServlet extends BaseHttpServlet implements CartePluginInter
             JobConfiguration jobConfiguration = getJobMap().getConfiguration( jobName );
 
             String carteObjectId = UUID.randomUUID().toString();
-            SimpleLoggingObject servletLoggingObject =
-              new SimpleLoggingObject( CONTEXT_PATH, LoggingObjectType.CARTE, null );
-            servletLoggingObject.setContainerObjectId( carteObjectId );
-
-            Job newJob = new Job( job.getRep(), job.getJobMeta(), servletLoggingObject );
+            Job newJob = BaseJobServlet.createJob( this, CONTEXT_PATH, carteObjectId, jobConfiguration );
             newJob.setLogLevel( job.getLogLevel() );
 
             // Discard old log lines from the old job

--- a/engine/src/main/java/org/pentaho/di/www/jaxrs/JobResource.java
+++ b/engine/src/main/java/org/pentaho/di/www/jaxrs/JobResource.java
@@ -189,7 +189,7 @@ public class JobResource {
 
       // Setting variables
       //
-      job.initializeVariablesFrom( null );
+      job.initializeVariablesFrom( jobMeta.getBowl().getADefaultVariableSpace() );
       job.getJobMeta().setInternalKettleVariables( job );
       job.injectVariables( jobConfiguration.getJobExecutionConfiguration().getVariables() );
       job.setArguments( jobExecutionConfiguration.getArgumentStrings() );

--- a/engine/src/test/java/org/pentaho/di/www/RegisterJobServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/RegisterJobServletTest.java
@@ -22,6 +22,7 @@
 package org.pentaho.di.www;
 
 
+import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobConfiguration;
@@ -86,6 +87,7 @@ public class RegisterJobServletTest {
     when( conf.getJobMeta() ).thenReturn( jobMeta );
     when( jobMap.getSlaveServerConfig() ).thenReturn( slaveServerConfig );
     when( jobMeta.listParameters() ).thenReturn( new String[] {} );
+    when( jobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
     return jobServlet.createJob( conf );
   }
 

--- a/engine/src/test/java/org/pentaho/di/www/RunTransServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/RunTransServletTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LoggingObjectType;
 import org.pentaho.di.core.logging.SimpleLoggingObject;
@@ -94,6 +95,7 @@ public class RunTransServletTest {
     }
     when( trans.getSteps() ).thenReturn( stepList );
     when( trans.getContainerObjectId() ).thenReturn( transId );
+    when( transMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
   }
 
   @Test
@@ -151,7 +153,7 @@ public class RunTransServletTest {
     String testParameter = "testParameter";
     Mockito.when( transMeta.listVariables() ).thenReturn( new String[] { testParameter } );
     Mockito.when( transMeta.getVariable( Mockito.anyString() ) ).thenReturn( "default value" );
-
+    Mockito.when( transMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
     Mockito.when( transMeta.listParameters() ).thenReturn( new String[] { testParameter } );
     Mockito.when( request.getParameterNames() ).thenReturn( new StringTokenizer( testParameter ) );
 


### PR DESCRIPTION
- use Bowl default variablespace rather than global
- Re-construct Job for re-run the same as it is initially constructed.