### PR TITLE
[BACKLOG-43082] Make Shared Objects config case-insensitive for Manag…

### DIFF
--- a/core/src/main/java/org/pentaho/di/connections/ConnectionManager.java
+++ b/core/src/main/java/org/pentaho/di/connections/ConnectionManager.java
@@ -699,7 +699,13 @@ public class ConnectionManager {
    */
   public ConnectionDetails getConnectionDetails( String name ) {
     initialize();
-    return clone( detailsByName.get( name ) );
+    // Get the details in ignoring the case
+    for ( String key : detailsByName.keySet() ) {
+      if ( key.equalsIgnoreCase( name ) ) {
+        return clone( detailsByName.get( key ) );
+      }
+    }
+    return null;
   }
 
   /* The following are sugar methods: `getDetails` and `getExistingDetails`. These perform casting of the result to the
@@ -939,4 +945,5 @@ public class ConnectionManager {
       return (MetaStoreException) super.getCause();
     }
   }
+
 }

--- a/core/src/main/java/org/pentaho/di/shared/DelegatingSharedObjectsIO.java
+++ b/core/src/main/java/org/pentaho/di/shared/DelegatingSharedObjectsIO.java
@@ -15,7 +15,6 @@ package org.pentaho.di.shared;
 
 import org.pentaho.di.core.exception.KettleException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -48,8 +47,11 @@ public class DelegatingSharedObjectsIO implements SharedObjectsIO {
     Map<String, Node> retMap = new HashMap<>();
     for ( SharedObjectsIO store : stores ) {
       Map<String, Node> storeMap = store.getSharedObjects( type );
-      for ( Map.Entry<String,Node> entry : storeMap.entrySet() ) {
-        retMap.putIfAbsent( entry.getKey(), entry.getValue() );
+      for ( Map.Entry<String, Node> entry : storeMap.entrySet() ) {
+        // case in-sensitive check to skip adding entry with same name
+        if ( !retMap.entrySet().stream().anyMatch( e -> e.getKey().equalsIgnoreCase( entry.getKey() ) ) ) {
+          retMap.put( entry.getKey(), entry.getValue() );
+        }
       }
     }
     return retMap;

--- a/core/src/main/java/org/pentaho/di/shared/MemorySharedObjectsIO.java
+++ b/core/src/main/java/org/pentaho/di/shared/MemorySharedObjectsIO.java
@@ -60,26 +60,56 @@ public class MemorySharedObjectsIO implements SharedObjectsIO {
     return getNodesMapForType( type );
   }
 
+  /**
+   * Save the SharedObject in memory. This operation is case-insensitive. If the SharedObject name exist in a different case,
+   * the existing entry will be deleted and the new entry will be saved with provided name
+   * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
+   * @param name The name is the name of the sharedObject
+   * @param node The Xml node containing the details of the shared object
+   * @throws KettleException
+   */
   @Override
   public void saveSharedObject( String type, String name, Node node ) throws KettleException {
     // Get the map for the type
     Map<String, Node> nodeMap = getNodesMapForType( type );
+    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap );
+    if ( existingName != null ) {
+      nodeMap.remove( existingName );
+    }
     // Add or Update the map entry for this name
     nodeMap.put( name, node );
   }
 
+  /**
+   * Return the node for the given SharedObject type and name. The lookup for the SharedObject
+   * using the name will be case-insensitive
+   * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
+   * @param name The name is the name of the sharedObject
+   * @return
+   * @throws KettleException
+   */
   @Override
   public Node getSharedObject( String type, String name ) throws KettleException {
     // Get the Map using the type
     Map<String, Node> nodeMap = getNodesMapForType( type );
-    return nodeMap.get( name );
+    return nodeMap.get( SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap ) );
   }
 
+  /**
+   * Remove the SharedObject for the type and name. The lookup for the SharedObject
+   * using the name will be case-insensitive
+   * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
+   * @param name The name is the name of the sharedObject
+   * @throws KettleException
+   */
   @Override
   public void delete( String type, String name ) throws KettleException {
     // Get the nodeMap for the type
     Map<String, Node> nodeTypeMap = getNodesMapForType( type );
-    Node removedNode = nodeTypeMap.remove( name );
+    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeTypeMap );
+    if ( existingName != null ) {
+      nodeTypeMap.remove( existingName );
+    }
   }
 
   @Override

