### PR TITLE
[BACKLOG-44786] - Update native spark steps (amqp, mqtt. meta inject,kafka) to reference libraries from the pdi plugin

### DIFF
--- a/plugins/meta-inject/impl/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
+++ b/plugins/meta-inject/impl/src/main/java/org/pentaho/di/trans/steps/metainject/MetaInjectMeta.java
@@ -25,6 +25,7 @@ import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.injection.InjectionSupported;
+import org.pentaho.di.core.plugins.ParentFirst;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaFactory;
 import org.pentaho.di.core.util.CurrentDirectoryResolver;
@@ -72,6 +73,7 @@ import java.util.Map.Entry;
     documentationUrl = "mk-95pdia003/pdi-transformation-steps/etl-metadata-injection" )
 @InjectionSupported( localizationPrefix = "MetaInject.Injection.", groups = { "SOURCE_OUTPUT_FIELDS",
   "MAPPING_FIELDS" } )
+@ParentFirst( patterns = { ".*" } )
 public class MetaInjectMeta extends BaseStepMeta implements StepMetaInterface, StepMetaChangeListenerInterface,
   HasRepositoryDirectories, ISubTransAwareMeta {
 

--- a/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerMeta.java
+++ b/plugins/streaming/impls/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerMeta.java
@@ -18,6 +18,7 @@ import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionSupported;
+import org.pentaho.di.core.plugins.ParentFirst;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
@@ -97,6 +98,7 @@ import static org.pentaho.metaverse.api.analyzer.kettle.step.ExternalResourceSte
   NODE_TYPE_EXTERNAL_CONNECTION )
 @Metaverse.EntityLink ( entity = MQTT_TOPIC_METAVERSE, link = LINK_CONTAINS_CONCEPT, parentEntity = MQTT_SERVER_METAVERSE )
 @Metaverse.EntityLink ( entity = MQTT_TOPIC_METAVERSE, link = LINK_PARENT_CONCEPT )
+@ParentFirst( patterns = { ".*" } )
 public class MQTTConsumerMeta extends BaseStreamStepMeta implements StepMetaInterface {
   private static final Class<?> PKG = MQTTConsumerMeta.class;
 


### PR DESCRIPTION
Related PR
https://github.com/pentaho/pdi-plugins-ee/pull/2098
https://github.com/pentaho/big-data-plugin/pull/2790
https://github.com/pentaho/spark-execution/pull/35