### PR TITLE
[BACKLOG-43080] - fix name collisions on edit and import

### DIFF
--- a/engine/src/main/java/org/pentaho/di/partition/PartitionSchema.java
+++ b/engine/src/main/java/org/pentaho/di/partition/PartitionSchema.java
@@ -81,7 +81,6 @@ public class PartitionSchema extends ChangedFlag implements Cloneable, SharedObj
   public Object clone() {
     PartitionSchema partitionSchema = new PartitionSchema();
     partitionSchema.replaceMeta( this );
-    partitionSchema.setObjectId( null );
     return partitionSchema;
   }
 

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PartitionDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PartitionDelegate.java
@@ -79,13 +79,6 @@ public class PartitionDelegate extends AbstractDelegate implements ITransformer,
     PartitionSchema partitionSchema = (PartitionSchema) element;
     DataNode rootNode = new DataNode( NODE_ROOT );
 
-    // Check for naming collision
-    ObjectId partitionId = repo.getPartitionSchemaID( partitionSchema.getName() );
-    if ( partitionId != null && !Objects.equals( partitionSchema.getObjectId(), partitionId ) ) {
-      // We have a naming collision, abort the save
-      throw new KettleException( "Failed to save object to repository. Object [" + partitionSchema.getName()
-          + "] already exists." );
-    }
     rootNode.setProperty( PROP_DYNAMIC_DEFINITION, partitionSchema.isDynamicallyDefined() );
     rootNode.setProperty( PROP_PARTITIONS_PER_SLAVE, partitionSchema.getNumberOfPartitionsPerSlave() );
 

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
@@ -981,11 +981,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
 
   @Override
   public ObjectId getClusterID( String name ) throws KettleException {
-    try {
-      return getObjectId( name, null, RepositoryObjectType.CLUSTER_SCHEMA, false );
-    } catch ( Exception e ) {
-      throw new KettleException( "Unable to get ID for cluster schema [" + name + "]", e );
-    }
+    return getObjectID( name, RepositoryObjectType.CLUSTER_SCHEMA );
   }
 
   @Override
