### PR TITLE
[BACKLOG-43080] - support case changes on SO import

### DIFF
--- a/core/src/main/java/org/pentaho/di/shared/MemorySharedObjectsIO.java
+++ b/core/src/main/java/org/pentaho/di/shared/MemorySharedObjectsIO.java
@@ -72,7 +72,7 @@ public class MemorySharedObjectsIO implements SharedObjectsIO {
   public void saveSharedObject( String type, String name, Node node ) throws KettleException {
     // Get the map for the type
     Map<String, Node> nodeMap = getNodesMapForType( type );
-    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap );
+    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap.keySet() );
     if ( existingName != null ) {
       nodeMap.remove( existingName );
     }
@@ -92,7 +92,7 @@ public class MemorySharedObjectsIO implements SharedObjectsIO {
   public Node getSharedObject( String type, String name ) throws KettleException {
     // Get the Map using the type
     Map<String, Node> nodeMap = getNodesMapForType( type );
-    return nodeMap.get( SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap ) );
+    return nodeMap.get( SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap.keySet() ) );
   }
 
   /**
@@ -106,7 +106,7 @@ public class MemorySharedObjectsIO implements SharedObjectsIO {
   public void delete( String type, String name ) throws KettleException {
     // Get the nodeMap for the type
     Map<String, Node> nodeTypeMap = getNodesMapForType( type );
-    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeTypeMap );
+    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeTypeMap.keySet() );
     if ( existingName != null ) {
       nodeTypeMap.remove( existingName );
     }

--- a/core/src/main/java/org/pentaho/di/shared/SharedObjectsIO.java
+++ b/core/src/main/java/org/pentaho/di/shared/SharedObjectsIO.java
@@ -13,10 +13,11 @@
 
 package org.pentaho.di.shared;
 
+import org.pentaho.di.core.exception.KettleException;
+
 import java.io.IOException;
 import java.util.Map;
-
-import org.pentaho.di.core.exception.KettleException;
+import java.util.Set;
 import org.w3c.dom.Node;
 
 /**
@@ -87,8 +88,8 @@ public interface SharedObjectsIO {
    */
   void clear( String type ) throws KettleException;
 
-  static String findSharedObjectIgnoreCase( String name, Map<String, Node> nodeMap ) {
-    for ( String key : nodeMap.keySet() ) {
+  static String findSharedObjectIgnoreCase( String name, Set<String> existingKeys ) {
+    for ( String key : existingKeys ) {
       if ( key.equalsIgnoreCase( name ) ) {
         return key;
       }

--- a/core/src/main/java/org/pentaho/di/shared/VfsSharedObjectsIO.java
+++ b/core/src/main/java/org/pentaho/di/shared/VfsSharedObjectsIO.java
@@ -201,7 +201,7 @@ public class VfsSharedObjectsIO implements SharedObjectsIO {
     }
     // Before adding, verify that the SharedObject with the name (case insensitive) does not exist,
     // if it exist, delete the entry from map
-    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap );
+    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap.keySet() );
     if ( existingName != null ) {
       nodeMap.remove( existingName );
     }
@@ -300,7 +300,7 @@ public class VfsSharedObjectsIO implements SharedObjectsIO {
   public Node getSharedObject( String type, String name ) throws KettleException {
     // Get the Map using the type
     Map<String, Node> nodeMap = getNodesMapForType( type );
-    return nodeMap.get( SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap ) );
+    return nodeMap.get( SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap.keySet() ) );
   }
 
   /**
@@ -313,7 +313,7 @@ public class VfsSharedObjectsIO implements SharedObjectsIO {
   public void delete( String type, String name ) throws KettleException {
     // Get the nodeMap for the type
     Map<String, Node> nodeTypeMap = getNodesMapForType( type );
-    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeTypeMap );
+    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeTypeMap.keySet() );
     if ( existingName != null ) {
       nodeTypeMap.remove( existingName );
       saveToFile();

--- a/engine/src/main/java/org/pentaho/di/shared/RepositorySharedObjectsIO.java
+++ b/engine/src/main/java/org/pentaho/di/shared/RepositorySharedObjectsIO.java
@@ -114,7 +114,7 @@ public class RepositorySharedObjectsIO implements SharedObjectsIO {
   @Override
   public Node getSharedObject( String type, String name ) throws KettleException {
     Map<String, Node> nodeMap = getSharedObjects( type );
-    return nodeMap.get( SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap ) );
+    return nodeMap.get( SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap.keySet() ) );
   }
 
   @Override
@@ -154,7 +154,7 @@ public class RepositorySharedObjectsIO implements SharedObjectsIO {
     SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
 
     Map<String, Node> nodeMap = getSharedObjects( type );
-    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap );
+    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap.keySet() );
     if ( existingName == null ) {
       existingName = name;
     }
@@ -192,12 +192,6 @@ public class RepositorySharedObjectsIO implements SharedObjectsIO {
   @Override
   public void saveSharedObject( String type, String name, Node node ) throws KettleException {
     SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
-
-    Map<String, Node> nodeMap = getSharedObjects( type );
-    String existingName = SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap );
-    if ( existingName != null ) {
-      deleteInner( objectType, existingName );
-    }
 
     RepositoryElementInterface repoElement = null;
     switch ( objectType ) {

--- a/engine/src/test/java/org/pentaho/di/shared/DatabaseConnectionManagerTest.java
+++ b/engine/src/test/java/org/pentaho/di/shared/DatabaseConnectionManagerTest.java
@@ -50,6 +50,7 @@ public class DatabaseConnectionManagerTest {
     dbManager.add( meta );
 
     Assert.assertNotNull( dbManager.get( "meta1" ) );
+    Assert.assertNotNull( dbManager.get( "META1" ) );
   }
 
   @Test
@@ -65,6 +66,18 @@ public class DatabaseConnectionManagerTest {
     Assert.assertEquals( "meta1", dbManager.get( "meta1" ).getName() );
     Assert.assertNotNull( dbManager.get( "meta2" ) );
     Assert.assertEquals( "meta2", dbManager.get( "meta2" ).getName() );
+
+    meta.setName( "META2" );
+    dbManager.add( meta );
+    Assert.assertNotNull( dbManager.get( "meta1" ) );
+    Assert.assertEquals( "meta1", dbManager.get( "meta1" ).getName() );
+    Assert.assertNotNull( dbManager.get( "meta2" ) );
+    Assert.assertNotNull( dbManager.get( "META2" ) );
+    Assert.assertEquals( "META2", dbManager.get( "meta2" ).getName() );
+    Assert.assertEquals( 2, dbManager.getAll().size() );
+
+    dbManager.remove( "META1" );
+    Assert.assertEquals( 1, dbManager.getAll().size() );
   }
 
   protected DatabaseMeta createDatabase( String name ) {

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/AbstractDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/AbstractDelegate.java
@@ -157,7 +157,8 @@ public abstract class AbstractDelegate {
 
   public boolean equals( RepositoryElementInterface first, RepositoryElementInterface second ) {
     try {
-      return elementToDataNode( first ).equals( elementToDataNode( second ) );
+      // check case. if case changes, we need to know.
+      return first.getName().equals( second.getName() ) && elementToDataNode( first ).equals( elementToDataNode( second ) );
     } catch ( KettleException e ) {
       return false;
     }


### PR DESCRIPTION
- change SharedObjectsIO.findSharedObjectIgnoreCase to take a Set instead of a Map so it can be used in more cases.
- Support case renames in BaseSharedObjectManager
- correct RepositorySharedObjectsIO handling of renames (DON'T delete first)
- make sure import identifies name changes as changes.