### PR TITLE
[BACKLOG-49333] Use Bowl vars as default for VFS. Pass vars on bucket browse

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/util/LazyLoader.java
+++ b/core/src/main/java/org/pentaho/di/core/util/LazyLoader.java
@@ -1,12 +1,18 @@
-package org.pentaho.di.plugins.repofvs.pur.converter;
+package org.pentaho.di.core.util;
 
 import java.util.function.Supplier;
 
 /**
- * Calls given supplier once (if successful) and caches the result. Thread-safe.
+ * Calls given supplier once (if non-null) and caches the result. Thread-safe.
+ * <br>
+ * Null values will not be cached. If you wish to use this with a supplier
+ * that returns null, consider wrapping it in an {@link java.util.Optional Optional}
  */
 public class LazyLoader<T> implements Supplier<T> {
   private final Supplier<T> loader;
+
+    // yes, sonar, volatile doesn't make T thread-safe...
+  @SuppressWarnings( "java:S3077" )
   private volatile T value;
 
   public LazyLoader( Supplier<T> loader ) {

--- a/core/src/main/java/org/pentaho/di/core/vfs/KettleVFSImpl.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/KettleVFSImpl.java
@@ -19,8 +19,8 @@ import org.pentaho.di.connections.vfs.provider.ConnectionFileSystem;
 import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.util.LazyLoader;
 import org.pentaho.di.core.util.UUIDUtil;
-import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.vfs.configuration.IKettleFileSystemConfigBuilder;
 import org.pentaho.di.core.vfs.configuration.KettleFileSystemConfigBuilderFactory;
@@ -35,6 +35,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.function.Supplier;
 
 import org.apache.commons.vfs2.FileContent;
 import org.apache.commons.vfs2.FileObject;
@@ -57,23 +58,17 @@ public class KettleVFSImpl implements IKettleVFS {
 
   private final Bowl bowl;
 
-  private static VariableSpace defaultVariableSpace;
-
-  static {
-    // Create a new empty variable space...
-    //
-    defaultVariableSpace = new Variables();
-    defaultVariableSpace.initializeVariablesFrom( null );
-  }
+  private Supplier<VariableSpace> defaultVariableSpace;
 
   // non-public. Should only be created by the factory in KettleVFS
   KettleVFSImpl( Bowl bowl ) {
     this.bowl = Preconditions.checkNotNull( bowl );
+    this.defaultVariableSpace = new LazyLoader<>( bowl::getADefaultVariableSpace );
   }
 
   @Override
   public FileObject getFileObject( String vfsFilename ) throws KettleFileException {
-    return getFileObject( vfsFilename, defaultVariableSpace );
+    return getFileObject( vfsFilename, defaultVariableSpace.get() );
   }
 
   @Override
@@ -83,7 +78,7 @@ public class KettleVFSImpl implements IKettleVFS {
 
   @Override
   public FileObject getFileObject( String vfsFilename, FileSystemOptions fsOptions ) throws KettleFileException {
-    return getFileObject( vfsFilename, defaultVariableSpace, fsOptions );
+    return getFileObject( vfsFilename, defaultVariableSpace.get(), fsOptions );
   }
 
   // IMPORTANT:
@@ -185,7 +180,7 @@ public class KettleVFSImpl implements IKettleVFS {
       return null;
     }
     if ( varSpace == null ) {
-      varSpace = defaultVariableSpace;
+      varSpace = defaultVariableSpace.get();
     }
 
     IKettleFileSystemConfigBuilder configBuilder =
@@ -230,7 +225,7 @@ public class KettleVFSImpl implements IKettleVFS {
 
   @Override
   public String getFriendlyURI( String filename ) {
-    return getFriendlyURI( filename, defaultVariableSpace );
+    return getFriendlyURI( filename, defaultVariableSpace.get() );
   }
 
   @Override
@@ -308,7 +303,7 @@ public class KettleVFSImpl implements IKettleVFS {
 
   @Override
   public InputStream getInputStream( String vfsFilename ) throws KettleFileException {
-    return getInputStream( vfsFilename, defaultVariableSpace );
+    return getInputStream( vfsFilename, defaultVariableSpace.get() );
   }
 
   @Override
@@ -354,7 +349,7 @@ public class KettleVFSImpl implements IKettleVFS {
 
   @Override
   public OutputStream getOutputStream( String vfsFilename, boolean append ) throws KettleFileException {
-    return getOutputStream( vfsFilename, defaultVariableSpace, append );
+    return getOutputStream( vfsFilename, defaultVariableSpace.get(), append );
   }
 
   @Override
@@ -431,8 +426,7 @@ public class KettleVFSImpl implements IKettleVFS {
 
   @Override
   public void reset() {
-    defaultVariableSpace = new Variables();
-    defaultVariableSpace.initializeVariablesFrom( null );
+    defaultVariableSpace = new LazyLoader<>( bowl::getADefaultVariableSpace );
   }
 
 

--- a/core/src/test/java/org/pentaho/di/connections/vfs/provider/ConnectionFileProviderTest.java
+++ b/core/src/test/java/org/pentaho/di/connections/vfs/provider/ConnectionFileProviderTest.java
@@ -160,8 +160,9 @@ public class ConnectionFileProviderTest {
       }
       @Override
       public VariableSpace getADefaultVariableSpace() {
-        return null;
-
+        var vars = new Variables();
+        vars.initializeVariablesFrom( null );
+        return vars;
       }
       @Override
       public Set<Bowl> getParentBowls() {

--- a/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/VFSFileProvider.java
+++ b/plugins/file-open-save-new/core/src/main/java/org/pentaho/di/plugins/fileopensave/providers/vfs/VFSFileProvider.java
@@ -315,6 +315,7 @@ public class VFSFileProvider extends BaseFileProvider<VFSFile> implements Update
 
     if ( fileName.isConnectionRoot() ) {
       VFSConnectionDetails details = getExistingDetails( bowl, fileName );
+      details.setSpace( space );
       if ( usesBuckets( details ) ) {
         return getBuckets( bowl, file, fileName, details );
       }

--- a/plugins/repo-vfs/repo-vfs-pdi/src/main/java/org/pentaho/di/repovfs/plugin/client/ClientRepositoryLoader.java
+++ b/plugins/repo-vfs/repo-vfs-pdi/src/main/java/org/pentaho/di/repovfs/plugin/client/ClientRepositoryLoader.java
@@ -3,7 +3,7 @@ package org.pentaho.di.repovfs.plugin.client;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.RepositoryPluginType;
-import org.pentaho.di.plugins.repofvs.pur.converter.LazyLoader;
+import org.pentaho.di.core.util.LazyLoader;
 import org.pentaho.di.plugins.repofvs.pur.vfs.PurFileSystemConfig;
 import org.pentaho.di.repository.RepositoriesMeta;
 import org.pentaho.di.repository.Repository;


### PR DESCRIPTION
VFS file resolution done without passing a VariableSpace will now default to using variables from the bowl.

File open-save-dialog wasn't setting a variable space when creating details for bucket listing