@@ -1018,23 +1014,27 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
 
   @Override
   public ObjectId getDatabaseID( final String name ) throws KettleException {
+    return getObjectID( name, RepositoryObjectType.DATABASE );
+  }
+
+  private ObjectId getObjectID( String name, RepositoryObjectType type ) throws KettleException {
     try {
-      ObjectId objectId = getObjectId( name, null, RepositoryObjectType.DATABASE, false );
+      ObjectId objectId = getObjectId( name, null, type, false );
       if ( objectId == null ) {
-        List<RepositoryFile> allDatabases = getAllFilesOfType( null, RepositoryObjectType.DATABASE, false );
-        String[] existingNames = new String[ allDatabases.size() ];
-        for ( int i = 0; i < allDatabases.size(); i++ ) {
-          RepositoryFile file = allDatabases.get( i );
+        List<RepositoryFile> allFilesOfType = getAllFilesOfType( null, type, false );
+        String[] existingNames = new String[ allFilesOfType.size() ];
+        for ( int i = 0; i < allFilesOfType.size(); i++ ) {
+          RepositoryFile file = allFilesOfType.get( i );
           existingNames[ i ] = file.getTitle();
         }
         int index = DatabaseMeta.indexOfName( existingNames, name );
         if ( index != -1 ) {
-          return new StringObjectId( allDatabases.get( index ).getId().toString() );
+          return new StringObjectId( allFilesOfType.get( index ).getId().toString() );
         }
       }
       return objectId;
     } catch ( Exception e ) {
-      throw new KettleException( "Unable to get ID for database [" + name + "]", e );
+      throw new KettleException( "Unable to get ID for " + type + " [" + name + "]", e );
     }
   }
 
@@ -1587,11 +1587,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
 
   @Override
   public ObjectId getPartitionSchemaID( String name ) throws KettleException {
-    try {
-      return getObjectId( name, null, RepositoryObjectType.PARTITION_SCHEMA, false );
-    } catch ( Exception e ) {
-      throw new KettleException( "Unable to get ID for partition schema [" + name + "]", e );
-    }
+    return getObjectID( name, RepositoryObjectType.PARTITION_SCHEMA );
   }
 
   @Override
@@ -1639,11 +1635,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
 
   @Override
   public ObjectId getSlaveID( String name ) throws KettleException {
-    try {
-      return getObjectId( name, null, RepositoryObjectType.SLAVE_SERVER, false );
-    } catch ( Exception e ) {
-      throw new KettleException( "Unable to get ID for slave server with name [" + name + "]", e );
-    }
+    return getObjectID( name, RepositoryObjectType.SLAVE_SERVER );
   }
 
   @Override

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonClustersDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonClustersDelegate.java
@@ -84,8 +84,12 @@ public class SpoonClustersDelegate extends SpoonSharedObjectDelegate {
           new ClusterSchemaDialog( spoon.getShell(), clusterSchema, manager.getAll(), slaveServers );
       if ( dialog.open() ) {
         String newName = clusterSchema.getName().trim();
-        if ( !newName.equals( originalName ) ) {
+        // This should be case insensitive. We only need to remove if the name changed beyond case. The Managers handle
+        // case-only changes.
+        if ( !newName.equalsIgnoreCase( originalName ) ) {
           manager.remove( originalName );
+          // ideally we wouldn't leak this repository-specific concept, but I don't see how at the moment.
+          clusterSchema.setObjectId( null );
         }
         manager.add( clusterSchema );
         refreshTree();

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonDBDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonDBDelegate.java
@@ -92,10 +92,14 @@ public class SpoonDBDelegate extends SpoonSharedObjectDelegate {
         databaseMeta = getDatabaseDialog().getDatabaseMeta();
         databaseMeta.setName( newname.trim() );
         databaseMeta.setDisplayName( newname.trim() );
-        if ( !newname.equals( originalName ) ) {
+        // This should be case insensitive. We only need to remove if the name changed beyond case. The Managers handle
+        // case-only changes.
+        if ( !newname.equalsIgnoreCase( originalName ) ) {
           dbManager.remove( originalName );
-          spoon.refreshDbConnection( newname.trim() );
+          // ideally we wouldn't leak this repository-specific concept, but I don't see how at the moment.
+          databaseMeta.setObjectId( null );
         }
+        spoon.refreshDbConnection( newname.trim() );
 
         dbManager.add( databaseMeta );
         spoon.refreshDbConnection( originalName );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonPartitionsDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonPartitionsDelegate.java
@@ -82,8 +82,12 @@ public class SpoonPartitionsDelegate extends SpoonSharedObjectDelegate {
                       databaseMetas, spoon.getBowl().getADefaultVariableSpace() );
       if ( dialog.open() ) {
         String newName = partitionSchema.getName().trim();
-        if ( !newName.equals( originalName ) ) {
+        // This should be case insensitive. We only need to remove if the name changed beyond case. The Managers handle
+        // case-only changes.
+        if ( !newName.equalsIgnoreCase( originalName ) ) {
           partitionSchemaManager.remove( originalName );
+          // ideally we wouldn't leak this repository-specific concept, but I don't see how at the moment.
+          partitionSchema.setObjectId( null );
         }
         partitionSchemaManager.add( partitionSchema );
         refreshTree();

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonSlaveDelegate.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/delegates/SpoonSlaveDelegate.java
@@ -120,8 +120,12 @@ public class SpoonSlaveDelegate extends SpoonSharedObjectDelegate {
       SlaveServerDialog dialog = new SlaveServerDialog( spoon.getShell(), slaveServer, slaveServerManager.getAll() );
       if ( dialog.open() ) {
         String newName = slaveServer.getName().trim();
-        if ( !newName.equals( originalName ) ) {
+        // This should be case insensitive. We only need to remove if the name changed beyond case. The Managers handle
+        // case-only changes.
+        if ( !newName.equalsIgnoreCase( originalName ) ) {
           slaveServerManager.remove( originalName );
+          // ideally we wouldn't leak this repository-specific concept, but I don't see how at the moment.
+          slaveServer.setObjectId( null );
         }
         slaveServerManager.add( slaveServer );
       }


### PR DESCRIPTION
- stop clearing object Id in PartitionSchema.clone
- stop checking for existing object in PartitionDelegate.elementToDataNode (now handled elsewhere)
- standardize on finding existing object ids in a case-insensitive manner for all shared object types in the repository
- Fix Spoon Delegate handling for checking for changed case. Only remove from the backing manager if the name changed *more* than just case.
- Clear the object ID if we're removing and adding to the manager so the repository sees the new object as a new object.