### PR TITLE
[BACKLOG-42827] - CRUD for Global objects in repository

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/bowl/BaseBowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/BaseBowl.java
@@ -61,8 +61,7 @@ public abstract class BaseBowl implements Bowl {
     parentBowls.add( parent );
   }
 
-  // use with caution. For testing only.
-  @VisibleForTesting
+  // use with caution.
   public synchronized void clearManagers() {
     managerInstances.clear();
   }

--- a/core/src/main/java/org/pentaho/di/core/bowl/DefaultBowl.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/DefaultBowl.java
@@ -95,11 +95,6 @@ public class DefaultBowl extends BaseBowl {
     return sharedObjectsIO;
   }
 
-  /**
-   * Set a specific metastore supplier for use by later calls to this class. Note that this will cause the
-   * ConnectionManager from this class and from ConnectionManager.getInstance() to return different instances.
-   */
-  @VisibleForTesting
   public void setSharedObjectsIO( SharedObjectsIO sharedObjectsIO ) {
     this.sharedObjectsIO = sharedObjectsIO;
   }

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
@@ -3,7 +3,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -617,7 +617,6 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
   public Object deepClone( boolean cloneUpdateFlag ) {
     DatabaseMeta databaseMeta = new DatabaseMeta();
     databaseMeta.replaceMeta( this, cloneUpdateFlag );
-    databaseMeta.setObjectId( null );
     return databaseMeta;
   }
 
@@ -1024,6 +1023,8 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
 
       setReadOnly( Boolean.valueOf( XMLHandler.getTagValue( con, "read_only" ) ) );
 
