### PR TITLE
[BACKLOG-43057] While doing Save/Save as, the FileOpenSaveDialog will…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -187,6 +187,9 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
   // memoized, load-once-on-demand supplier for the embedded provider key.
   private Supplier<String> embeddedMetastoreProvKeySupplier = Suppliers.memoize( this::getEmbeddedMetastoreKey );
 
+  // This is used as default directory for new jobs/transformation while saving the file
+  private String defaultSaveDirectory;
+
   private String getEmbeddedMetastoreKey() {
     if ( getMetastoreLocatorOsgi() != null ) {
       return getMetastoreLocatorOsgi().setEmbeddedMetastore( getEmbeddedMetaStore() );
@@ -2273,5 +2276,23 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
 
     return null;
   }
+
+  /**
+   * Return the default save directory for a transformation/Job
+   * @return directory The full path to the default directory for saving transformation/Job
+   */
+  public String getDefaultSaveDirectory() {
+    return defaultSaveDirectory;
+  }
+
+  /**
+   * Set the default save directory for transformation/Job
+   * @param defaultDir The directory displayed as default directory in FileOpenSaveDialog when this transformation/Job is
+   *                   saved
+   */
+  public void setDefaultSaveDirectory( String defaultDir ) {
+    defaultSaveDirectory = defaultDir;
+  }
+
 }
 

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -5044,6 +5044,9 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
           // User has not opened any file but the lastOpenProvier was repository and use is not connected to the
           // repository so set the session to the user's home folder
           defaultFileDialogOperationToUserHome( fileDialogOperation );
+        } else if ( getActiveAbstractMeta() != null && getActiveAbstractMeta().getDefaultSaveDirectory() != null ) {
+          // if the default save directory is present, set the path to this directory
+          fileDialogOperation.setPath( getActiveAbstractMeta().getDefaultSaveDirectory() );
         } else if ( !Utils.isEmpty( lastFileOpened ) ) {
           //User has opened a file previously, set the save folder be the last file opened folder
           int parentIndex = lastFileOpened.lastIndexOf('\\');
@@ -5466,6 +5469,30 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       new ErrorDialog(
         shell, BaseMessages.getString( PKG, "Spoon.Exception.ErrorCreatingNewJob.Title" ), BaseMessages
           .getString( PKG, "Spoon.Exception.ErrorCreatingNewJob.Message" ), e );
+    }
+  }
+
+  /**
+   * Called when new Job is being created.
+   * @param defaultDir This directory will be default save directory in FileOpenSaveDialog when Save/Save as is called
+   */
+  public void newJobFile( String defaultDir ){
+    newJobFile();
+    JobMeta jobMeta = getActiveJob();
+    if ( jobMeta != null ) {
+      jobMeta.setDefaultSaveDirectory( defaultDir );
+    }
+  }
+
+  /**
+   * Called when new Transformation is being created.
+   * @param defaultDir This directory will be default save directory in FileOpenSaveDialog when Save/Save as is called
+   */
+  public void newTransFile( String defaultDir ){
+    newTransFile();
+    TransMeta transMeta = getActiveTransformation();
+    if ( transMeta != null ) {
+      transMeta.setDefaultSaveDirectory( defaultDir );
     }
   }
 


### PR DESCRIPTION
… default to the folder where the job/transformation is being created, if the folder value exist.

-Updated AbstractMeta to include sgetter/setter for defaultSaveDirectory. -Added methods in Spoon to set the defaultSaveDirectory while creating new job/transformation.