### PR TITLE
fix: avoid dead lock in `PurRepository.loadAndCacheSharedObject`

### DIFF
--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
@@ -1953,6 +1953,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
   protected Map<RepositoryObjectType, List<? extends SharedObjectInterface>> loadAndCacheSharedObjects(
     final boolean deepCopy ) throws KettleException {
     if ( sharedObjectsByType == null ) {
+      readWriteLock.readLock().lock();
       sharedObjectsLock.writeLock().lock();
       try {
         sharedObjectsByType =
@@ -1966,6 +1967,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
         throw new KettleException( "Unable to read shared objects from repository", e ); //$NON-NLS-1$
       } finally {
         sharedObjectsLock.writeLock().unlock();
+        readWriteLock.readLock().unlock();
       }
     }
     return deepCopy ? deepCopy( sharedObjectsByType ) : sharedObjectsByType;


### PR DESCRIPTION
This pull request includes changes to the `PurRepository` class to improve thread safety by adding read locks. The most important changes include adding a read lock at the beginning of the `loadAndCacheSharedObjects` method and unlocking it in the finally block. This will avoid a dead lock happening by making sure that a `readWriteLock` is always obtained before a `sharedObjectsLock`.

Thread safety improvements:

* [`plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java`](diffhunk://#diff-be1e027bd3bdaab8c997a83ea1f1509516efe8727c8c2de3cc1a69d6dd855ed7R1956): Added a read lock at the start of the `loadAndCacheSharedObjects` method to ensure thread safety when reading shared objects.
* [`plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java`](diffhunk://#diff-be1e027bd3bdaab8c997a83ea1f1509516efe8727c8c2de3cc1a69d6dd855ed7R1970): Added a corresponding unlock for the read lock in the finally block to ensure the lock is released properly.