### PR TITLE
[PDI-20292] - The count of records is not accurately determined in the Text file input step when multiple input files are used.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputReader.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/fileinput/text/TextFileInputReader.java
@@ -60,6 +60,7 @@ public class TextFileInputReader implements IBaseFileInputReader {
     this.meta = meta;
     this.data = data;
     this.log = log;
+    this.linesWritten = step.getLinesWritten();
 
     CompressionProvider provider =
         CompressionProviderFactory.getInstance().getCompressionProviderByName( meta.content.fileCompression );


### PR DESCRIPTION
A new `TextFileInputReader` is initialized for each input file of several in a step.

Before the creation of the `linesWritten` variable, we used `step.getLinesWritten()` directly, which prevented the count of lines written from being reset when we move on to a new input file (and therefore a new reader).

The changed was done in this PR: https://github.com/pentaho/pentaho-kettle/pull/9200 (because using `step.getLinesWritten()` directly caused other problems regarding the order in which the lines were processed).

For this reason, the only thing we have to do is initialize the count in the new reader as the ongoing count stored in the step.

@pentaho/tatooine_dev 