### PR TITLE
[SP-6775] fix: add pentaho-repoting plugin missing dependency

### DIFF
--- a/plugins/pentaho-reporting/assemblies/plugin/pom.xml
+++ b/plugins/pentaho-reporting/assemblies/plugin/pom.xml
@@ -141,6 +141,7 @@
                 commons-digester,
                 commons-lang3,
                 commons-xul-core,
+                ehcache-core,
                 flute,
                 groovy-all,
                 openpdf,


### PR DESCRIPTION
This pull request includes a small change to the `plugins/pentaho-reporting/assemblies/plugin/pom.xml` file. The change adds `ehcache-core` to the list of dependencies.

(cherry picked from commit https://github.com/pentaho/pentaho-kettle/commit/7f7d38b1fd9e1ab316aa5fc4348b658c924ba341)

@pentaho/tatooine_dev 