### PR TITLE
[SP-6677] - Backport of PDI-20195 - inconsistent variable names recently created (10.2 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1679,6 +1679,21 @@ public class Const {
   public static final String COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW = "COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW";
 
   /**
+   Value to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as job input mode.
+   */
+  public static final String KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT = "KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT";
+
+  /**
+   Value to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as trans input mode.
+   */
+  public static final String KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT = "KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT";
+
+  /**
+   Value to show/not show the Warning messages regarding the configured behaviour of the flag "Execute every Input Row"
+   */
+  public static final String KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW = "KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW";
+
+  /**
    Value to Configure if we want to export only the used connections to the XML file
    */
   public static final String STRING_ONLY_USED_DB_TO_XML = "STRING_ONLY_USED_DB_TO_XML";

--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -1229,16 +1229,36 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
   }
 
   private boolean shouldConsiderOldBehaviourForEveryInputRow( ) {
-    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
-    if ( "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "N" ) ) ) {
+    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
+    String shouldExecuteWithZeroRowsCompat = System.getProperty( Const.COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT );
+    if ( !Utils.isEmpty( shouldExecuteWithZeroRowsCompat ) && "Y".equalsIgnoreCase( shouldExecuteWithZeroRowsCompat ) != shouldExecuteWithZeroRows ) {
+      log.logError(
+        "COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT property is deprecated, please use KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT and remove the old one."
+      );
+      //Assumes the old variable setting until it is deleted
+      shouldExecuteWithZeroRows = !shouldExecuteWithZeroRows;
+    }
+
+    boolean showWarnings = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "Y" ) );
+    String showWarningsCompat = System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW );
+    if ( !Utils.isEmpty( showWarningsCompat ) && "Y".equalsIgnoreCase( showWarningsCompat ) != showWarnings  ) {
+      log.logError(
+        "COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW property is deprecated, please use KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW."
+      );
+      //Assumes the old variable setting until it is deleted
+      showWarnings = !showWarnings;
+    }
+
+    if (  showWarnings  ) {
       if ( shouldExecuteWithZeroRows ) {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       } else {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       }
     }
+
     return shouldExecuteWithZeroRows;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/job/JobEntryJob.java
@@ -1229,37 +1229,36 @@ public class JobEntryJob extends JobEntryBase implements Cloneable, JobEntryInte
   }
 
   private boolean shouldConsiderOldBehaviourForEveryInputRow( ) {
-    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
-    String shouldExecuteWithZeroRowsCompat = System.getProperty( Const.COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT );
-    if ( !Utils.isEmpty( shouldExecuteWithZeroRowsCompat ) && "Y".equalsIgnoreCase( shouldExecuteWithZeroRowsCompat ) != shouldExecuteWithZeroRows ) {
-      log.logError(
-        "COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT property is deprecated, please use KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT and remove the old one."
-      );
-      //Assumes the old variable setting until it is deleted
-      shouldExecuteWithZeroRows = !shouldExecuteWithZeroRows;
-    }
+    boolean showWarnings = calculateExecuteForEveryRowKettleProperty( Const.KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW );
+    boolean shouldExecuteWithZeroRows = calculateExecuteForEveryRowKettleProperty( Const.KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, Const.COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT );
 
-    boolean showWarnings = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "Y" ) );
-    String showWarningsCompat = System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW );
-    if ( !Utils.isEmpty( showWarningsCompat ) && "Y".equalsIgnoreCase( showWarningsCompat ) != showWarnings  ) {
-      log.logError(
-        "COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW property is deprecated, please use KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW."
-      );
-      //Assumes the old variable setting until it is deleted
-      showWarnings = !showWarnings;
-    }
-
-    if (  showWarnings  ) {
+    if ( showWarnings ) {
       if ( shouldExecuteWithZeroRows ) {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT." );
       } else {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT." );
       }
     }
 
     return shouldExecuteWithZeroRows;
+  }
+
+  private boolean calculateExecuteForEveryRowKettleProperty( String kettleCompatabilityProperty, String compatibilityProperty ) {
+    String kValue = System.getProperty( kettleCompatabilityProperty );
+
+    if ( !Utils.isEmpty( kValue ) ) {
+      return "Y".equalsIgnoreCase( kValue );
+    }
+
+    String cValue = System.getProperty( compatibilityProperty );
+    if ( !Utils.isEmpty( cValue ) ) {
+      log.logError( compatibilityProperty + " property is deprecated, please use " + kettleCompatabilityProperty
+        + " and remove the old one." );
+    }
+
+    return "Y".equalsIgnoreCase( cValue );
   }
 
   private boolean createParentFolder( String filename ) {

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1255,16 +1255,36 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
   }
 
   private boolean shouldConsiderOldBehaviourForEveryInputRow() {
-    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
-    if ( "Y".equalsIgnoreCase( System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "N" ) ) ) {
+    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
+    String shouldExecuteWithZeroRowsCompat = System.getProperty( Const.COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT );
+    if ( !Utils.isEmpty( shouldExecuteWithZeroRowsCompat ) && "Y".equalsIgnoreCase( shouldExecuteWithZeroRowsCompat ) != shouldExecuteWithZeroRows ) {
+      log.logError(
+        "COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT property is deprecated, please use KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT and remove the old one."
+      );
+      //Assumes the old variable setting until it is deleted
+      shouldExecuteWithZeroRows = !shouldExecuteWithZeroRows;
+    }
+
+    boolean showWarnings = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "Y" ) );
+    String showWarningsCompat = System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW );
+    if ( !Utils.isEmpty( showWarningsCompat ) && "Y".equalsIgnoreCase( showWarningsCompat ) != showWarnings  ) {
+      log.logError(
+        "COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW property is deprecated, please use KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW."
+      );
+      //Assumes the old variable setting until it is deleted
+      showWarnings = !showWarnings;
+    }
+
+    if (  showWarnings  ) {
       if ( shouldExecuteWithZeroRows ) {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       } else {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
       }
     }
