### PR TITLE
fix: Prevent MappingOutput configuration override in BaseStep

### DIFF
--- a/engine/src/main/java/org/pentaho/di/trans/step/BaseStep.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/BaseStep.java
@@ -2055,7 +2055,8 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
    */
   protected void openRemoteOutputStepSocketsOnce() throws KettleStepException {
     if ( remoteOutputSteps.isEmpty()
-      || remoteOutputStepsInitialized ) {
+      || remoteOutputStepsInitialized
+      || stepMeta.isMappingOutput() ) { // PDI-20183 MappingOutput is configured in the Mapping step
 
       return;
     }

--- a/engine/src/main/java/org/pentaho/di/trans/step/BaseStep.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/BaseStep.java
@@ -2016,31 +2016,33 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
    * <b>This method should be called before any data is read from previous steps.</b> <br>
    * This action is executed only once.
    *
-   * @throws KettleStepException
+   * @throws KettleStepException if there is an error opening socket connections to the remote input steps
    */
   protected void openRemoteInputStepSocketsOnce() throws KettleStepException {
-    if ( !remoteInputSteps.isEmpty() ) {
-      if ( !remoteInputStepsInitialized ) {
-        // Loop over the remote steps and open client sockets to them
-        // Just be careful in case we're dealing with a partitioned clustered step.
-        // A partitioned clustered step has only one. (see dispatch())
-        //
-        inputRowSetsLock.writeLock().lock();
-        try {
-          for ( RemoteStep remoteStep : remoteInputSteps ) {
-            try {
-              BlockingRowSet rowSet = remoteStep.openReaderSocket( this );
-              inputRowSets.add( rowSet );
-            } catch ( Exception e ) {
-              throw new KettleStepException( "Error opening reader socket to remote step '" + remoteStep + "'", e );
-            }
-          }
-        } finally {
-          inputRowSetsLock.writeLock().unlock();
-        }
-        remoteInputStepsInitialized = true;
-      }
+    if ( remoteInputSteps.isEmpty()
+      || remoteInputStepsInitialized ) {
+
+      return;
     }
+
+    // Loop over the remote steps and open client sockets to them
+    // Just be careful in case we're dealing with a partitioned clustered step.
+    // A partitioned clustered step has only one. (see dispatch())
+    //
+    inputRowSetsLock.writeLock().lock();
+    try {
+      for ( RemoteStep remoteStep : remoteInputSteps ) {
+        try {
+          BlockingRowSet rowSet = remoteStep.openReaderSocket( this );
+          inputRowSets.add( rowSet );
+        } catch ( Exception e ) {
+          throw new KettleStepException( "Error opening reader socket to remote step '" + remoteStep + "'", e );
+        }
+      }
+    } finally {
+      inputRowSetsLock.writeLock().unlock();
+    }
+    remoteInputStepsInitialized = true;
   }
 
   /**
@@ -2049,48 +2051,48 @@ public class BaseStep implements VariableSpace, StepInterface, LoggingObjectInte
    * as soon as possible to avoid time-out situations. <br>
    * This action is executed only once.
    *
-   * @throws KettleStepException
+   * @throws KettleStepException if there is an error opening socket connections to the remote output steps
    */
   protected void openRemoteOutputStepSocketsOnce() throws KettleStepException {
-    if ( !remoteOutputSteps.isEmpty() ) {
-      if ( !remoteOutputStepsInitialized ) {
+    if ( remoteOutputSteps.isEmpty()
+      || remoteOutputStepsInitialized ) {
 
-        outputRowSetsLock.writeLock().lock();
-        try {
-          // Set the current slave target name on all the current output steps (local)
-          //
-          for ( RowSet rowSet : outputRowSets ) {
-            rowSet.setRemoteSlaveServerName( getVariable( Const.INTERNAL_VARIABLE_SLAVE_SERVER_NAME ) );
-            if ( getVariable( Const.INTERNAL_VARIABLE_SLAVE_SERVER_NAME ) == null ) {
-              throw new KettleStepException( "Variable '"
-                + Const.INTERNAL_VARIABLE_SLAVE_SERVER_NAME + "' is not defined." );
-            }
-          }
-
-          // Start threads: one per remote step to funnel the data through...
-          //
-          for ( RemoteStep remoteStep : remoteOutputSteps ) {
-            try {
-              if ( remoteStep.getTargetSlaveServerName() == null ) {
-                throw new KettleStepException(
-                  "The target slave server name is not defined for remote output step: " + remoteStep );
-              }
-              BlockingRowSet rowSet = remoteStep.openWriterSocket();
-              if ( log.isDetailed() ) {
-                logDetailed( BaseMessages.getString( PKG, "BaseStep.Log.OpenedWriterSocketToRemoteStep", remoteStep ) );
-              }
-              outputRowSets.add( rowSet );
-            } catch ( IOException e ) {
-              throw new KettleStepException( "Error opening writer socket to remote step '" + remoteStep + "'", e );
-            }
-          }
-        } finally {
-          outputRowSetsLock.writeLock().unlock();
-        }
-
-        remoteOutputStepsInitialized = true;
-      }
+      return;
     }
+
+    outputRowSetsLock.writeLock().lock();
+    try {
+      // Set the current slave target name on all the current output steps (local)
+      //
+      for ( RowSet rowSet : outputRowSets ) {
+        rowSet.setRemoteSlaveServerName( getVariable( Const.INTERNAL_VARIABLE_SLAVE_SERVER_NAME ) );
+        if ( getVariable( Const.INTERNAL_VARIABLE_SLAVE_SERVER_NAME ) == null ) {
+          throw new KettleStepException( "Variable '"
+            + Const.INTERNAL_VARIABLE_SLAVE_SERVER_NAME + "' is not defined." );
+        }
+      }
+
+      // Start threads: one per remote step to funnel the data through...
+      //
+      for ( RemoteStep remoteStep : remoteOutputSteps ) {
+        try {
+          if ( remoteStep.getTargetSlaveServerName() == null ) {
+            throw new KettleStepException(
+              "The target slave server name is not defined for remote output step: " + remoteStep );
+          }
+          BlockingRowSet rowSet = remoteStep.openWriterSocket();
+          if ( log.isDetailed() ) {
+            logDetailed( BaseMessages.getString( PKG, "BaseStep.Log.OpenedWriterSocketToRemoteStep", remoteStep ) );
+          }
+          outputRowSets.add( rowSet );
+        } catch ( IOException e ) {
+          throw new KettleStepException( "Error opening writer socket to remote step '" + remoteStep + "'", e );
+        }
+      }
+    } finally {
+      outputRowSetsLock.writeLock().unlock();
+    }
+    remoteOutputStepsInitialized = true;
   }
 
   /**


### PR DESCRIPTION
### Summary
This PR addresses the issue described in PDI-20183, where the `MappingOutput` remote steps configuration, done in `Mapping.processRow()`, was being overridden in `BaseStep.openRemoteOutputStepSocketsOnce()`.

### Fix Details
- **Issue**: The configuration for `MappingOutput` remote steps was overridden by the logic in `BaseStep.openRemoteOutputStepSocketsOnce()`.
- **Solution**: Added a new exit condition in `BaseStep.openRemoteOutputStepSocketsOnce()` to skip its logic if the step is a `MappingOutput` step.

### Enhancements
- **Code Refactoring**: Reduced cognitive complexity in the methods handling remote socket openings to improve readability and maintainability.

For more details, refer to the related issue [PDI-20183](https://jira.pentaho.com/browse/PDI-20183).

[PDI-20183]: https://hv-eng.atlassian.net/browse/PDI-20183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