### PR TITLE
[BACKLOG-44457]-Remove Usage of SecurityManager and Ensure JDK 21 Compatibility in Pentaho_kettle unit tests

### DIFF
--- a/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
@@ -47,6 +47,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.i18n.LanguageChoice;
 import org.pentaho.di.metastore.MetaStoreConst;
 import org.pentaho.di.pan.CommandLineOption;
+import org.pentaho.di.security.ExitInterceptor;
 
 public class Kitchen {
   private static Class<?> PKG = Kitchen.class; // for i18n purposes, needed by Translator2!!
@@ -344,7 +345,7 @@ public class Kitchen {
 
   private static final void exitJVM( int status ) {
 
-    System.exit( status );
+    ExitInterceptor.exit( status );
   }
 
   public static KitchenCommandExecutor getCommandExecutor() {

--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -35,6 +35,7 @@ import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.i18n.LanguageChoice;
 import org.pentaho.di.kitchen.Kitchen;
+import org.pentaho.di.security.ExitInterceptor;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 
@@ -299,7 +300,7 @@ public class Pan {
       KettleLogStore.getAppender().removeLoggingEventListener( fileLoggingEventListener );
     }
 
-    System.exit( status );
+    ExitInterceptor.exit( status );
   }
 
   public static PanCommandExecutor getCommandExecutor() {

--- a/engine/src/main/java/org/pentaho/di/security/ExitInterceptor.java
+++ b/engine/src/main/java/org/pentaho/di/security/ExitInterceptor.java
@@ -1,0 +1,34 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.security;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ExitInterceptor {
+    private static final AtomicBoolean interceptEnabled = new AtomicBoolean(false);
+
+    public static void enableIntercept() {
+        interceptEnabled.set( true );
+    }
+
+    public static void disableIntercept() {
+        interceptEnabled.set( false );
+    }
+
+    public static void exit( int status ) {
+        if ( interceptEnabled.get() ) {
+            throw new SecurityException( "System exit not allowed" );
+        }
+        System.exit( status );
+    }
+}

--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
@@ -28,6 +28,7 @@ import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.repository.RepositoryMeta;
 import org.pentaho.di.repository.RepositoryOperation;
+import org.pentaho.di.security.ExitInterceptor;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -52,7 +53,6 @@ public class KitchenTest {
   private ByteArrayOutputStream sysOutContent;
   private ByteArrayOutputStream sysErrContent;
 
-  private SecurityManager oldSecurityManager;
 
   RepositoriesMeta mockRepositoriesMeta;
   RepositoryMeta mockRepositoryMeta;
@@ -62,10 +62,9 @@ public class KitchenTest {
   @Before
   public void setUp() throws KettleException {
     KettleEnvironment.init();
-    oldSecurityManager = System.getSecurityManager();
+    ExitInterceptor.enableIntercept();
     sysOutContent = new ByteArrayOutputStream();
     sysErrContent = new ByteArrayOutputStream();
-    System.setSecurityManager( new MySecurityManager( oldSecurityManager ) );
     mockRepositoriesMeta = mock( RepositoriesMeta.class );
     mockRepositoryMeta = mock( RepositoryMeta.class );
     mockRepository = mock( Repository.class );
@@ -74,7 +73,7 @@ public class KitchenTest {
 
   @After
   public void tearDown() {
-    System.setSecurityManager( oldSecurityManager );
+    ExitInterceptor.disableIntercept();
     sysOutContent = null;
     sysErrContent = null;
     mockRepositoriesMeta = null;
@@ -297,27 +296,6 @@ public class KitchenTest {
     public Repository establishRepositoryConnection( RepositoryMeta repositoryMeta, final String username, final String password,
                                                          final RepositoryOperation... operations ) throws KettleException, KettleSecurityException {
       return testRepository != null ? testRepository : super.establishRepositoryConnection( repositoryMeta, username, password, operations );
-    }
-  }
-
-  public class MySecurityManager extends SecurityManager {
-
-    private SecurityManager baseSecurityManager;
-
-    public MySecurityManager( SecurityManager baseSecurityManager ) {
-      this.baseSecurityManager = baseSecurityManager;
-    }
-
-    @Override
-    public void checkPermission( Permission permission ) {
-      if ( permission.getName().startsWith( "exitVM" ) ) {
-        throw new SecurityException( "System exit not allowed" );
-      }
-      if ( baseSecurityManager != null ) {
-        baseSecurityManager.checkPermission( permission );
-      } else {
-        return;
-      }
     }
   }
 }

--- a/engine/src/test/java/org/pentaho/di/pan/PanTest.java
+++ b/engine/src/test/java/org/pentaho/di/pan/PanTest.java
@@ -31,6 +31,7 @@ import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.repository.RepositoryMeta;
 import org.pentaho.di.repository.RepositoryOperation;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.security.ExitInterceptor;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 
@@ -58,8 +59,6 @@ public class PanTest {
   private ByteArrayOutputStream sysOutContent;
   private ByteArrayOutputStream sysErrContent;
 
-  private SecurityManager oldSecurityManager;
-
   RepositoriesMeta mockRepositoriesMeta;
   RepositoryMeta mockRepositoryMeta;
   Repository mockRepository;
@@ -72,10 +71,9 @@ public class PanTest {
 
   @Before
   public void setUp() {
-    oldSecurityManager = System.getSecurityManager();
+    ExitInterceptor.enableIntercept();
     sysOutContent = new ByteArrayOutputStream();
     sysErrContent = new ByteArrayOutputStream();
-    System.setSecurityManager( new MySecurityManager( oldSecurityManager ) );
     mockRepositoriesMeta = mock( RepositoriesMeta.class );
     mockRepositoryMeta = mock( RepositoryMeta.class );
     mockRepository = mock( Repository.class );
@@ -84,7 +82,7 @@ public class PanTest {
 
   @After
   public void tearDown() {
-    System.setSecurityManager( oldSecurityManager );
+    ExitInterceptor.disableIntercept();
     sysOutContent = null;
     sysErrContent = null;
     mockRepositoriesMeta = null;
@@ -318,27 +316,5 @@ public class PanTest {
                                                      final RepositoryOperation... operations ) throws KettleException, KettleSecurityException {
       return testRepository != null ? testRepository : super.establishRepositoryConnection( repositoryMeta, username, password, operations );
     }
-  }
-
-  public class MySecurityManager extends SecurityManager {
-
-    private SecurityManager baseSecurityManager;
-
-    public MySecurityManager( SecurityManager baseSecurityManager ) {
-      this.baseSecurityManager = baseSecurityManager;
-    }
-
-    @Override
-    public void checkPermission( Permission permission ) {
-      if ( permission.getName().startsWith( "exitVM" ) ) {
-        throw new SecurityException( "System exit not allowed" );
-      }
-      if ( baseSecurityManager != null ) {
-        baseSecurityManager.checkPermission( permission );
-      } else {
-        return;
-      }
-    }
-
   }
 }


### PR DESCRIPTION
[BACKLOG-44457]-Remove Usage of SecurityManager and Ensure JDK 21 Compatibility in Pentaho_kettle unit tests

[BACKLOG-44457]: https://hv-eng.atlassian.net/browse/BACKLOG-44457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