### PR TITLE
[PPP-5589][PPP-5620] Vulnerable Component: commons-io (PDI Core Plugin)

### DIFF
--- a/plugins/core/impl/pom.xml
+++ b/plugins/core/impl/pom.xml
@@ -43,6 +43,13 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons-io.version}</version>
+    </dependency>
+
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
- update commons-io to v2.16.1

QA validation depends on https://github.com/pentaho/pentaho-reporting/pull/1742