### PR TITLE
[BACKLOG-42865] - fix db edit, exception

### DIFF
--- a/dbdialog/src/main/java/org/pentaho/ui/database/event/DataHandler.java
+++ b/dbdialog/src/main/java/org/pentaho/ui/database/event/DataHandler.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -147,6 +147,8 @@ public class DataHandler extends AbstractXulEventHandler {
   }
 
   protected DatabaseMeta databaseMeta = null;
+
+  protected String originalName = null;
 
   protected DatabaseMeta cache = new DatabaseMeta();
 
@@ -863,6 +865,7 @@ public class DataHandler extends AbstractXulEventHandler {
     if ( meta == null ) {
       return;
     }
+    originalName = meta.getName();
 
     if ( meta.getAttributes().containsKey( EXTRA_OPTION_WEB_APPLICATION_NAME ) ) {
       meta.setDBName( (String) meta.getAttributes().get( EXTRA_OPTION_WEB_APPLICATION_NAME ) );

--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -515,7 +515,7 @@ public class JobMeta extends AbstractMeta
       DatabaseMeta[] dbs = jobEntryCopy.getEntry().getUsedDatabaseConnections();
       if ( dbs != null ) {
         for ( DatabaseMeta db : dbs ) {
-          if ( db.getName().equals( name ) ) {
+          if ( db != null && db.getName().equals( name ) ) {
             updateFields( db, newDatabaseMeta );
           }
         }

--- a/engine/src/main/java/org/pentaho/di/job/entries/tableexists/JobEntryTableExists.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/tableexists/JobEntryTableExists.java
@@ -203,7 +203,11 @@ public class JobEntryTableExists extends JobEntryBase implements Cloneable, JobE
   }
 
   public DatabaseMeta[] getUsedDatabaseConnections() {
-    return new DatabaseMeta[] { connection, };
+    if ( connection != null ) {
+      return new DatabaseMeta[] { connection, };
+    } else {
+      return new DatabaseMeta[ 0 ];
+    }
   }
 
   public List<ResourceReference> getResourceDependencies( JobMeta jobMeta ) {

--- a/ui/src/main/java/org/pentaho/di/ui/core/database/dialog/DataOverrideHandler.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/database/dialog/DataOverrideHandler.java
@@ -23,6 +23,7 @@
 package org.pentaho.di.ui.core.database.dialog;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Rectangle;
@@ -62,9 +63,11 @@ public class DataOverrideHandler extends DataHandler {
     if ( databases != null ) {
       DatabaseMeta database = new DatabaseMeta();
       this.getInfo( database );
-      if ( DialogUtils.objectWithTheSameNameExists( database, databases ) ) {
-        DatabaseDialog.showDatabaseExistsDialog( getShell(), database );
-        return;
+      if ( ! Objects.equals( database.getName(), originalName ) ) {
+        if ( DialogUtils.objectWithTheSameNameExists( database, databases ) ) {
+          DatabaseDialog.showDatabaseExistsDialog( getShell(), database );
+          return;
+        }
       }
     }
     super.onOK();


### PR DESCRIPTION
Exception was caused by an array with a single null member. Fixed both the code that produced it, and added a safety check in the consumer.