### PR TITLE
[BACKLOG-44457]-Remove Usage of SecurityManager and Ensure JDK 21 Compatibility in Pentaho_kettle unit tests

### DIFF
--- a/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
@@ -38,6 +38,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.i18n.LanguageChoice;
 import org.pentaho.di.pan.CommandExecutorResult;
 import org.pentaho.di.pan.CommandLineOption;
+import org.pentaho.di.security.ExitInterceptor;
 import org.pentaho.di.pan.CommandLineOptionProvider;
 
 import java.util.AbstractMap;


### PR DESCRIPTION
[BACKLOG-44457]-Remove Usage of SecurityManager and Ensure JDK 21 Compatibility in Pentaho_kettle unit tests

[BACKLOG-44457]: https://hv-eng.atlassian.net/browse/BACKLOG-44457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