### PR TITLE
[BACKLOG-44647] - propagate changes from RepositoryBowl vfs connections

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -543,6 +543,7 @@
               <includes>
                 <include>org/pentaho/di/junit/**</include>
                 <include>org/pentaho/di/concurrency/**</include>
+                <include>org/pentaho/di/connections/**</include>
                 <include>*.xml</include>
               </includes>
             </configuration>

--- a/engine/src/main/java/org/pentaho/di/repository/RepositoryBowl.java
+++ b/engine/src/main/java/org/pentaho/di/repository/RepositoryBowl.java
@@ -23,7 +23,11 @@
 package org.pentaho.di.repository;
 
 import org.pentaho.di.cluster.SlaveServerManagementInterface;
+import org.pentaho.di.connections.ConnectionManager;
 import org.pentaho.di.core.bowl.BaseBowl;
+import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.di.core.bowl.UpdateSubscriber;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.i18n.BaseMessages;
@@ -40,11 +44,31 @@ public class RepositoryBowl extends BaseBowl implements HasRepositoryInterface{
 
   private final Repository repository;
   private final RepositorySharedObjectsIO sharedObjectsIO;
+  // Need to hang on to this reference until 'this' goes out of scope.
+  private UpdateSubscriber defaultBowlUpdater;
 
   public RepositoryBowl( Repository repository ) {
     this.repository = Objects.requireNonNull( repository );
     this.sharedObjectsIO = new RepositorySharedObjectsIO( repository, () ->
       getManager( SlaveServerManagementInterface.class ).getAll() );
+  }
+
+  @Override
+  public <T> T getManager( Class<T> managerClass) throws KettleException {
+    T manager = super.getManager( managerClass );
+    synchronized( this ) {
+      if ( defaultBowlUpdater == null && managerClass == ConnectionManager.class ) {
+        // Ensure changes to this Bowl's VFS connections propagate back to the DefaultBowl's VFS connections
+        // This allows backwards-compatible steps that use backwards-compatible APIs that use DefaultBowl to see changes
+        // written through this RepositoryBowl.
+        ConnectionManager mgr = (ConnectionManager) manager;
+        ConnectionManager defaultMgr = DefaultBowl.getInstance().getManager( ConnectionManager.class );
+        defaultBowlUpdater = () -> defaultMgr.notifyChanged();
+        // inform the Default manager about changes in our connections
+        mgr.addSubscriber( defaultBowlUpdater );
+      }
+    }
+    return manager;
   }
 
   @Override

--- a/engine/src/test/java/org/pentaho/di/repository/RepositoryBowlTest.java
+++ b/engine/src/test/java/org/pentaho/di/repository/RepositoryBowlTest.java
@@ -1,0 +1,85 @@
+package org.pentaho.di.repository;
+
+import org.pentaho.di.connections.common.bucket.TestConnectionWithBucketsDetails;
+import org.pentaho.di.connections.common.bucket.TestConnectionWithBucketsProvider;
+import org.pentaho.di.connections.ConnectionDetails;
+import org.pentaho.di.connections.ConnectionManager;
+import org.pentaho.di.connections.utils.EncryptUtils;
+import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.metastore.stores.memory.MemoryMetaStore;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class RepositoryBowlTest {
+
+  private static final String DESCRIPTION = "Connection Description";
+  private static final String CONNECTION_NAME = "Connection Name";
+  private static final String PASSWORD = "testpassword";
+  private static final String PASSWORD2 = "testpassword2";
+  private static final String ROLE1 = "role1";
+  private static final String ROLE2 = "role2";
+
+  @Test
+  public void testChangeSubscriber() throws Exception {
+    // metastore shared between bowls like they would while connected to a Repository.
+    MemoryMetaStore metastore = new MemoryMetaStore();
+    metastore.setName( "RepositoryBowlTest" );
+    DefaultBowl mockDefaultBowl = spy( DefaultBowl.class );
+
+    Repository mockRepository = mock( Repository.class );
+    RepositoryBowl realRepositoryBowl = new RepositoryBowl( mockRepository );
+    RepositoryBowl mockRepositoryBowl = spy( realRepositoryBowl );
+    mockDefaultBowl.setMetastoreSupplier( () -> metastore );
+    when( mockRepositoryBowl.getMetastore() ).thenReturn( metastore );
+
+    try ( MockedStatic<DefaultBowl> defaultBowlMockedStatic = mockStatic( DefaultBowl.class );
+          MockedStatic<EncryptUtils> encryptUtils = mockStatic( EncryptUtils.class ) ) {
+      when( DefaultBowl.getInstance() ).thenReturn( mockDefaultBowl );
+      ConnectionManager repoManager = mockRepositoryBowl.getManager( ConnectionManager.class );
+      ConnectionManager defaultManager = mockDefaultBowl.getManager( ConnectionManager.class );
+
+      addOne( repoManager );
+      addProvider( defaultManager );
+
+      //initialize caches
+      ConnectionDetails repoRead = repoManager.getConnectionDetails( CONNECTION_NAME );
+      ConnectionDetails defRead = defaultManager.getConnectionDetails( CONNECTION_NAME );
+      assertNotNull( repoRead );
+      assertNotNull( defRead );
+
+      ConnectionDetails clone = repoRead.cloneDetails();
+      clone.setDescription( "Not the original" );
+      repoManager.save( clone );
+      ConnectionDetails defRead2 = defaultManager.getConnectionDetails( CONNECTION_NAME );
+      assertNotNull( defRead2 );
+      assertEquals( clone.getDescription(), defRead2.getDescription() );
+    }
+  }
+
+
+  private void addProvider( ConnectionManager connectionManager ) {
+    connectionManager.addConnectionProvider( TestConnectionWithBucketsProvider.SCHEME,
+      new TestConnectionWithBucketsProvider() );
+  }
+
+  private void addOne( ConnectionManager connectionManager ) {
+    addProvider( connectionManager );
+    TestConnectionWithBucketsDetails testConnectionDetails = new TestConnectionWithBucketsDetails();
+    testConnectionDetails.setDescription( DESCRIPTION );
+    testConnectionDetails.setName( CONNECTION_NAME );
+    testConnectionDetails.setPassword( PASSWORD );
+    testConnectionDetails.setPassword1( PASSWORD2 );
+    testConnectionDetails.getBaRoles().add( ROLE1 );
+    testConnectionDetails.getBaRoles().add( ROLE2 );
+    connectionManager.save( testConnectionDetails );
+  }
+
+}


### PR DESCRIPTION
DefaultBowl and RepositoryBowl each have a ConnectionManager instance that caches connections. The RepositoryBowl is used to make edits.

At runtime, code that has been updated to support Bowls will use the RepositoryBowl to access VFS connections, but code that has not been updated will use legacy APIs that use DefaultBowl. DefaultBowl will still find the connections from the repository metastore thanks to using the metastore locator, but it caches the results. That means that if an edit is made in RepositoryBowl, it will not be reflected in code that uses DefaultBowl.

This change adds cache invalidation to DefaultBowl ConnectionManager whenever edits are made to the RepositoryBowl ConnectionManager.