### PR TITLE
[BACKLOG-44645] - extend cache invalidation to all managers

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/bowl/CachingManager.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/CachingManager.java
@@ -1,0 +1,24 @@
+package org.pentaho.di.core.bowl;
+
+
+/**
+ * This indicates that the implementing manager can both react to changes and can have others subscribe to changes,
+ * primarily for cache invalidation.
+ * <p>
+ * See CachingManagerFactory for how to use this with BowlManagerFactoryRegistry
+ */
+public interface CachingManager {
+
+  /**
+   * Adds a subscriber that should be notified when the members of this manager are changed.
+   *
+   * @param subscriber an UpdateSubscriber (not necessarily another CachingManager) that should be notified
+   */
+  void addSubscriber( UpdateSubscriber subscriber );
+
+  /**
+   * Notify this manager that changes in another manager have happened.
+   *
+   */
+  void notifyChanged();
+}

--- a/core/src/main/java/org/pentaho/di/core/bowl/CachingManagerFactory.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/CachingManagerFactory.java
@@ -1,0 +1,37 @@
+package org.pentaho.di.core.bowl;
+
+import org.pentaho.di.core.exception.KettleException;
+
+import java.util.WeakHashMap;
+
+/**
+ * Wraps a base factory to apply cache invalidation for updates from managers in parent bowls.
+ *
+ *
+ * @param <T>
+ */
+public class CachingManagerFactory<T extends CachingManager> implements ManagerFactory<T> {
+
+  // need to hang onto the subscriber as long as the Bowl exists
+  private final WeakHashMap<Bowl, UpdateSubscriber> subscribers = new WeakHashMap<>();
+
+  private final Class<T> clazz;
+  private final ManagerFactory<T> baseFactory;
+
+  public CachingManagerFactory( Class<T> clazz, ManagerFactory<T> baseFactory ) {
+    this.clazz = clazz;
+    this.baseFactory = baseFactory;
+  }
+
+  public T apply( Bowl bowl ) throws KettleException {
+    T manager = baseFactory.apply( bowl );
+    if ( !bowl.getParentBowls().isEmpty() ) {
+      UpdateSubscriber subscriber = manager::notifyChanged;
+      for ( Bowl parentBowl : bowl.getParentBowls() ) {
+        parentBowl.getManager( clazz ).addSubscriber( subscriber );
+      }
+      subscribers.put( bowl, subscriber );
+    }
+    return manager;
+  }
+}

--- a/core/src/main/java/org/pentaho/di/core/bowl/UpdateSubscriber.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/UpdateSubscriber.java
@@ -11,14 +11,14 @@
  ******************************************************************************/
 
 
-package org.pentaho.di.connections;
+package org.pentaho.di.core.bowl;
 
 /**
- * Interface to be notified by ConnectionManager when changes are made.
+ * Interface to be notified by a Manager when changes are made.
  *
  */
 @FunctionalInterface
