### PR TITLE
[BACKLOG-44621] - revert change to copy parent job variables

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
+++ b/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
@@ -156,8 +156,7 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
         case FILENAME:
           String realFilename = tmpSpace.environmentSubstitute( filename );
           try {
-            theMeta = attemptLoadMeta( bowl, realFilename, rep, metaStore, tmpSpace,
-                                       jobEntryBase.getParentVariableSpace(), idContainer );
+            theMeta = attemptLoadMeta( bowl, realFilename, rep, metaStore, tmpSpace, null, idContainer );
           } catch ( KettleException e ) {
             // try to load from repository, this trans may have been developed locally and later uploaded to the
             // repository


### PR DESCRIPTION
Fixes an issue where we were incorrectly passing along parent job params to child transformation. This change was originally introduced for BACKLOG-40920, but is apparently not actually needed to make that work.