+      readObjectId( con );
+
       // Also, read the database attributes...
       Node attrsnode = XMLHandler.getSubNode( con, "attributes" );
       if ( attrsnode != null ) {
@@ -1075,6 +1076,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     retval.append( "    " ).append( XMLHandler.addTagValue( "servername", getServername() ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "data_tablespace", getDataTablespace() ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "index_tablespace", getIndexTablespace() ) );
+    appendObjectId( retval );
 
     // only write the tag out if it is set to true
     if ( isReadOnly() ) {

--- a/core/src/main/java/org/pentaho/di/repository/RepositoryElementInterface.java
+++ b/core/src/main/java/org/pentaho/di/repository/RepositoryElementInterface.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,6 +21,10 @@
  ******************************************************************************/
 
 package org.pentaho.di.repository;
+
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.shared.SharedObjectInterface;
+import org.w3c.dom.Node;
 
 /**
  * A repository element is an object that can be saved or loaded from the repository. As such, we need to be able to
@@ -101,5 +105,20 @@ public interface RepositoryElementInterface extends RepositoryObjectInterface {
    * @param objectRevision
    */
   public void setObjectRevision( ObjectRevision objectRevision );
+
+  default void appendObjectId( StringBuilder builder ) {
+    if ( getObjectId() != null ) {
+      builder.append( "    " ).append( XMLHandler.addTagValue( SharedObjectInterface.OBJECT_ID,
+        getObjectId().toString() ) );
+    }
+  }
+
+  default void readObjectId( Node node ) {
+    String objectId = XMLHandler.getTagValue( node, SharedObjectInterface.OBJECT_ID );
+    if ( objectId != null ) {
+      setObjectId( new StringObjectId( objectId ) );
+    }
+  }
+
 
 }

--- a/core/src/main/java/org/pentaho/di/shared/SharedObjectInterface.java
+++ b/core/src/main/java/org/pentaho/di/shared/SharedObjectInterface.java
@@ -29,6 +29,8 @@ import org.w3c.dom.Node;
 
 public interface SharedObjectInterface<T extends SharedObjectInterface> {
 
+  static final String OBJECT_ID = "object_id";
+
   /**
    * @deprecated
    *

--- a/core/src/main/java/org/pentaho/di/shared/VfsSharedObjectsIO.java
+++ b/core/src/main/java/org/pentaho/di/shared/VfsSharedObjectsIO.java
@@ -193,6 +193,16 @@ public class VfsSharedObjectsIO implements SharedObjectsIO {
   public void saveSharedObject( String type, String name, Node node ) throws KettleException {
     // Get the map for the type
     Map<String, Node> nodeMap = getNodesMapForType( type );
+
+    // strip out any Object IDs
+    NodeList children = node.getChildNodes();
+    for ( int i = 0; i < children.getLength(); i++ ) {
+      Node childNode = children.item( i );
+      if ( childNode.getNodeName().equalsIgnoreCase( SharedObjectInterface.OBJECT_ID ) ) {
+        node.removeChild( childNode );
+      }
+    }
+
     // Add or Update the map entry for this name
     nodeMap.put( name, node );
 

--- a/engine/src/main/java/org/pentaho/di/cluster/ClusterSchema.java
+++ b/engine/src/main/java/org/pentaho/di/cluster/ClusterSchema.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -169,6 +169,7 @@ public class ClusterSchema extends ChangedFlag implements Cloneable, SharedObjec
     xml.append( "        " ).append( XMLHandler.addTagValue( "sockets_flush_interval", socketsFlushInterval ) );
     xml.append( "        " ).append( XMLHandler.addTagValue( "sockets_compressed", socketsCompressed ) );
     xml.append( "        " ).append( XMLHandler.addTagValue( "dynamic", dynamic ) );
+    appendObjectId( xml );
 
     xml.append( "        " ).append( XMLHandler.openTag( "slaveservers" ) ).append( Const.CR );
     for ( int i = 0; i < slaveServers.size(); i++ ) {
@@ -190,6 +191,7 @@ public class ClusterSchema extends ChangedFlag implements Cloneable, SharedObjec
     socketsCompressed = "Y".equalsIgnoreCase( XMLHandler.getTagValue( clusterSchemaNode, "sockets_compressed" ) );
     dynamic = "Y".equalsIgnoreCase( XMLHandler.getTagValue( clusterSchemaNode, "dynamic" ) );
 
+    readObjectId( clusterSchemaNode );
     Node slavesNode = XMLHandler.getSubNode( clusterSchemaNode, "slaveservers" );
     int nrSlaves = XMLHandler.countNodes( slavesNode, "name" );
     for ( int i = 0; i < nrSlaves; i++ ) {

--- a/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
+++ b/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
@@ -246,6 +246,7 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
     this.master = "Y".equalsIgnoreCase( XMLHandler.getTagValue( slaveNode, "master" ) );
     initializeVariablesFrom( null );
     this.log = new LogChannel( this );
+    readObjectId( slaveNode );
 
     setSslMode( "Y".equalsIgnoreCase( XMLHandler.getTagValue( slaveNode, SSL_MODE_TAG ) ) );
     Node sslConfig = XMLHandler.getSubNode( slaveNode, SslConfiguration.XML_TAG );
@@ -277,6 +278,7 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
       xml.append( "        " ).append( XMLHandler.addTagValue( "non_proxy_hosts", nonProxyHosts ) );
       xml.append( "        " ).append( XMLHandler.addTagValue( "master", master ) );
       xml.append( "        " ).append( XMLHandler.addTagValue( SSL_MODE_TAG, isSslMode(), false ) );
+      appendObjectId( xml );
       if ( sslConfig != null ) {
         xml.append( sslConfig.getXML() );
       }

--- a/engine/src/main/java/org/pentaho/di/partition/PartitionSchema.java
+++ b/engine/src/main/java/org/pentaho/di/partition/PartitionSchema.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -164,6 +164,7 @@ public class PartitionSchema extends ChangedFlag implements Cloneable, SharedObj
     xml
       .append( "        " ).append(
         XMLHandler.addTagValue( "partitions_per_slave", numberOfPartitionsPerSlave ) );
+    appendObjectId( xml );
 
     xml.append( "      " ).append( XMLHandler.closeTag( XML_TAG ) ).append( Const.CR );
     return xml.toString();
@@ -179,6 +180,7 @@ public class PartitionSchema extends ChangedFlag implements Cloneable, SharedObj
       Node partitionNode = XMLHandler.getSubNodeByNr( partitionSchemaNode, "partition", i, false );
       partitionIDs.add( XMLHandler.getTagValue( partitionNode, "id" ) );
     }
+    readObjectId( partitionSchemaNode );
 
     dynamicallyDefined = "Y".equalsIgnoreCase( XMLHandler.getTagValue( partitionSchemaNode, "dynamic" ) );
     numberOfPartitionsPerSlave = XMLHandler.getTagValue( partitionSchemaNode, "partitions_per_slave" );

--- a/engine/src/main/java/org/pentaho/di/repository/filerep/KettleFileRepository.java
+++ b/engine/src/main/java/org/pentaho/di/repository/filerep/KettleFileRepository.java
@@ -958,7 +958,6 @@ public class KettleFileRepository extends AbstractRepository {
     jobMeta.setRepository( this );
     jobMeta.setMetaStore( MetaStoreConst.getDefaultMetastore() );
 
-    readDatabases( jobMeta, true );
     jobMeta.clearChanged();
 
     return jobMeta;
@@ -1118,44 +1117,9 @@ public class KettleFileRepository extends AbstractRepository {
     transMeta.setName( transname );
     transMeta.setObjectId( new StringObjectId( calcObjectId( repdir, transname, EXT_TRANSFORMATION ) ) );
 
-    readDatabases( transMeta, true );
     transMeta.clearChanged();
 
     return transMeta;
-  }
-
-  /**
-   * Read all the databases from the repository, insert into the has databases object, overwriting optionally
-   *
-   * @param TransMeta
-   *          The transformation to load into.
-   * @param overWriteShared
-   *          if an object with the same name exists, overwrite
-   * @throws KettleException
-   */
-  public void readDatabases( AbstractMeta transMeta, boolean overWriteShared ) throws KettleException {
-    try {
-      ObjectId[] dbids = getDatabaseIDs( false );
-      for ( int i = 0; i < dbids.length; i++ ) {
-        DatabaseMeta databaseMeta = loadDatabaseMeta( dbids[i], null ); // reads last version
-        if ( transMeta instanceof VariableSpace ) {
-          databaseMeta.shareVariablesWith( (VariableSpace) transMeta );
-        }
-
-        DatabaseMeta check = transMeta.findDatabase( databaseMeta.getName() ); // Check if there already is one in the
-                                                                               // transformation
-        if ( check == null || overWriteShared ) { // We only add, never overwrite database connections.
-          if ( databaseMeta.getName() != null ) {
-            transMeta.getDatabaseManagementInterface().add( databaseMeta );
-            if ( !overWriteShared ) {
-              databaseMeta.setChanged( false );
-            }
-          }
-        }
-      }
-    } catch ( KettleException e ) {
-      throw e;
-    }
   }
 
   public ValueMetaAndData loadValueMetaAndData( ObjectId id_value ) throws KettleException {
@@ -1191,49 +1155,12 @@ public class KettleFileRepository extends AbstractRepository {
 
   @Override
   public void readJobMetaSharedObjects( JobMeta jobMeta ) throws KettleException {
-
-    // Then we read the databases etc...
-    //
-    for ( ObjectId id : getDatabaseIDs( false ) ) {
-      DatabaseMeta databaseMeta = loadDatabaseMeta( id, null ); // Load last version
-      databaseMeta.shareVariablesWith( jobMeta );
-      jobMeta.getDatabaseManagementInterface().add( databaseMeta );
-    }
-
-    for ( ObjectId id : getSlaveIDs( false ) ) {
-      SlaveServer slaveServer = loadSlaveServer( id, null ); // Load last version
-      slaveServer.shareVariablesWith( jobMeta );
-      jobMeta.addOrReplaceSlaveServer( slaveServer );
-    }
+    // No-Op
   }
 
   @Override
   public void readTransSharedObjects( TransMeta transMeta ) throws KettleException {
-
-    // Then we read the databases etc...
-    //
-    for ( ObjectId id : getDatabaseIDs( false ) ) {
-      DatabaseMeta databaseMeta = loadDatabaseMeta( id, null ); // Load last version
-      databaseMeta.shareVariablesWith( transMeta );
-      transMeta.getDatabaseManagementInterface().add( databaseMeta );
-    }
-
-    for ( ObjectId id : getSlaveIDs( false ) ) {
-      SlaveServer slaveServer = loadSlaveServer( id, null ); // Load last version
-      slaveServer.shareVariablesWith( transMeta );
-      transMeta.addOrReplaceSlaveServer( slaveServer );
-    }
-
-    for ( ObjectId id : getClusterIDs( false ) ) {
-      ClusterSchema clusterSchema = loadClusterSchema( id, transMeta.getSlaveServers(), null ); // Load last version
-      clusterSchema.shareVariablesWith( transMeta );
-      transMeta.addOrReplaceClusterSchema( clusterSchema );
-    }
-
-    for ( ObjectId id : getPartitionSchemaIDs( false ) ) {
-      PartitionSchema partitionSchema = loadPartitionSchema( id, null ); // Load last version
-      transMeta.addOrReplacePartitionSchema( partitionSchema );
-    }
+    // No-Op
   }
 
   private ObjectId renameObject( ObjectId id, RepositoryDirectoryInterface newDirectory, String newName,

--- a/engine/src/main/java/org/pentaho/di/shared/RepositorySharedObjectsIO.java
+++ b/engine/src/main/java/org/pentaho/di/shared/RepositorySharedObjectsIO.java
@@ -1,0 +1,239 @@
+/*!
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.pentaho.di.shared;
+
+import org.pentaho.di.cluster.ClusterSchema;
+import org.pentaho.di.cluster.ClusterSchemaManagementInterface.SlaveServersSupplier;
+import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.partition.PartitionSchema;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryElementInterface;
+import org.pentaho.di.repository.RepositoryExtended;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.w3c.dom.Node;
+
+/**
+ * An implementation of SharedObjectsIO that backs to a Repository.
+ * <p>
+ * This class does not cache anything. Note that PurRepository does its own caching, but only through the
+ * RepositoryExtended interface, which this class makes use of.
+ *
+ */
+public class RepositorySharedObjectsIO implements SharedObjectsIO {
+
+  private final Repository repository;
+  private final SlaveServersSupplier slaveServerSupplier;
+
+  public RepositorySharedObjectsIO( Repository repository, SlaveServersSupplier slaveServerSupplier ) {
+    this.repository = Objects.requireNonNull( repository );
+    this.slaveServerSupplier = slaveServerSupplier;
+  }
+
+  @Override
+  public Map<String, Node> getSharedObjects( String type ) throws KettleException {
+    SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
+    List<? extends SharedObjectInterface> objects = null;
+    if ( repository instanceof RepositoryExtended ) {
+      // use the methods that support caching
+      RepositoryExtended extended = (RepositoryExtended) repository;
+      switch ( objectType ) {
+          case CONNECTION:
+            objects = extended.getConnections( true );
+            break;
+          case SLAVESERVER:
+            objects = extended.getSlaveServers( true );
+            break;
+          case PARTITIONSCHEMA:
+            objects = extended.getPartitions( true );
+            break;
+          case CLUSTERSCHEMA:
+            objects = extended.getClusters( true );
+            break;
+      }
+    } else {
+      switch ( objectType ) {
+          case CONNECTION:
+            objects = repository.readDatabases();
+            break;
+          case SLAVESERVER:
+            objects = repository.getSlaveServers();
+            break;
+          case PARTITIONSCHEMA:
+            ObjectId[] psids = repository.getPartitionSchemaIDs( false );
+            List<PartitionSchema> pss = new ArrayList<PartitionSchema>();
+            if ( psids != null ) {
+              for ( ObjectId id : psids ) {
+                pss.add( repository.loadPartitionSchema( id, null ) );
+              }
+            }
+            objects = pss;
+            break;
+          case CLUSTERSCHEMA:
+            ObjectId[] csids = repository.getClusterIDs( false );
+            List<ClusterSchema> css = new ArrayList<ClusterSchema>();
+            if ( csids != null ) {
+              List<SlaveServer> sss = slaveServerSupplier.get();
+              for ( ObjectId id : csids ) {
+                css.add( repository.loadClusterSchema( id, sss, null ) );
+              }
+            }
+            objects = css;
+            break;
+      }
+    }
+    if ( objects != null ) {
+      Map<String, Node> result = new HashMap<>();
+      for ( SharedObjectInterface object : objects ) {
+        result.put( object.getName(), object.toNode() );
+      }
+      return result;
+    }
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public Node getSharedObject( String type, String name ) throws KettleException {
+    SharedObjectInterface object = null;
+    ObjectId id = null;
+    SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
+    switch ( objectType ) {
+        case CONNECTION:
+          id = repository.getDatabaseID( name );
+          if ( id != null ) {
+            object = repository.loadDatabaseMeta( id, null );
+          }
+          break;
+        case SLAVESERVER:
+          id = repository.getSlaveID( name );
+          if ( id != null ) {
+            object = repository.loadSlaveServer( id, null );
+          }
+          break;
+        case PARTITIONSCHEMA:
+          id = repository.getPartitionSchemaID( name );
+          if ( id != null ) {
+            object = repository.loadPartitionSchema( id, null );
+          }
+          break;
+        case CLUSTERSCHEMA:
+          id = repository.getClusterID( name );
+          if ( id != null ) {
+            object = repository.loadClusterSchema( id, slaveServerSupplier.get(), null );
+          }
+          break;
+    }
+    if ( object != null ) {
+      return object.toNode();
+    }
+    return null;
+  }
+
+  @Override
+  public void clear( String type ) throws KettleException {
+    SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
+    ObjectId[] ids = null;
+    switch ( objectType ) {
+        case CONNECTION:
+          String[] names = repository.getDatabaseNames( false );
+          for ( String name : names ) {
+            repository.deleteDatabaseMeta( name );
+          }
+          break;
+        case SLAVESERVER:
+          ids = repository.getSlaveIDs( false );
+          for ( ObjectId id : ids ) {
+            repository.deleteSlave( id );
+          }
+          break;
+        case PARTITIONSCHEMA:
+          ids = repository.getPartitionSchemaIDs( false );
+          for ( ObjectId id : ids ) {
+            repository.deletePartitionSchema( id );
+          }
+          break;
+        case CLUSTERSCHEMA:
+          ids = repository.getClusterIDs( false );
+          for ( ObjectId id : ids ) {
+            repository.deleteClusterSchema( id );
+          }
+          break;
+    }
+  }
+
+  @Override
+  public void delete( String type, String name ) throws KettleException {
+    SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
+    ObjectId id;
+    switch ( objectType ) {
+        case CONNECTION:
+          repository.deleteDatabaseMeta( name );
+          break;
+        case SLAVESERVER:
+          id = repository.getSlaveID( name );
+          if ( id != null ) {
+            repository.deleteSlave( id );
+          }
+          break;
+        case PARTITIONSCHEMA:
+          id = repository.getPartitionSchemaID( name );
+          if ( id != null ) {
+            repository.deletePartitionSchema( id );
+          }
+          break;
+        case CLUSTERSCHEMA:
+          id = repository.getClusterID( name );
+          if ( id != null ) {
+            repository.deleteClusterSchema( id );
+          }
+          break;
+    }
+  }
+
+  @Override
+  public void saveSharedObject( String type, String name, Node node ) throws KettleException {
+    RepositoryElementInterface repoElement = null;
+    SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
+    switch ( objectType ) {
+        case CONNECTION:
+          repoElement = new DatabaseMeta( node );
+          break;
+        case SLAVESERVER:
+          repoElement = new SlaveServer( node );
+          break;
+        case PARTITIONSCHEMA:
+          repoElement = new PartitionSchema( node );
+          break;
+        case CLUSTERSCHEMA:
+          repoElement = new ClusterSchema( node, slaveServerSupplier.get() );
+          break;
+    }
+    if ( repoElement != null ) {
+      repository.save( repoElement, Const.VERSION_COMMENT_EDIT_VERSION, null );
+    }
+  }
+}
+

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -732,6 +732,7 @@ public class TransMeta extends AbstractMeta
     log = LogChannel.GENERAL;
   }
 
+  @Override
   protected void initializeNonLocalSharedObjects() {
     super.initializeNonLocalSharedObjects();
     localClusterSchemaManager =

--- a/engine/src/test/java/org/pentaho/di/shared/RepositorySharedObjectsIOTest.java
+++ b/engine/src/test/java/org/pentaho/di/shared/RepositorySharedObjectsIOTest.java
@@ -1,0 +1,248 @@
+/*!
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.pentaho.di.shared;
+
+import org.pentaho.di.cluster.ClusterSchema;
+import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.partition.PartitionSchema;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.steps.loadsave.MemoryRepository;
+import org.pentaho.di.trans.steps.loadsave.MemoryRepositoryExtended;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.w3c.dom.Node;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith( Parameterized.class )
+public class RepositorySharedObjectsIOTest {
+
+  private MemoryRepository rep;
+  private RepositorySharedObjectsIO shared;
+
+  public RepositorySharedObjectsIOTest( MemoryRepository rep ) {
+    this.rep = rep;
+  }
+
+  /**
+   * Test both Repository APIs
+   */
+  @Parameterized.Parameters
+  public static List<Object[]> repositories() {
+    ArrayList<Object[]> reps = new ArrayList<>();
+    reps.add( new Object[] { new MemoryRepository() } );
+    reps.add( new Object[] { new MemoryRepositoryExtended() } );
+    return reps;
+  }
+
+  @Before
+  public void setup() throws Exception {
+    shared = new RepositorySharedObjectsIO( rep, () -> Collections.emptyList() );
+  }
+
+  @Test
+  public void testSave() throws Exception {
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( "foo" );
+    db.setDBName( "bar" );
+
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+
+    Node node = shared.getSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName() );
+    assertNotNull( node );
+    DatabaseMeta readDb = new DatabaseMeta( node );
+    assertNotNull( readDb.getObjectId() );
+
+    Map<String, Node> dbs = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertNotNull( dbs );
+    assertEquals( 1, dbs.size() );
+    assertNotNull( dbs.get( "foo" ) );
+    readDb = new DatabaseMeta( dbs.get( "foo" ) );
+    assertNotNull( readDb.getObjectId() );
+  }
+
+  @Test
+  public void testUpdate() throws Exception {
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( "foo" );
+    db.setDBName( "bar" );
+
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+
+    Map<String, Node> dbs = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertEquals( 1, dbs.size() );
+    Node createdNode = shared.getSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName() );
+    assertNotNull( createdNode );
+
+    DatabaseMeta afterCreate = new DatabaseMeta( createdNode );
+
+    db.setServername( "testing" );
+
+    // should replace the existing item.
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+
+    dbs = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertEquals( 1, dbs.size() );
+    Node updatedNode = shared.getSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName() );
+    assertNotNull( updatedNode );
+
+    DatabaseMeta afterUpdate = new DatabaseMeta( updatedNode );
+
+    assertEquals( db.getDescription(), afterUpdate.getDescription() );
+
+    assertNull( afterCreate.getServername() );
+    assertEquals( "testing", afterUpdate.getServername() );
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( "foo" );
+    db.setDBName( "bar" );
+
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+
+    Node node = shared.getSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName() );
+    assertNotNull( node );
+
+    Map<String, Node> dbs = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertNotNull( dbs );
+    assertEquals( 1, dbs.size() );
+    assertNotNull( dbs.get( "foo" ) );
+
+    shared.delete( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), "foo" );
+
+    node = shared.getSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName() );
+    assertNull( node );
+
+    dbs = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertNotNull( dbs );
+    assertEquals( 0, dbs.size() );
+  }
+
+  @Test
+  public void testOtherTypes() throws Exception {
+    //test the non-db types.
+    SlaveServer slaveServer = new SlaveServer();
+    slaveServer.setName( "slave 1" );
+
+    PartitionSchema partitionSchema = new PartitionSchema();
+    partitionSchema.setName( "pschema 1" );
+
+    ClusterSchema clusterSchema = new ClusterSchema();
+    clusterSchema.setName( "Cluster Schema 1" );
+    clusterSchema.setSlaveServers( Collections.singletonList( slaveServer ) );
+
+    shared = new RepositorySharedObjectsIO( rep, () -> Collections.singletonList( slaveServer ) );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.SLAVESERVER.getName(), slaveServer.getName(),
+      slaveServer.toNode() );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.PARTITIONSCHEMA.getName(), partitionSchema.getName(),
+      partitionSchema.toNode() );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CLUSTERSCHEMA.getName(), clusterSchema.getName(),
+      clusterSchema.toNode() );
+
+    SlaveServer readSlaveServer = new SlaveServer( shared.getSharedObject(
+      SharedObjectsIO.SharedObjectType.SLAVESERVER.getName(), slaveServer.getName() ) );
+
+    PartitionSchema readPartitionSchema = new PartitionSchema( shared.getSharedObject(
+      SharedObjectsIO.SharedObjectType.PARTITIONSCHEMA.getName(), partitionSchema.getName() ) );
+
+    ClusterSchema readClusterSchema = new ClusterSchema( shared.getSharedObject( SharedObjectsIO.SharedObjectType.CLUSTERSCHEMA.getName(), clusterSchema.getName() ), Collections.singletonList( slaveServer ) );
+
+    assertNotNull( readSlaveServer );
+    assertNotNull( readSlaveServer.getObjectId() );
+    assertNotNull( readPartitionSchema );
+    assertNotNull( readPartitionSchema.getObjectId() );
+    assertNotNull( readClusterSchema );
+    assertEquals( 1, readClusterSchema.getSlaveServers().size() );
+    assertNotNull( readClusterSchema.getObjectId() );
+
+    Map<String, Node> readObjects = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.SLAVESERVER.getName() );
+    assertEquals( 1, readObjects.size() );
+    readSlaveServer = new SlaveServer( readObjects.get( slaveServer.getName() ) );
+    assertNotNull( readSlaveServer );
+    assertNotNull( readSlaveServer.getObjectId() );
+
+    readObjects = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.PARTITIONSCHEMA.getName() );
+    assertEquals( 1, readObjects.size() );
+    readPartitionSchema = new PartitionSchema( readObjects.get( partitionSchema.getName() ) );
+    assertNotNull( readPartitionSchema );
+    assertNotNull( readPartitionSchema.getObjectId() );
+
+    readObjects = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CLUSTERSCHEMA.getName() );
+    assertEquals( 1, readObjects.size() );
+    readClusterSchema = new ClusterSchema( readObjects.get( clusterSchema.getName() ),
+      Collections.singletonList( slaveServer ) );
+    assertNotNull( readClusterSchema );
+    assertNotNull( readClusterSchema.getObjectId() );
+
+    shared.delete( SharedObjectsIO.SharedObjectType.SLAVESERVER.getName(), slaveServer.getName() );
+    shared.delete( SharedObjectsIO.SharedObjectType.PARTITIONSCHEMA.getName(), partitionSchema.getName() );
+    shared.delete( SharedObjectsIO.SharedObjectType.CLUSTERSCHEMA.getName(), clusterSchema.getName() );
+
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.SLAVESERVER.getName() ).size() );
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.PARTITIONSCHEMA.getName() ).size() );
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CLUSTERSCHEMA.getName() ).size() );
+  }
+
+  @Test
+  public void testClear() throws Exception {
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( "foo" );
+    db.setDBName( "bar" );
+
+    SlaveServer slaveServer = new SlaveServer();
+    slaveServer.setName( "slave 1" );
+
+    PartitionSchema partitionSchema = new PartitionSchema();
+    partitionSchema.setName( "pschema 1" );
+
+    ClusterSchema clusterSchema = new ClusterSchema();
+    clusterSchema.setName( "Cluster Schema 1" );
+    clusterSchema.setSlaveServers( Collections.singletonList( slaveServer ) );
+
+    shared = new RepositorySharedObjectsIO( rep, () -> Collections.singletonList( slaveServer ) );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.SLAVESERVER.getName(), slaveServer.getName(),
+      slaveServer.toNode() );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.PARTITIONSCHEMA.getName(), partitionSchema.getName(),
+      partitionSchema.toNode() );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CLUSTERSCHEMA.getName(), clusterSchema.getName(),
+      clusterSchema.toNode() );
+
+    shared.clear( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    shared.clear( SharedObjectsIO.SharedObjectType.SLAVESERVER.getName() );
+    shared.clear( SharedObjectsIO.SharedObjectType.PARTITIONSCHEMA.getName() );
+    shared.clear( SharedObjectsIO.SharedObjectType.CLUSTERSCHEMA.getName() );
+
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() ).size() );
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.SLAVESERVER.getName() ).size() );
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.PARTITIONSCHEMA.getName() ).size() );
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CLUSTERSCHEMA.getName() ).size() );
+  }
+
+}