-public interface ConnectionUpdateSubscriber {
+public interface UpdateSubscriber {
 
   /**
    * Notify that any write operation was performed (create/update/delete)

--- a/core/src/test/java/org/pentaho/di/connections/ConnectionManagerTest.java
+++ b/core/src/test/java/org/pentaho/di/connections/ConnectionManagerTest.java
@@ -29,6 +29,7 @@ import org.pentaho.di.connections.vfs.VFSLookupFilter;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.di.core.bowl.UpdateSubscriber;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.metastore.api.IMetaStore;
@@ -163,14 +164,14 @@ public class ConnectionManagerTest {
   @Test
   public void testSubscribers() {
 
-    class MyConnectionUpdateSubscriber implements ConnectionUpdateSubscriber {
+    class MyUpdateSubscriber implements UpdateSubscriber {
         boolean called = false;
 
         public void notifyChanged() {
           called = true;
         }
       };
-    MyConnectionUpdateSubscriber sub = new MyConnectionUpdateSubscriber();
+    MyUpdateSubscriber sub = new MyUpdateSubscriber();
 
     connectionManager.addSubscriber( sub );
     addOne();

--- a/engine/src/main/java/org/pentaho/di/core/KettleEnvironment.java
+++ b/engine/src/main/java/org/pentaho/di/core/KettleEnvironment.java
@@ -20,6 +20,7 @@ import org.pentaho.di.cluster.SlaveServerManager;
 import org.pentaho.di.core.auth.AuthenticationConsumerPluginType;
 import org.pentaho.di.core.auth.AuthenticationProviderPluginType;
 import org.pentaho.di.core.bowl.BowlManagerFactoryRegistry;
+import org.pentaho.di.core.bowl.CachingManagerFactory;
 import org.pentaho.di.core.compress.CompressionPluginType;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettlePluginException;
@@ -263,13 +264,13 @@ public class KettleEnvironment {
    */
   private static void registerSharedObjectManagersWithBowl(){
     BowlManagerFactoryRegistry registry = BowlManagerFactoryRegistry.getInstance();
-    registry.registerManagerFactory( DatabaseManagementInterface.class,
-      new DatabaseConnectionManager.DatabaseConnectionManagerFactory() );
-    registry.registerManagerFactory( SlaveServerManagementInterface.class,
-      new SlaveServerManager.SlaveServerManagerFactory() );
-    registry.registerManagerFactory( ClusterSchemaManagementInterface.class,
-      new ClusterSchemaManager.ClusterSchemaManagerFactory() );
-    registry.registerManagerFactory( PartitionSchemaManagementInterface.class,
-      new PartitionSchemaManager.PartitionSchemaManagerFactory() );
+    registry.registerManagerFactory( DatabaseManagementInterface.class, new CachingManagerFactory(
+      DatabaseManagementInterface.class, new DatabaseConnectionManager.DatabaseConnectionManagerFactory() ) );
+    registry.registerManagerFactory( SlaveServerManagementInterface.class, new CachingManagerFactory(
+      SlaveServerManagementInterface.class, new SlaveServerManager.SlaveServerManagerFactory() ) );
+    registry.registerManagerFactory( ClusterSchemaManagementInterface.class, new CachingManagerFactory(
+      ClusterSchemaManagementInterface.class, new ClusterSchemaManager.ClusterSchemaManagerFactory() ) );
+    registry.registerManagerFactory( PartitionSchemaManagementInterface.class, new CachingManagerFactory(
+      PartitionSchemaManagementInterface.class, new PartitionSchemaManager.PartitionSchemaManagerFactory() ) );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/shared/DatabaseConnectionManagerTest.java
+++ b/engine/src/test/java/org/pentaho/di/shared/DatabaseConnectionManagerTest.java
@@ -13,12 +13,17 @@
 
 package org.pentaho.di.shared;
 
+import org.pentaho.di.core.bowl.BaseBowl;
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.plugins.DatabasePluginType;
 import org.pentaho.di.core.row.value.ValueMetaPluginType;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.metastore.api.IMetaStore;
 
-
+import java.util.Collections;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -80,11 +85,81 @@ public class DatabaseConnectionManagerTest {
     Assert.assertEquals( 1, dbManager.getAll().size() );
   }
 
+  @Test
+  public void testCacheInvalidation() throws Exception {
+    Bowl parentBowl = createTestBowl( null );
+    Bowl childBowl = createTestBowl( parentBowl );
+
+    String name = "meta1";
+
+    DatabaseMeta parentMeta = createDatabase( name );
+    parentMeta.setDBName( "from parent" );
+
+    DatabaseManagementInterface parentManager = parentBowl.getManager( DatabaseManagementInterface.class );
+    DatabaseManagementInterface childManager = childBowl.getManager( DatabaseManagementInterface.class );
+
+    parentManager.add( parentMeta );
+
+    DatabaseMeta readChildMeta = childManager.get( name );
+    Assert.assertNotNull( readChildMeta );
+    Assert.assertEquals( parentMeta.getDatabaseName(), readChildMeta.getDatabaseName() );
+
+    // now change it in the parent, and make sure the child has the updated version
+    parentMeta.setDBName( "edited" );
+    parentManager.add( parentMeta );
+
+    readChildMeta = childManager.get( name );
+    Assert.assertNotNull( readChildMeta );
+    Assert.assertEquals( parentMeta.getDatabaseName(), readChildMeta.getDatabaseName() );
+
+    // remove from parent, make sure it's removed in the child
+    parentManager.remove( name );
+    readChildMeta = childManager.get( name );
+    Assert.assertNull( readChildMeta );
+  }
+
   protected DatabaseMeta createDatabase( String name ) {
     DatabaseMeta db = new DatabaseMeta();
     db.setName( name );
     db.getDatabaseInterface().setDatabaseName( name );
     return db;
   }
+
+  // parentBowl is optional. If present, this bowl will delegate to it.
+  private Bowl createTestBowl( Bowl parentBowl ) {
+    SharedObjectsIO bowlSharedObjectsIO;
+    Set<Bowl> parents;
+
+    if ( parentBowl != null ) {
+      bowlSharedObjectsIO = new DelegatingSharedObjectsIO( new MemorySharedObjectsIO(),
+        parentBowl.getSharedObjectsIO() );
+      parents = Collections.singleton( parentBowl );
+    } else {
+      bowlSharedObjectsIO = new MemorySharedObjectsIO();
+      parents = Collections.emptySet();
+    }
+
+    return new BaseBowl() {
+      @Override
+      public IMetaStore getMetastore() {
+        return null;
+      }
+      @Override
+      public VariableSpace getADefaultVariableSpace() {
+        return null;
+
+      }
+      @Override
+      public Set<Bowl> getParentBowls() {
+        return parents;
+      }
+
+      @Override
+      public SharedObjectsIO getSharedObjectsIO() {
+        return bowlSharedObjectsIO;
+      }
+    };
+  }
+
 
 }


### PR DESCRIPTION
That opt in. This cache invalidation makes sure that changes made in parent/"management" bowls propagate to child/execution bowls that need to see those changes.