### PR TITLE
[BACKLOG-44457]-Remove Usage of SecurityManager and Ensure JDK 21 Compatibility in Pentaho_kettle unit tests

### DIFF
--- a/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
+++ b/engine/src/main/java/org/pentaho/di/kitchen/Kitchen.java
@@ -39,6 +39,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.i18n.LanguageChoice;
 import org.pentaho.di.pan.CommandLineOption;
 import org.pentaho.di.pan.CommandLineOptionProvider;
+import org.pentaho.di.security.ExitInterceptor;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -224,6 +225,7 @@ public class Kitchen {
     if ( args.size() == 2 ) {
       CommandLineOption.printUsage( updatedOptionList.toArray( new CommandLineOption[ 0 ] ) );
       blockAndThrow( kettleInitFuture );
+      exitJVM( 9 );
     }
 
     CommandLineOption.parseArguments( args, options, log );
@@ -253,6 +255,7 @@ public class Kitchen {
       if ( !Utils.isEmpty( optionVersion ) ) {
         getCommandExecutor().printVersion();
         if ( a.length == 1 ) {
+          exitJVM( CommandExecutorCodes.Pan.KETTLE_VERSION_PRINT.getCode() );
         }
       }
 
@@ -305,6 +308,7 @@ public class Kitchen {
       }
     }
 
+    exitJVM( result.getExitStatus() );
 
   }
 
@@ -409,6 +413,10 @@ public class Kitchen {
     }
   }
 
+  private static final void exitJVM( int status ) {
+
+    ExitInterceptor.exit( status );
+  }
 
   public static KitchenCommandExecutor getCommandExecutor() {
     return commandExecutor;

--- a/engine/src/main/java/org/pentaho/di/pan/Pan.java
+++ b/engine/src/main/java/org/pentaho/di/pan/Pan.java
@@ -33,6 +33,7 @@ import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.i18n.LanguageChoice;
 import org.pentaho.di.kitchen.Kitchen;
+import org.pentaho.di.security.ExitInterceptor;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 
@@ -360,6 +361,7 @@ public class Pan {
       KettleLogStore.getAppender().removeLoggingEventListener( fileLoggingEventListener );
     }
 
+    ExitInterceptor.exit( status );
   }
 
   public static PanCommandExecutor getCommandExecutor() {

--- a/engine/src/main/java/org/pentaho/di/security/ExitInterceptor.java
+++ b/engine/src/main/java/org/pentaho/di/security/ExitInterceptor.java
@@ -1,0 +1,34 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.security;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ExitInterceptor {
+    private static final AtomicBoolean interceptEnabled = new AtomicBoolean(false);
+
+    public static void enableIntercept() {
+        interceptEnabled.set( true );
+    }
+
+    public static void disableIntercept() {
+        interceptEnabled.set( false );
+    }
+
+    public static void exit( int status ) {
+        if ( interceptEnabled.get() ) {
+            throw new SecurityException( "System exit not allowed" );
+        }
+        System.exit( status );
+    }
+}

--- a/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
+++ b/engine/src/test/java/org/pentaho/di/kitchen/KitchenTest.java
@@ -42,6 +42,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import org.pentaho.di.security.ExitInterceptor;
 
 public class KitchenTest {
 
@@ -61,6 +62,7 @@ public class KitchenTest {
   @Before
   public void setUp() throws KettleException {
     KettleEnvironment.init();
+    ExitInterceptor.enableIntercept();
     sysOutContent = new ByteArrayOutputStream();
     sysErrContent = new ByteArrayOutputStream();
     mockRepositoriesMeta = mock( RepositoriesMeta.class );
@@ -71,6 +73,7 @@ public class KitchenTest {
 
   @After
   public void tearDown() {
+    ExitInterceptor.disableIntercept();
     sysOutContent = null;
     sysErrContent = null;
     mockRepositoriesMeta = null;

--- a/engine/src/test/java/org/pentaho/di/pan/PanTest.java
+++ b/engine/src/test/java/org/pentaho/di/pan/PanTest.java
@@ -31,6 +31,7 @@ import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.repository.RepositoryMeta;
 import org.pentaho.di.repository.RepositoryOperation;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.security.ExitInterceptor;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 
@@ -70,6 +71,7 @@ public class PanTest {
 
   @Before
   public void setUp() {
+    ExitInterceptor.enableIntercept();
     sysOutContent = new ByteArrayOutputStream();
     sysErrContent = new ByteArrayOutputStream();
     mockRepositoriesMeta = mock( RepositoriesMeta.class );
@@ -80,6 +82,7 @@ public class PanTest {
 
   @After
   public void tearDown() {
+    ExitInterceptor.disableIntercept();
     sysOutContent = null;
     sysErrContent = null;
     mockRepositoriesMeta = null;


### PR DESCRIPTION
[BACKLOG-44457]-Remove Usage of SecurityManager and Ensure JDK 21 Compatibility in Pentaho_kettle unit tests