### PR TITLE
[BACKLOG-43081] - import-export.sh working with global/local

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -535,6 +535,8 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
     return getDatabases().get( i );
   }
 
+  public abstract Set<String> getUsedDatabaseConnectionNames();
+
   public void importFromMetaStore() throws MetaStoreException, KettlePluginException {
     // Read the databases...
     //

--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -100,6 +100,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * The definition of a PDI job is represented by a JobMeta object. It is typically loaded from a .kjb file, a PDI
@@ -525,13 +526,23 @@ public class JobMeta extends AbstractMeta
       }
     }
 
-    databaseMetas.add( jobLogTable.getDatabaseMeta() );
+    if ( jobLogTable.getDatabaseMeta() != null ) {
+      databaseMetas.add( jobLogTable.getDatabaseMeta() );
+    }
 
     for ( LogTableInterface logTable : getExtraLogTables() ) {
-      databaseMetas.add( logTable.getDatabaseMeta() );
+      if ( logTable.getDatabaseMeta() != null ) {
+        databaseMetas.add( logTable.getDatabaseMeta() );
+      }
     }
     return databaseMetas;
   }
+
+  @Override
+  public Set<String> getUsedDatabaseConnectionNames() {
+    return getUsedDatabaseMetas().stream().map( DatabaseMeta::getName ).collect( Collectors.toSet() );
+  }
+
 
   /**
    * This method asks all steps in the transformation whether or not the specified database connection is used. The

--- a/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
+++ b/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
@@ -481,8 +481,9 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
   }
 
   // filters which shared objects will be imported
-  private <T extends SharedObjectInterface<T>> void filterSharedObjects( AbstractMeta source,
-    Class<? extends SharedObjectsManagementInterface<T>> managerClass, String message, String importAskPref )
+  private <T extends SharedObjectInterface<T> & RepositoryElementInterface>
+    void filterSharedObjects( AbstractMeta source, Class<? extends SharedObjectsManagementInterface<T>> managerClass,
+                              String message, String importAskPref )
     throws KettleException {
 
     SharedObjectsManagementInterface<T> srcManager = source.getSharedObjectManager( managerClass );
@@ -539,10 +540,7 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
   }
 
   void patchDatabaseConnections( AbstractMeta meta ) throws KettleException {
-    DatabaseManagementInterface dbMgr = rep.getBowl().getManager( DatabaseManagementInterface.class );
-    for ( DatabaseMeta storedDB : dbMgr.getAll() ) {
-      meta.databaseUpdated( storedDB.getName() );
-    }
+    SharedObjectUtil.patchDatabaseConnections( rep.getBowl(), meta );
   }
 
   private void patchJobEntries( JobMeta jobMeta ) {

--- a/engine/src/main/java/org/pentaho/di/shared/BaseSharedObjectsManager.java
+++ b/engine/src/main/java/org/pentaho/di/shared/BaseSharedObjectsManager.java
@@ -14,6 +14,8 @@
 package org.pentaho.di.shared;
 
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.RepositoryElementInterface;
+
 import org.w3c.dom.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +31,8 @@ import java.util.stream.Collectors;
  * This class caches the state of the underlying SharedObjectsIO, and does not re-read from the source. Only changes
  * written through this interface will be reflected.
  */
