### PR TITLE
fix[PDI-20494]: save correct String value of "waitfors" in CheckDBConnections job entry

### DIFF
--- a/plugins/core/ui/src/main/java/org/pentaho/di/ui/job/entries/checkdbconnection/JobEntryCheckDbConnectionsDialog.java
+++ b/plugins/core/ui/src/main/java/org/pentaho/di/ui/job/entries/checkdbconnection/JobEntryCheckDbConnectionsDialog.java
@@ -324,7 +324,7 @@ public class JobEntryCheckDbConnectionsDialog extends JobEntryDialog implements 
         TableItem ti = wFields.table.getItem( i );
         if ( jobEntry.getConnections()[i] != null ) {
           ti.setText( 1, jobEntry.getConnections()[i].getName() );
-          ti.setText( 2, "" + Const.toInt( jobEntry.getWaitfors()[i], 0 ) );
+          ti.setText( 2, jobEntry.getWaitfors()[i] );
           ti.setText( 3, JobEntryCheckDbConnections.getWaitTimeDesc( jobEntry.getWaittimes()[i] ) );
         }
       }
@@ -363,7 +363,7 @@ public class JobEntryCheckDbConnectionsDialog extends JobEntryDialog implements 
       DatabaseMeta dbMeta = jobMeta.findDatabase( arg );
       if ( dbMeta != null ) {
         connections[i] = dbMeta;
-        waitfors[i] = "" + Const.toInt( wFields.getNonEmpty( i ).getText( 2 ), 0 );
+        waitfors[i] = wFields.getNonEmpty( i ).getText( 2 );
         waittimes[i] =
           JobEntryCheckDbConnections.getWaitTimeByDesc( wFields.getNonEmpty( i ).getText( 3 ) );
       }


### PR DESCRIPTION
This does not introduce any issues parsing the value since [this line in JobEntryCheckDbConnections.java](https://github.com/pentaho/pentaho-kettle/blob/acb1dd8498f40dbf73b9694325d2ca004379f314/plugins/core/impl/src/main/java/org/pentaho/di/job/entries/checkdbconnection/JobEntryCheckDbConnections.java#L287) correctly checks for environment variable substitution and does also correctly convert the value to integer.