--- a/engine/src/test/java/org/pentaho/di/trans/steps/loadsave/MemoryRepositoryExtended.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/loadsave/MemoryRepositoryExtended.java
@@ -1,0 +1,112 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.loadsave;
+
+import org.pentaho.di.cluster.ClusterSchema;
+import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.partition.PartitionSchema;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.RepositoryDirectoryInterface;
+import org.pentaho.di.repository.RepositoryExtended;
+import org.pentaho.di.repository.RepositoryObjectInterface;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.json.simple.parser.ParseException;
+
+/**
+ * Used for testing Extended Repository methods
+ *
+ */
+public class MemoryRepositoryExtended extends MemoryRepository implements RepositoryExtended {
+  public MemoryRepositoryExtended() {
+    super();
+  }
+
+  public MemoryRepositoryExtended( String json ) throws ParseException {
+    super( json );
+  }
+
+  @Override
+  @Deprecated
+  public RepositoryDirectoryInterface loadRepositoryDirectoryTree( boolean eager ) throws KettleException {
+    return null;
+  }
+
+  @Override
+  public RepositoryDirectoryInterface loadRepositoryDirectoryTree(
+      String path,
+      String filter,
+      int depth,
+      boolean showHidden,
+      boolean includeEmptyFolder,
+      boolean includeAcls )
+    throws KettleException {
+    return null;
+  }
+
+  @Override
+  public ObjectId renameRepositoryDirectory( final ObjectId dirId, final RepositoryDirectoryInterface newParent,
+                                             final String newName, final boolean renameHomeDirectories )
+      throws KettleException {
+    return null;
+  }
+
+  @Override
+  public void deleteRepositoryDirectory( final RepositoryDirectoryInterface dir, final boolean deleteHomeDirectories )
+          throws KettleException {
+  }
+
+  @Override
+  public List<RepositoryObjectInterface> getChildren( String path, String filter ) {
+    return null;
+  }
+
+  @Override
+  public List<DatabaseMeta> getConnections( boolean cached ) throws KettleException {
+    return elements.values().stream().filter( e -> e instanceof DatabaseMeta )
+      .map( e -> (DatabaseMeta) e ).collect( Collectors.toList() );
+  }
+
+  @Override
+  public List<SlaveServer> getSlaveServers( boolean cached ) throws KettleException {
+    return elements.values().stream().filter( e -> e instanceof SlaveServer )
+      .map( e -> (SlaveServer) e ).collect( Collectors.toList() );
+  }
+
+  @Override
+  public List<PartitionSchema> getPartitions( boolean cached ) throws KettleException {
+    return elements.values().stream().filter( e -> e instanceof PartitionSchema )
+      .map( e -> (PartitionSchema) e ).collect( Collectors.toList() );
+  }
+
+  @Override
+  public List<ClusterSchema> getClusters( boolean cached ) throws KettleException {
+    return elements.values().stream().filter( e -> e instanceof ClusterSchema )
+      .map( e -> (ClusterSchema) e ).collect( Collectors.toList() );
+  }
+
+
+}

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/repository/model/RepositoryDirectory.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/repository/model/RepositoryDirectory.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2017-2023 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2017-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -26,6 +26,8 @@ import org.pentaho.di.plugins.fileopensave.api.providers.EntityType;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.plugins.fileopensave.api.providers.Directory;
 import org.pentaho.di.plugins.fileopensave.providers.repository.RepositoryFileProvider;