-public abstract class BaseSharedObjectsManager<T extends SharedObjectInterface<T>> implements SharedObjectsManagementInterface<T> {
+public abstract class BaseSharedObjectsManager<T extends SharedObjectInterface<T> & RepositoryElementInterface>
+  implements SharedObjectsManagementInterface<T> {
 
   protected SharedObjectsIO sharedObjectsIO;
 
@@ -86,7 +89,7 @@ public abstract class BaseSharedObjectsManager<T extends SharedObjectInterface<T
    */
 
   @Override
-  public synchronized void add( T sharedObjectInterface )  throws KettleException {
+  public synchronized void add( T sharedObjectInterface ) throws KettleException {
     populateSharedObjectMap();
     String name = sharedObjectInterface.getName();
     Node node = sharedObjectInterface.toNode();
@@ -101,7 +104,7 @@ public abstract class BaseSharedObjectsManager<T extends SharedObjectInterface<T
     }
 
     sharedObjectsIO.saveSharedObject( sharedObjectType, name, node );
-    Node readBackNode = sharedObjectsIO.getSharedObject( sharedObjectType, sharedObjectInterface.getName() );
+    Node readBackNode = sharedObjectsIO.getSharedObject( sharedObjectType, name );
     T readBack = createSharedObjectUsingNode( readBackNode );
 
     sharedObjectsMap.put( name, readBack.makeClone() );

--- a/engine/src/main/java/org/pentaho/di/shared/ChangeTrackingSharedObjectManager.java
+++ b/engine/src/main/java/org/pentaho/di/shared/ChangeTrackingSharedObjectManager.java
@@ -14,6 +14,7 @@
 package org.pentaho.di.shared;
 
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.RepositoryElementInterface;
 
 import java.util.List;
 
@@ -21,7 +22,8 @@ import java.util.List;
  * This Manager wraps another manager and tracks changes.
  *
 */
-public class ChangeTrackingSharedObjectManager<T extends SharedObjectInterface<T>> implements SharedObjectsManagementInterface<T> {
+public class ChangeTrackingSharedObjectManager<T extends SharedObjectInterface<T> & RepositoryElementInterface>
+  implements SharedObjectsManagementInterface<T> {
 
   private final SharedObjectsManagementInterface<T> parent;
   private volatile boolean changed = false;

--- a/engine/src/main/java/org/pentaho/di/shared/PassthroughManager.java
+++ b/engine/src/main/java/org/pentaho/di/shared/PassthroughManager.java
@@ -14,6 +14,7 @@
 package org.pentaho.di.shared;
 
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.RepositoryElementInterface;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +26,8 @@ import org.w3c.dom.Node;
  * This Manager that does not cache anything. Complete passthrough to the provided SharedObjectsIO instance.
  *
 */
-public abstract class PassthroughManager<T extends SharedObjectInterface<T>> implements SharedObjectsManagementInterface<T> {
+public abstract class PassthroughManager<T extends SharedObjectInterface<T> & RepositoryElementInterface>
+  implements SharedObjectsManagementInterface<T> {
 
   private final SharedObjectsIO sharedObjectsIO;
   private final String type;

--- a/engine/src/main/java/org/pentaho/di/shared/SharedObjectsManagementInterface.java
+++ b/engine/src/main/java/org/pentaho/di/shared/SharedObjectsManagementInterface.java
@@ -14,6 +14,7 @@
 package org.pentaho.di.shared;
 
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.RepositoryElementInterface;
 import java.util.List;
 
 /**
@@ -21,7 +22,7 @@ import java.util.List;
  * be scoped based on the bowl and can be retrieved using bowl's getManager()
  *
  */
-public interface SharedObjectsManagementInterface<T extends SharedObjectInterface> {
+public interface SharedObjectsManagementInterface<T extends SharedObjectInterface<T> & RepositoryElementInterface> {
 
   /**
    * Add the SharedObject to global or project specific file store(shared.xml) depending on the bowl

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -5365,7 +5365,23 @@ public class TransMeta extends AbstractMeta
     }
 
     return transLogTable.getDatabaseMeta() != null && transLogTable.getDatabaseMeta().equals( databaseMeta );
+  }
 
+  @Override
+  public Set<String> getUsedDatabaseConnectionNames() {
+    Set<String> dbNames = new HashSet<>();
+    for ( int i = 0; i < nrSteps(); i++ ) {
+      StepMeta stepMeta = getStep( i );
+      DatabaseMeta[] dbs = stepMeta.getStepMetaInterface().getUsedDatabaseConnections();
+      for ( int d = 0; d < dbs.length; d++ ) {
+        dbNames.add( dbs[d].getName() );
+      }
+    }
+
+    if ( transLogTable.getDatabaseMeta() != null ) {
+      dbNames.add( transLogTable.getDatabaseMeta().getName() );
+    }
+    return dbNames;
   }
 
   @Override

--- a/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
@@ -805,6 +805,11 @@ public class AbstractMetaTest {
     }
 
     @Override
+    public Set<String> getUsedDatabaseConnectionNames() {
+      return Collections.emptySet();
+    }
+
+    @Override
     public String getXML() throws KettleException {
       return null;
     }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -2878,17 +2878,17 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
 
   @FunctionalInterface
   private static interface SharedObjectOp<M extends SharedObjectsManagementInterface<T>,
-                                          T extends SharedObjectInterface<T>> {
+                                          T extends SharedObjectInterface<T> & RepositoryElementInterface> {
     void op( M manager, T sharedObject ) throws KettleException;
   }
 
-  private <M extends SharedObjectsManagementInterface<T>, T extends SharedObjectInterface<T>>
+  private <M extends SharedObjectsManagementInterface<T>, T extends SharedObjectInterface<T> & RepositoryElementInterface>
       void withSharedObject( Class<M> clazz, SharedObjectOp<M, T> sso ) {
     SpoonTreeLeveledSelection leveledSelection = (SpoonTreeLeveledSelection) selectionObject;
     withSharedObject( leveledSelection, clazz, sso );
   }
 
-  private <M extends SharedObjectsManagementInterface<T>, T extends SharedObjectInterface<T>>
+  private <M extends SharedObjectsManagementInterface<T>, T extends SharedObjectInterface<T> & RepositoryElementInterface>
       void withSharedObject( SpoonTreeLeveledSelection leveledSelection, Class<M> clazz, SharedObjectOp<M, T> sso ) {
     M manager = null;
     T sharedObject = null;


### PR DESCRIPTION
- copy shared objects from the RepositoryBowl to the TransMeta or JobMeta before export in StreamToJobNodeConverter and StreamToTransNodeConverter.
- Strip object ids from meta before exporting
- move shared objects to RepositoryBowl and fix database connections on import in StreamToJobNodeConverter and StreamToTransNodeConverter
- new API to list names of used database connections from AbstractMeta (more efficient than asking the meta about each connection)
- SharedObjectUtil methods:
  - copy used db and all other shared objects into meta from a (Repository) Bowl, for export
  - moved patchDatabaseConnections here to use in other import mechanisms
  - stripObjectIds, for use before export