### PR TITLE
[PDI-20322] -Disable gather performance metrics when scheduling jobs/ktrs from Spoon's schedule perspective

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1704,6 +1704,11 @@ public class Const {
   public static final String KETTLE_EXECUTE_TEMPORARY_GENERATED_FILE = "KETTLE_EXECUTE_TEMPORARY_GENERATED_FILE";
 
   /**
+   Value that overrides gather performance metrics checkbox value in scheduler dialog
+   */
+  public static final String KETTLE_PUC_SCHEDULE_GATHER_METRICS_OVERRIDE_VALUE = "KETTLE_PUC_SCHEDULE_GATHER_METRICS_OVERRIDE_VALUE";
+
+  /**
    Value to Configure if we want to export only the used connections to the XML file
    */
   public static final String STRING_ONLY_USED_DB_TO_XML = "STRING_ONLY_USED_DB_TO_XML";

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -675,4 +675,11 @@
     <default-value>157286400</default-value>
   </kettle-variable>
 
+  <kettle-variable>
+    <description>Set this variable to Y/N to override gather performance metrics checkbox value in scheduler dialog.
+    </description>
+    <variable>KETTLE_PUC_SCHEDULE_GATHER_METRICS_OVERRIDE_VALUE</variable>
+    <default-value>N</default-value>
+  </kettle-variable>
+
 </kettle-variables>


### PR DESCRIPTION
@pentaho/tatooine_dev 