### PR TITLE
[PDI-19580]-Enable Use of OAUTH for PDI Mail Steps and Entries that use IMAP/SMTP

### DIFF
--- a/plugins/email-messages/impl/src/main/java/org/pentaho/di/trans/steps/mailinput/MailInputMeta.java
+++ b/plugins/email-messages/impl/src/main/java/org/pentaho/di/trans/steps/mailinput/MailInputMeta.java
@@ -388,6 +388,7 @@ public class MailInputMeta extends BaseStepMeta implements StepMetaInterface {
       rep.saveStepAttribute( id_transformation, id_step, "redirectURI", redirectUri );
       rep.saveStepAttribute( id_transformation, id_step, "refreshToken", refresh_token );
       rep.saveStepAttribute( id_transformation, id_step, "use_grantType", grant_type );
+      rep.saveStepAttribute( id_transformation, id_step, "use_auth", usingAuthentication );
       rep.saveStepAttribute( id_transformation, id_step, "usessl", usessl );
       rep.saveStepAttribute( id_transformation, id_step, "sslport", sslport );
       rep.saveStepAttribute( id_transformation, id_step, "retrievemails", retrievemails );


### PR DESCRIPTION
[PDI-19580]-Enable Use of OAUTH for PDI Mail Steps and Entries that use IMAP/SMTP

[PDI-19580]: https://hv-eng.atlassian.net/browse/PDI-19580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