+
+import java.util.Objects;
 
 /**
  * Created by bmorrise on 5/16/17.
@@ -51,6 +53,11 @@ public class RepositoryDirectory extends RepositoryFile implements Directory {
     repositoryDirectory.setParent( parentPath );
     repositoryDirectory.setName( repositoryDirectoryInterface.getName() );
     repositoryDirectory.setPath( parentPath == null ? repositoryDirectoryInterface.getPath() : parentPath + "/" + repositoryDirectoryInterface.getName() );
+    if ( Objects.equals( parentPath, "/" ) || parentPath == null ) {
+      repositoryDirectory.setPath( repositoryDirectoryInterface.getPath() );
+    } else {
+      repositoryDirectory.setPath( parentPath + "/" + repositoryDirectoryInterface.getName() );
+    }
     repositoryDirectory.setObjectId( repositoryDirectoryInterface.getObjectId().getId() );
     repositoryDirectory.setHidden( !repositoryDirectoryInterface.isVisible() );
     repositoryDirectory.setRoot( RepositoryFileProvider.NAME );

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/ISharedObjectsTransformer.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/ISharedObjectsTransformer.java
@@ -26,10 +26,21 @@ import org.pentaho.di.shared.SharedObjectInterface;
 import org.pentaho.di.shared.SharedObjects;
 
 public interface ISharedObjectsTransformer extends ITransformer {
+
+  /**
+   * @deprecated Shared Objects from the Repository are now accessed through a Bowl, they are no longer loaded into or
+   *             saved from the Meta.
+   */
+  @Deprecated
   void loadSharedObjects( final RepositoryElementInterface element,
       final Map<RepositoryObjectType, List<? extends SharedObjectInterface>> sharedObjectsByType )
     throws KettleException;
 
