### PR TITLE
[BACKLOG-41283]-Upgrading Pentaho kettle from Java EE 9 to Jakarta EE 10

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -71,7 +71,6 @@
     <rxjava.version>2.2.3</rxjava.version>
     <xmlunit.version>1.5</xmlunit.version>
     <wiremock.version>2.25.0</wiremock.version>
-    <hk2.version>2.6.1</hk2.version>
   </properties>
 
   <dependencyManagement>
@@ -590,21 +589,6 @@
       <version>${jersey.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-utils</artifactId>
-      <version>${hk2.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-api</artifactId>
-      <version>${hk2.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-locator</artifactId>
-      <version>${hk2.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
       <version>${jersey.version}</version>
@@ -850,6 +834,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-session</artifactId>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/plugins/rest/core/src/test/java/org/pentaho/di/trans/steps/rest/RestTest.java
+++ b/plugins/rest/core/src/test/java/org/pentaho/di/trans/steps/rest/RestTest.java
@@ -21,7 +21,6 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientConfig;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -48,7 +47,6 @@ import static org.mockito.Mockito.when;
 
 @RunWith( MockitoJUnitRunner.StrictStubs.class )
 public class RestTest {
-  @Ignore
   @Test
   public void testCallEndpointWithGetVerb() throws KettleException {
     Invocation.Builder builder = mock( Invocation.Builder.class );


### PR DESCRIPTION
[BACKLOG-41283]-Upgrading Pentaho kettle from Java EE 9 to Jakarta EE 10

[BACKLOG-41283]: https://hv-eng.atlassian.net/browse/BACKLOG-41283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