### PR TITLE
[BACKLOG-41965] - avoid leaking Bowls and ConnectionManagers

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/bowl/BowlReference.java
+++ b/core/src/main/java/org/pentaho/di/core/bowl/BowlReference.java
@@ -1,0 +1,44 @@
+package org.pentaho.di.core.bowl;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Wraps a WeakReference to a Bowl and provides equality based on the "==" equality of the referenced Bowl.
+ * Used to prevent leaking Bowls in the vfs layer. 
+ */
+public class BowlReference {
+  private final WeakReference<Bowl> bowlRef;
+
+  public BowlReference( Bowl bowl ) {
+    this.bowlRef = new WeakReference<>( bowl );
+  }
+
+  public Bowl getBowl() {
+    return bowlRef.get();
+  }
+
+  @Override
+  public boolean equals( Object obj ) {
+    if ( this == obj ) {
+      return true;
+    }
+    if ( obj == null || getClass() != obj.getClass() ) {
+      return false;
+    }
+    BowlReference that = (BowlReference) obj;
+    Bowl thisBowl = this.getBowl();
+    Bowl thatBowl = that.getBowl();
+    if ( thisBowl == null || thatBowl == null ) {
+      return false;
+    }
+    // Compare by identity, so that newly opened Bowls get new FileSystems.
+    return thisBowl == thatBowl;
+  }
+
+  // this is used by FileSystemOptions.compareTo, so it needs to match the Bowl identity, not the equals method. 
+  @Override
+  public int hashCode() {
+    Bowl bowl = bowlRef.get();
+    return bowl != null ? System.identityHashCode( bowl ) : 0;
+  }
+}

--- a/core/src/main/java/org/pentaho/di/core/vfs/configuration/KettleGenericFileSystemConfigBuilder.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/configuration/KettleGenericFileSystemConfigBuilder.java
@@ -13,18 +13,19 @@
 
 package org.pentaho.di.core.vfs.configuration;
 
-import java.io.IOException;
-
-import org.apache.commons.vfs2.FileSystemConfigBuilder;
-import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.FileSystem;
-import org.apache.commons.vfs2.util.DelegatingFileSystemOptionsBuilder;
 import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.bowl.BowlReference;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.KettleVFS;
+
+import java.io.IOException;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemConfigBuilder;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.util.DelegatingFileSystemOptionsBuilder;
 
 /**
  * A generic FileSystemConfigBuilder that inserts parameters and values as literally specified.
@@ -146,11 +147,12 @@ public class KettleGenericFileSystemConfigBuilder extends FileSystemConfigBuilde
 
   @Override
   public void setBowl( FileSystemOptions opts, Bowl bowl ) {
-    super.setParam( opts, BOWL_KEY, bowl );
+    super.setParam( opts, BOWL_KEY, new BowlReference( bowl ) );
   }
 
   @Override
   public Bowl getBowl( FileSystemOptions opts ) {
-    return super.getParam( opts, BOWL_KEY );
+    BowlReference bowlRef = (BowlReference) super.getParam( opts, BOWL_KEY );
+    return bowlRef != null ? bowlRef.getBowl() : null;
   }
 }

--- a/core/src/main/resources/org/pentaho/di/core/vfs/messages/messages_en_US.properties
+++ b/core/src/main/resources/org/pentaho/di/core/vfs/messages/messages_en_US.properties
@@ -9,6 +9,7 @@ CustomVfsSettingsParser.Log.FailedToLoad=Failed to load custom vfs settings pars
 ConnectionFileNameParser.ConnectionNameEmpty=Connection name must not be empty.
 ConnectionFileNameParser.ConnectionNameInvalidCharacter=Connection name '{0}' must not contain the character '{1}'.
 ConnectionFileProvider.FailedLoadConnectionManager=Failed to load the bowl's connection manager.
+ConnectionFileSystem.ConnectionManagerGone=Attempted to use filesystem from closed Bowl
 ConnectionFileSystem.ExpectedConnectionNotFound=Expected connection '{0}' to exist.
 ConnectionFileSystem.FailedTransformProviderFilename=Failed to transform provider uri '{0}' to a PVFS uri of connection '{1}'.
 ConnectionFileObject.PVFSRoot.UnsupportedOperation=Unsupported operation at the PVFS root level.


### PR DESCRIPTION
Change references from VFS ConnectionFileSystems and FileSystemOptions to be WeakReferences to Bowls and ConnectionManagers, to a) prevent them from keeping the Bowl in memory when it is no longer being used and b) allow a new Bowl to mean refreshed config for the VFS connections, rather than continuing to use the old cached one that would never be updated, since the Bowl went out of scope.