+  /**
+   * @deprecated Shared Objects from the Repository are now accessed through a Bowl, they are no longer loaded into or
+   *             saved from the Meta.
+   */
+  @Deprecated
   void saveSharedObjects( final RepositoryElementInterface element, final String versionComment )
     throws KettleException;
 }

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/JobDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/JobDelegate.java
@@ -180,43 +180,18 @@ public class JobDelegate extends AbstractDelegate implements ISharedObjectsTrans
   // ~ Methods =========================================================================================================
   @SuppressWarnings( "unchecked" )
   @Override
+  @Deprecated // Shared Object reads should now go through a SharedObjectsIO
   public void loadSharedObjects( final RepositoryElementInterface element,
       final Map<RepositoryObjectType, List<? extends SharedObjectInterface>> sharedObjectsByType )
     throws KettleException {
-    JobMeta jobMeta = (JobMeta) element;
-
-    // Repository objects take priority so let's overwrite them...
-    //
-    readDatabases( jobMeta, true, (List<DatabaseMeta>) sharedObjectsByType.get( RepositoryObjectType.DATABASE ) );
-    readSlaves( jobMeta, true, (List<SlaveServer>) sharedObjectsByType.get( RepositoryObjectType.SLAVE_SERVER ) );
+    // NO-OP
   }
 
