### PR TITLE
[BACKLOG-44081] [BACKLOG-44082] - Update SparkEngine class to use as a simple pojo instead of a service, Update the PluginRegistryResolver to register all coalesce steps within the class instead of a configuration file.

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/plugins/EnginePluginType.java
+++ b/engine/src/main/java/org/pentaho/di/core/plugins/EnginePluginType.java
@@ -32,6 +32,7 @@ public class EnginePluginType extends BasePluginType implements PluginTypeInterf
 
   private EnginePluginType() {
     super( EnginePlugin.class, "ENGINE_PLUGIN", "Engine Plugin" );
+    populateFolders(null);  // Register plugin folders to search for this plugin type
   }
 
   public static EnginePluginType getInstance() {


### PR DESCRIPTION

This PR has to be merged along with - https://github.com/pentaho/spark-execution/pull/14