--- a/core/src/main/java/org/pentaho/di/shared/SharedObjectsIO.java
+++ b/core/src/main/java/org/pentaho/di/shared/SharedObjectsIO.java
@@ -52,7 +52,8 @@ public interface SharedObjectsIO {
   Map<String, Node> getSharedObjects( String type ) throws KettleException;
 
   /**
-   * Save the SharedObject node for the type and name.
+   * Save the SharedObject node for the type and name. If the SharedObject name exist but in a
+   * different case, the existing entry will be deleted and the new entry will be saved with provided name
    * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
    * @param name The name is the name of the sharedObject
    * @param node The Xml node containing the details of the shared object
@@ -61,7 +62,8 @@ public interface SharedObjectsIO {
   void saveSharedObject( String type, String name, Node node ) throws KettleException;
 
   /**
-   * Return the Shared Object Node for the given type and name
+   * Return the Shared Object Node for the given type and name. The lookup for the SharedObject
+   * using the name will be case-insensitive
    * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
    * @param name The name is the name of the sharedObject
    * @return Xml node
@@ -70,7 +72,7 @@ public interface SharedObjectsIO {
   Node getSharedObject( String type, String name ) throws KettleException;
 
   /**
-   * Delete the SharedObject for the given type and name
+   * Delete the SharedObject for the given type and name. The delete operation will be case-insensitive.
    * @param type The type is shared object type for example, "connection", "slaveserver", "partitionschema" and clusterschema"
    * @param name The name is the name of the sharedObject
    * @throws KettleException
@@ -84,5 +86,14 @@ public interface SharedObjectsIO {
    * @param type Type to clear
    */
   void clear( String type ) throws KettleException;
+
+  static String findSharedObjectIgnoreCase( String name, Map< String, Node> nodeMap ) {
+    for ( String key : nodeMap.keySet() ) {
+      if ( key.equalsIgnoreCase( name ) ) {
+        return key;
+      }
+    }
+    return null;
+  }
 
 }

