### PR TITLE
FUSE-265 CMS connection provider for KTR files

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -458,6 +458,22 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${fasterxml-jackson.non-osgi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${fasterxml-jackson.non-osgi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml-jackson.non-osgi.version}</version>
+    </dependency>
+
     <!-- Endorsed Standards Excluded from Java 11+ -->
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/core/src/main/java/org/pentaho/di/core/database/BaseDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/BaseDatabaseMeta.java
@@ -261,6 +261,7 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterfaceEx
 
   private static final String FIELDNAME_PROTECTOR = "_";
 
+  private String id;
   private String name;
   private String displayName;
   private int accessType; // Database.TYPE_ODBC / NATIVE / OCI
@@ -363,6 +364,16 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterfaceEx
   @Override
   public void setChanged( boolean changed ) {
     this.changed = changed;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public void setId( String id ) {
+    this.id = id;
   }
 
   /**

--- a/core/src/main/java/org/pentaho/di/core/database/ConnectionManagementServiceMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/ConnectionManagementServiceMeta.java
@@ -1,0 +1,235 @@
+package org.pentaho.di.core.database;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.HttpClientManager;
+
+import java.io.IOException;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Acts as a placeholder for the Connection Management Service connection, which is not a real database, but needs to be
+ * acting as one in the internal flow.
+ * <p>
+ * Internally contains an instance of a real database and proxies all calls to it after it's data is fetched from the
+ * connection management service.
+ */
+public class ConnectionManagementServiceMeta extends BaseDatabaseMeta implements DatabaseInterface {
+
+    public static final String SERVICE_URL_VAR = "CONNECTION_MANAGEMENT_SERVICE_URL";
+
+    public static final String TOKEN_VAR = "CONNECTION_MANAGEMENT_SERVICE_TOKEN";
+
+    private DatabaseInterface delegate;
+
+    @Override
+    public String getFieldDefinition(ValueMetaInterface v, String tk, String pk, boolean useAutoinc, boolean addFieldName, boolean addCr) {
+        return delegate == null ? null : delegate.getFieldDefinition(v, tk, pk, useAutoinc, addFieldName, addCr);
+    }
+
+    @Override
+    public int[] getAccessTypeList() {
+        return delegate == null ? new int[]{} : delegate.getAccessTypeList();
+    }
+
+    @Override
+    public String getDriverClass() {
+        return delegate == null ? null : delegate.getDriverClass();
+    }
+
+    @Override
+    public String getURL(String hostname, String port, String databaseName) throws KettleDatabaseException {
+        return delegate == null ? null : delegate.getURL(hostname, port, databaseName);
+    }
+
+    @Override
+    public boolean supportsIndexes() {
+        return delegate != null && delegate.supportsIndexes();
+    }
+
+    @Override
+    public String getAddColumnStatement(String tablename, ValueMetaInterface v, String tk, boolean useAutoinc, String pk, boolean semicolon) {
+        return delegate == null ? null : delegate.getAddColumnStatement(tablename, v, tk, useAutoinc, pk, semicolon);
+    }
+
+    @Override
+    public String getModifyColumnStatement(String tablename, ValueMetaInterface v, String tk, boolean useAutoinc, String pk, boolean semicolon) {
+        return delegate == null ? null : delegate.getModifyColumnStatement(tablename, v, tk, useAutoinc, pk, semicolon);
+    }
+
+    @Override
+    public String[] getUsedLibraries() {
+        return delegate == null ? new String[]{} : delegate.getUsedLibraries();
+    }
+
+    @Override
+    public String getSQLListOfSchemas(DatabaseMeta dbMeta) {
+        return delegate == null ? null : delegate.getSQLListOfSchemas(dbMeta);
+    }
+
+    @Override
+    public SqlScriptParser createSqlScriptParser() {
+        return delegate == null ? null : delegate.createSqlScriptParser();
+    }
+
+    @Override
+    public boolean supportsStandardTableOutput() {
+        return delegate != null && delegate.supportsStandardTableOutput();
+    }
+
+    @Override
+    public String getUnsupportedTableOutputMessage() {
+        return delegate == null ? null : delegate.getUnsupportedTableOutputMessage();
+    }
+
+    @Override
+    public String getLegacyColumnName(DatabaseMetaData dbMetaData, ResultSetMetaData rsMetaData, int index) throws KettleDatabaseException {
+        return delegate == null ? null : delegate.getLegacyColumnName(dbMetaData, rsMetaData, index);
+    }
+
+    @Override
+    public void putOptionalOptions(Map<String, String> extraOptions) {
+        if (delegate != null) {
+            delegate.putOptionalOptions(extraOptions);
+        };
+    }
+
+    @Override
+    public ResultSet getSchemas(DatabaseMetaData databaseMetaData, DatabaseMeta dbMeta) throws SQLException {
+        return delegate == null ? null : delegate.getSchemas(databaseMetaData, dbMeta);
+    }
+
+    @Override
+    public ResultSet getTables(DatabaseMetaData databaseMetaData, DatabaseMeta dbMeta, String schemaPattern, String tableNamePattern, String[] tableTypes) throws SQLException {
+        return delegate == null ? null : delegate.getTables(databaseMetaData, dbMeta, schemaPattern, tableNamePattern, tableTypes);
+    }
+
+    @Override
+    public List<String> getNamedClusterList() {
+        return delegate == null ? Collections.emptyList() : delegate.getNamedClusterList();
+    }
+
+    @Override
+    public void setConnectionSpecificInfoFromAttributes(Map<String, String> attributes) {
+        if (delegate != null) {
+            delegate.setConnectionSpecificInfoFromAttributes(attributes);
+        }
+    }
+
+    @Override
+    public String getHostname() {
+        return delegate == null ? null : delegate.getHostname();
+    }
+
+    @Override
+    public String getDatabasePortNumberString() {
+        return delegate == null ? null : delegate.getDatabasePortNumberString();
+    }
+
+    @Override
+    public String getUsername() {
+        return delegate == null ? null : delegate.getUsername();
+    }
+
+    @Override
+    public String getPassword() {
+        return delegate == null ? null : delegate.getPassword();
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return delegate == null ? null : delegate.getDatabaseName();
+    }
+
+    public boolean isDataLoaded() {
+        return delegate != null;
+    }
+
+    public DatabaseInterface getDelegateDatabaseInterface() {
+        return delegate;
+    }
+
+    public void fetchConnectionDetails() {
+
+        try (var client = getHttpClient()) {
+            var request = prepareRequest();
+            var response = client.execute(request);
+            var connectionDetails = verifyResponse(response);
+
+            parseConnectionResponse(connectionDetails);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    private HttpGet prepareRequest() {
+        var requestUrl = System.getenv(SERVICE_URL_VAR) + this.getId();
+        var request =new HttpGet( requestUrl );
+
+        var token = System.getenv(TOKEN_VAR);
+        request.addHeader("Content-Type", "application/json");
+        request.addHeader("Authorization", "Bearer " + token);
+
+        return request;
+    }
+
+    private JsonNode verifyResponse(HttpResponse response) throws IOException {
+        var statusCode = response.getStatusLine().getStatusCode();
+
+        if (statusCode != 200) {
+            throw new RuntimeException("Failed to fetch connection details from the connection management service. Status code: " + statusCode);
+        }
+
+        var content = new String(response.getEntity().getContent().readAllBytes());
+        var mapper = new ObjectMapper();
+
+        return mapper.readTree(content);
+    }
+
+    private void parseConnectionResponse(JsonNode connectionNode) {
+        var databaseConnection = connectionNode.path("databaseConnection");
+        var detail = databaseConnection.path("detail");
+        var type = detail.path("databaseType").path("shortName").asText();
+
+        try {
+            this.delegate = DatabaseMeta.getDatabaseInterface(type);
+
+            this.delegate.setId(databaseConnection.path("id").asText());
+            this.delegate.setName(databaseConnection.path("name").asText());
+            this.delegate.setHostname(detail.path("hostname").asText() );
+            this.delegate.setDatabaseName(detail.path("databaseName").asText());
+            this.delegate.setDatabasePortNumberString(detail.path("databasePort").asText());
+
+            // TODO: process credentials properly
+            // this.delegate.setUsername(databaseConnection.path("credentials").path("username").asText());
+            // this.delegate.setPassword(databaseConnection.path("credentials").path("password").asText());
+            this.delegate.setUsername("myuser");
+            this.delegate.setPassword("Encrypted ");
+
+            this.delegate.setDataTablespace(detail.path("dataTablespace").asText());
+            this.delegate.setIndexTablespace(detail.path("indexTablespace").asText());
+
+            // connection.put( "access", databaseConnectionDetail.path("accessType").asText() );
+            // connection.put( "servername", dbConnectionDTO.getServer() );
+        } catch (KettleDatabaseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CloseableHttpClient getHttpClient() {
+        return HttpClientManager.getInstance()
+                .createBuilder()
+                .build();
+    }
+}

--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -583,7 +583,9 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
         password = clusterPassword;
       } else {
         username = environmentSubstitute( databaseMeta.getUsername() );
-        password = Encr.decryptPasswordOptionallyEncrypted( environmentSubstitute( databaseMeta.getPassword() ) );
+
+        // In order for Spike to work passwords do not use encryption
+        password = environmentSubstitute( databaseMeta.getPassword() );
       }
 
       Properties properties = databaseMeta.getConnectionProperties();

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
@@ -80,6 +80,17 @@ public interface DatabaseInterface extends Cloneable {
   void setChanged( boolean changed );
 
   /**
+   * @return Returns connection Id in the connection management service.
+   */
+  String getId();
+
+  /**
+   * @param id
+   *      The connection Id to set.
+   */
+  void setId( String id );
+
+  /**
    * @return Returns the connection Name.
    */
   String getName();

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
@@ -14,6 +14,7 @@
 
 package org.pentaho.di.core.database;
 
+import org.apache.commons.lang3.StringUtils;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.encryption.Encr;
@@ -505,6 +506,11 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
    * @return the system dependend database interface for this database metadata definition
    */
   public DatabaseInterface getDatabaseInterface() {
+    // if database interface is a proxy one, and it has loaded the actual one - return it
+    if ( databaseInterface instanceof ConnectionManagementServiceMeta cmsMeta && cmsMeta.isDataLoaded()) {
+      return cmsMeta.getDelegateDatabaseInterface();
+    }
+
     return databaseInterface;
   }
 
@@ -548,6 +554,10 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
    *           when the type could not be found or referenced.
    */
   private static final DatabaseInterface findDatabaseInterface( String databaseTypeDesc ) throws KettleDatabaseException {
+    if ( StringUtils.isBlank( databaseTypeDesc ) ) {
+      return new ConnectionManagementServiceMeta();
+    }
+
     PluginRegistry registry = PluginRegistry.getInstance();
     PluginInterface plugin = registry.getPlugin( DatabasePluginType.class, databaseTypeDesc );
     if ( plugin == null ) {
@@ -590,9 +600,16 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
 
   public void replaceMeta( DatabaseMeta databaseMeta, boolean cloneUpdateFlag ) {
     this.setValues(
-      databaseMeta.getName(), databaseMeta.getPluginId(), databaseMeta.getAccessTypeDesc(), databaseMeta
-        .getHostname(), databaseMeta.getDatabaseName(), databaseMeta.getDatabasePortNumberString(),
-      databaseMeta.getUsername(), databaseMeta.getPassword() );
+            databaseMeta.getId(),
+            databaseMeta.getName(),
+            databaseMeta.getPluginId(),
+            databaseMeta.getAccessTypeDesc(),
+            databaseMeta.getHostname(),
+            databaseMeta.getDatabaseName(),
+            databaseMeta.getDatabasePortNumberString(),
+            databaseMeta.getUsername(),
+            databaseMeta.getPassword()
+    );
     this.setServername( databaseMeta.getServername() );
     this.setDataTablespace( databaseMeta.getDataTablespace() );
     this.setIndexTablespace( databaseMeta.getIndexTablespace() );
@@ -610,7 +627,11 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     replaceMeta( databaseMeta, false );
   }
 
-  public void setValues( String name, String type, String access, String host, String db, String port,
+  public void setValues( String name, String type, String access, String host, String db, String port, String user, String pass ) {
+    setValues( null, name, type, access, host, db, port, user, pass);
+  }
+
+  public void setValues( String id, String name, String type, String access, String host, String db, String port,
     String user, String pass ) {
     try {
       databaseInterface = getDatabaseInterface( type );
@@ -618,6 +639,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
       throw new RuntimeException( "Database type not found!", kde );
     }
 
+    setId( id );
     setName( name );
     setAccessType( getAccessType( access ) );
     setHostname( host );
@@ -638,6 +660,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
       throw new RuntimeException( "Database type [" + type + "] not found!", kde );
     }
 
+    setId( oldInterface.getId() );
     setName( oldInterface.getName() );
     setDisplayName( oldInterface.getDisplayName() );
     setAccessType( oldInterface.getAccessType() );
@@ -654,6 +677,14 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
 
   public void setValues( DatabaseMeta info ) {
     databaseInterface = (DatabaseInterface) info.databaseInterface.clone();
+  }
+
+  public void setId( String id) {
+    databaseInterface.setId( id );
+  }
+
+  public String getId() {
+    return databaseInterface.getId();
   }
 
   /**
@@ -970,6 +1001,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
       
       setDefaultAttributesValues();
 
+      setId( XMLHandler.getTagValue( con, "id" ) );
       setName( XMLHandler.getTagValue( con, "name" ) );
       setDisplayName( getName() );
       setHostname( XMLHandler.getTagValue( con, "server" ) );
@@ -1030,6 +1062,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     StringBuilder retval = new StringBuilder( 250 );
 
     retval.append( "  <" ).append( XML_TAG ).append( '>' ).append( Const.CR );
+    retval.append( "    " ).append( XMLHandler.addTagValue( "id", getId() ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "name", getName() ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "server", getHostname() ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "type", getPluginId() ) );
@@ -1072,6 +1105,10 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
 
     retval.append( "  </" + XML_TAG + ">" ).append( Const.CR );
     return retval.toString();
+  }
+
+  public boolean isConnectionManagementServiceConnection() {
+    return databaseInterface instanceof ConnectionManagementServiceMeta;
   }
 
   @Override

--- a/engine/src/main/java/org/pentaho/di/core/util/ConnectionUtil.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/ConnectionUtil.java
@@ -15,7 +15,11 @@ package org.pentaho.di.core.util;
 
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.connections.ConnectionManager;
+import org.pentaho.di.core.database.ConnectionManagementServiceMeta;
+import org.pentaho.di.core.database.DatabaseInterface;
+import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.metastore.MetaStoreConst;
+import org.pentaho.di.trans.TransMeta;
 
 /**
  * Utility for managing embedded named connections
@@ -35,4 +39,23 @@ public class ConnectionUtil {
     connectionManager.setMetastoreSupplier( MetaStoreConst.getDefaultMetastoreSupplier() );
   }
 
+  /**
+   * Find remote connection-management-service connections and initiate them.
+   *
+   * @param meta The meta containing named connections
+   */
+  public static void initConnectionManagementServiceConnections( TransMeta meta) {
+    meta.getSteps().forEach(step -> {
+      DatabaseMeta[] dbMetaList = step.getStepMetaInterface().getUsedDatabaseConnections();
+
+      if ( dbMetaList.length != 0 ) {
+        DatabaseMeta dbMeta = dbMetaList[0];
+        DatabaseInterface dbInterface = dbMeta.getDatabaseInterface();
+
+        if (dbInterface instanceof ConnectionManagementServiceMeta cmsMeta) {
+          cmsMeta.fetchConnectionDetails();
+        }
+      }
+    });
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/shared/BaseSharedObjectsManager.java
+++ b/engine/src/main/java/org/pentaho/di/shared/BaseSharedObjectsManager.java
@@ -119,9 +119,11 @@ public abstract class BaseSharedObjectsManager<T extends SharedObjectInterface<T
 
       sharedObjectsIO.saveSharedObject( sharedObjectType, name, node );
       Node readBackNode = sharedObjectsIO.getSharedObject( sharedObjectType, name );
-      T readBack = createSharedObjectUsingNode( readBackNode );
 
-      sharedObjectsMap.put( name, readBack.makeClone() );
+      if ( readBackNode != null ) {
+        T readBack = createSharedObjectUsingNode( readBackNode );
+        sharedObjectsMap.put( name, readBack.makeClone() );
+      }
     } finally {
       sharedObjectsIO.unlock();
     }

--- a/engine/src/main/java/org/pentaho/di/shared/RepositorySharedObjectsIO.java
+++ b/engine/src/main/java/org/pentaho/di/shared/RepositorySharedObjectsIO.java
@@ -202,23 +202,19 @@ public class RepositorySharedObjectsIO implements SharedObjectsIO {
 
   @Override
   public void saveSharedObject( String type, String name, Node node ) throws KettleException {
-    SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
+    var objectType = SharedObjectType.valueOf( type.toUpperCase() );
+    var repoElement = switch (objectType) {
+        case CONNECTION -> new DatabaseMeta(node);
+//      // in case we do not want to persist database meta
+//        {
+//          var dbMeta = new DatabaseMeta(node);
+//          yield dbMeta.isConnectionManagementServiceConnection() ? null : dbMeta;
+//        }
+        case SLAVESERVER -> new SlaveServer(node);
+        case PARTITIONSCHEMA -> new PartitionSchema(node);
+        case CLUSTERSCHEMA -> new ClusterSchema(node, slaveServerSupplier.get());
+    };
 
-    RepositoryElementInterface repoElement = null;
-    switch ( objectType ) {
-      case CONNECTION:
-        repoElement = new DatabaseMeta( node );
-        break;
-      case SLAVESERVER:
-        repoElement = new SlaveServer( node );
-        break;
-      case PARTITIONSCHEMA:
-        repoElement = new PartitionSchema( node );
-        break;
-      case CLUSTERSCHEMA:
-        repoElement = new ClusterSchema( node, slaveServerSupplier.get() );
-        break;
-    }
     if ( repoElement != null ) {
       repository.save( repoElement, Const.VERSION_COMMENT_EDIT_VERSION, null );
     }

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -832,6 +832,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     transMeta.activateParameters();
     ConnectionUtil.init( transMeta );
 
+    ConnectionUtil.initConnectionManagementServiceConnections( transMeta );
+
     if ( transMeta.getName() == null ) {
       if ( transMeta.getFilename() != null ) {
         log.logBasic( BaseMessages.getString( PKG, "Trans.Log.DispacthingStartedForFilename", transMeta

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/DatabaseDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/DatabaseDelegate.java
@@ -26,11 +26,7 @@ import org.pentaho.platform.api.repository2.unified.data.node.DataProperty;
 import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFileData;
 import org.pentaho.platform.repository.RepositoryFilenameUtils;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 public class DatabaseDelegate extends AbstractDelegate implements ITransformer, SharedObjectAssembler<DatabaseMeta>,
     java.io.Serializable {
@@ -84,6 +80,7 @@ public class DatabaseDelegate extends AbstractDelegate implements ITransformer, 
 
     // Then the basic db information
     //
+    rootNode.setProperty( "ID", databaseMeta.getId() );
     rootNode.setProperty( PROP_TYPE, databaseMeta.getPluginId() );
     rootNode.setProperty( PROP_CONTYPE, DatabaseMeta.getAccessTypeDesc( databaseMeta.getAccessType() ) );
     rootNode.setProperty( PROP_HOST_NAME, databaseMeta.getHostname() );
@@ -149,13 +146,17 @@ public class DatabaseDelegate extends AbstractDelegate implements ITransformer, 
   public void dataNodeToElement( final DataNode rootNode, final RepositoryElementInterface element )
     throws KettleException {
     DatabaseMeta databaseMeta = (DatabaseMeta) element;
+
+    // if there is an ID - no need for the rest of the fields?
+    databaseMeta.setId( getString( rootNode, "ID" ) );
     databaseMeta.setDatabaseType( getString( rootNode, PROP_TYPE ) );
     databaseMeta.setAccessType( DatabaseMeta.getAccessType( getString( rootNode, PROP_CONTYPE ) ) );
     databaseMeta.setHostname( getString( rootNode, PROP_HOST_NAME ) );
     databaseMeta.setDBName( getString( rootNode, PROP_DATABASE_NAME ) );
     databaseMeta.setDBPort( getString( rootNode, PROP_PORT ) );
     databaseMeta.setUsername( getString( rootNode, PROP_USERNAME ) );
-    databaseMeta.setPassword( Encr.decryptPasswordOptionallyEncrypted( getString( rootNode, PROP_PASSWORD ) ) );
+    // in order for the spike to work we need to disable encryption
+    databaseMeta.setPassword( getString( rootNode, PROP_PASSWORD ) );
     databaseMeta.setServername( getString( rootNode, PROP_SERVERNAME ) );
     databaseMeta.setDataTablespace( getString( rootNode, PROP_DATA_TBS ) );
     databaseMeta.setIndexTablespace( getString( rootNode, PROP_INDEX_TBS ) );


### PR DESCRIPTION
### [FUSE-265](https://hv-eng.atlassian.net/browse/FUSE-265) CMS connection provider for KTR files

Spike for integration of the connection management service into the kettle-core project.

### What was done?

Main change is addition of a new DatabaseMeta implementation, namely ConnectionManagementServiceMeta. Goal of this implementation is to serve as a proxy to a real connection in the connection management service while containing the necessary minimum information in the kettle-core right until the transformation execution. This means that by default this meta contains connection Id (from the connection management service) and a connection name. While being imported into Pentaho Server this data is used and no actual connection info is being fetched. This produces some issues as Type of the connection is unknown, so some places still might break. ConnectionManagementServiceMeta tries to avoid defining itself for as long as possible. During the transformation preparation phase specific call to a DatabaseMeta is done and if it is of a CMS type - it will fetch the real connection data. After this calls to this meta will be proxied to the underlying delegate object (this point needs to be refined more as it is prone to confusing behaviour). Thus during transformation execution this meta will provide ACTUAL  database type which will allow for a proper drivers/plugins to be loaded and used.

[FUSE-265]: https://hv-eng.atlassian.net/browse/FUSE-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