### PR TITLE
[BACKLOG-41544] - Spoon execution with Projects in Repository

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -455,8 +455,14 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
    */
   @Override
   public void setRepository( Repository repository ) {
-    if ( !Objects.equals( this.repository, repository ) ) {
-      // TODO BACKLOG-41158  When we implement execution from repository with projects, revisit this.
+    if ( Objects.equals( this.repository, repository ) ) {
+      // covers both null
+      return;
+    }
+    if ( this.repository == null || repository == null || !Objects.equals( this.repository.getName(), repository.getName() ) ) {
+      // In debug, the existing this.repository is a PurRepository, but the incoming repository is a
+      // Proxy, probably caused by the xul call that eventually calls Spoon.saveToFile. Have to compare names instead
+      // of just references
       this.repository = repository;
       if ( repository != null ) {
         setBowl( repository.getBowl() );

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
@@ -2490,6 +2490,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
     transMeta.setRepository( this );
     transMeta.setRepositoryDirectory( parentDir );
     transMeta.setMetaStore( MetaStoreConst.getDefaultMetastore() );
+    ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.TransSharedObjectsLoaded.id, transMeta );
     transDelegate.dataNodeToElement( data.getNode(), transMeta );
     transMeta.clearChanged();
     return transMeta;
@@ -2604,6 +2605,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
     jobMeta.setRepository( this );
     jobMeta.setRepositoryDirectory( parentDir );
     jobMeta.setMetaStore( MetaStoreConst.getDefaultMetastore() );
+    ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobSharedObjectsLoaded.id, jobMeta );
     jobDelegate.dataNodeToElement( data.getNode(), jobMeta );
     jobMeta.clearChanged();
     return jobMeta;
@@ -3199,6 +3201,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
         // Additional obfuscation through obscurity
         jobMeta.setRepositoryLock( unifiedRepositoryLockService.getLock( file ) );
 
+        ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.JobSharedObjectsLoaded.id, jobMeta );
         jobDelegate.dataNodeToElement( pur.getDataAtVersionForRead( idJob.getId(), versionLabel,
           NodeRepositoryFileData.class ).getNode(), jobMeta );
 
@@ -3239,6 +3242,7 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
         transMeta.setRepositoryLock( unifiedRepositoryLockService.getLock( file ) );
         transMeta.setMetaStore( MetaStoreConst.getDefaultMetastore() ); // inject metastore
 
+        ExtensionPointHandler.callExtensionPoint( log, KettleExtensionPoint.TransSharedObjectsLoaded.id, transMeta );
         transDelegate.dataNodeToElement(
           pur.getDataAtVersionForRead( idTransformation.getId(), versionLabel, NodeRepositoryFileData.class ).getNode(),
           transMeta );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -5907,6 +5907,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       }
       if ( meta instanceof JobMeta ) {
         existingId = rep.getJobId( meta.getName(), meta.getRepositoryDirectory() );
+        saveEventId = KettleExtensionPoint.JobAfterSave.id;
       }
 
       boolean saved = false;
@@ -7016,7 +7017,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   }
 
   private String[] pickupPartitionSchemaNames( TransMeta transMeta ) throws KettleException {
-    return ( rep == null ) ? transMeta.getPartitionSchemasNames() : rep.getPartitionSchemaNames( false );
+    return transMeta.getPartitionSchemasNames();
   }
 
 
@@ -7025,16 +7026,6 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   }
 
   private List<PartitionSchema> pickupPartitionSchemas( TransMeta transMeta ) throws KettleException {
-    if ( rep != null ) {
-      ObjectId[] ids = rep.getPartitionSchemaIDs( false );
-      List<PartitionSchema> result = new ArrayList<>( ids.length );
-      for ( ObjectId id : ids ) {
-        PartitionSchema schema = rep.loadPartitionSchema( id, null );
-        result.add( schema );
-      }
-      return result;
-    }
-
     return transMeta.getPartitionSchemas();
   }
 


### PR DESCRIPTION
- Better Repository change handling in AbstractMeta
- Call the ExtensionPoints needed by the projects plugin while loading from the Repository
- Store references to Shared Objects by Name when they don't have an ObjectId, allowing steps and JobEntries to refer to objects from a Project.
- cleaned up some PartitionSchema serialization that was going directly to the repository instead of through the Meta/Bowls.