--- a/core/src/test/java/org/pentaho/di/shared/DelegatingSharedObjectsIOTest.java
+++ b/core/src/test/java/org/pentaho/di/shared/DelegatingSharedObjectsIOTest.java
@@ -27,6 +27,7 @@ import org.w3c.dom.Node;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class DelegatingSharedObjectsIOTest {
   private static final String DB_TYPE = SharedObjectsIO.SharedObjectType.CONNECTION.getName();
@@ -106,6 +107,53 @@ public class DelegatingSharedObjectsIOTest {
       // expected
       return;
     }
+  }
+
+  /**
+   * Test to verify that getSharedObjects() returns the deduplicated list of items from
+   * different SharedObjectsIO
+   * @throws Exception
+   */
+  @Test
+  public void testGetSharedObjectsDeduplicated() throws Exception {
+    primary.saveSharedObject( DB_TYPE, "foo", toNode( DB_TYPE, "valuefoo" ) );
+    primary.saveSharedObject( DB_TYPE, "b", toNode( DB_TYPE, "valueb" ) );
+    secondary.saveSharedObject( DB_TYPE, "FOO", toNode( DB_TYPE, "valueFOO" ) );
+
+    DelegatingSharedObjectsIO sharedIO = new DelegatingSharedObjectsIO( primary, secondary );
+    // This  will return the list of sharedObjects from primary + any objects from secondary that do not
+    // have the same name (case insensitive)
+    Map<String, Node> combined = sharedIO.getSharedObjects( DB_TYPE );
+    assertEquals( 2, combined.size() );
+
+    Node nodeFoo = combined.get( "foo" );
+    assertNotNull( nodeFoo );
+    String valueFoo = toValue( nodeFoo, DB_TYPE );
+    assertEquals( "valuefoo", valueFoo );
+    // Node "FOO" should not be added to combined  map
+    Node nodeFOO = combined.get( "FOO" );
+    assertNull( nodeFOO );
+
+  }
+
+  @Test
+  public void testGetSharedObjectCaseInsensitive() throws Exception {
+    primary.saveSharedObject( DB_TYPE, "foo", toNode( DB_TYPE, "valuefoo" ) );
+    primary.saveSharedObject( DB_TYPE, "b", toNode( DB_TYPE, "valueb" ) );
+    secondary.saveSharedObject( DB_TYPE, "c", toNode( DB_TYPE, "valuec" ) );
+
+    DelegatingSharedObjectsIO sharedIO = new DelegatingSharedObjectsIO( primary, secondary );
+    // getSharedObject is case insensitive. Both "foo" and "FOO" can be used to retrieve the value "valuefoo"
+    Node node = sharedIO.getSharedObject( DB_TYPE, "foo" );
+    assertNotNull( node );
+
+    String value = toValue( node, DB_TYPE );
+    assertEquals( "valuefoo", value );
+    // key "FOO" can also be used to access the same entry
+    Node nodeFOO = sharedIO.getSharedObject( DB_TYPE, "FOO" );
+    value = toValue( nodeFOO, DB_TYPE );
+    assertEquals( "valuefoo", value );
+
   }
 
   private Node toNode( String type, String value ) throws Exception {

--- a/core/src/test/java/org/pentaho/di/shared/MemorySharedObjectsIOTest.java
+++ b/core/src/test/java/org/pentaho/di/shared/MemorySharedObjectsIOTest.java
@@ -1,0 +1,85 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.shared;
+
+import org.junit.Test;
+import org.junit.BeforeClass;
+import org.junit.Before;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettlePluginException;
+import org.pentaho.di.core.plugins.DatabasePluginType;
+import org.pentaho.di.core.row.value.ValueMetaPluginType;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.w3c.dom.Node;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class MemorySharedObjectsIOTest {
+
+  private MemorySharedObjectsIO sharedObjectsIO;
+  private String db_type;
+
+  @BeforeClass
+  public static void setUpOnce() throws KettlePluginException, KettleException {
+    // Register Natives to create a default DatabaseMeta
+    DatabasePluginType.getInstance().searchPlugins();
+    ValueMetaPluginType.getInstance().searchPlugins();
+    KettleClientEnvironment.init();
+  }
+
+  @Before
+  public void setup() throws Exception {
+    db_type = String.valueOf( SharedObjectsIO.SharedObjectType.CONNECTION );
+    sharedObjectsIO = new MemorySharedObjectsIO( );
+
+  }
+
+  @Test
+  public void testSaveSharedObject() throws Exception {
+    String connectionName = "NewConn";
+    // Create a new DatabaseMeta object
+    DatabaseMeta dbMeta = createDatabaseMeta( connectionName );
+    sharedObjectsIO.saveSharedObject( db_type, dbMeta.getName(), dbMeta.toNode() );
+
+    // Create another connection with same name different case
+    dbMeta = createDatabaseMeta( "NEWCONN" );
+    sharedObjectsIO.saveSharedObject( db_type, dbMeta.getName(), dbMeta.toNode() );
+
+    Map<String, Node> nodeMap = sharedObjectsIO.getSharedObjects( db_type );
+    assertEquals( 1, nodeMap.size() );
+
+    Node node = sharedObjectsIO.getSharedObject( db_type, dbMeta.getName() );
+    assertEquals( "NEWCONN", XMLHandler.getTagValue( node, "name" ) );
+  }
+
+  @Test
+  public void testGetSharedObjectCaseInsensitive() throws Exception {
+    String connectionName = "NewConn";
+    // Create a new DatabaseMeta object
+    DatabaseMeta dbMeta = createDatabaseMeta( connectionName );
+    sharedObjectsIO.saveSharedObject( db_type, dbMeta.getName(), dbMeta.toNode() );
+
+    Node node = sharedObjectsIO.getSharedObject( db_type, "NEWCONN" );
+    assertEquals( connectionName, XMLHandler.getTagValue( node, "name" ) );
+  }
+  private DatabaseMeta createDatabaseMeta( String name ) {
+    DatabaseMeta dbMeta = new DatabaseMeta();
+    dbMeta.setName( name );
+    return dbMeta;
+  }
+
+}

--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -754,6 +754,7 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
   public List<SlaveServer> getSlaveServers() {
     try {
       List<SlaveServer> slaveServers = readSlaveServerManager.getAll();
+      Collections.sort( slaveServers, SlaveServer.COMPARATOR );
       return slaveServers;
     } catch ( KettleException exception ) {
       LogChannel.GENERAL.logError( exception.getMessage(), exception );
@@ -805,6 +806,7 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
   public String[] getSlaveServerNames() {
     try {
       List<SlaveServer> slaveServers = readSlaveServerManager.getAll();
+      Collections.sort( slaveServers, SlaveServer.COMPARATOR );
       return slaveServers.stream().map( SlaveServer::getName ).toArray( String[]::new );
     } catch ( KettleException ex ) {
       return null;
@@ -1310,6 +1312,7 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
   public String[] getDatabaseNames() {
     try {
       List<DatabaseMeta> databases = readDbManager.getAll();
+      Collections.sort( databases, DatabaseMeta.comparator );
       return databases.stream().map( DatabaseMeta::getName ).toArray( String[]::new );
     } catch ( KettleException ex ) {
       return null;

--- a/engine/src/main/java/org/pentaho/di/cluster/ClusterSchema.java
+++ b/engine/src/main/java/org/pentaho/di/cluster/ClusterSchema.java
@@ -14,6 +14,7 @@
 package org.pentaho.di.cluster;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +57,7 @@ public class ClusterSchema extends ChangedFlag implements Cloneable, SharedObjec
   public static final String XML_TAG = "clusterschema";
 
   public static final RepositoryObjectType REPOSITORY_ELEMENT_TYPE = RepositoryObjectType.CLUSTER_SCHEMA;
+  public static final Comparator<ClusterSchema> COMPARATOR = Comparator.comparing( ClusterSchema::getName, String.CASE_INSENSITIVE_ORDER );
 
   /** the name of the cluster schema */
   private String name;

--- a/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
+++ b/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
@@ -96,6 +96,7 @@ import java.net.InetAddress;
 import java.net.URLEncoder;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -110,6 +111,7 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
   private static Class<?> PKG = SlaveServer.class; // for i18n purposes, needed by Translator2!!
 
   public static final String STRING_SLAVESERVER = "Slave Server";
+  public static final Comparator<SlaveServer> COMPARATOR = Comparator.comparing( SlaveServer::getName, String.CASE_INSENSITIVE_ORDER );
 
   private static final Random RANDOM = new Random();
 

--- a/engine/src/main/java/org/pentaho/di/partition/PartitionSchema.java
+++ b/engine/src/main/java/org/pentaho/di/partition/PartitionSchema.java
@@ -14,6 +14,7 @@
 package org.pentaho.di.partition;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
@@ -45,6 +46,8 @@ public class PartitionSchema extends ChangedFlag implements Cloneable, SharedObj
   public static final String XML_TAG = "partitionschema";
 
   public static final RepositoryObjectType REPOSITORY_ELEMENT_TYPE = RepositoryObjectType.PARTITION_SCHEMA;
+  public static final Comparator<PartitionSchema> COMPARATOR = Comparator.comparing( PartitionSchema::getName,
+                                                                                     String.CASE_INSENSITIVE_ORDER);
 
   private String name;
 

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -5569,7 +5569,9 @@ public class TransMeta extends AbstractMeta
    */
   public List<PartitionSchema> getPartitionSchemas() {
     try {
-      return readPartitionSchemaManager.getAll();
+      List<PartitionSchema> partitionSchemas =  readPartitionSchemaManager.getAll();
+      Collections.sort( partitionSchemas, PartitionSchema.COMPARATOR );
+      return partitionSchemas;
     } catch ( KettleException exception ) {
       LogChannel.GENERAL.logError( " Error getting the list of partitionSchema ", exception );
       return null;
@@ -5601,6 +5603,7 @@ public class TransMeta extends AbstractMeta
   public String[] getPartitionSchemasNames() {
     try {
       List<PartitionSchema> partitionSchemas = readPartitionSchemaManager.getAll();
+      Collections.sort( partitionSchemas, PartitionSchema.COMPARATOR );
       return partitionSchemas.stream().map( PartitionSchema::getName ).toArray( String[]::new );
     } catch ( KettleException exception ) {
       LogChannel.GENERAL.logError( " Error getting the list of partitionSchema ", exception );
@@ -5672,7 +5675,9 @@ public class TransMeta extends AbstractMeta
    */
   public List<ClusterSchema> getClusterSchemas() {
     try {
-      return readClusterSchemaManager.getAll();
+      List<ClusterSchema> clusterSchemas =  readClusterSchemaManager.getAll();
+      Collections.sort( clusterSchemas, ClusterSchema.COMPARATOR );
+      return clusterSchemas;
     } catch ( KettleException exception ) {
       LogChannel.GENERAL.logError( exception.getMessage(), exception );
       return null;
@@ -5704,6 +5709,7 @@ public class TransMeta extends AbstractMeta
   public String[] getClusterSchemaNames() {
     try {
       List<ClusterSchema> clusterSchemas = readClusterSchemaManager.getAll();
+      Collections.sort( clusterSchemas, ClusterSchema.COMPARATOR );
       return clusterSchemas.stream().map( ClusterSchema::getName ).toArray( String[]::new );
     } catch ( KettleException ex ) {
       return null;

--- a/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/tree/ConnectionFolderProvider.java
+++ b/plugins/connections/ui/src/main/java/org/pentaho/di/connections/ui/tree/ConnectionFolderProvider.java
@@ -70,7 +70,7 @@ public class ConnectionFolderProvider extends TreeFolderProvider {
           continue;
         }
         createTreeNode( treeNode, name, GUIResource.getInstance().getImageSlaveTree(), LeveledTreeNode.LEVEL.GLOBAL,
-                        bowlNames.contains( name ) );
+                        containsIgnoreCase( bowlNames, name ) );
       }
     } catch ( KettleException e ) {
       new ErrorDialog( Spoon.getInstance().getShell(),

--- a/plugins/connections/ui/src/main/java/org/pentaho/di/vfs/connections/ui/dialog/ConnectionDelegate.java
+++ b/plugins/connections/ui/src/main/java/org/pentaho/di/vfs/connections/ui/dialog/ConnectionDelegate.java
@@ -141,6 +141,8 @@ public class ConnectionDelegate {
           new ConnectionOverwriteDialog( spoonSupplier.get().getShell() );
         if ( !( connectionOverwriteDialog.open( name ) == SWT.YES ) ) {
           return;
+        } else {
+          targetBowl.getManager( ConnectionManager.class ).delete( targetConnection.getName() );
         }
       }
 

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationDelegate.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationDelegate.java
@@ -201,10 +201,12 @@ public class RunConfigurationDelegate {
                          boolean deleteSource ) {
     CheckedMetaStoreSupplier ms = () -> targetBowl.getMetastore();
     RunConfigurationManager targetManager = RunConfigurationManager.getInstance( ms );
-    if ( targetManager.getNames().contains( runConfiguration.getName() ) ) {
+    if ( targetManager.getNames().stream().anyMatch( element -> element.equalsIgnoreCase( runConfiguration.getName() ) ) ) {
       if ( !shouldOverwrite( BaseMessages.getString( PKG, "RunConfigurationDialog.OverwriteRunConfigurationYN",
         runConfiguration.getName() ) ) ) {
         return;
+      } else {
+        targetManager.delete( runConfiguration.getName() );
       }
     }
     targetManager.save( runConfiguration );

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
@@ -84,7 +84,7 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
       }
       String imageFile = runConfiguration.isReadOnly() ? "images/run_tree_disabled.svg" : "images/run_tree.svg";
       TreeNode childTreeNode = createChildTreeNode( treeNode, runConfiguration.getName(), getRunConfigurationImage(
-              guiResource, imageFile ), level, bowlNames.contains( runConfiguration.getName() ) );
+              guiResource, imageFile ), level, containsIgnoreCase( bowlNames, runConfiguration.getName() ) );
       if ( runConfiguration.isReadOnly() ) {
         childTreeNode.setForeground( getDisabledColor() );
       }

--- a/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobDialog.java
@@ -82,6 +82,7 @@ import org.pentaho.di.ui.core.widget.TableView;
 import org.pentaho.di.ui.core.widget.TextVar;
 import org.pentaho.di.ui.repository.RepositoryDirectoryUI;
 import org.pentaho.di.ui.spoon.Spoon;
+import org.pentaho.di.ui.spoon.tree.provider.DBConnectionFolderProvider;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 import org.pentaho.di.ui.util.HelpUtils;
 
@@ -898,6 +899,8 @@ public class JobDialog extends Dialog {
             DatabaseManagementInterface dbMgr =
               Spoon.getInstance().getBowl().getManager( DatabaseManagementInterface.class );
             dbMgr.add( getDatabaseDialog().getDatabaseMeta() );
+            // Refresh left hand tree
+            Spoon.getInstance().refreshTree( DBConnectionFolderProvider.STRING_CONNECTIONS );
           } catch ( KettleException dbe ) {
             new ErrorDialog(
               shell, BaseMessages.getString( PKG, "JobDialog.Dialog.ErrorAddingDatabase.Title" ), BaseMessages

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonDBDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonDBDelegate.java
@@ -63,7 +63,7 @@ import org.pentaho.di.ui.spoon.dialog.GetJobSQLProgressDialog;
 import org.pentaho.di.ui.spoon.dialog.GetSQLProgressDialog;
 import org.pentaho.di.ui.spoon.tree.provider.DBConnectionFolderProvider;
 
-public class SpoonDBDelegate extends SpoonDelegate {
+public class SpoonDBDelegate extends SpoonSharedObjectDelegate {
   private static Class<?> PKG = Spoon.class; // for i18n purposes, needed by Translator2!!
   private DatabaseDialog databaseDialog;
 
@@ -165,10 +165,9 @@ public class SpoonDBDelegate extends SpoonDelegate {
   }
 
   /**
-   * Delete a database connection
-   *
-   * @param name
-   *          The name of the database connection.
+   * Delete the database connection
+   * @param dbMgr
+   * @param db
    */
   public void delConnection( DatabaseManagementInterface dbMgr, DatabaseMeta db ) {
     UndoInterface undoInterface = spoon.getActiveUndoInterface();
@@ -225,46 +224,25 @@ public class SpoonDBDelegate extends SpoonDelegate {
   }
 
   public void moveToGlobal( DatabaseMeta databaseMeta, DatabaseManagementInterface dbManager ) throws KettleException {
-    moveCopy( dbManager, spoon.getGlobalManagementBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, true );
+    moveCopy( dbManager, spoon.getGlobalManagementBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, true,
+      "Spoon.Message.OverwriteConnectionYN"  );
   }
 
   public void moveToProject( DatabaseMeta databaseMeta, DatabaseManagementInterface dbManager ) throws KettleException {
-    moveCopy( dbManager, spoon.getBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, true );
+    moveCopy( dbManager, spoon.getBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, true,
+      "Spoon.Message.OverwriteConnectionYN" );
   }
 
   public void copyToGlobal( DatabaseMeta databaseMeta, DatabaseManagementInterface dbManager ) throws KettleException {
-    moveCopy( dbManager, spoon.getGlobalManagementBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, false );
+    moveCopy( dbManager, spoon.getGlobalManagementBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, false,
+      "Spoon.Message.OverwriteConnectionYN" );
   }
 
   public void copyToProject( DatabaseMeta databaseMeta, DatabaseManagementInterface dbManager ) throws KettleException {
-    moveCopy( dbManager, spoon.getBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, false );
+    moveCopy( dbManager, spoon.getBowl().getManager( DatabaseManagementInterface.class ), databaseMeta, false,
+      "Spoon.Message.OverwriteConnectionYN" );
   }
 
-  private void moveCopy( DatabaseManagementInterface srcDbManager, DatabaseManagementInterface targetDbManager,
-                        DatabaseMeta databaseMeta, boolean deleteFromSource ) {
-    try {
-      // Check if the connection already exist in target, prompt for override
-      if ( targetDbManager.get( databaseMeta.getName() ) != null ) {
-        if ( !spoon.overwritePrompt( BaseMessages.getString( PKG, "Spoon.Message.OverwriteConnectionYN", databaseMeta.getName() ),
-          BaseMessages.getString( PKG, "Spoon.Message.OverwriteConnection.DontShowAnyMoreMessage" ), Props.STRING_ASK_ABOUT_REPLACING_DATABASES ) ) {
-
-          return;
-        }
-      }
-      // Adding the databaseMeta to target dbManager
-      targetDbManager.add( databaseMeta );
-
-      if ( deleteFromSource ) {
-        srcDbManager.remove( databaseMeta );
-      }
-      refreshTree();
-    } catch ( Exception ex ) {
-      new ErrorDialog(
-        spoon.getShell(), BaseMessages.getString( PKG, "Spoon.Dialog.UnexpectedError.Title" ),
-        BaseMessages.getString( PKG, "Spoon.Dialog.UnexpectedDbError.Message" ), new KettleException( ex.getMessage(), ex ) );
-    }
-
-  }
   public void getSQL() {
     TransMeta transMeta = spoon.getActiveTransformation();
     if ( transMeta != null ) {
@@ -548,7 +526,7 @@ public class SpoonDBDelegate extends SpoonDelegate {
         BaseMessages.getString( PKG, "Spoon.Dialog.UnexpectedDbError.Message" ), new KettleException( ex.getMessage(), ex ) );
     }
   }
-  private void refreshTree() {
+  protected void refreshTree() {
     spoon.refreshTree( DBConnectionFolderProvider.STRING_CONNECTIONS );
   }
 }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonSharedObjectDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonSharedObjectDelegate.java
@@ -72,10 +72,15 @@ public abstract class SpoonSharedObjectDelegate<T extends SharedObjectInterface<
       String overWritePromptKey ) throws KettleException {
     try {
       // If object already exist, prompt for overwrite
-      if ( findObject( targetManager.getAll(), object.getName() ) != null ) {
+      T existingObject = findObject( targetManager.getAll(), object.getName() );
+      if ( existingObject != null ) {
         if ( !shouldOverwrite( BaseMessages.getString( PKG, overWritePromptKey, object.getName() ) ) ) {
           return;
+        } else {
+          // Remove the existing object from target with same name and different case
+          targetManager.remove( existingObject );
         }
+
       }
       // Add the object to target
       targetManager.add( object );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/TreeFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/TreeFolderProvider.java
@@ -19,6 +19,7 @@ import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.ui.core.gui.GUIResource;
 import org.pentaho.di.ui.core.widget.tree.TreeNode;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -66,5 +67,14 @@ public abstract class TreeFolderProvider {
 
   public void setTreeManager( TreeManager treeManager ) {
     this.treeManager = treeManager;
+  }
+
+  protected boolean containsIgnoreCase( Collection<String> stringList, String nodeName ) {
+    for ( String treeNodeName : stringList ){
+      if ( treeNodeName.equalsIgnoreCase( nodeName )) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/ClustersFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/ClustersFolderProvider.java
@@ -86,7 +86,7 @@ public class ClustersFolderProvider extends TreeFolderProvider {
 
         globalClusterNames.add( clusterSchema.getName() );
         TreeNode childTreeNode = createTreeNode( treeNode, clusterSchema.getName(), guiResource.getImageClusterMedium(),
-          LeveledTreeNode.LEVEL.GLOBAL, projectClusterNames.contains( clusterSchema.getName() ) );
+          LeveledTreeNode.LEVEL.GLOBAL, containsIgnoreCase( projectClusterNames, clusterSchema.getName() ) );
       }
 
       // Local ClusterSchemas
@@ -103,8 +103,8 @@ public class ClustersFolderProvider extends TreeFolderProvider {
 
             TreeNode childTreeNode = createTreeNode( treeNode, sharedObjectInterface.getName(),
               guiResource.getImageClusterMedium(), LeveledTreeNode.LEVEL.LOCAL,
-              projectClusterNames.contains( sharedObjectInterface.getName() ) ||
-                globalClusterNames.contains( sharedObjectInterface.getName() ) );
+              containsIgnoreCase( projectClusterNames, sharedObjectInterface.getName() ) ||
+                containsIgnoreCase( globalClusterNames, sharedObjectInterface.getName() ) );
           }
         }
       }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/DBConnectionFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/DBConnectionFolderProvider.java
@@ -85,7 +85,7 @@ public class DBConnectionFolderProvider extends TreeFolderProvider {
         DatabaseMeta databaseMeta = collector.getMetaFor( name );
         globalDbNames.add( databaseMeta.getDisplayName() );
         createTreeNode( treeNode, databaseMeta.getDisplayName(), guiResource.getImageConnectionTree(), LeveledTreeNode.LEVEL.GLOBAL,
-          projectDbNames.contains( name ) );
+          containsIgnoreCase( projectDbNames, name ) );
       }
 
       // Local Db connection
@@ -98,7 +98,7 @@ public class DBConnectionFolderProvider extends TreeFolderProvider {
           }
           DatabaseMeta databaseMeta = collector.getMetaFor( name );
           createTreeNode( treeNode, databaseMeta.getDisplayName(), guiResource.getImageConnectionTree(), LeveledTreeNode.LEVEL.LOCAL,
-            projectDbNames.contains( name ) || globalDbNames.contains( name ) );
+            containsIgnoreCase( projectDbNames, name ) || containsIgnoreCase( globalDbNames, name ) );
         }
       }
     } catch ( KettleException e ) {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/PartitionsFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/PartitionsFolderProvider.java
@@ -86,7 +86,7 @@ public class PartitionsFolderProvider extends TreeFolderProvider {
         }
         globalSchemaNames.add( partitionSchema.getName() );
         TreeNode childTreeNode = createTreeNode( treeNode, partitionSchema.getName(), guiResource.getImagePartitionSchema(),
-          LeveledTreeNode.LEVEL.GLOBAL, projectSchemaNames.contains( partitionSchema.getName() ) );
+          LeveledTreeNode.LEVEL.GLOBAL, containsIgnoreCase( projectSchemaNames, partitionSchema.getName() ) );
       }
 
       // Local
@@ -100,7 +100,7 @@ public class PartitionsFolderProvider extends TreeFolderProvider {
             }
             TreeNode childTreeNode = createTreeNode( treeNode, partitionSchema.getName(), guiResource.getImagePartitionSchema(),
               LeveledTreeNode.LEVEL.LOCAL,
-              projectSchemaNames.contains( partitionSchema.getName() ) || globalSchemaNames.contains( partitionSchema.getName() ) );
+              containsIgnoreCase( projectSchemaNames, partitionSchema.getName() ) || containsIgnoreCase( globalSchemaNames, partitionSchema.getName() ) );
           }
         }
       }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/SlavesFolderProvider.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/tree/provider/SlavesFolderProvider.java
@@ -82,7 +82,7 @@ public class SlavesFolderProvider extends TreeFolderProvider {
 
         globalServerNames.add( slaveServer.getName() );
         TreeNode childTreeNode = createTreeNode( treeNode, slaveServer.getName(), guiResource.getImageSlaveTree(),
-          LeveledTreeNode.LEVEL.GLOBAL, projectSlaveServerNames.contains( slaveServer.getName() ) );
+          LeveledTreeNode.LEVEL.GLOBAL, containsIgnoreCase( projectSlaveServerNames, slaveServer.getName() ) );
       }
 
       // Local SlaveServers
@@ -95,7 +95,8 @@ public class SlavesFolderProvider extends TreeFolderProvider {
           }
 
           TreeNode childTreeNode = createTreeNode( treeNode, sharedObjectInterface.getName(), guiResource.getImageSlaveTree(),
-            LeveledTreeNode.LEVEL.LOCAL, projectSlaveServerNames.contains( sharedObjectInterface.getName() ) || globalServerNames.contains( sharedObjectInterface.getName() ) );
+            LeveledTreeNode.LEVEL.LOCAL, containsIgnoreCase( projectSlaveServerNames, sharedObjectInterface.getName() ) ||
+                    containsIgnoreCase( globalServerNames, sharedObjectInterface.getName() ) );
         }
       }
     } catch ( KettleException exception ) {

--- a/ui/src/main/java/org/pentaho/di/ui/trans/dialog/TransDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/dialog/TransDialog.java
@@ -84,6 +84,7 @@ import org.pentaho.di.ui.core.widget.TableView;
 import org.pentaho.di.ui.core.widget.TextVar;
 import org.pentaho.di.ui.repository.RepositoryDirectoryUI;
 import org.pentaho.di.ui.spoon.Spoon;
+import org.pentaho.di.ui.spoon.tree.provider.DBConnectionFolderProvider;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 
 
@@ -912,6 +913,8 @@ public class TransDialog extends Dialog {
             DatabaseManagementInterface dbMgr =
               Spoon.getInstance().getBowl().getManager( DatabaseManagementInterface.class );
             dbMgr.add( getDatabaseDialog().getDatabaseMeta() );
+            // Refresh left hand tree
+            Spoon.getInstance().refreshTree( DBConnectionFolderProvider.STRING_CONNECTIONS );
           } catch ( KettleException dbe ) {
             new ErrorDialog(
               shell, BaseMessages.getString( PKG, "TransDialog.ErrorAddingDatabase.Title" ), BaseMessages

--- a/ui/src/main/java/org/pentaho/di/ui/util/DialogUtils.java
+++ b/ui/src/main/java/org/pentaho/di/ui/util/DialogUtils.java
@@ -57,6 +57,9 @@ public class DialogUtils {
   }
 
   public static void removeMatchingObject( String nameToRemove, Collection<? extends SharedObjectInterface> objects ) {
+    if ( nameToRemove == null ) {
+      return;
+    }
     Iterator<? extends SharedObjectInterface> iter = objects.iterator();
     while ( iter.hasNext() ) {
       if ( nameToRemove.equals( iter.next().getName() ) ) {


### PR DESCRIPTION
…ement and Execution

Changes include -
- Updated the left hand navigation tree to grey out the items if the item exist wth name (case  insensitive) at the higher precedence level
- The drop down for Db connection name, partitionSchema name, SlaveServer names are now sorted and deduplicated based on case insensitivity -move operation on all config objects in left hand navigation tree is updated to handle case insensitive checks
-Tested during execution that the sharedobjects are picked up based on the precedence level (project/global/local)

Additional changes
- Updated the SharedObjectsIO api to make the get(), save() and delete()   case insensitive 
- Added unit test for API changes