### PR TITLE
[BACKLOG-43259] File Open/Save dialog fails to open

### DIFF
--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/recents/RecentFileProvider.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/recents/RecentFileProvider.java
@@ -193,7 +193,7 @@ public class RecentFileProvider extends BaseFileProvider<RecentFile> {
           objectID = spoonInstance.rep.getJobId( lastUsedFile.getFilename(),
             spoonInstance.rep.findDirectory( lastUsedFile.getDirectory() ) );
         }
-      } catch ( KettleException e ) {
+      } catch ( KettleException | IllegalAccessError e ) {
         objectID = null;
       }
       if ( objectID != null ) {


### PR DESCRIPTION
- If the .spoonrc file is referring to repolastdir and reposlastfile that does not exist in repository, the FileOpenSave dialog throws an IllegalAccessError which was not caught. Updated the catch to also  catch IllegalAccessError