+  @Override
+  @Deprecated // Shared Object writes should now go through a SharedObjectsIO
   public void saveSharedObjects( final RepositoryElementInterface element, final String versionComment )
     throws KettleException {
-    JobMeta jobMeta = (JobMeta) element;
-    // Now store the databases in the job.
-    // Only store if the database has actually changed or doesn't have an object ID (imported)
-    //
-    for ( DatabaseMeta databaseMeta : jobMeta.getDatabases() ) {
-      if ( databaseMeta.hasChanged() || databaseMeta.getObjectId() == null ) {
-        if ( databaseMeta.getObjectId() == null
-            || unifiedRepositoryConnectionAclService.hasAccess( databaseMeta.getObjectId(),
-                RepositoryFilePermission.WRITE ) ) {
-          repo.save( databaseMeta, versionComment, null );
-        } else {
-          log.logError( BaseMessages.getString( PKG, "PurRepository.ERROR_0004_DATABASE_UPDATE_ACCESS_DENIED",
-              databaseMeta.getName() ) );
-        }
-      }
-    }
-
-    // Store the slave server
-    //
-    for ( SlaveServer slaveServer : jobMeta.getSlaveServers() ) {
-      if ( slaveServer.hasChanged() || slaveServer.getObjectId() == null ) {
-        repo.save( slaveServer, versionComment, null );
-      }
-    }
+    // NO-OP
   }
 
   public RepositoryElementInterface dataNodeToElement( final DataNode rootNode ) throws KettleException {

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
@@ -2032,12 +2032,12 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
 
   @Override
   public void readJobMetaSharedObjects( final JobMeta jobMeta ) throws KettleException {
-    jobDelegate.loadSharedObjects( jobMeta, loadAndCacheSharedObjects( true ) );
+    // NO-OP
   }
 
   @Override
   public void readTransSharedObjects( final TransMeta transMeta ) throws KettleException {
-    transDelegate.loadSharedObjects( transMeta, loadAndCacheSharedObjects( true ) );
+    // NO-OP
   }
 
   @Override
@@ -2503,7 +2503,6 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
     transMeta.setRepository( this );
     transMeta.setRepositoryDirectory( parentDir );
     transMeta.setMetaStore( MetaStoreConst.getDefaultMetastore() );
-    readTransSharedObjects( transMeta ); // This should read from the local cache
     transDelegate.dataNodeToElement( data.getNode(), transMeta );
     transMeta.clearChanged();
     return transMeta;
@@ -2618,7 +2617,6 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
     jobMeta.setRepository( this );
     jobMeta.setRepositoryDirectory( parentDir );
     jobMeta.setMetaStore( MetaStoreConst.getDefaultMetastore() );
-    readJobMetaSharedObjects( jobMeta ); // This should read from the local cache
     jobDelegate.dataNodeToElement( data.getNode(), jobMeta );
     jobMeta.clearChanged();
     return jobMeta;
@@ -3211,7 +3209,6 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
 
         jobMeta.setMetaStore( MetaStoreConst.getDefaultMetastore() ); // inject metastore
 
-        readJobMetaSharedObjects( jobMeta );
         // Additional obfuscation through obscurity
         jobMeta.setRepositoryLock( unifiedRepositoryLockService.getLock( file ) );
 
@@ -3254,8 +3251,6 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
         transMeta.setRepositoryDirectory( findDirectory( getParentPath( file.getPath() ) ) );
         transMeta.setRepositoryLock( unifiedRepositoryLockService.getLock( file ) );
         transMeta.setMetaStore( MetaStoreConst.getDefaultMetastore() ); // inject metastore
-
-        readTransSharedObjects( transMeta );
 
         transDelegate.dataNodeToElement(
           pur.getDataAtVersionForRead( idTransformation.getId(), versionLabel, NodeRepositoryFileData.class ).getNode(),
@@ -3421,10 +3416,6 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
       // We don't have possibility to read this file via UI
       throw new KettleException( BaseMessages.getString( PKG, "PurRepository.fileCannotBeSavedInRootDirectory",
         element.getName() + element.getRepositoryElementType().getExtension() ) );
-    }
-
-    if ( saveSharedObjects ) {
-      objectTransformer.saveSharedObjects( element, versionComment );
     }
 
     ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.BeforeSaveToRepository.id, element );

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/TransDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/TransDelegate.java
@@ -856,18 +856,11 @@ public class TransDelegate extends AbstractDelegate implements ITransformer, ISh
 
   @SuppressWarnings( "unchecked" )
   @Override
