### PR TITLE
[SP-6734][PDI-20282] Ensure job status of parallel sub jobs gets pass…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -900,6 +900,13 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
       throw threadExceptions.poll();
     }
 
+    // In parallel execution, we aggregate all the results, simply add them to
+    // the previous result...
+    //
+    for ( Result threadResult : threadResults ) {
+      res.add( threadResult );
+    }
+
     // If there have been errors, logically, we need to set the result to
     // "false"...
     //


### PR DESCRIPTION
…ed back to (#9762) -- backport to 10.2 suite for 10.2.0.2

the parent.  This reverts the change made for PDI-20199, which will need to be reconsidered.