### PR TITLE
fix: add pentaho-repoting plugin missing dependency

### DIFF
--- a/plugins/pentaho-reporting/assemblies/plugin/pom.xml
+++ b/plugins/pentaho-reporting/assemblies/plugin/pom.xml
@@ -141,6 +141,7 @@
                 commons-digester,
                 commons-lang3,
                 commons-xul-core,
+                ehcache-core,
                 flute,
                 groovy-all,
                 openpdf,


### PR DESCRIPTION
This pull request includes a small change to the `plugins/pentaho-reporting/assemblies/plugin/pom.xml` file. The change adds `ehcache-core` to the list of dependencies.

* [`plugins/pentaho-reporting/assemblies/plugin/pom.xml`](diffhunk://#diff-55eeefb3eaffa596eaf788d38cbdb14106a520fd98ad0dc738648435a520c7d1R144): Added `ehcache-core` to the list of dependencies.

This missing dependency was causing the issue described in [PDI-20342](https://hv-eng.atlassian.net/browse/PDI-20342)