+
     return shouldExecuteWithZeroRows;
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1255,37 +1255,36 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
   }
 
   private boolean shouldConsiderOldBehaviourForEveryInputRow() {
-    boolean shouldExecuteWithZeroRows = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, "N" ) );
-    String shouldExecuteWithZeroRowsCompat = System.getProperty( Const.COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT );
-    if ( !Utils.isEmpty( shouldExecuteWithZeroRowsCompat ) && "Y".equalsIgnoreCase( shouldExecuteWithZeroRowsCompat ) != shouldExecuteWithZeroRows ) {
-      log.logError(
-        "COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT property is deprecated, please use KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT and remove the old one."
-      );
-      //Assumes the old variable setting until it is deleted
-      shouldExecuteWithZeroRows = !shouldExecuteWithZeroRows;
-    }
+    boolean showWarnings = calculateExecuteForEveryRowKettleProperty( Const.KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW );
+    boolean shouldExecuteWithZeroRows = calculateExecuteForEveryRowKettleProperty( Const.KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT, Const.COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT );
 
-    boolean showWarnings = "Y".equalsIgnoreCase( System.getProperty( Const.KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW, "Y" ) );
-    String showWarningsCompat = System.getProperty( Const.COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW );
-    if ( !Utils.isEmpty( showWarningsCompat ) && "Y".equalsIgnoreCase( showWarningsCompat ) != showWarnings  ) {
-      log.logError(
-        "COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW property is deprecated, please use KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW."
-      );
-      //Assumes the old variable setting until it is deleted
-      showWarnings = !showWarnings;
-    }
-
-    if (  showWarnings  ) {
+    if ( showWarnings ) {
       if ( shouldExecuteWithZeroRows ) {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying desired behavior, to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT." );
       } else {
         log.logBasic(
-          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT" );
+          "WARN Detected \"Execute for every row\" but no rows were detected, applying default behavior, not to execute. In case this is not desired behavior, please read property KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT." );
       }
     }
 
     return shouldExecuteWithZeroRows;
+  }
+
+  private boolean calculateExecuteForEveryRowKettleProperty( String kettleCompatabilityProperty, String compatibilityProperty ) {
+    String kValue = System.getProperty( kettleCompatabilityProperty );
+
+    if ( !Utils.isEmpty( kValue ) ) {
+      return "Y".equalsIgnoreCase( kValue );
+    }
+
+    String cValue = System.getProperty( compatibilityProperty );
+    if ( !Utils.isEmpty( cValue ) ) {
+      log.logError( compatibilityProperty + " property is deprecated, please use " + kettleCompatabilityProperty
+        + " and remove the old one." );
+    }
+
+    return "Y".equalsIgnoreCase( cValue );
   }
 
   protected void updateResult( Result result ) {

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -645,7 +645,6 @@
       See Jira issue PPP-20033 for details.
     </description>
     <variable>KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
-    <default-value>N</default-value>
   </kettle-variable>
 
   <kettle-variable>
@@ -653,7 +652,6 @@
       See Jira issue PPP-20033 for details.
     </description>
     <variable>KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
-    <default-value>N</default-value>
   </kettle-variable>
 
   <kettle-variable>
@@ -661,6 +659,5 @@
       See Jira issue PPP-20033 for details.
     </description>
     <variable>KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW</variable>
-    <default-value>Y</default-value>
   </kettle-variable>
 </kettle-variables>

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -644,7 +644,7 @@
     <description>Set this variable to Y to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as job input mode.
       See Jira issue PPP-20033 for details.
     </description>
-    <variable>COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
+    <variable>KETTLE_COMPATIBILITY_JOB_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
     <default-value>N</default-value>
   </kettle-variable>
 
@@ -652,7 +652,7 @@
     <description>Set this variable to Y to revert the behaviour of the flag "Execute every Input Row" behavior back to executing even with 0 rows as trans input mode.
       See Jira issue PPP-20033 for details.
     </description>
-    <variable>COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
+    <variable>KETTLE_COMPATIBILITY_TRANS_EXECUTE_FOR_EVERY_ROW_ON_NO_INPUT</variable>
     <default-value>N</default-value>
   </kettle-variable>
 
@@ -660,7 +660,7 @@
     <description>Set this variable to Y/N to show/not show the Warning messages regarding the configured behaviour of the flag "Execute every Input Row".
       See Jira issue PPP-20033 for details.
     </description>
-    <variable>COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW</variable>
+    <variable>KETTLE_COMPATIBILITY_SHOW_WARNINGS_EXECUTE_EVERY_INPUT_ROW</variable>
     <default-value>Y</default-value>
   </kettle-variable>
 </kettle-variables>


### PR DESCRIPTION
original PRs:
https://github.com/pentaho/pentaho-kettle/pull/9640
https://github.com/pentaho/pentaho-kettle/pull/9714
@pentaho/tatooine_dev 