+  @Deprecated // Shared Object reads should now go through a SharedObjectsIO
   public void loadSharedObjects( final RepositoryElementInterface element,
       final Map<RepositoryObjectType, List<? extends SharedObjectInterface>> sharedObjectsByType )
     throws KettleException {
-    TransMeta transMeta = (TransMeta) element;
-
-    // Repository objects take priority so let's overwrite them...
-    //
-    readDatabases( transMeta, true, (List<DatabaseMeta>) sharedObjectsByType.get( RepositoryObjectType.DATABASE ) );
-    readPartitionSchemas( transMeta, true, (List<PartitionSchema>) sharedObjectsByType
-        .get( RepositoryObjectType.PARTITION_SCHEMA ) );
-    readSlaves( transMeta, true, (List<SlaveServer>) sharedObjectsByType.get( RepositoryObjectType.SLAVE_SERVER ) );
-    readClusters( transMeta, true, (List<ClusterSchema>) sharedObjectsByType.get( RepositoryObjectType.CLUSTER_SCHEMA ) );
+    // NO-OP
   }
 
   /**
@@ -961,51 +954,10 @@ public class TransDelegate extends AbstractDelegate implements ITransformer, ISh
     }
   }
 
+  @Deprecated // Shared Object writes should now go through a SharedObjectsIO
   public void saveSharedObjects( final RepositoryElementInterface element, final String versionComment )
     throws KettleException {
-    TransMeta transMeta = (TransMeta) element;
-    // First store the databases and other depending objects in the transformation.
-    //
-
-    // Only store if the database has actually changed or doesn't have an object ID (imported)
-    //
-    for ( DatabaseMeta databaseMeta : transMeta.getDatabases() ) {
-      if ( databaseMeta.hasChanged() || databaseMeta.getObjectId() == null ) {
-        if ( databaseMeta.getObjectId() == null
-            || unifiedRepositoryConnectionAclService.hasAccess( databaseMeta.getObjectId(),
-                RepositoryFilePermission.WRITE ) ) {
-          repo.save( databaseMeta, versionComment, null );
-        } else {
-          log.logError( BaseMessages.getString( PKG, "PurRepository.ERROR_0004_DATABASE_UPDATE_ACCESS_DENIED",
-              databaseMeta.getName() ) );
-        }
-      }
-    }
-
-    // Store the slave servers...
-    //
-    for ( SlaveServer slaveServer : transMeta.getSlaveServers() ) {
-      if ( slaveServer.hasChanged() || slaveServer.getObjectId() == null ) {
-        repo.save( slaveServer, versionComment, null );
-      }
-    }
-
-    // Store the cluster schemas
-    //
-    for ( ClusterSchema clusterSchema : transMeta.getClusterSchemas() ) {
-      if ( clusterSchema.hasChanged() || clusterSchema.getObjectId() == null ) {
-        repo.save( clusterSchema, versionComment, null );
-      }
-    }
-
-    // Save the partition schemas
-    //
-    for ( PartitionSchema partitionSchema : transMeta.getPartitionSchemas() ) {
-      if ( partitionSchema.hasChanged() || partitionSchema.getObjectId() == null ) {
-        repo.save( partitionSchema, versionComment, null );
-      }
-    }
-
+    // NO-OP
   }
 
 }

--- a/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/controller/RepositoryConnectController.java
+++ b/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/controller/RepositoryConnectController.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -375,7 +375,7 @@ public class RepositoryConnectController implements IConnectedRepositoryInstance
     spoon.setRepository( repository );
     setConnectedRepository( repositoryMeta );
     fireListeners();
-    spoon.updateTreeForActiveAbstractMetas();
+    spoon.forceRefreshTree();
     spoon.clearRepositoryDirectory();
   }
 


### PR DESCRIPTION
    - RepositorySharedObjectsIO and test
    - fixed file-open-save for repositories (partial backport)
    - stopped saving or loading shared objects to the repository as part of
      transformations or jobs.
    - Still links steps to databases
    - Keep ObjectId in various Node-based memory structures, but don't store on
      disk in VfsSharedObjectsIO
    - Reset DefaultBowl managers on connect/disconnect from Repository
