### PR TITLE
[BACKLOG-42915] - Repository Bowl

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -461,6 +461,11 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
   @Override
   public void setRepository( Repository repository ) {
     this.repository = repository;
+    if ( repository != null ) {
+      setBowl( repository.getBowl() );
+    } else {
+      setBowl( DefaultBowl.getInstance() );
+    }
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/repository/AbstractRepository.java
+++ b/engine/src/main/java/org/pentaho/di/repository/AbstractRepository.java
@@ -13,17 +13,20 @@
 
 package org.pentaho.di.repository;
 
-import java.util.List;
-
-import org.pentaho.di.core.ProgressMonitorListener;
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+
+import java.util.List;
 
 /**
  * Implementing convenience methods that can be described in terms of other methods in the interface
  */
 public abstract class AbstractRepository implements Repository {
+
+  private final Bowl bowl = new RepositoryBowl( this );
 
   @Override
   public long getJobEntryAttributeInteger( ObjectId id_jobentry, String code ) throws KettleException {
@@ -135,5 +138,10 @@ public abstract class AbstractRepository implements Repository {
   @Override
   public IUnifiedRepository getUnderlyingRepository() {
     return null;
+  }
+
+  @Override
+  public Bowl getBowl() {
+    return bowl;
   }
 }

--- a/engine/src/main/java/org/pentaho/di/repository/Repository.java
+++ b/engine/src/main/java/org/pentaho/di/repository/Repository.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import org.pentaho.di.cluster.ClusterSchema;
 import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.Condition;
 import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.database.DatabaseMeta;
@@ -759,4 +760,12 @@ public interface Repository {
    * @return repository for connect to server
    */
   public IUnifiedRepository getUnderlyingRepository();
+
+  /**
+   * Get a Bowl that represents context for the repository. Metastore and SharedObjects will come from the repository.
+   *
+   *
+   * @return Bowl
+   */
+  Bowl getBowl();
 }

--- a/engine/src/main/java/org/pentaho/di/repository/RepositoryBowl.java
+++ b/engine/src/main/java/org/pentaho/di/repository/RepositoryBowl.java
@@ -1,0 +1,64 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2025 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.repository;
+
+import org.pentaho.di.cluster.SlaveServerManagementInterface;
+import org.pentaho.di.core.bowl.BaseBowl;
+import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.shared.RepositorySharedObjectsIO;
+import org.pentaho.di.shared.SharedObjectsIO;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+import org.pentaho.metastore.api.IMetaStore;
+
+import java.util.Objects;
+
+public class RepositoryBowl extends BaseBowl {
+
+  private final Repository repository;
+  private final RepositorySharedObjectsIO sharedObjectsIO;
+
+  public RepositoryBowl( Repository repository ) {
+    this.repository = Objects.requireNonNull( repository );
+    this.sharedObjectsIO = new RepositorySharedObjectsIO( repository, () ->
+      getManager( SlaveServerManagementInterface.class ).getAll() );
+  }
+
+  @Override
+  public IMetaStore getMetastore() throws MetaStoreException {
+    return repository.getRepositoryMetaStore();
+  }
+
+  @Override
+  public SharedObjectsIO getSharedObjectsIO() {
+    return sharedObjectsIO;
+  }
+
+  @Override
+  public VariableSpace getADefaultVariableSpace() {
+    VariableSpace space = new Variables();
+    space.initializeVariablesFrom( null );
+    return space;
+  }
+
+}

--- a/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
+++ b/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
@@ -13,6 +13,44 @@
 
 package org.pentaho.di.repository;
 
+import org.pentaho.di.base.AbstractMeta;
+import org.pentaho.di.cluster.ClusterSchema;
+import org.pentaho.di.cluster.ClusterSchemaManagementInterface;
+import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.cluster.SlaveServerManagementInterface;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleMissingPluginsException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.exception.LookupReferencesException;
+import org.pentaho.di.core.gui.HasOverwritePrompter;
+import org.pentaho.di.core.gui.OverwritePrompter;
+import org.pentaho.di.core.gui.SpoonFactory;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.ObjectLocationSpecificationMethod;
+import org.pentaho.di.core.Props;
+import org.pentaho.di.core.util.StringUtil;
+import org.pentaho.di.core.util.Utils;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.imp.ImportRules;
+import org.pentaho.di.imp.rule.ImportValidationFeedback;
+import org.pentaho.di.job.entry.JobEntryCopy;
+import org.pentaho.di.job.entry.JobEntryInterface;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.partition.PartitionSchema;
+import org.pentaho.di.partition.PartitionSchemaManagementInterface;
+import org.pentaho.di.shared.DatabaseManagementInterface;
+import org.pentaho.di.shared.SharedObjectInterface;
+import org.pentaho.di.shared.SharedObjects;
+import org.pentaho.di.shared.SharedObjectsManagementInterface;
+import org.pentaho.di.shared.SharedObjectUtil;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
+import org.pentaho.di.trans.TransMeta;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,37 +64,6 @@ import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
 
-import org.pentaho.di.base.AbstractMeta;
-import org.pentaho.di.cluster.ClusterSchema;
-import org.pentaho.di.cluster.SlaveServer;
-import org.pentaho.di.core.Const;
-import org.pentaho.di.core.util.Utils;
-import org.pentaho.di.core.ObjectLocationSpecificationMethod;
-import org.pentaho.di.core.Props;
-import org.pentaho.di.core.database.DatabaseMeta;
-import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.exception.KettleMissingPluginsException;
-import org.pentaho.di.core.exception.KettleXMLException;
-import org.pentaho.di.core.exception.LookupReferencesException;
-import org.pentaho.di.core.gui.HasOverwritePrompter;
-import org.pentaho.di.core.gui.OverwritePrompter;
-import org.pentaho.di.core.gui.SpoonFactory;
-import org.pentaho.di.core.logging.LogChannel;
-import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.core.util.StringUtil;
-import org.pentaho.di.core.xml.XMLHandler;
-import org.pentaho.di.i18n.BaseMessages;
-import org.pentaho.di.imp.ImportRules;
-import org.pentaho.di.imp.rule.ImportValidationFeedback;
-import org.pentaho.di.job.JobMeta;
-import org.pentaho.di.job.entry.JobEntryCopy;
-import org.pentaho.di.job.entry.JobEntryInterface;
-import org.pentaho.di.partition.PartitionSchema;
-import org.pentaho.di.shared.SharedObjectInterface;
-import org.pentaho.di.shared.SharedObjects;
-import org.pentaho.di.trans.TransMeta;
-import org.pentaho.di.trans.step.StepMeta;
-import org.pentaho.di.trans.step.StepMetaInterface;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXParseException;
@@ -362,6 +369,15 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
     if ( obj2 == null ) {
       return false;
     }
+    if ( obj1 instanceof DatabaseMeta && obj2 instanceof DatabaseMeta ) {
+      return equals( (DatabaseMeta) obj1, (DatabaseMeta) obj2 );
+    } else if ( obj1 instanceof ClusterSchema && obj2 instanceof ClusterSchema ) {
+      return equals( (ClusterSchema) obj1, (ClusterSchema) obj2 );
+    } else if ( obj1 instanceof PartitionSchema && obj2 instanceof PartitionSchema ) {
+      return equals( (PartitionSchema) obj1, (PartitionSchema) obj2 );
+    } else if ( obj1 instanceof SlaveServer && obj2 instanceof SlaveServer ) {
+      return equals( (SlaveServer) obj1, (SlaveServer) obj2 );
+    }
     return obj1.equals( obj2 );
   }
 
@@ -464,101 +480,50 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
     return true;
   }
 
-  private void replaceSharedObjects( AbstractMeta abstractMeta ) throws KettleException {
-    for ( DatabaseMeta databaseMeta : getSharedObjects( DatabaseMeta.class ) ) {
-      // Database...
-      DatabaseMeta imported = abstractMeta.getDatabaseManagementInterface().get( databaseMeta.getName() );
-      if ( imported == null ) {
-        abstractMeta.getDatabaseManagementInterface().add( databaseMeta );
-      } else {
-        // Preserve the object id so we can update without having to look up the id
-        imported.setObjectId( databaseMeta.getObjectId() );
-        if ( equals( databaseMeta, imported )
-            || !getPromptResult( BaseMessages.getString( PKG,
-                "RepositoryImporter.Dialog.ConnectionExistsOverWrite.Message", imported.getName() ), BaseMessages
-                .getString( PKG, "RepositoryImporter.Dialog.ConnectionExistsOverWrite.DontShowAnyMoreMessage" ),
-                IMPORT_ASK_ABOUT_REPLACE_DB ) ) {
-          imported.replaceMeta( databaseMeta );
-          // We didn't actually change anything
-          imported.clearChanged();
-        } else {
-          imported.setChanged();
-        }
-      }
-    }
+  // filters which shared objects will be imported
+  private <T extends SharedObjectInterface<T>> void filterSharedObjects( AbstractMeta source,
+    Class<? extends SharedObjectsManagementInterface<T>> managerClass, String message, String importAskPref )
+    throws KettleException {
 
-    for ( SlaveServer slaveServer : getSharedObjects( SlaveServer.class ) ) {
-      int index = abstractMeta.getSlaveServers().indexOf( slaveServer );
-      if ( index < 0 ) {
-        abstractMeta.getSlaveServers().add( slaveServer );
+    SharedObjectsManagementInterface<T> srcManager = source.getSharedObjectManager( managerClass );
+    SharedObjectsManagementInterface<T> tgtManager = rep.getBowl().getManager( managerClass );
+
+    for ( T srcObject : srcManager.getAll() ) {
+      T destObject = tgtManager.get( srcObject.getName() );
+      if ( destObject == null ) {
+        continue;
       } else {
-        SlaveServer imported = abstractMeta.getSlaveServers().get( index );
-        // Preserve the object id so we can update without having to look up the id
-        imported.setObjectId( slaveServer.getObjectId() );
-        if ( equals( slaveServer, imported )
-            || !getPromptResult( BaseMessages.getString( PKG,
-                "RepositoryImporter.Dialog.SlaveServerExistsOverWrite.Message", imported.getName() ), BaseMessages
-                .getString( PKG, "RepositoryImporter.Dialog.ConnectionExistsOverWrite.DontShowAnyMoreMessage" ),
-                IMPORT_ASK_ABOUT_REPLACE_SS ) ) {
-          imported.replaceMeta( slaveServer );
-          // We didn't actually change anything
-          imported.clearChanged();
-        } else {
-          imported.setChanged();
+        if ( equals( srcObject, destObject )
+             || !getPromptResult( BaseMessages.getString( PKG, message, srcObject.getName() ), BaseMessages
+                 .getString( PKG, "RepositoryImporter.Dialog.ConnectionExistsOverWrite.DontShowAnyMoreMessage" ),
+                 importAskPref ) ) {
+            // not overwriting, remove so we don't try to use it.
+            srcManager.remove( srcObject.getName() );
         }
       }
     }
   }
 
-  protected void replaceSharedObjects( TransMeta transMeta ) throws KettleException {
-    replaceSharedObjects( (AbstractMeta) transMeta );
-    for ( ClusterSchema clusterSchema : getSharedObjects( ClusterSchema.class ) ) {
-      int index = transMeta.getClusterSchemas().indexOf( clusterSchema );
-      if ( index < 0 ) {
-        transMeta.getClusterSchemas().add( clusterSchema );
-      } else {
-        ClusterSchema imported = transMeta.getClusterSchemas().get( index );
-        // Preserve the object id so we can update without having to look up the id
-        imported.setObjectId( clusterSchema.getObjectId() );
-        if ( equals( clusterSchema, imported )
-            || !getPromptResult( BaseMessages.getString( PKG,
-                "RepositoryImporter.Dialog.ClusterSchemaExistsOverWrite.Message", imported.getName() ), BaseMessages
-                .getString( PKG, "RepositoryImporter.Dialog.ConnectionExistsOverWrite.DontShowAnyMoreMessage" ),
-                IMPORT_ASK_ABOUT_REPLACE_CS ) ) {
-          imported.replaceMeta( clusterSchema );
-          // We didn't actually change anything
-          imported.clearChanged();
-        } else {
-          imported.setChanged();
-        }
-      }
-    }
+  private void filterSharedObjects( AbstractMeta abstractMeta ) throws KettleException {
+    filterSharedObjects( abstractMeta, DatabaseManagementInterface.class,
+      "RepositoryImporter.Dialog.ConnectionExistsOverWrite.Message", IMPORT_ASK_ABOUT_REPLACE_DB );
 
-    for ( PartitionSchema partitionSchema : getSharedObjects( PartitionSchema.class ) ) {
-      int index = transMeta.getPartitionSchemas().indexOf( partitionSchema );
-      if ( index < 0 ) {
-        transMeta.getPartitionSchemas().add( partitionSchema );
-      } else {
-        PartitionSchema imported = transMeta.getPartitionSchemas().get( index );
-        // Preserve the object id so we can update without having to look up the id
-        imported.setObjectId( partitionSchema.getObjectId() );
-        if ( equals( partitionSchema, imported )
-            || !getPromptResult( BaseMessages.getString( PKG,
-                "RepositoryImporter.Dialog.PartitionSchemaExistsOverWrite.Message", imported.getName() ), BaseMessages
-                .getString( PKG, "RepositoryImporter.Dialog.ConnectionExistsOverWrite.DontShowAnyMoreMessage" ),
-                IMPORT_ASK_ABOUT_REPLACE_PS ) ) {
-          imported.replaceMeta( partitionSchema );
-          // We didn't actually change anything
-          imported.clearChanged();
-        } else {
-          imported.setChanged();
-        }
-      }
-    }
+    filterSharedObjects( abstractMeta, SlaveServerManagementInterface.class,
+      "RepositoryImporter.Dialog.SlaveServerExistsOverWrite.Message", IMPORT_ASK_ABOUT_REPLACE_SS );
   }
 
-  protected void replaceSharedObjects( JobMeta transMeta ) throws KettleException {
-    replaceSharedObjects( (AbstractMeta) transMeta );
+  protected void filterSharedObjects( TransMeta transMeta ) throws KettleException {
+    filterSharedObjects( (AbstractMeta) transMeta );
+
+    filterSharedObjects( transMeta, ClusterSchemaManagementInterface.class,
+      "RepositoryImporter.Dialog.ClusterSchemaExistsOverWrite.Message", IMPORT_ASK_ABOUT_REPLACE_CS );
+
+    filterSharedObjects( transMeta, PartitionSchemaManagementInterface.class,
+      "RepositoryImporter.Dialog.PartitionSchemaExistsOverWrite.Message", IMPORT_ASK_ABOUT_REPLACE_PS );
+  }
+
+  protected void filterSharedObjects( JobMeta transMeta ) throws KettleException {
+    filterSharedObjects( (AbstractMeta) transMeta );
   }
 
   /**
@@ -573,13 +538,21 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
     }
   }
 
+  void patchTransDatabaseConnections( TransMeta transMeta ) throws KettleException {
+    DatabaseManagementInterface dbMgr = rep.getBowl().getManager( DatabaseManagementInterface.class );
+    for ( DatabaseMeta storedDB : dbMgr.getAll() ) {
+      transMeta.databaseUpdated( storedDB.getName() );
+    }
+  }
+
   private void patchJobEntries( JobMeta jobMeta ) {
     for ( JobEntryCopy copy : jobMeta.getJobCopies() ) {
       JobEntryInterface jobEntryInterface = copy.getEntry();
       if ( jobEntryInterface instanceof HasRepositoryDirectories ) {
         patchRepositoryDirectories( jobEntryInterface.isReferencedObjectEnabled(), (HasRepositoryDirectories) jobEntryInterface  );
       }
-    } }
+    }
+  }
 
   private void patchRepositoryDirectories( boolean[] referenceEnabled, HasRepositoryDirectories metaWithReferences ) {
     String[] repDirectories = metaWithReferences.getDirectories();
@@ -650,6 +623,7 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
     // Load transformation from XML into a directory, possibly created!
     //
     TransMeta transMeta = createTransMetaForNode( transnode ); // ignore shared objects
+    transMeta.setRepository( rep );
     feedback.setLabel( BaseMessages.getString( PKG, "RepositoryImporter.ImportTrans.Label", Integer
         .toString( transformationNumber ), transMeta.getName() ) );
 
@@ -689,10 +663,13 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
     }
 
     if ( existingId == null || overwrite ) {
-      replaceSharedObjects( transMeta );
+      filterSharedObjects( transMeta );
+      SharedObjectUtil.moveAllSharedObjects( transMeta, rep.getBowl() );
+
       transMeta.setObjectId( existingId );
       transMeta.setRepositoryDirectory( targetDirectory );
       patchTransSteps( transMeta );
+      patchTransDatabaseConnections( transMeta );
 
       try {
         // Keep info on who & when this transformation was created...
@@ -752,6 +729,7 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
     // Load the job from the XML node.
     //
     JobMeta jobMeta = createJobMetaForNode( jobnode );
+    jobMeta.setRepository( rep );
     feedback.setLabel( BaseMessages.getString( PKG, "RepositoryImporter.ImportJob.Label",
         Integer.toString( jobNumber ), jobMeta.getName() ) );
     validateImportedElement( importRules, jobMeta );
@@ -793,7 +771,9 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
     jobMeta.clearCurrentDirectoryChangedListeners();
 
     if ( existintId == null || overwrite ) {
-      replaceSharedObjects( jobMeta );
+      filterSharedObjects( jobMeta );
+      SharedObjectUtil.moveAllSharedObjects( jobMeta, rep.getBowl() );
+
       jobMeta.setRepositoryDirectory( targetDirectory );
       jobMeta.setObjectId( existintId );
       patchJobEntries( jobMeta );

--- a/engine/src/main/java/org/pentaho/di/shared/BaseSharedObjectsManager.java
+++ b/engine/src/main/java/org/pentaho/di/shared/BaseSharedObjectsManager.java
@@ -91,8 +91,10 @@ public abstract class BaseSharedObjectsManager<T extends SharedObjectInterface<T
     String name = sharedObjectInterface.getName();
     Node node = sharedObjectInterface.toNode();
     sharedObjectsIO.saveSharedObject( sharedObjectType, name, node );
+    Node readBackNode = sharedObjectsIO.getSharedObject( sharedObjectType, sharedObjectInterface.getName() );
+    T readBack = createSharedObjectUsingNode( readBackNode );
 
-    sharedObjectsMap.put( name, sharedObjectInterface.makeClone() );
+    sharedObjectsMap.put( name, readBack.makeClone() );
   }
 
   /**

--- a/engine/src/main/java/org/pentaho/di/shared/SharedObjectUtil.java
+++ b/engine/src/main/java/org/pentaho/di/shared/SharedObjectUtil.java
@@ -1,0 +1,72 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2025 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.di.shared;
+
+import org.pentaho.di.base.AbstractMeta;
+import org.pentaho.di.cluster.ClusterSchemaManagementInterface;
+import org.pentaho.di.cluster.SlaveServerManagementInterface;
+import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.partition.PartitionSchemaManagementInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utilities for dealing with Shared Objects
+ *
+ */
+public class SharedObjectUtil {
+
+  /**
+   * Moves all shared objects from the source to the target
+   */
+  public static void moveAllSharedObjects( AbstractMeta sourceMeta, Bowl targetBowl ) throws KettleException {
+    moveAll( sourceMeta.getSharedObjectManager( ClusterSchemaManagementInterface.class ),
+             targetBowl.getManager(ClusterSchemaManagementInterface.class ) );
+    moveAll( sourceMeta.getSharedObjectManager( DatabaseManagementInterface.class ),
+             targetBowl.getManager( DatabaseManagementInterface.class ) );
+    moveAll( sourceMeta.getSharedObjectManager( PartitionSchemaManagementInterface.class ),
+             targetBowl.getManager( PartitionSchemaManagementInterface.class ) );
+    moveAll( sourceMeta.getSharedObjectManager( SlaveServerManagementInterface.class ),
+             targetBowl.getManager( SlaveServerManagementInterface.class ) );
+  }
+
+  public static <T extends SharedObjectInterface<T>> void moveAll( SharedObjectsManagementInterface<T> sourceManager,
+    SharedObjectsManagementInterface<T> targetManager ) throws KettleException {
+    if ( sourceManager != null && targetManager != null ) {
+      copyAll( sourceManager, targetManager );
+      sourceManager.clear();
+    }
+  }
+
+  public static <T extends SharedObjectInterface<T>> void copyAll( SharedObjectsManagementInterface<T> sourceManager,
+    SharedObjectsManagementInterface<T> targetManager ) throws KettleException {
+    if ( sourceManager != null && targetManager != null ) {
+      for ( T object : sourceManager.getAll() ) {
+        targetManager.add( object );
+      }
+    }
+  }
+
+}
+

--- a/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
@@ -51,6 +51,7 @@ import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.ObjectRevision;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.repository.RepositoryObjectType;
 import org.pentaho.di.shared.MemorySharedObjectsIO;
@@ -113,6 +114,7 @@ public class AbstractMetaTest {
     meta = new AbstractMetaStub();
     objectId = mock( ObjectId.class );
     repo = mock( Repository.class );
+    when( repo.getBowl() ).thenReturn( new RepositoryBowl( repo ) );
   }
 
   @Test

--- a/engine/src/test/java/org/pentaho/di/job/JobMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/JobMetaTest.java
@@ -10,7 +10,6 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.di.job;
 
 import org.junit.Assert;
@@ -36,6 +35,7 @@ import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.repository.ObjectRevision;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.resource.ResourceDefinition;
@@ -348,6 +348,7 @@ public class JobMetaTest {
     RepositoryDirectory repDirectory =
       new RepositoryDirectory( new RepositoryDirectory( new RepositoryDirectory(), "home" ), "admin" );
     Mockito.when( rep.findDirectory( Mockito.eq( directory ) ) ).thenReturn( repDirectory );
+    Mockito.when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
     JobMeta meta = new JobMeta();
 
     meta.loadXML( jobNode, null, rep, Mockito.mock( IMetaStore.class ), false,
@@ -375,7 +376,9 @@ public class JobMetaTest {
     RepositoryDirectoryInterface repoDir = mock( RepositoryDirectoryInterface.class );
     when( repoDir.getPath() ).thenReturn( pathAfter );
 
-    jobMeta.setRepository( mock( Repository.class ) );
+    Repository rep = mock( Repository.class );
+    Mockito.when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
+    jobMeta.setRepository( rep );
     jobMeta.setRepositoryDirectory( repoDirOrig );
 
     CurrentDirectoryChangedListener listener = mock( CurrentDirectoryChangedListener.class );
@@ -448,7 +451,9 @@ public class JobMetaTest {
     RepositoryDirectoryInterface path = mock( RepositoryDirectoryInterface.class );
 
     when( path.getPath() ).thenReturn( "aPath" );
-    jobMetaTest.setRepository( mock( Repository.class ) );
+    Repository rep = mock( Repository.class );
+    Mockito.when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
+    jobMetaTest.setRepository( rep );
     jobMetaTest.setRepositoryDirectory( path );
     jobMetaTest.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "Original value defined at run execution" );
     jobMetaTest.setVariable( Const.INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY, "file:///C:/SomeFilenameDirectory" );
@@ -488,7 +493,9 @@ public class JobMetaTest {
     RepositoryDirectoryInterface path = mock( RepositoryDirectoryInterface.class );
 
     when( path.getPath() ).thenReturn( "aPath" );
-    jobMetaTest.setRepository( mock( Repository.class ) );
+    Repository rep = mock( Repository.class );
+    Mockito.when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
+    jobMetaTest.setRepository( rep );
     jobMetaTest.setRepositoryDirectory( path );
     jobMetaTest.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "Original value defined at run execution" );
     jobMetaTest.setVariable( Const.INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY, "file:///C:/SomeFilenameDirectory" );

--- a/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/trans/JobEntryTransTest.java
@@ -35,6 +35,7 @@ import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.resource.ResourceNamingInterface;
@@ -341,6 +342,7 @@ public class JobEntryTransTest {
     jobEntryTrans.setParentJobMeta( parentJobMeta);
 
     Repository rep = Mockito.mock( Repository.class );
+    when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
     RepositoryDirectory repositoryDirectory = Mockito.mock( RepositoryDirectory.class );
     RepositoryDirectoryInterface repositoryDirectoryInterface = Mockito.mock( RepositoryDirectoryInterface.class );
     Mockito.doReturn( repositoryDirectoryInterface ).when( rep ).loadRepositoryDirectoryTree();
@@ -390,6 +392,7 @@ public class JobEntryTransTest {
     jobEntryTrans.setParentJobMeta( parentJobMeta);
 
     Repository rep = Mockito.mock( Repository.class );
+    Mockito.when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
     RepositoryDirectory repositoryDirectory = Mockito.mock( RepositoryDirectory.class );
     RepositoryDirectoryInterface repositoryDirectoryInterface = Mockito.mock( RepositoryDirectoryInterface.class );
     Mockito.doReturn( repositoryDirectoryInterface ).when( rep ).loadRepositoryDirectoryTree();

--- a/engine/src/test/java/org/pentaho/di/repository/RepositoryImporterTest.java
+++ b/engine/src/test/java/org/pentaho/di/repository/RepositoryImporterTest.java
@@ -13,24 +13,35 @@
 
 package org.pentaho.di.repository;
 
-import java.util.Collections;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.pentaho.di.cluster.ClusterSchemaManagementInterface;
+import org.pentaho.di.cluster.SlaveServerManagementInterface;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleMissingPluginsException;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.job.entry.JobEntryInterface;
+import org.pentaho.di.partition.PartitionSchemaManagementInterface;
+import org.pentaho.di.shared.DatabaseManagementInterface;
+import org.pentaho.di.shared.MemorySharedObjectsIO;
+import org.pentaho.di.shared.PassthroughClusterSchemaManager;
+import org.pentaho.di.shared.PassthroughDbConnectionManager;
+import org.pentaho.di.shared.PassthroughPartitionSchemaManager;
+import org.pentaho.di.shared.PassthroughSlaveServerManager;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
+
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -49,6 +60,11 @@ public class RepositoryImporterTest {
   private RepositoryDirectoryInterface baseDirectory;
 
   private Node entityNode;
+
+  @BeforeClass
+  public static void setupBeforeClass() throws KettleException {
+    KettleClientEnvironment.init();
+  }
 
   @Before
   public void beforeTest() {
@@ -205,6 +221,8 @@ public class RepositoryImporterTest {
                                                               StepMetaInterface stepMetaInterface,
                                                               final boolean needToCheckPathForVariables ) {
     Repository repository = mock( Repository.class );
+    when( repository.getBowl() ).thenReturn( new RepositoryBowl( repository ) );
+
     LogChannelInterface log = mock( LogChannelInterface.class );
     RepositoryImporter importer = new RepositoryImporter( repository, log ) {
 
@@ -214,6 +232,8 @@ public class RepositoryImporterTest {
         JobEntryCopy jec = mock( JobEntryCopy.class );
         when( jec.getEntry() ).thenReturn( jobEntryInterface );
         when( meta.getJobCopies() ).thenReturn( Collections.singletonList( jec ) );
+        doAnswer( invocationOnMock -> getSharedObjectManager( invocationOnMock.getArgument( 0 ) ) )
+          .when( meta ).getSharedObjectManager( any() );
         return meta;
       }
 
@@ -223,15 +243,9 @@ public class RepositoryImporterTest {
         StepMeta stepMeta = mock( StepMeta.class );
         when( stepMeta.getStepMetaInterface() ).thenReturn( stepMetaInterface );
         when( meta.getSteps() ).thenReturn( Collections.singletonList( stepMeta ) );
+        doAnswer( invocationOnMock -> getSharedObjectManager( invocationOnMock.getArgument( 0 ) ) )
+                  .when( meta ).getSharedObjectManager( any() );
         return meta;
-      }
-
-      @Override
-      protected void replaceSharedObjects( JobMeta transMeta ) throws KettleException {
-      }
-
-      @Override
-      protected void replaceSharedObjects( TransMeta transMeta ) throws KettleException {
       }
 
       @Override
@@ -240,6 +254,19 @@ public class RepositoryImporterTest {
       }
     };
     return importer;
+  }
+
+  private static <T> T getSharedObjectManager( Class<T> clazz ) {
+    if ( clazz.isAssignableFrom( SlaveServerManagementInterface.class ) ) {
+      return clazz.cast( new PassthroughSlaveServerManager( new MemorySharedObjectsIO() ) );
+    } else if ( clazz.isAssignableFrom( DatabaseManagementInterface.class ) ) {
+      return clazz.cast( new PassthroughDbConnectionManager( new MemorySharedObjectsIO() ) );
+    } else if ( clazz.isAssignableFrom( ClusterSchemaManagementInterface.class ) ) {
+      return clazz.cast( new PassthroughClusterSchemaManager( new MemorySharedObjectsIO(), Collections::emptyList ) );
+    } else if ( clazz.isAssignableFrom( PartitionSchemaManagementInterface.class ) ) {
+      return clazz.cast( new PassthroughPartitionSchemaManager( new MemorySharedObjectsIO() ) );
+    }
+    return null;
   }
 
 }

--- a/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
@@ -29,6 +29,7 @@ import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.resource.ResourceNamingInterface;
 import org.pentaho.di.trans.step.StepDataInterface;
@@ -175,6 +176,7 @@ public class StepWithMappingMetaTest {
 
 
     Repository rep = mock( Repository.class );
+    Mockito.when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
     Mockito.doReturn( Mockito.mock( RepositoryDirectoryInterface.class ) ).when( rep ).findDirectory( anyString() );
 
     TransMeta child = new TransMeta();
@@ -361,6 +363,7 @@ public class StepWithMappingMetaTest {
     Mockito.when( mappingMetaMock.getParentStepMeta() ).thenReturn( stepMeta );
 
     Repository rep = mock( Repository.class );
+    Mockito.when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
     RepositoryDirectoryInterface directoryInterface = Mockito.mock( RepositoryDirectoryInterface.class );
     Mockito.doReturn( directoryInterface ).when( rep ).findDirectory( anyString() );
     Mockito.doReturn( new TransMeta() ).when( rep )

--- a/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
@@ -40,6 +40,7 @@ import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.metastore.DatabaseMetaStoreUtil;
 import org.pentaho.di.repository.ObjectRevision;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.trans.step.StepIOMeta;
@@ -483,6 +484,7 @@ public class TransMetaTest {
     Mockito.when( jobNode.getChildNodes() ).thenReturn( nodeList );
 
     Repository rep = Mockito.mock( Repository.class );
+    Mockito.when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
     RepositoryDirectory repDirectory =
       new RepositoryDirectory( new RepositoryDirectory( new RepositoryDirectory(), "home" ), "admin" );
     Mockito.when( rep.findDirectory( Mockito.eq( directory ) ) ).thenReturn( repDirectory );
@@ -838,7 +840,9 @@ public class TransMetaTest {
     RepositoryDirectoryInterface path = mock( RepositoryDirectoryInterface.class );
 
     when( path.getPath() ).thenReturn( "aPath" );
-    transMetaTest.setRepository( mock( Repository.class ) );
+    Repository rep = mock( Repository.class );
+    Mockito.when( rep.getBowl() ).thenReturn( new RepositoryBowl( rep ) );
+    transMetaTest.setRepository( rep );
     transMetaTest.setRepositoryDirectory( path );
     transMetaTest.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "Original value defined at run execution" );
     transMetaTest.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, "file:///C:/SomeFilenameDirectory" );

--- a/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/jobexecutor/JobExecutorMetaTest.java
@@ -28,6 +28,7 @@ import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.resource.ResourceNamingInterface;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
@@ -135,6 +136,7 @@ public class JobExecutorMetaTest {
 
     JobExecutorMeta jobExecutorMeta = spy( new JobExecutorMeta() );
     Repository repository = Mockito.mock( Repository.class );
+    Mockito.when( repository.getBowl() ).thenReturn( new RepositoryBowl( repository ) );
 
     JobMeta meta = new JobMeta();
     meta.setVariable( param2, "childValue2 should be override" );

--- a/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/tree/ConnectionFolderProvider.java
+++ b/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/tree/ConnectionFolderProvider.java
@@ -17,7 +17,6 @@ import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.connections.ConnectionDetails;
 import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.Repository;
@@ -51,7 +50,9 @@ public class ConnectionFolderProvider extends TreeFolderProvider {
     try {
       Set<String> bowlNames = new HashSet<>();
       Bowl currentBowl = Spoon.getInstance().getBowl();
-      if ( !currentBowl.equals( DefaultBowl.getInstance() ) ) {
+      Bowl globalBowl = Spoon.getInstance().getGlobalManagementBowl();
+
+      if ( !currentBowl.equals( globalBowl ) ) {
         ConnectionManager bowlCM = currentBowl.getManager( ConnectionManager.class );
         for ( String name : bowlCM.getNames() ) {
           if ( !filterMatch( name, filter ) ) {
@@ -63,7 +64,7 @@ public class ConnectionFolderProvider extends TreeFolderProvider {
         }
       }
 
-      ConnectionManager globalCM = DefaultBowl.getInstance().getManager( ConnectionManager.class );
+      ConnectionManager globalCM = globalBowl.getManager( ConnectionManager.class );
       for ( String name : globalCM.getNames() ) {
         if ( !filterMatch( name, filter ) ) {
           continue;

--- a/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/tree/ConnectionPopupMenuExtension.java
+++ b/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/tree/ConnectionPopupMenuExtension.java
@@ -29,7 +29,6 @@ import org.pentaho.di.ui.core.ConstUI;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.spoon.TreeSelection;
 import org.pentaho.di.connections.vfs.VFSConnectionDetails;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.ui.core.widget.tree.LeveledTreeNode;
 
 import java.util.function.Supplier;
@@ -132,7 +131,7 @@ public class ConnectionPopupMenuExtension implements ExtensionPointInterface {
       } );
     }
     if ( vfsConnectionTreeItem.getLevel() == LeveledTreeNode.LEVEL.GLOBAL
-         && spoonSupplier.get().getBowl() != DefaultBowl.getInstance() ) {
+         && spoonSupplier.get().getBowl() != spoonSupplier.get().getGlobalManagementBowl() ) {
       MenuItem moveMenuItem = new MenuItem( itemMenu, SWT.NONE );
       moveMenuItem.setText( BaseMessages.getString( PKG, "VFSConnectionPopupMenuExtension.MenuItem.MoveToProject" ) );
       moveMenuItem.addSelectionListener( new SelectionAdapter() {

--- a/plugins/connections/ui/src/main/java/org/pentaho/di/vfs/connections/ui/dialog/ConnectionDelegate.java
+++ b/plugins/connections/ui/src/main/java/org/pentaho/di/vfs/connections/ui/dialog/ConnectionDelegate.java
@@ -20,7 +20,6 @@ import org.pentaho.di.connections.ui.dialog.ConnectionDeleteDialog;
 import org.pentaho.di.connections.ui.dialog.ConnectionOverwriteDialog;
 import org.pentaho.di.connections.ui.tree.ConnectionFolderProvider;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.EngineMetaInterface;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.i18n.BaseMessages;
@@ -119,19 +118,19 @@ public class ConnectionDelegate {
   }
 
   public void copyToGlobal( String name ) {
-    moveCopy( name, spoonSupplier.get().getBowl(), DefaultBowl.getInstance(), false );
+    moveCopy( name, spoonSupplier.get().getBowl(), spoonSupplier.get().getGlobalManagementBowl(), false );
   }
 
   public void copyToProject( String name ) {
-    moveCopy( name, DefaultBowl.getInstance(), spoonSupplier.get().getBowl(), false );
+    moveCopy( name, spoonSupplier.get().getGlobalManagementBowl(), spoonSupplier.get().getBowl(), false );
   }
 
   public void moveToGlobal( String name ) {
-    moveCopy( name, spoonSupplier.get().getBowl(), DefaultBowl.getInstance(), true );
+    moveCopy( name, spoonSupplier.get().getBowl(), spoonSupplier.get().getGlobalManagementBowl(), true );
   }
 
   public void moveToProject( String name ) {
-    moveCopy( name, DefaultBowl.getInstance(), spoonSupplier.get().getBowl(), true );
+    moveCopy( name, spoonSupplier.get().getGlobalManagementBowl(), spoonSupplier.get().getBowl(), true );
   }
 
   private void moveCopy( String name, Bowl sourceBowl, Bowl targetBowl, boolean deleteSource ) {
@@ -164,7 +163,7 @@ public class ConnectionDelegate {
     if ( level == LeveledTreeNode.LEVEL.PROJECT ) {
       return spoon.getBowl();
     } else {
-      return DefaultBowl.getInstance();
+      return spoon.getGlobalManagementBowl();
     }
   }
 

--- a/plugins/connections/ui/src/test/java/org/pentaho/di/connections/ui/tree/ConnectionFolderProviderTest.java
+++ b/plugins/connections/ui/src/test/java/org/pentaho/di/connections/ui/tree/ConnectionFolderProviderTest.java
@@ -69,6 +69,7 @@ public class ConnectionFolderProviderTest {
   public void create_TestAdmin(){
     doReturn( mockRepository ).when( mockSpoon ).getRepository();
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
     doReturn( mockUser ).when( mockRepository ).getUserInfo();
     doReturn( true ).when( mockUser ).isAdmin();
     connectionFolderProvider = new ConnectionFolderProvider();
@@ -99,6 +100,7 @@ public class ConnectionFolderProviderTest {
   public void create_TestNullRepo(){
     doReturn( null ).when( mockSpoon ).getRepository();
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
     connectionFolderProvider = new ConnectionFolderProvider();
     TreeNode parentTreeNode = new TreeNode();
     assertFalse( parentTreeNode.hasChildren() );
@@ -115,6 +117,7 @@ public class ConnectionFolderProviderTest {
   public void create_TestNullIsAdmin(){
     doReturn( mockRepository ).when( mockSpoon ).getRepository();
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
     doReturn( mockUser ).when( mockRepository ).getUserInfo();
     doReturn( null ).when( mockUser ).isAdmin();
     connectionFolderProvider = new ConnectionFolderProvider();
@@ -133,6 +136,7 @@ public class ConnectionFolderProviderTest {
   public void create_TestNullUser(){
     doReturn( mockRepository ).when( mockSpoon ).getRepository();
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
     doReturn( null ).when( mockRepository ).getUserInfo();
     connectionFolderProvider = new ConnectionFolderProvider();
     TreeNode parentTreeNode = new TreeNode();

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationUI.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationUI.java
@@ -30,7 +30,6 @@ import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.cluster.SlaveServerManagementInterface;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.engine.configuration.api.RunConfigurationDialog;
@@ -367,12 +366,14 @@ public class DefaultRunConfigurationUI implements RunConfigurationUI {
       try {
         // Get the slave servers for the project
         Bowl currentBowl = spoonSupplier.get().getBowl();
-        if ( currentBowl != DefaultBowl.getInstance() ) {
+        Bowl globalBowl = spoonSupplier.get().getGlobalManagementBowl();
+
+        if ( currentBowl != globalBowl ) {
           slaveServers = currentBowl.getManager( SlaveServerManagementInterface.class ).getAll();
         }
 
         // Add any  global slave servers to the list
-        List<SlaveServer> globalServers = DefaultBowl.getInstance().getManager( SlaveServerManagementInterface.class ).getAll();
+        List<SlaveServer> globalServers = globalBowl.getManager( SlaveServerManagementInterface.class ).getAll();
         for ( SlaveServer slaveServer : globalServers ) {
           if ( !slaveServers.contains( slaveServer ) ) {
             slaveServers.add( slaveServer );

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationDelegate.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationDelegate.java
@@ -19,7 +19,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPointHandler;
 import org.pentaho.di.core.extension.KettleExtensionPoint;
@@ -183,7 +182,7 @@ public class RunConfigurationDelegate {
   }
 
   public void copyToGlobal( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
-    moveCopy( manager, runConfiguration, DefaultBowl.getInstance(), false );
+    moveCopy( manager, runConfiguration, spoonSupplier.get().getGlobalManagementBowl(), false );
   }
 
   public void copyToProject( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
@@ -191,7 +190,7 @@ public class RunConfigurationDelegate {
   }
 
   public void moveToGlobal( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
-    moveCopy( manager, runConfiguration, DefaultBowl.getInstance(), true );
+    moveCopy( manager, runConfiguration, spoonSupplier.get().getGlobalManagementBowl(), true );
   }
 
   public void moveToProject( RunConfigurationManager manager, RunConfiguration runConfiguration ) {

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
@@ -19,7 +19,6 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
 import org.pentaho.di.i18n.BaseMessages;
@@ -50,7 +49,9 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
     GUIResource guiResource = GUIResource.getInstance();
     Set<String> bowlNames = new HashSet<>();
     Bowl currentBowl = Spoon.getInstance().getBowl();
-    if ( !currentBowl.equals( DefaultBowl.getInstance() ) ) {
+    Bowl globalBowl = Spoon.getInstance().getGlobalManagementBowl();
+
+    if ( !currentBowl.equals( globalBowl ) ) {
       RunConfigurationDelegate bowlDelegate =
         RunConfigurationDelegate.getInstance( () -> currentBowl.getMetastore() );
       for ( RunConfiguration runConfiguration : bowlDelegate.load() ) {
@@ -71,7 +72,7 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
     }
 
     RunConfigurationDelegate globalDelegate =
-      RunConfigurationDelegate.getInstance( () -> DefaultBowl.getInstance().getMetastore() );
+      RunConfigurationDelegate.getInstance( () -> globalBowl.getMetastore() );
 
     for ( RunConfiguration runConfiguration : globalDelegate.load() ) {
       if ( !filterMatch( runConfiguration.getName(), filter ) ) {

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationPopupMenuExtension.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationPopupMenuExtension.java
@@ -20,7 +20,6 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Tree;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
@@ -143,7 +142,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       } );
     }
 
-    if ( runConfigurationTreeItem.getLevel() == LeveledTreeNode.LEVEL.GLOBAL && spoonSupplier.get().getBowl() != DefaultBowl.getInstance() ) {
+    if ( runConfigurationTreeItem.getLevel() == LeveledTreeNode.LEVEL.GLOBAL &&
+         spoonSupplier.get().getBowl() != spoonSupplier.get().getGlobalManagementBowl() ) {
       MenuItem moveMenuItem = new MenuItem( itemMenu, SWT.NONE );
       moveMenuItem.setText( BaseMessages.getString( PKG, "RunConfigurationPopupMenuExtension.MenuItem.MoveToProject" ) );
       moveMenuItem.addSelectionListener( new SelectionAdapter() {
@@ -201,9 +201,9 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
   private Bowl getEventBowl() {
     // Edit and Delete use the bowl that the item is in
     if ( runConfigurationTreeItem.getLevel().equals( LeveledTreeNode.LEVEL.GLOBAL ) ) {
-      return DefaultBowl.getInstance();
+      return spoonSupplier.get().getGlobalManagementBowl();
     } else {
-      return Spoon.getInstance().getBowl();
+      return spoonSupplier.get().getBowl();
     }
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationViewTreeExtension.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationViewTreeExtension.java
@@ -20,7 +20,6 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.TreeItem;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
@@ -50,7 +49,7 @@ public class RunConfigurationViewTreeExtension implements ExtensionPointInterfac
 
         Bowl bowl;
         if ( level.equals( LeveledTreeNode.LEVEL.GLOBAL ) ) {
-          bowl = DefaultBowl.getInstance();
+          bowl = Spoon.getInstance().getGlobalManagementBowl();
         } else {
           bowl = Spoon.getInstance().getBowl();
         }

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/VFSFileProvider.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/VFSFileProvider.java
@@ -29,7 +29,6 @@ import org.pentaho.di.connections.vfs.provider.ConnectionFileName;
 import org.pentaho.di.connections.vfs.provider.ConnectionFileNameParser;
 import org.pentaho.di.connections.vfs.provider.ConnectionFileProvider;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;

--- a/plugins/get-repository-names/impl/src/test/java/org/pentaho/di/trans/steps/getrepositorynames/GetRepositoryNamesTest.java
+++ b/plugins/get-repository-names/impl/src/test/java/org/pentaho/di/trans/steps/getrepositorynames/GetRepositoryNamesTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.job.JobMeta;
@@ -55,6 +56,7 @@ import org.pentaho.di.repository.RepositoryObject;
 import org.pentaho.di.repository.RepositoryObjectType;
 import org.pentaho.di.repository.filerep.KettleFileRepository;
 import org.pentaho.di.repository.filerep.KettleFileRepositoryMeta;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
@@ -67,6 +69,7 @@ public class GetRepositoryNamesTest {
 
   @BeforeClass
   public static void setUpBeforeClass() throws KettleException, IOException {
+    KettleClientEnvironment.init();
     prepareFileRepository();
     prepareExtendedRepository();
   }
@@ -167,6 +170,7 @@ public class GetRepositoryNamesTest {
     IUser user = Mockito.mock( IUser.class );
     Mockito.when( user.isAdmin() ).thenReturn( true );
     Mockito.when( repoExtended.getUserInfo() ).thenReturn( user );
+    Mockito.when( repoExtended.getBowl() ).thenReturn( new RepositoryBowl( repoExtended ) );
   }
 
   @AfterClass

--- a/plugins/pentaho-googledrive-vfs/core/src/main/java/org/pentaho/googledrive/vfs/ui/GoogleDriveFileChooserDialog.java
+++ b/plugins/pentaho-googledrive-vfs/core/src/main/java/org/pentaho/googledrive/vfs/ui/GoogleDriveFileChooserDialog.java
@@ -75,7 +75,7 @@ public class GoogleDriveFileChooserDialog extends CustomVfsUiPanel {
     } else if ( Spoon.getInstance().getActiveJob() != null ) {
       return Spoon.getInstance().getActiveJob().getBowl();
     } else {
-      return DefaultBowl.getInstance();
+      return Spoon.getInstance().getExecutionBowl();
     }
   }
 }

--- a/plugins/pentaho-repository-vfs/core/src/main/java/org/pentaho/repositoryvfs/dialog/RepositoryVfsProviderDialog.java
+++ b/plugins/pentaho-repository-vfs/core/src/main/java/org/pentaho/repositoryvfs/dialog/RepositoryVfsProviderDialog.java
@@ -15,7 +15,6 @@ package org.pentaho.repositoryvfs.dialog;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
@@ -49,7 +48,7 @@ public class RepositoryVfsProviderDialog extends CustomVfsUiPanel {
 
   public FileObject resolveFile( String fileUri ) throws FileSystemException {
     try {
-      return KettleVFS.getInstance( DefaultBowl.getInstance() )
+      return KettleVFS.getInstance( Spoon.getInstance().getGlobalManagementBowl() )
         .getFileObject( fileUri, getVariableSpace(), getFileSystemOptions() );
     } catch ( KettleFileException e ) {
       throw new FileSystemException( e );

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryImporter.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryImporter.java
@@ -87,18 +87,6 @@ public class PurRepositoryImporter extends RepositoryImporter implements java.io
   }
 
   @Override
-  protected void replaceSharedObjects( TransMeta transMeta ) throws KettleException {
-    populateSharedObjectsMap();
-    super.replaceSharedObjects( transMeta );
-  }
-
-  @Override
-  protected void replaceSharedObjects( JobMeta jobMeta ) throws KettleException {
-    populateSharedObjectsMap();
-    super.replaceSharedObjects( jobMeta );
-  }
-
-  @Override
   protected boolean equals( DatabaseMeta databaseMeta, DatabaseMeta databaseMeta2 ) {
     return rep.getDatabaseMetaTransformer().equals( databaseMeta, databaseMeta2 );
   }

--- a/plugins/pur/core/src/test/java/com/pentaho/repository/importexport/StreamToJobNodeConverterTest.java
+++ b/plugins/pur/core/src/test/java/com/pentaho/repository/importexport/StreamToJobNodeConverterTest.java
@@ -22,6 +22,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.repository.StringObjectId;
 import org.pentaho.di.shared.MemorySharedObjectsIO;
 import org.pentaho.platform.api.repository2.unified.ConverterException;
@@ -61,6 +62,8 @@ public class StreamToJobNodeConverterTest {
 
     Repository repository = mock( Repository.class );
     when( repository.loadJob( any( StringObjectId.class ), anyString() ) ).thenReturn( jobMeta );
+    when( repository.getBowl() ).thenReturn( new RepositoryBowl( repository ) );
+
 
     StreamToJobNodeConverter jobNodeConverter = new StreamToJobNodeConverter( pur );
     jobNodeConverter = spy( jobNodeConverter );

--- a/plugins/pur/core/src/test/java/com/pentaho/repository/importexport/StreamToTransNodeConverterTest.java
+++ b/plugins/pur/core/src/test/java/com/pentaho/repository/importexport/StreamToTransNodeConverterTest.java
@@ -28,7 +28,9 @@ import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.repository.StringObjectId;
+import org.pentaho.di.shared.MemorySharedObjectsIO;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.platform.api.repository2.unified.ConverterException;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
@@ -53,7 +55,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pentaho.di.core.util.Assert.assertTrue;
-import org.pentaho.di.shared.MemorySharedObjectsIO;
 
 public class StreamToTransNodeConverterTest {
   @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
@@ -104,6 +105,8 @@ public class StreamToTransNodeConverterTest {
 
     Repository repository = mock( Repository.class );
     when( repository.loadTransformation( any( StringObjectId.class ), anyString() ) ).thenReturn( transMeta );
+    when( repository.getBowl() ).thenReturn( new RepositoryBowl( repository ) );
+
 
     StreamToTransNodeConverter transNodeConverter = new StreamToTransNodeConverter( pur );
     transNodeConverter = spy( transNodeConverter );

--- a/plugins/pur/repository-proxy/src/main/java/org/pentaho/di/repository/pur/provider/PurRepositoryProxy.java
+++ b/plugins/pur/repository-proxy/src/main/java/org/pentaho/di/repository/pur/provider/PurRepositoryProxy.java
@@ -14,6 +14,7 @@ package org.pentaho.di.repository.pur.provider;
 
 import org.pentaho.di.cluster.ClusterSchema;
 import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.Condition;
 import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.database.DatabaseMeta;
@@ -175,6 +176,11 @@ public class PurRepositoryProxy implements Repository {
   @Override
   public void init( RepositoryMeta repositoryMeta ) {
     getDelegate().init( repositoryMeta );
+  }
+
+  @Override
+  public Bowl getBowl() {
+    return getDelegate().getBowl();
   }
 
   @Override

--- a/ui/src/main/java/org/pentaho/di/ui/job/entry/JobEntryDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/entry/JobEntryDialog.java
@@ -26,7 +26,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Dialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
@@ -417,7 +416,7 @@ public class JobEntryDialog extends Dialog {
           DatabaseManagementInterface dbMgr =
             spoonSupplier.get().getBowl().getManager( DatabaseManagementInterface.class );
           DatabaseManagementInterface globalDbMgr =
-            DefaultBowl.getInstance().getManager( DatabaseManagementInterface.class );
+            spoonSupplier.get().getGlobalManagementBowl().getManager( DatabaseManagementInterface.class );
           DatabaseManagementInterface jobDbMgr = jobMeta.getDatabaseManagementInterface();
 
           if ( applicableDbMgr == null && dbMgr.get( originalName ) != null ) {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -191,6 +191,7 @@ import org.pentaho.di.pkg.JarfileGenerator;
 import org.pentaho.di.repository.KettleRepositoryLostException;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryBowl;
 import org.pentaho.di.repository.RepositoryCapabilities;
 import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
@@ -494,6 +495,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   public PropsUI props;
 
   // should never be null
+  private Bowl globalManagementBowl = DefaultBowl.getInstance();
   private Bowl managementBowl = DefaultBowl.getInstance();
   private Bowl executionBowl = DefaultBowl.getInstance();
 
@@ -3157,7 +3159,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     if ( level == LeveledTreeNode.LEVEL.PROJECT ) {
       return managementBowl.getManager( clazz );
     } else if ( level == LeveledTreeNode.LEVEL.GLOBAL ) {
-      return DefaultBowl.getInstance().getManager( clazz );
+      return globalManagementBowl.getManager( clazz );
     } else if ( level == LeveledTreeNode.LEVEL.LOCAL ) {
       AbstractMeta meta = getActiveAbstractMeta();
       return meta != null ? meta.getSharedObjectManager( clazz ) : null;
@@ -3289,7 +3291,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       }
 
       if ( leveledSelection.getLevel() == LeveledTreeNode.LEVEL.GLOBAL ) {
-        if ( getBowl() != DefaultBowl.getInstance() ) {
+        if ( getBowl() != getGlobalManagementBowl() ) {
           moveProjectItem.setVisible( true );
           moveGlobalItem.setVisible( false );
         } else {
@@ -3298,7 +3300,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         }
       }
       if ( leveledSelection.getLevel() == LeveledTreeNode.LEVEL.LOCAL ) {
-        if ( getBowl() == DefaultBowl.getInstance() ) {
+        if ( getBowl() == getGlobalManagementBowl() ) {
           moveGlobalItem.setVisible( true );
           moveProjectItem.setVisible( false );
         } else {
@@ -3318,7 +3320,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       }
 
       if ( leveledSelection.getLevel() == LeveledTreeNode.LEVEL.GLOBAL ) {
-        if ( getBowl() != DefaultBowl.getInstance() ) {
+        if ( getBowl() != getGlobalManagementBowl() ) {
           copyProjectItem.setVisible( true );
           copyGlobalItem.setVisible( false );
         } else {
@@ -3327,7 +3329,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         }
       }
       if ( leveledSelection.getLevel() == LeveledTreeNode.LEVEL.LOCAL ) {
-        if ( getBowl() == DefaultBowl.getInstance() ) {
+        if ( getBowl() == getGlobalManagementBowl() ) {
           copyGlobalItem.setVisible( true );
           copyProjectItem.setVisible( false );
         } else {
@@ -6736,7 +6738,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     Map<String, String> newProperties = dialog.open();
     if ( newProperties != null ) {
       VariableSpace bowlSpace;
-      if ( managementBowl.equals( DefaultBowl.getInstance() ) ) {
+      if ( managementBowl.equals( getGlobalManagementBowl() ) ) {
         bowlSpace = new Variables();
       } else {
         bowlSpace = managementBowl.getADefaultVariableSpace();
@@ -9149,9 +9151,9 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     this.rep = rep;
 
     if ( rep != null ) {
-      DefaultBowl.getInstance().setSharedObjectsIO( new RepositorySharedObjectsIO( rep, () ->
-            getExecutionBowl().getManager( SlaveServerManagementInterface.class ).getAll() ) );
-      DefaultBowl.getInstance().clearManagers();
+      globalManagementBowl = new RepositoryBowl( rep );
+      managementBowl = globalManagementBowl;
+      executionBowl = globalManagementBowl;
 
       this.repositoryName = rep.getName();
       List<LastUsedFile> lastUsedFiles = getLastUsedRepoFiles();
@@ -9161,9 +9163,9 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         lastFileOpenedProvider = ProviderFilterType.REPOSITORY.toString();
       }
     } else {
-      // will be generated on the next call
-      DefaultBowl.getInstance().setSharedObjectsIO( null );
-      DefaultBowl.getInstance().clearManagers();
+      globalManagementBowl = DefaultBowl.getInstance();
+      managementBowl = globalManagementBowl;
+      executionBowl = globalManagementBowl;
 
       this.repositoryName = null;
       lastFileOpened = props.getLastUsedLocalFile();
@@ -9784,9 +9786,19 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   }
 
   /**
+   * Retrieves the Bowl for the Global Management context. This Bowl should be used for write operations specifically at
+   * the Global level. This Bowl will only return objects directly owned by the global context.
+   *
+   * @return Bowl The Bowl that should be used during execution.
+   */
+  public Bowl getGlobalManagementBowl() {
+    return globalManagementBowl;
+  }
+
+  /**
    * Retrieves the Bowl for the Management context. This Bowl should be used for write operations. This Bowl will only
    * return objects directly owned by the particular context. It will not include objects owned by the global context.
-   * Use DefaultBowl to access the global context.
+   * Use getGlobalManagementBowl() to access the global context.
    *
    * @return Bowl The Bowl that should be used during execution.
    */

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonClustersDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonClustersDelegate.java
@@ -19,7 +19,6 @@ import org.pentaho.di.cluster.ClusterSchema;
 import org.pentaho.di.cluster.ClusterSchemaManagementInterface;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.cluster.SlaveServerManagementInterface;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.i18n.BaseMessages;
@@ -112,7 +111,7 @@ public class SpoonClustersDelegate extends SpoonSharedObjectDelegate {
 
   public void moveToGlobal( ClusterSchemaManagementInterface clusterSchemaManager, ClusterSchema clusterSchema )
       throws KettleException {
-    moveCopy( clusterSchemaManager, DefaultBowl.getInstance().getManager( ClusterSchemaManagementInterface.class ),
+    moveCopy( clusterSchemaManager, spoon.getGlobalManagementBowl().getManager( ClusterSchemaManagementInterface.class ),
               clusterSchema, true, "Spoon.Message.OverwriteClusterSchemaYN" );
   }
 
@@ -124,7 +123,7 @@ public class SpoonClustersDelegate extends SpoonSharedObjectDelegate {
 
   public void copyToGlobal( ClusterSchemaManagementInterface clusterSchemaManager, ClusterSchema clusterSchema )
       throws KettleException {
-    moveCopy( clusterSchemaManager, DefaultBowl.getInstance().getManager( ClusterSchemaManagementInterface.class ),
+    moveCopy( clusterSchemaManager, spoon.getGlobalManagementBowl().getManager( ClusterSchemaManagementInterface.class ),
               clusterSchema, false, "Spoon.Message.OverwriteClusterSchemaYN" );
   }
 

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonDBDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonDBDelegate.java
@@ -23,7 +23,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.MessageBox;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.Props;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.DBCache;
 import org.pentaho.di.core.NotePadMeta;
@@ -226,7 +225,7 @@ public class SpoonDBDelegate extends SpoonDelegate {
   }
 
   public void moveToGlobal( DatabaseMeta databaseMeta, DatabaseManagementInterface dbManager ) throws KettleException {
-    moveCopy( dbManager, DefaultBowl.getInstance().getManager( DatabaseManagementInterface.class ), databaseMeta, true );
+    moveCopy( dbManager, spoon.getGlobalManagementBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, true );
   }
 
   public void moveToProject( DatabaseMeta databaseMeta, DatabaseManagementInterface dbManager ) throws KettleException {
@@ -234,7 +233,7 @@ public class SpoonDBDelegate extends SpoonDelegate {
   }
 
   public void copyToGlobal( DatabaseMeta databaseMeta, DatabaseManagementInterface dbManager ) throws KettleException {
-    moveCopy( dbManager, DefaultBowl.getInstance().getManager( DatabaseManagementInterface.class ), databaseMeta, false );
+    moveCopy( dbManager, spoon.getGlobalManagementBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, false );
   }
 
   public void copyToProject( DatabaseMeta databaseMeta, DatabaseManagementInterface dbManager ) throws KettleException {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonPartitionsDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonPartitionsDelegate.java
@@ -18,7 +18,6 @@ import java.util.List;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.MessageBox;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.i18n.BaseMessages;
@@ -126,7 +125,7 @@ public class SpoonPartitionsDelegate extends SpoonSharedObjectDelegate {
 
   public void moveToGlobal( PartitionSchemaManagementInterface partitionSchemaManager, PartitionSchema partitionSchema )
     throws KettleException {
-    moveCopy( partitionSchemaManager, DefaultBowl.getInstance().getManager( PartitionSchemaManagementInterface.class ), partitionSchema, true,
+    moveCopy( partitionSchemaManager, spoon.getGlobalManagementBowl().getManager( PartitionSchemaManagementInterface.class ), partitionSchema, true,
       "Spoon.Message.OverwritePartitionSchemaYN" );
   }
 
@@ -138,7 +137,7 @@ public class SpoonPartitionsDelegate extends SpoonSharedObjectDelegate {
 
   public void copyToGlobal( PartitionSchemaManagementInterface partitionSchemaManager, PartitionSchema partitionSchema )
     throws KettleException {
-    moveCopy( partitionSchemaManager, DefaultBowl.getInstance().getManager( PartitionSchemaManagementInterface.class ), partitionSchema, false,
+    moveCopy( partitionSchemaManager, spoon.getGlobalManagementBowl().getManager( PartitionSchemaManagementInterface.class ), partitionSchema, false,
       "Spoon.Message.OverwritePartitionSchemaYN" );
   }
 

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonSlaveDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonSlaveDelegate.java
@@ -16,7 +16,6 @@ package org.pentaho.di.ui.spoon.delegates;
 
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.cluster.SlaveServerManagementInterface;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -136,7 +135,7 @@ public class SpoonSlaveDelegate extends SpoonSharedObjectDelegate {
 
   public void moveToGlobal( SlaveServerManagementInterface slaveServerManager, SlaveServer slaveServer )
       throws KettleException {
-    moveCopy( slaveServerManager, DefaultBowl.getInstance().getManager( SlaveServerManagementInterface.class ),
+    moveCopy( slaveServerManager, spoon.getGlobalManagementBowl().getManager( SlaveServerManagementInterface.class ),
               slaveServer, true, "Spoon.Message.OverwriteSlaveServerYN" );
   }
 
@@ -148,7 +147,7 @@ public class SpoonSlaveDelegate extends SpoonSharedObjectDelegate {
 
   public void copyToGlobal( SlaveServerManagementInterface slaveServerManager, SlaveServer slaveServer )
       throws KettleException {
-    moveCopy( slaveServerManager, DefaultBowl.getInstance().getManager( SlaveServerManagementInterface.class ),
+    moveCopy( slaveServerManager, spoon.getGlobalManagementBowl().getManager( SlaveServerManagementInterface.class ),
               slaveServer, false, "Spoon.Message.OverwriteSlaveServerYN" );
   }
 

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/TreePopupMenuProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/TreePopupMenuProvider.java
@@ -14,7 +14,6 @@
 package org.pentaho.di.ui.spoon.tree;
 
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.widget.tree.LeveledTreeNode;
 import org.pentaho.di.ui.spoon.Spoon;
@@ -33,6 +32,7 @@ public class TreePopupMenuProvider {
   public void createSharedObjectMenuItems( XulDomContainer mainSpoonContainer,
       SpoonTreeLeveledSelection leveledSelection, String menubarPrefix ) {
     Bowl currentBowl = Spoon.getInstance().getBowl();
+    Bowl globalBowl = Spoon.getInstance().getGlobalManagementBowl();
 
     XulMenuitem moveProjectItem =
       (XulMenuitem) mainSpoonContainer.getDocumentRoot().getElementById( menubarPrefix + "-inst-move-project"  );
@@ -46,7 +46,7 @@ public class TreePopupMenuProvider {
       }
 
       if ( leveledSelection.getLevel() == LeveledTreeNode.LEVEL.GLOBAL ) {
-        if ( currentBowl != DefaultBowl.getInstance() ) {
+        if ( currentBowl != globalBowl ) {
           moveProjectItem.setVisible( true );
           moveGlobalItem.setVisible( false );
         } else {
@@ -55,7 +55,7 @@ public class TreePopupMenuProvider {
         }
       }
       if ( leveledSelection.getLevel() == LeveledTreeNode.LEVEL.LOCAL ) {
-        if ( currentBowl == DefaultBowl.getInstance() ) {
+        if ( currentBowl == globalBowl ) {
           moveGlobalItem.setVisible( true );
           moveProjectItem.setVisible( false );
         } else {
@@ -76,7 +76,7 @@ public class TreePopupMenuProvider {
       }
 
       if ( leveledSelection.getLevel() == LeveledTreeNode.LEVEL.GLOBAL ) {
-        if ( currentBowl != DefaultBowl.getInstance() ) {
+        if ( currentBowl != globalBowl ) {
           copyProjectItem.setVisible( true );
           copyGlobalItem.setVisible( false );
         } else {
@@ -85,7 +85,7 @@ public class TreePopupMenuProvider {
         }
       }
       if ( leveledSelection.getLevel() == LeveledTreeNode.LEVEL.LOCAL ) {
-        if ( currentBowl == DefaultBowl.getInstance() ) {
+        if ( currentBowl == globalBowl ) {
           copyGlobalItem.setVisible( true );
           copyProjectItem.setVisible( false );
         } else {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/ClustersFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/ClustersFolderProvider.java
@@ -17,7 +17,6 @@ import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.cluster.ClusterSchema;
 import org.pentaho.di.cluster.ClusterSchemaManagementInterface;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.shared.SharedObjectInterface;
@@ -56,10 +55,11 @@ public class ClustersFolderProvider extends TreeFolderProvider {
   @Override
   public void refresh( Optional<AbstractMeta> meta, TreeNode treeNode, String filter ) {
     Bowl currentBowl = Spoon.getInstance().getBowl();
+    Bowl globalBowl = Spoon.getInstance().getGlobalManagementBowl();
     try {
       Set<String> projectClusterNames = new HashSet<>();
       // Bowl specific
-      if ( currentBowl != DefaultBowl.getInstance() ) {
+      if ( currentBowl != globalBowl ) {
         ClusterSchemaManagementInterface clusterSchemaManager =
           currentBowl.getManager( ClusterSchemaManagementInterface.class );
         List<ClusterSchema> clusterSchemas = clusterSchemaManager.getAll();
@@ -76,7 +76,7 @@ public class ClustersFolderProvider extends TreeFolderProvider {
 
       // Global
       ClusterSchemaManagementInterface globalClusterMgr =
-        DefaultBowl.getInstance().getManager( ClusterSchemaManagementInterface.class );
+        globalBowl.getManager( ClusterSchemaManagementInterface.class );
       Set<String> globalClusterNames = new HashSet<>();
       List<ClusterSchema> clusters = globalClusterMgr.getAll();
       for ( SharedObjectInterface clusterSchema : clusters ) {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/DBConnectionFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/DBConnectionFolderProvider.java
@@ -16,7 +16,6 @@ package org.pentaho.di.ui.spoon.tree.provider;
 import org.eclipse.swt.graphics.Image;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.i18n.BaseMessages;
@@ -57,9 +56,10 @@ public class DBConnectionFolderProvider extends TreeFolderProvider {
   @Override
   public void refresh( Optional<AbstractMeta> meta, TreeNode treeNode, String filter ) {
     Bowl currentBowl = Spoon.getInstance().getBowl();
+    Bowl globalBowl = Spoon.getInstance().getGlobalManagementBowl();
     try {
       Set<String> projectDbNames = new HashSet<>();
-      if ( currentBowl != DefaultBowl.getInstance() ) {
+      if ( currentBowl != globalBowl ) {
 
         DatabaseManagementInterface dbManager = currentBowl.getManager( DatabaseManagementInterface.class );
         DatabasesCollector collector = new DatabasesCollector( dbManager, null );
@@ -75,7 +75,7 @@ public class DBConnectionFolderProvider extends TreeFolderProvider {
         }
       }
       // Global
-      DatabaseManagementInterface globalDbConnMgr = DefaultBowl.getInstance().getManager( DatabaseManagementInterface.class );
+      DatabaseManagementInterface globalDbConnMgr = globalBowl.getManager( DatabaseManagementInterface.class );
       DatabasesCollector collector = new DatabasesCollector( globalDbConnMgr, null );
       Set<String> globalDbNames = new HashSet<>();
       for ( String name : collector.getDatabaseNames() ) {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/PartitionsFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/PartitionsFolderProvider.java
@@ -16,7 +16,6 @@ package org.pentaho.di.ui.spoon.tree.provider;
 import org.eclipse.swt.graphics.Image;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.partition.PartitionSchema;
@@ -59,11 +58,11 @@ public class PartitionsFolderProvider extends TreeFolderProvider {
   @Override
   public void refresh( Optional<AbstractMeta> meta, TreeNode treeNode, String filter ) {
     Bowl currentBowl = Spoon.getInstance().getBowl();
-
+    Bowl globalBowl = Spoon.getInstance().getGlobalManagementBowl();
     List<PartitionSchema> partitionSchemas;
     try {
       Set<String> projectSchemaNames = new HashSet<>();
-      if ( currentBowl != DefaultBowl.getInstance() ) {
+      if ( currentBowl != globalBowl ) {
         PartitionSchemaManagementInterface partitionManager = currentBowl.getManager( PartitionSchemaManagementInterface.class );
 
         partitionSchemas = partitionManager.getAll();
@@ -78,7 +77,7 @@ public class PartitionsFolderProvider extends TreeFolderProvider {
       }
 
       // Global
-      PartitionSchemaManagementInterface globalPartitionManager = DefaultBowl.getInstance().getManager( PartitionSchemaManagementInterface.class );
+      PartitionSchemaManagementInterface globalPartitionManager = globalBowl.getManager( PartitionSchemaManagementInterface.class );
       Set<String> globalSchemaNames = new HashSet<>();
       partitionSchemas = globalPartitionManager.getAll();
       for ( PartitionSchema partitionSchema : partitionSchemas ) {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/SlavesFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/SlavesFolderProvider.java
@@ -18,7 +18,6 @@ import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.cluster.SlaveServerManagementInterface;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.shared.SharedObjectInterface;
@@ -54,10 +53,11 @@ public class SlavesFolderProvider extends TreeFolderProvider {
   @Override
   public void refresh( Optional<AbstractMeta> meta, TreeNode treeNode, String filter ) {
     Bowl currentBowl = Spoon.getInstance().getBowl();
+    Bowl globalBowl = Spoon.getInstance().getGlobalManagementBowl();
     try {
       Set<String> projectSlaveServerNames = new HashSet<>();
       // Bowl specific
-      if ( currentBowl != DefaultBowl.getInstance() ) {
+      if ( currentBowl != globalBowl ) {
         SlaveServerManagementInterface slaveServerManager = currentBowl.getManager( SlaveServerManagementInterface.class );
         List<SlaveServer> slaveServers = slaveServerManager.getAll();
 
@@ -72,7 +72,7 @@ public class SlavesFolderProvider extends TreeFolderProvider {
       }
 
       // Global
-      SlaveServerManagementInterface globalServerMgr = DefaultBowl.getInstance().getManager( SlaveServerManagementInterface.class );
+      SlaveServerManagementInterface globalServerMgr = globalBowl.getManager( SlaveServerManagementInterface.class );
       Set<String> globalServerNames = new HashSet<>();
       List<SlaveServer> servers = globalServerMgr.getAll();
       for ( SharedObjectInterface slaveServer : servers ) {

--- a/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
@@ -41,7 +41,6 @@ import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.SourceToTargetMapping;
-import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -1556,7 +1555,7 @@ public class BaseStepDialog extends Dialog {
           DatabaseManagementInterface dbMgr =
             spoonSupplier.get().getBowl().getManager( DatabaseManagementInterface.class );
           DatabaseManagementInterface globalDbMgr =
-            DefaultBowl.getInstance().getManager( DatabaseManagementInterface.class );
+            spoonSupplier.get().getGlobalManagementBowl().getManager( DatabaseManagementInterface.class );
           DatabaseManagementInterface transDbMgr = transMeta.getDatabaseManagementInterface();
 
           if ( applicableDbMgr == null && dbMgr.get( originalName ) != null ) {

--- a/ui/src/test/java/org/pentaho/di/ui/job/entry/JobEntryDialog_ConnectionLine_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/job/entry/JobEntryDialog_ConnectionLine_Test.java
@@ -76,6 +76,7 @@ public class JobEntryDialog_ConnectionLine_Test {
     Whitebox.setInternalState( mockDialog, "spoonSupplier", mockSupplier );
     when( mockSupplier.get() ).thenReturn( mockSpoon );
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
 
     dbMgr = DefaultBowl.getInstance().getManager( DatabaseManagementInterface.class );
   }

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshClustersSubtreeTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshClustersSubtreeTest.java
@@ -64,6 +64,7 @@ public class SpoonRefreshClustersSubtreeTest {
     when( GUIResource.getInstance() ).thenReturn( mockGuiResource );
     when( DefaultBowl.getInstance() ).thenReturn( mockDefaultBowl );
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
     mockClusterSchemaManager = mock( ClusterSchemaManager.class );
     when( mockDefaultBowl.getManager( ClusterSchemaManagementInterface.class ) ).thenReturn( mockClusterSchemaManager );
 

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshDbConnectionsSubtreeTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshDbConnectionsSubtreeTest.java
@@ -71,6 +71,7 @@ public class SpoonRefreshDbConnectionsSubtreeTest {
 
     treeNode = new TreeNode();
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
     when( mockDefaultBowl.getManager( DatabaseManagementInterface.class ) ).thenReturn( mockDbManager );
   }
 

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshPartitionsSubtreeTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshPartitionsSubtreeTest.java
@@ -72,6 +72,7 @@ public class SpoonRefreshPartitionsSubtreeTest {
     treeNode = new TreeNode();
 
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
     when( mockDefaultBowl.getManager( PartitionSchemaManagementInterface.class ) ).thenReturn( mockPartitionSchemaManager );
   }
   @After

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshSlavesSubtreeTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonRefreshSlavesSubtreeTest.java
@@ -67,6 +67,7 @@ public class SpoonRefreshSlavesSubtreeTest {
     treeNode = new TreeNode();
 
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
     when( mockDefaultBowl.getManager( SlaveServerManagementInterface.class ) ).thenReturn( mockSlaveServerManager );
   }
 

--- a/ui/src/test/java/org/pentaho/di/ui/trans/step/BaseStepDialog_ConnectionLine_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/trans/step/BaseStepDialog_ConnectionLine_Test.java
@@ -79,6 +79,7 @@ public class BaseStepDialog_ConnectionLine_Test {
     Whitebox.setInternalState( mockDialog, "shell", shell );
     when( mockSupplier.get() ).thenReturn( mockSpoon );
     doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getBowl();
+    doReturn( DefaultBowl.getInstance() ).when( mockSpoon ).getGlobalManagementBowl();
 
     dbMgr = DefaultBowl.getInstance().getManager( DatabaseManagementInterface.class );
   }


### PR DESCRIPTION
Rather than set a SharedObjectsIO on the DefaultBowl, this switches to using a RepositoryBowl for the Repository. Spoon now tracks 3 different bowls: the existing management bowl and execution bowl, and now a global management bowl.

Earlier code that compared the management bowl to the DefaultBowl now compare to the global management bowl.

Repositories now have a Bowl. This ensures there's only one instance per Repository so caches work correctly.

AbstractMeta and Spoon both start using the Repository's bowl when a Repository is assigned, rather than assuming something else will set the bowl directly. The Project Plugin will need to set the bowl again where appropriate.

Lots of tests updated to have a Repository Bowl.

Refactored Import to use the Repository Bowl rather than a DefaultBowl with different SharedObjectsIO.

Added SharedObjectUtil with helper methods to move/copy all objects between AbstractMeta and Bowls.