### PR TITLE
[BACKLOG-48954] enhance RunConfiguration Manager lifecycle

### DIFF
--- a/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
+++ b/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
@@ -307,6 +307,8 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
       this.proxyHostname = slaveServer.proxyHostname;
       this.proxyPort = slaveServer.proxyPort;
       this.nonProxyHosts = slaveServer.nonProxyHosts;
+      this.propertiesMasterName = slaveServer.propertiesMasterName;
+      this.overrideExistingProperties = slaveServer.overrideExistingProperties;
       this.master = slaveServer.master;
 
       this.id = slaveServer.id;
@@ -515,6 +517,15 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
   }
 
   /**
+   * @param propertiesMasterName the master name for reading properties
+   */
+  public void setPropertiesMasterName( String propertiesMasterName ) {
+    lock.writeLock().lock();
+    this.propertiesMasterName = propertiesMasterName;
+    lock.writeLock().unlock();
+  }
+
+  /**
    * @return flag for read properties from Master
    */
   public boolean isOverrideExistingProperties() {
@@ -524,6 +535,15 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
     } finally {
       lock.readLock().unlock();
     }
+  }
+
+  /**
+   * @param overrideExistingProperties flag for overriding existing properties from master
+   */
+  public void setOverrideExistingProperties( boolean overrideExistingProperties ) {
+    lock.writeLock().lock();
+    this.overrideExistingProperties = overrideExistingProperties;
+    lock.writeLock().unlock();
   }
 
   /**

--- a/plugins/engine-configuration/api/src/main/java/org/pentaho/di/engine/configuration/api/RunConfigurationProvider.java
+++ b/plugins/engine-configuration/api/src/main/java/org/pentaho/di/engine/configuration/api/RunConfigurationProvider.java
@@ -17,6 +17,8 @@ package org.pentaho.di.engine.configuration.api;
  * Created by bmorrise on 3/16/17.
  */
 public interface RunConfigurationProvider extends RunConfigurationFactory {
+  String DEFAULT_CONFIG_NAME = "Pentaho local";
+
   RunConfiguration getConfiguration();
   RunConfigurationExecutor getExecutor();
   String getType();

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/RunConfigurationManager.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/RunConfigurationManager.java
@@ -13,12 +13,12 @@
 
 package org.pentaho.di.engine.configuration.impl;
 
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.engine.configuration.api.CheckedMetaStoreSupplier;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
 import org.pentaho.di.engine.configuration.api.RunConfigurationExecutor;
 import org.pentaho.di.engine.configuration.api.RunConfigurationProvider;
 import org.pentaho.di.engine.configuration.api.RunConfigurationService;
-import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,6 +31,16 @@ public class RunConfigurationManager implements RunConfigurationService {
 
   private final List<RunConfigurationProvider> runConfigurationProviders;
 
+  public static RunConfigurationManager getInstance( Bowl bowl ) {
+    return new RunConfigurationManager(
+      RunConfigurationProviderFactoryManagerImpl.getInstance().generateProviders( bowl::getMetastore ) );
+  }
+
+  /**
+   * @deprecated Use {@link #getInstance(Bowl)} or {@link Bowl#getManager(Class)} with
+   * {@code RunConfigurationService.class} instead.
+   */
+  @Deprecated
   public static RunConfigurationManager getInstance( CheckedMetaStoreSupplier bowlSupplier ) {
     return new RunConfigurationManager(
       RunConfigurationProviderFactoryManagerImpl.getInstance().generateProviders( bowlSupplier ) );
@@ -51,7 +61,7 @@ public class RunConfigurationManager implements RunConfigurationService {
       runConfigurations.addAll( runConfigurationProvider.load() );
     }
     Collections.sort( runConfigurations, ( o1, o2 ) -> {
-      if ( o2.getName().equals( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
+      if ( o2.getName().equals( RunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
         return 1;
       }
       return o1.getName().compareToIgnoreCase( o2.getName() );
@@ -107,7 +117,7 @@ public class RunConfigurationManager implements RunConfigurationService {
       names.addAll( runConfigurationProvider.getNames() );
     }
     Collections.sort( names, ( o1, o2 ) -> {
-      if ( o2.equals( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
+      if ( o2.equals( RunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
         return 1;
       }
       return o1.compareToIgnoreCase( o2 );
@@ -121,7 +131,7 @@ public class RunConfigurationManager implements RunConfigurationService {
       names.addAll( runConfigurationProvider.getNames() );
     }
     Collections.sort( names, ( o1, o2 ) -> {
-      if ( o2.equals( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
+      if ( o2.equals( RunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
         return 1;
       }
       return o1.compareToIgnoreCase( o2 );

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/RunConfigurationManager.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/RunConfigurationManager.java
@@ -13,6 +13,7 @@
 
 package org.pentaho.di.engine.configuration.impl;
 
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.engine.configuration.api.CheckedMetaStoreSupplier;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
 import org.pentaho.di.engine.configuration.api.RunConfigurationExecutor;
@@ -31,6 +32,15 @@ public class RunConfigurationManager implements RunConfigurationService {
 
   private final List<RunConfigurationProvider> runConfigurationProviders;
 
+  public static RunConfigurationManager getInstance( Bowl bowl ) {
+    return getInstance( bowl::getMetastore );
+  }
+
+  /**
+   * @deprecated Use {@link #getInstance(Bowl)} or {@link Bowl#getManager(Class)} with
+   * {@code RunConfigurationService.class} instead.
+   */
+  @Deprecated
   public static RunConfigurationManager getInstance( CheckedMetaStoreSupplier bowlSupplier ) {
     return new RunConfigurationManager(
       RunConfigurationProviderFactoryManagerImpl.getInstance().generateProviders( bowlSupplier ) );

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/RunConfigurationProviderFactoryManagerImpl.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/RunConfigurationProviderFactoryManagerImpl.java
@@ -12,20 +12,21 @@
 
 package org.pentaho.di.engine.configuration.impl;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.pentaho.di.core.bowl.BowlManagerFactoryRegistry;
 import org.pentaho.di.core.exception.KettlePluginException;
 import org.pentaho.di.core.service.PluginServiceLoader;
 import org.pentaho.di.engine.configuration.api.CheckedMetaStoreSupplier;
 import org.pentaho.di.engine.configuration.api.RunConfigurationProvider;
 import org.pentaho.di.engine.configuration.api.RunConfigurationProviderFactory;
 import org.pentaho.di.engine.configuration.api.RunConfigurationProviderFactoryManager;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProviderFactory;
-import org.pentaho.di.metastore.MetaStoreConst;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The RunConfigurationProviderFactoryManager is used to manage the registration of RunConfiguration types and
@@ -52,6 +53,9 @@ public class RunConfigurationProviderFactoryManagerImpl implements RunConfigurat
   }
 
   private RunConfigurationProviderFactoryManagerImpl() {
+    BowlManagerFactoryRegistry.getInstance().registerManagerFactory( RunConfigurationService.class,
+      bowl -> new RunConfigurationManager( getInstance().generateProviders( bowl::getMetastore ) ) );
+
     factories = new ArrayList<>();
     factories.add( new DefaultRunConfigurationProviderFactory() );
 

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationExtensionPoint.java
@@ -17,7 +17,8 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.ui.spoon.Spoon;
 
 import java.util.ArrayList;
@@ -36,8 +37,9 @@ public class RunConfigurationExtensionPoint implements ExtensionPointInterface {
     List<String> runConfigurations = (ArrayList<String>) ( (Object[]) o )[ 0 ];
     String type = (String) ( (Object[]) o )[ 1 ];
 
-    RunConfigurationManager runConfigurationManager =
-      RunConfigurationManager.getInstance( () -> Spoon.getInstance().getExecutionBowl().getMetastore() );
+    RunConfigurationProviderFactoryManagerImpl.getInstance();
+    RunConfigurationService runConfigurationManager =
+      Spoon.getInstance().getExecutionBowl().getManager( RunConfigurationService.class );
 
     runConfigurations.addAll( runConfigurationManager.getNames( type ) );
   }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPoint.java
@@ -13,7 +13,6 @@
 
 package org.pentaho.di.engine.configuration.impl.extension;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
 import org.pentaho.di.core.exception.KettleException;
@@ -22,17 +21,20 @@ import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
+import org.pentaho.di.engine.configuration.api.RunConfigurationProvider;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.EmbeddedRunConfigurationManager;
 import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfiguration;
-import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.trans.JobEntryTrans;
 import org.pentaho.di.job.entry.JobEntryCopy;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.function.Function;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,26 +47,25 @@ import java.util.stream.Collectors;
   description = "" )
 public class RunConfigurationImportExtensionPoint implements ExtensionPointInterface {
 
-  private Function<AbstractMeta, RunConfigurationManager> rcmProvider =
-    am -> RunConfigurationManager.getInstance( () -> am.getBowl().getMetastore() );
+  private RunConfigurationService runConfigurationManager;
 
   @Override public void callExtensionPoint( LogChannelInterface logChannelInterface, Object o ) throws KettleException {
     AbstractMeta abstractMeta = (AbstractMeta) o;
 
     final EmbeddedMetaStore embeddedMetaStore = abstractMeta.getEmbeddedMetaStore();
-    RunConfigurationManager runConfigurationManager = getRunConfigurationManager( abstractMeta );
+    RunConfigurationService runConfigurationService = getRunConfigurationManager( abstractMeta );
 
     RunConfigurationManager embeddedRunConfigurationManager =
       EmbeddedRunConfigurationManager.build( embeddedMetaStore );
 
     List<RunConfiguration> runConfigurationList = embeddedRunConfigurationManager.load();
     List<String> runConfigurationNames = runConfigurationList.stream().map( RunConfiguration::getName ).collect( Collectors.toList() );
-    runConfigurationNames.addAll( runConfigurationManager.getNames() );
+    runConfigurationNames.addAll( runConfigurationService.getNames() );
     runConfigurationList.addAll( createSlaveServerRunConfigurations( runConfigurationNames, abstractMeta ) );
 
     for ( RunConfiguration runConfiguration : runConfigurationList ) {
-      if ( !runConfiguration.getName().equals( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
-        runConfigurationManager.save( runConfiguration );
+      if ( !runConfiguration.getName().equals( RunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
+        runConfigurationService.save( runConfiguration );
       }
     }
   }
@@ -121,10 +122,15 @@ public class RunConfigurationImportExtensionPoint implements ExtensionPointInter
 
   @VisibleForTesting
   void setRunConfigurationManager( RunConfigurationManager runConfigurationManager ) {
-    this.rcmProvider = x -> runConfigurationManager;
+    this.runConfigurationManager = runConfigurationManager;
   }
 
-  private RunConfigurationManager getRunConfigurationManager( AbstractMeta meta) {
-    return rcmProvider.apply( meta );
+  private RunConfigurationService getRunConfigurationManager( AbstractMeta meta ) throws KettleException {
+    if ( runConfigurationManager != null ) {
+      return runConfigurationManager;
+    }
+
+    RunConfigurationProviderFactoryManagerImpl.getInstance();
+    return meta.getBowl().getManager( RunConfigurationService.class );
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationImportExtensionPoint.java
@@ -22,8 +22,10 @@ import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.EmbeddedRunConfigurationManager;
 import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfiguration;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
 import org.pentaho.di.job.JobMeta;
@@ -32,10 +34,10 @@ import org.pentaho.di.job.entry.JobEntryCopy;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.function.Function;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -45,14 +47,21 @@ import java.util.stream.Collectors;
   description = "" )
 public class RunConfigurationImportExtensionPoint implements ExtensionPointInterface {
 
-  private Function<AbstractMeta, RunConfigurationManager> rcmProvider =
-    am -> RunConfigurationManager.getInstance( () -> am.getBowl().getMetastore() );
+  private Function<AbstractMeta, RunConfigurationService> rcsProvider =
+    meta -> {
+      try {
+        RunConfigurationProviderFactoryManagerImpl.getInstance();
+        return meta.getBowl().getManager( RunConfigurationService.class );
+      } catch ( KettleException e ) {
+        throw new IllegalStateException( "Unable to access run configuration manager", e );
+      }
+    };
 
   @Override public void callExtensionPoint( LogChannelInterface logChannelInterface, Object o ) throws KettleException {
     AbstractMeta abstractMeta = (AbstractMeta) o;
 
     final EmbeddedMetaStore embeddedMetaStore = abstractMeta.getEmbeddedMetaStore();
-    RunConfigurationManager runConfigurationManager = getRunConfigurationManager( abstractMeta );
+    RunConfigurationService runConfigurationManager = getRunConfigurationManager( abstractMeta );
 
     RunConfigurationManager embeddedRunConfigurationManager =
       EmbeddedRunConfigurationManager.build( embeddedMetaStore );
@@ -121,10 +130,10 @@ public class RunConfigurationImportExtensionPoint implements ExtensionPointInter
 
   @VisibleForTesting
   void setRunConfigurationManager( RunConfigurationManager runConfigurationManager ) {
-    this.rcmProvider = x -> runConfigurationManager;
+    this.rcsProvider = meta -> runConfigurationManager;
   }
 
-  private RunConfigurationManager getRunConfigurationManager( AbstractMeta meta) {
-    return rcmProvider.apply( meta );
+  private RunConfigurationService getRunConfigurationManager( AbstractMeta meta ) {
+    return rcsProvider.apply( meta );
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationInjectExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationInjectExtensionPoint.java
@@ -13,22 +13,23 @@
 
 package org.pentaho.di.engine.configuration.impl.extension;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.EmbeddedRunConfigurationManager;
 import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobExecutionExtension;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.job.JobEntryJob;
 import org.pentaho.di.job.entries.trans.JobEntryTrans;
 
-import java.util.function.Function;
+import com.google.common.annotations.VisibleForTesting;
 
 @ExtensionPoint(
     id = "RunConfigurationInjectExtensionPoint",
@@ -37,8 +38,7 @@ import java.util.function.Function;
   )
 public class RunConfigurationInjectExtensionPoint implements ExtensionPointInterface {
 
-  private Function<JobMeta, RunConfigurationManager> rcmProvider =
-    jm -> RunConfigurationManager.getInstance( () -> jm.getBowl().getMetastore() );
+  private RunConfigurationService runConfigurationManager;
 
   @Override
   public void callExtensionPoint( LogChannelInterface log, Object object ) throws KettleException {
@@ -71,11 +71,16 @@ public class RunConfigurationInjectExtensionPoint implements ExtensionPointInter
 
   @VisibleForTesting
   void setRunConfigurationManager( RunConfigurationManager runConfigurationManager ) {
-    this.rcmProvider = x -> runConfigurationManager;
+    this.runConfigurationManager = runConfigurationManager;
   }
 
-  private RunConfigurationManager getRunConfigurationManager( JobMeta meta) {
-    return rcmProvider.apply( meta );
+  private RunConfigurationService getRunConfigurationManager( JobMeta meta ) throws KettleException {
+    if ( runConfigurationManager != null ) {
+      return runConfigurationManager;
+    }
+
+    RunConfigurationProviderFactoryManagerImpl.getInstance();
+    return meta.getBowl().getManager( RunConfigurationService.class );
   }
 
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationInjectExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationInjectExtensionPoint.java
@@ -20,8 +20,10 @@ import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.EmbeddedRunConfigurationManager;
 import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobExecutionExtension;
 import org.pentaho.di.job.JobMeta;
@@ -37,8 +39,15 @@ import java.util.function.Function;
   )
 public class RunConfigurationInjectExtensionPoint implements ExtensionPointInterface {
 
-  private Function<JobMeta, RunConfigurationManager> rcmProvider =
-    jm -> RunConfigurationManager.getInstance( () -> jm.getBowl().getMetastore() );
+  private Function<JobMeta, RunConfigurationService> rcsProvider =
+    meta -> {
+      try {
+        RunConfigurationProviderFactoryManagerImpl.getInstance();
+        return meta.getBowl().getManager( RunConfigurationService.class );
+      } catch ( KettleException e ) {
+        throw new IllegalStateException( "Unable to access run configuration manager", e );
+      }
+    };
 
   @Override
   public void callExtensionPoint( LogChannelInterface log, Object object ) throws KettleException {
@@ -71,11 +80,11 @@ public class RunConfigurationInjectExtensionPoint implements ExtensionPointInter
 
   @VisibleForTesting
   void setRunConfigurationManager( RunConfigurationManager runConfigurationManager ) {
-    this.rcmProvider = x -> runConfigurationManager;
+    this.rcsProvider = meta -> runConfigurationManager;
   }
 
-  private RunConfigurationManager getRunConfigurationManager( JobMeta meta) {
-    return rcmProvider.apply( meta );
+  private RunConfigurationService getRunConfigurationManager( JobMeta meta ) {
+    return rcsProvider.apply( meta );
   }
 
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationIsPentahoExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationIsPentahoExtensionPoint.java
@@ -19,7 +19,8 @@ import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
-import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfiguration;
 import org.pentaho.di.ui.spoon.Spoon;
 
@@ -39,7 +40,8 @@ public class RunConfigurationIsPentahoExtensionPoint implements ExtensionPointIn
     String name = (String) items.get( 0 );
 
     Bowl bowl = Spoon.getInstance().getExecutionBowl();
-    RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( () -> bowl.getMetastore() );
+    RunConfigurationProviderFactoryManagerImpl.getInstance();
+    RunConfigurationService runConfigurationManager = bowl.getManager( RunConfigurationService.class );
 
     RunConfiguration runConfiguration = runConfigurationManager.load( name );
     if ( runConfiguration != null && runConfiguration.getType().equals( DefaultRunConfiguration.TYPE ) ) {

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationIsRemoteExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationIsRemoteExtensionPoint.java
@@ -19,7 +19,8 @@ import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
-import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfiguration;
 import org.pentaho.di.ui.spoon.Spoon;
 
@@ -38,7 +39,8 @@ public class RunConfigurationIsRemoteExtensionPoint implements ExtensionPointInt
     List<Object> items = (List<Object>) o;
     String name = (String) items.get( 0 );
     Bowl bowl = Spoon.getInstance().getExecutionBowl();
-    RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( () -> bowl.getMetastore() );
+    RunConfigurationProviderFactoryManagerImpl.getInstance();
+    RunConfigurationService runConfigurationManager = bowl.getManager( RunConfigurationService.class );
 
     RunConfiguration runConfiguration = runConfigurationManager.load( name );
     if ( runConfiguration != null && runConfiguration.getType().equals( DefaultRunConfiguration.TYPE ) ) {

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationRunExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationRunExtensionPoint.java
@@ -25,8 +25,9 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
 import org.pentaho.di.engine.configuration.api.RunConfigurationExecutor;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.EmbeddedRunConfigurationManager;
-import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.TransMeta;
@@ -43,9 +44,7 @@ public class RunConfigurationRunExtensionPoint implements ExtensionPointInterfac
 
   private static Class<?> PKG = RunConfigurationRunExtensionPoint.class;
   // basically exists for testing.
-  private Function<Bowl, RunConfigurationManager> rcmProvider = bowl ->
-    RunConfigurationManager.getInstance( () -> bowl != null ? bowl.getMetastore() :
-                                         DefaultBowl.getInstance().getMetastore() );
+  private Function<Bowl, RunConfigurationService> rcmProvider;
 
   @Override public void callExtensionPoint( LogChannelInterface logChannelInterface, Object o ) throws KettleException {
     ExecutionConfiguration executionConfiguration = (ExecutionConfiguration) ( (Object[]) o )[ 0 ];
@@ -54,12 +53,12 @@ public class RunConfigurationRunExtensionPoint implements ExtensionPointInterfac
     Repository repository = (Repository) ( (Object[]) o )[ 3 ];
     EmbeddedMetaStore embeddedMetaStore = meta.getEmbeddedMetaStore();
 
-    RunConfigurationManager runConfigurationManager = rcmProvider.apply( meta.getBowl() );
+    RunConfigurationService runConfigurationManager = getRunConfigurationManager( meta.getBowl() );
     RunConfiguration runConfiguration =
       runConfigurationManager.load( executionConfiguration.getRunConfiguration() );
 
     if ( runConfiguration == null ) {
-      RunConfigurationManager embeddedRunConfigurationManager =
+      RunConfigurationService embeddedRunConfigurationManager =
         EmbeddedRunConfigurationManager.build( embeddedMetaStore );
       runConfiguration = embeddedRunConfigurationManager.load( executionConfiguration.getRunConfiguration() );
     }
@@ -83,7 +82,18 @@ public class RunConfigurationRunExtensionPoint implements ExtensionPointInterfac
   }
 
   @VisibleForTesting
-  void setRunConfigurationManagerProvider ( Function<Bowl, RunConfigurationManager> provider ) {
+  void setRunConfigurationManagerProvider ( Function<Bowl, RunConfigurationService> provider ) {
     this.rcmProvider = provider;
+  }
+
+  private RunConfigurationService getRunConfigurationManager( Bowl bowl ) throws KettleException {
+    if ( rcmProvider != null ) {
+      return rcmProvider.apply( bowl );
+    }
+
+    // ensure the factory is initialized so that the managers are registered to the bowl
+    RunConfigurationProviderFactoryManagerImpl.getInstance();
+    Bowl sourceBowl = bowl != null ? bowl : DefaultBowl.getInstance();
+    return sourceBowl.getManager( RunConfigurationService.class );
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationRunExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationRunExtensionPoint.java
@@ -25,8 +25,10 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
 import org.pentaho.di.engine.configuration.api.RunConfigurationExecutor;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.EmbeddedRunConfigurationManager;
 import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.TransMeta;
@@ -43,9 +45,7 @@ public class RunConfigurationRunExtensionPoint implements ExtensionPointInterfac
 
   private static Class<?> PKG = RunConfigurationRunExtensionPoint.class;
   // basically exists for testing.
-  private Function<Bowl, RunConfigurationManager> rcmProvider = bowl ->
-    RunConfigurationManager.getInstance( () -> bowl != null ? bowl.getMetastore() :
-                                         DefaultBowl.getInstance().getMetastore() );
+  private Function<Bowl, RunConfigurationManager> rcmProvider;
 
   @Override public void callExtensionPoint( LogChannelInterface logChannelInterface, Object o ) throws KettleException {
     ExecutionConfiguration executionConfiguration = (ExecutionConfiguration) ( (Object[]) o )[ 0 ];
@@ -54,7 +54,7 @@ public class RunConfigurationRunExtensionPoint implements ExtensionPointInterfac
     Repository repository = (Repository) ( (Object[]) o )[ 3 ];
     EmbeddedMetaStore embeddedMetaStore = meta.getEmbeddedMetaStore();
 
-    RunConfigurationManager runConfigurationManager = rcmProvider.apply( meta.getBowl() );
+    RunConfigurationManager runConfigurationManager = getRunConfigurationManager( meta.getBowl() );
     RunConfiguration runConfiguration =
       runConfigurationManager.load( executionConfiguration.getRunConfiguration() );
 
@@ -85,5 +85,16 @@ public class RunConfigurationRunExtensionPoint implements ExtensionPointInterfac
   @VisibleForTesting
   void setRunConfigurationManagerProvider ( Function<Bowl, RunConfigurationManager> provider ) {
     this.rcmProvider = provider;
+  }
+
+  private RunConfigurationManager getRunConfigurationManager( Bowl bowl ) throws KettleException {
+    if ( rcmProvider != null ) {
+      return rcmProvider.apply( bowl );
+    }
+
+    // ensure the factory is initialized so that the managers are registered to the bowl
+    RunConfigurationProviderFactoryManagerImpl.getInstance();
+    Bowl sourceBowl = bowl != null ? bowl : DefaultBowl.getInstance();
+    return (RunConfigurationManager) sourceBowl.getManager( RunConfigurationService.class );
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationSaveExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationSaveExtensionPoint.java
@@ -13,7 +13,6 @@
 
 package org.pentaho.di.engine.configuration.impl.extension;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.core.attributes.metastore.EmbeddedMetaStore;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
@@ -22,15 +21,19 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
+import org.pentaho.di.engine.configuration.api.RunConfigurationProvider;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.EmbeddedRunConfigurationManager;
 import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.job.entry.JobEntryRunConfigurableInterface;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.ArrayList;
-import java.util.function.Function;
 import java.util.List;
 
 /**
@@ -40,8 +43,7 @@ import java.util.List;
   description = "" )
 public class RunConfigurationSaveExtensionPoint implements ExtensionPointInterface {
 
-  private Function<JobMeta, RunConfigurationManager> rcmProvider =
-    jm -> RunConfigurationManager.getInstance( () -> jm.getBowl().getMetastore() );
+  private RunConfigurationService runConfigurationManager;
 
   @Override public void callExtensionPoint( LogChannelInterface logChannelInterface, Object o ) throws KettleException {
     JobMeta jobMeta = (JobMeta) ( (Object[]) o )[ 0 ];
@@ -70,7 +72,8 @@ public class RunConfigurationSaveExtensionPoint implements ExtensionPointInterfa
     }
   }
 
-  private void embedAllRunConfigurations( JobMeta jobMeta, RunConfigurationManager embeddedRunConfigurationManager ) {
+  private void embedAllRunConfigurations( JobMeta jobMeta,
+                                          RunConfigurationManager embeddedRunConfigurationManager ) throws KettleException {
     List<RunConfiguration> runConfigurations = getRunConfigurationManager( jobMeta ).load();
     for ( RunConfiguration loadedRunConfiguration : runConfigurations ) {
       if ( !loadedRunConfiguration.isReadOnly() ) {
@@ -80,9 +83,9 @@ public class RunConfigurationSaveExtensionPoint implements ExtensionPointInterfa
   }
 
   private void embedRunConfigurations( JobMeta jobMeta, RunConfigurationManager embeddedRunConfigurationManager,
-                                       List<String> runConfigurationNames ) {
+                                       List<String> runConfigurationNames ) throws KettleException {
     for ( String runConfigurationName : runConfigurationNames ) {
-      if ( !runConfigurationName.equals( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
+      if ( !runConfigurationName.equals( RunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
         RunConfiguration loadedRunConfiguration = getRunConfigurationManager( jobMeta ).load( runConfigurationName );
         embeddedRunConfigurationManager.save( loadedRunConfiguration );
       }
@@ -91,10 +94,15 @@ public class RunConfigurationSaveExtensionPoint implements ExtensionPointInterfa
 
   @VisibleForTesting
   void setRunConfigurationManager( RunConfigurationManager runConfigurationManager ) {
-    this.rcmProvider = x -> runConfigurationManager;
+    this.runConfigurationManager = runConfigurationManager;
   }
 
-  private RunConfigurationManager getRunConfigurationManager( JobMeta meta) {
-    return rcmProvider.apply( meta );
+  private RunConfigurationService getRunConfigurationManager( JobMeta meta ) throws KettleException {
+    if ( runConfigurationManager != null ) {
+      return runConfigurationManager;
+    }
+
+    RunConfigurationProviderFactoryManagerImpl.getInstance();
+    return meta.getBowl().getManager( RunConfigurationService.class );
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationSaveExtensionPoint.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/extension/RunConfigurationSaveExtensionPoint.java
@@ -22,16 +22,18 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.EmbeddedRunConfigurationManager;
 import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryCopy;
 import org.pentaho.di.job.entry.JobEntryRunConfigurableInterface;
 
 import java.util.ArrayList;
-import java.util.function.Function;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Created by bmorrise on 5/3/17.
@@ -40,8 +42,15 @@ import java.util.List;
   description = "" )
 public class RunConfigurationSaveExtensionPoint implements ExtensionPointInterface {
 
-  private Function<JobMeta, RunConfigurationManager> rcmProvider =
-    jm -> RunConfigurationManager.getInstance( () -> jm.getBowl().getMetastore() );
+  private Function<JobMeta, RunConfigurationService> rcsProvider =
+    meta -> {
+      try {
+        RunConfigurationProviderFactoryManagerImpl.getInstance();
+        return meta.getBowl().getManager( RunConfigurationService.class );
+      } catch ( KettleException e ) {
+        throw new IllegalStateException( "Unable to access run configuration manager", e );
+      }
+    };
 
   @Override public void callExtensionPoint( LogChannelInterface logChannelInterface, Object o ) throws KettleException {
     JobMeta jobMeta = (JobMeta) ( (Object[]) o )[ 0 ];
@@ -91,10 +100,10 @@ public class RunConfigurationSaveExtensionPoint implements ExtensionPointInterfa
 
   @VisibleForTesting
   void setRunConfigurationManager( RunConfigurationManager runConfigurationManager ) {
-    this.rcmProvider = x -> runConfigurationManager;
+    this.rcsProvider = meta -> runConfigurationManager;
   }
 
-  private RunConfigurationManager getRunConfigurationManager( JobMeta meta) {
-    return rcmProvider.apply( meta );
+  private RunConfigurationService getRunConfigurationManager( JobMeta meta ) {
+    return rcsProvider.apply( meta );
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationProvider.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationProvider.java
@@ -35,7 +35,6 @@ import java.util.List;
 public class DefaultRunConfigurationProvider extends MetaStoreRunConfigurationFactory
   implements RunConfigurationProvider {
 
-  public static final String DEFAULT_CONFIG_NAME = "Pentaho local";
   private static final String TYPE = "Pentaho";
   private List<String> supported = Arrays.asList( TransMeta.XML_TAG, JobMeta.XML_TAG );
 
@@ -44,7 +43,7 @@ public class DefaultRunConfigurationProvider extends MetaStoreRunConfigurationFa
   private DefaultRunConfigurationExecutor defaultRunConfigurationExecutor;
 
   static {
-    defaultRunConfiguration.setName( DEFAULT_CONFIG_NAME );
+    defaultRunConfiguration.setName( RunConfigurationProvider.DEFAULT_CONFIG_NAME );
     defaultRunConfiguration.setReadOnly( true );
     defaultRunConfiguration.setLocal( true );
   }
@@ -75,7 +74,7 @@ public class DefaultRunConfigurationProvider extends MetaStoreRunConfigurationFa
   }
 
   @Override public RunConfiguration load( String name ) {
-    if ( Utils.isEmpty( name ) || name.equals( DEFAULT_CONFIG_NAME ) ) {
+    if ( Utils.isEmpty( name ) || name.equals( RunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
       return defaultRunConfiguration;
     }
     return super.load( name );

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationProvider.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/configuration/impl/pentaho/DefaultRunConfigurationProvider.java
@@ -35,7 +35,6 @@ import java.util.List;
 public class DefaultRunConfigurationProvider extends MetaStoreRunConfigurationFactory
   implements RunConfigurationProvider {
 
-  public static final String DEFAULT_CONFIG_NAME = "Pentaho local";
   private static final String TYPE = "Pentaho";
   private List<String> supported = Arrays.asList( TransMeta.XML_TAG, JobMeta.XML_TAG );
 

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationDelegate.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationDelegate.java
@@ -24,8 +24,6 @@ import org.pentaho.di.core.extension.ExtensionPointHandler;
 import org.pentaho.di.core.extension.KettleExtensionPoint;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
 import org.pentaho.di.engine.configuration.api.RunConfigurationService;
-import org.pentaho.di.engine.configuration.api.CheckedMetaStoreSupplier;
-import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfiguration;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
@@ -33,7 +31,6 @@ import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.job.entry.JobEntryRunConfigurableInterface;
 import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.core.widget.TreeUtil;
-import org.pentaho.di.ui.repository.exception.RepositoryExceptionUtils;
 import org.pentaho.di.ui.spoon.Spoon;
 
 import java.util.HashSet;
@@ -51,12 +48,12 @@ public class RunConfigurationDelegate {
 
   private RunConfigurationService configurationManager;
 
-  private RunConfigurationDelegate( CheckedMetaStoreSupplier supplier ) {
-    configurationManager = RunConfigurationManager.getInstance( supplier );
+  private RunConfigurationDelegate( Bowl bowl ) throws KettleException {
+    configurationManager = bowl.getManager( RunConfigurationService.class );
   }
 
-  public static RunConfigurationDelegate getInstance( CheckedMetaStoreSupplier supplier ) {
-    return new RunConfigurationDelegate( supplier );
+  public static RunConfigurationDelegate getInstance( Bowl bowl ) throws KettleException {
+    return new RunConfigurationDelegate( bowl );
   }
 
   /**
@@ -70,7 +67,7 @@ public class RunConfigurationDelegate {
     try {
       operation.run();
     } catch ( Exception e ) {
-      if ( RepositoryExceptionUtils.isSessionExpired( e ) ) {
+      if ( spoonSupplier.get().isAuthenticationException( e ) ) {
         boolean reconnected;
         try {
           reconnected = spoonSupplier.get().handleSessionExpiryWithRelogin();
@@ -221,28 +218,28 @@ public class RunConfigurationDelegate {
     }, "Error deleting run configuration" );
   }
 
-  public void loadAndCopyToGlobal( RunConfigurationManager manager, String name ) {
+  public void loadAndCopyToGlobal( RunConfigurationService manager, String name ) {
     executeWithSessionRetry( () -> {
       RunConfiguration runConfiguration = configurationManager.load( name );
       copyToGlobalInternal( manager, runConfiguration );
     }, "Error copying to global" );
   }
 
-  public void loadAndCopyToProject( RunConfigurationManager manager, String name ) {
+  public void loadAndCopyToProject( RunConfigurationService manager, String name ) {
     executeWithSessionRetry( () -> {
       RunConfiguration runConfiguration = configurationManager.load( name );
       copyToProjectInternal( manager, runConfiguration );
     }, "Error copying to project" );
   }
 
-  public void loadAndMoveToGlobal( RunConfigurationManager manager, String name ) {
+  public void loadAndMoveToGlobal( RunConfigurationService manager, String name ) {
     executeWithSessionRetry( () -> {
       RunConfiguration runConfiguration = configurationManager.load( name );
       moveToGlobalInternal( manager, runConfiguration );
     }, "Error moving to global" );
   }
 
-  public void loadAndMoveToProject( RunConfigurationManager manager, String name ) {
+  public void loadAndMoveToProject( RunConfigurationService manager, String name ) {
     executeWithSessionRetry( () -> {
       RunConfiguration runConfiguration = configurationManager.load( name );
       moveToProjectInternal( manager, runConfiguration );
@@ -291,42 +288,46 @@ public class RunConfigurationDelegate {
     dialog.open();
   }
 
-  public void copyToGlobal( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
+  public void copyToGlobal( RunConfigurationService manager, RunConfiguration runConfiguration ) {
     executeWithSessionRetry( () -> copyToGlobalInternal( manager, runConfiguration ), "Error copying to global" );
   }
 
-  private void copyToGlobalInternal( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
+  private void copyToGlobalInternal( RunConfigurationService manager, RunConfiguration runConfiguration ) {
     moveCopy( manager, runConfiguration, spoonSupplier.get().getGlobalManagementBowl(), false );
   }
 
-  public void copyToProject( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
+  public void copyToProject( RunConfigurationService manager, RunConfiguration runConfiguration ) {
     executeWithSessionRetry( () -> copyToProjectInternal( manager, runConfiguration ), "Error copying to project" );
   }
 
-  private void copyToProjectInternal( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
+  private void copyToProjectInternal( RunConfigurationService manager, RunConfiguration runConfiguration ) {
     moveCopy( manager, runConfiguration, spoonSupplier.get().getManagementBowl(), false );
   }
 
-  public void moveToGlobal( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
+  public void moveToGlobal( RunConfigurationService manager, RunConfiguration runConfiguration ) {
     executeWithSessionRetry( () -> moveToGlobalInternal( manager, runConfiguration ), "Error moving to global" );
   }
 
-  private void moveToGlobalInternal( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
+  private void moveToGlobalInternal( RunConfigurationService manager, RunConfiguration runConfiguration ) {
     moveCopy( manager, runConfiguration, spoonSupplier.get().getGlobalManagementBowl(), true );
   }
 
-  public void moveToProject( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
+  public void moveToProject( RunConfigurationService manager, RunConfiguration runConfiguration ) {
     executeWithSessionRetry( () -> moveToProjectInternal( manager, runConfiguration ), "Error moving to project" );
   }
 
-  private void moveToProjectInternal( RunConfigurationManager manager, RunConfiguration runConfiguration ) {
-    moveCopy( manager, runConfiguration, Spoon.getInstance().getManagementBowl(), true );
+  private void moveToProjectInternal( RunConfigurationService manager, RunConfiguration runConfiguration ) {
+    moveCopy( manager, runConfiguration, spoonSupplier.get().getManagementBowl(), true );
   }
 
-  private void moveCopy( RunConfigurationManager srcManager, RunConfiguration runConfiguration, Bowl targetBowl,
+  private void moveCopy( RunConfigurationService srcManager, RunConfiguration runConfiguration, Bowl targetBowl,
                          boolean deleteSource ) {
-    CheckedMetaStoreSupplier ms = () -> targetBowl.getMetastore();
-    RunConfigurationManager targetManager = RunConfigurationManager.getInstance( ms );
+    RunConfigurationService targetManager;
+    try {
+      targetManager = targetBowl.getManager( RunConfigurationService.class );
+    } catch ( KettleException e ) {
+      throw new IllegalStateException( "Unable to access run configuration manager", e );
+    }
     if ( targetManager.getNames().stream().anyMatch( element -> element.equalsIgnoreCase( runConfiguration.getName() ) ) ) {
       if ( !shouldOverwrite( BaseMessages.getString( PKG, "RunConfigurationDialog.OverwriteRunConfigurationYN",
         runConfiguration.getName() ) ) ) {

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
@@ -13,14 +13,12 @@
 
 package org.pentaho.di.engine.ui;
 
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Device;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.widgets.Display;
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
-import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
+import org.pentaho.di.engine.configuration.api.RunConfigurationProvider;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.ConstUI;
 import org.pentaho.di.ui.core.gui.GUIResource;
@@ -29,7 +27,14 @@ import org.pentaho.di.ui.core.widget.tree.TreeNode;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.spoon.tree.TreeFolderProvider;
 
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
+
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -50,48 +55,43 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
     Set<String> bowlNames = new HashSet<>();
     Bowl currentBowl = Spoon.getInstance().getManagementBowl();
     Bowl globalBowl = Spoon.getInstance().getGlobalManagementBowl();
-    String levelName;
     if ( !currentBowl.equals( globalBowl ) ) {
-      RunConfigurationDelegate bowlDelegate =
-        RunConfigurationDelegate.getInstance( () -> currentBowl.getMetastore() );
-      for ( RunConfiguration runConfiguration : bowlDelegate.load() ) {
-        if ( !filterMatch( runConfiguration.getName(), filter ) ) {
-          continue;
-        }
-        if ( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME.equals( runConfiguration.getName() ) ) {
-          continue;
-        }
-        bowlNames.add( runConfiguration.getName() );
-        String imageFile = runConfiguration.isReadOnly() ? "images/run_tree_disabled.svg" : "images/run_tree.svg";
-        TreeNode childTreeNode = createChildTreeNode( treeNode, runConfiguration.getName(), getRunConfigurationImage(
-                guiResource, imageFile ), LeveledTreeNode.LEVEL.PROJECT, currentBowl.getLevelDisplayName(), false );
-        if ( runConfiguration.isReadOnly() ) {
-          childTreeNode.setForeground( getDisabledColor() );
+      for ( RunConfiguration runConfiguration : loadRunConfigurations( currentBowl ) ) {
+        if ( filterMatch( runConfiguration.getName(), filter )
+          && !RunConfigurationProvider.DEFAULT_CONFIG_NAME.equals( runConfiguration.getName() ) ) {
+          bowlNames.add( runConfiguration.getName() );
+          addRunConfigurationNode( treeNode, guiResource, runConfiguration,
+            LeveledTreeNode.LEVEL.PROJECT, currentBowl.getLevelDisplayName(), false );
         }
       }
     }
 
-    RunConfigurationDelegate globalDelegate =
-      RunConfigurationDelegate.getInstance( () -> globalBowl.getMetastore() );
+    addGlobalRunConfigurationNodes( treeNode, filter, guiResource, bowlNames, globalBowl );
+  }
 
-    for ( RunConfiguration runConfiguration : globalDelegate.load() ) {
-      if ( !filterMatch( runConfiguration.getName(), filter ) ) {
-        continue;
-      }
-      LeveledTreeNode.LEVEL level = LeveledTreeNode.LEVEL.GLOBAL;
-      levelName = globalBowl.getLevelDisplayName();
+  private void addGlobalRunConfigurationNodes( TreeNode treeNode, String filter, GUIResource guiResource,
+                                               Set<String> bowlNames, Bowl globalBowl ) {
+    for ( RunConfiguration runConfiguration : loadRunConfigurations( globalBowl ) ) {
+      if ( filterMatch( runConfiguration.getName(), filter ) ) {
+        boolean isDefault = RunConfigurationProvider.DEFAULT_CONFIG_NAME.equals( runConfiguration.getName() );
+        LeveledTreeNode.LEVEL level = isDefault ? LeveledTreeNode.LEVEL.DEFAULT : LeveledTreeNode.LEVEL.GLOBAL;
+        String levelName = isDefault ? LeveledTreeNode.LEVEL_DEFAULT_DISPLAY_NAME : globalBowl.getLevelDisplayName();
 
-      if ( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME.equals( runConfiguration.getName() ) ) {
-        level = LeveledTreeNode.LEVEL.DEFAULT;
-        levelName = LeveledTreeNode.LEVEL_DEFAULT_DISPLAY_NAME;
+        addRunConfigurationNode( treeNode, guiResource, runConfiguration, level, levelName,
+          containsIgnoreCase( bowlNames, runConfiguration.getName() ) );
       }
+    }
+  }
 
-      String imageFile = runConfiguration.isReadOnly() ? "images/run_tree_disabled.svg" : "images/run_tree.svg";
-      TreeNode childTreeNode = createChildTreeNode( treeNode, runConfiguration.getName(), getRunConfigurationImage(
-              guiResource, imageFile ), level, levelName, containsIgnoreCase( bowlNames, runConfiguration.getName() ) );
-      if ( runConfiguration.isReadOnly() ) {
-        childTreeNode.setForeground( getDisabledColor() );
-      }
+  private void addRunConfigurationNode( TreeNode treeNode, GUIResource guiResource,
+                                        RunConfiguration runConfiguration, LeveledTreeNode.LEVEL level,
+                                        String levelName, boolean overridden ) {
+    String imageFile = runConfiguration.isReadOnly() ? "images/run_tree_disabled.svg" : "images/run_tree.svg";
+    TreeNode childTreeNode = createChildTreeNode( treeNode, runConfiguration.getName(),
+      getRunConfigurationImage( guiResource, imageFile ), level, levelName, overridden );
+
+    if ( runConfiguration.isReadOnly() ) {
+      childTreeNode.setForeground( getDisabledColor() );
     }
   }
 
@@ -128,5 +128,14 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
   public TreeNode createTreeNode( TreeNode parent, String text, Image image ) {
     TreeNode treeNode = super.createTreeNode( parent, text, image );
     return treeNode;
+  }
+
+  private List<RunConfiguration> loadRunConfigurations( Bowl bowl ) {
+    try {
+      return RunConfigurationDelegate.getInstance( bowl ).load();
+    } catch ( KettleException e ) {
+      LogChannel.GENERAL.logError( "Unable to access run configuration delegate", e );
+      return Collections.emptyList();
+    }
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationFolderProvider.java
@@ -53,7 +53,7 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
     String levelName;
     if ( !currentBowl.equals( globalBowl ) ) {
       RunConfigurationDelegate bowlDelegate =
-        RunConfigurationDelegate.getInstance( () -> currentBowl.getMetastore() );
+        getRunConfigurationDelegate( currentBowl );
       for ( RunConfiguration runConfiguration : bowlDelegate.load() ) {
         if ( !filterMatch( runConfiguration.getName(), filter ) ) {
           continue;
@@ -72,7 +72,7 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
     }
 
     RunConfigurationDelegate globalDelegate =
-      RunConfigurationDelegate.getInstance( () -> globalBowl.getMetastore() );
+      getRunConfigurationDelegate( globalBowl );
 
     for ( RunConfiguration runConfiguration : globalDelegate.load() ) {
       if ( !filterMatch( runConfiguration.getName(), filter ) ) {
@@ -128,5 +128,13 @@ public class RunConfigurationFolderProvider extends TreeFolderProvider {
   public TreeNode createTreeNode( TreeNode parent, String text, Image image ) {
     TreeNode treeNode = super.createTreeNode( parent, text, image );
     return treeNode;
+  }
+
+  private RunConfigurationDelegate getRunConfigurationDelegate( Bowl bowl ) {
+    try {
+      return RunConfigurationDelegate.getInstance( bowl );
+    } catch ( Exception e ) {
+      throw new IllegalStateException( "Unable to access run configuration delegate", e );
+    }
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationLifecycleListener.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationLifecycleListener.java
@@ -17,6 +17,7 @@ import org.pentaho.di.core.annotations.LifecyclePlugin;
 import org.pentaho.di.core.lifecycle.LifeEventHandler;
 import org.pentaho.di.core.lifecycle.LifecycleException;
 import org.pentaho.di.core.lifecycle.LifecycleListener;
+import org.pentaho.di.engine.configuration.impl.RunConfigurationProviderFactoryManagerImpl;
 import org.pentaho.di.ui.spoon.Spoon;
 
 import java.util.function.Supplier;
@@ -34,6 +35,9 @@ public class RunConfigurationLifecycleListener implements LifecycleListener {
 
   @Override
   public void onStart( LifeEventHandler handler ) throws LifecycleException {
+    // Ensure the RunConfigurationService manager factory is registered exactly once at startup.
+    RunConfigurationProviderFactoryManagerImpl.getInstance();
+
     Spoon spoon = spoonSupplier.get();
     if ( spoon != null ) {
       spoon.getTreeManager().addTreeProvider( Spoon.STRING_CONFIGURATIONS, new RunConfigurationFolderProvider() );

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationPopupMenuExtension.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationPopupMenuExtension.java
@@ -13,27 +13,31 @@
 
 package org.pentaho.di.engine.ui;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.widgets.Menu;
-import org.eclipse.swt.widgets.MenuItem;
-import org.eclipse.swt.widgets.Tree;
 import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
-import org.pentaho.di.engine.configuration.api.CheckedMetaStoreSupplier;
-import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
-import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
+import org.pentaho.di.engine.configuration.api.RunConfigurationProvider;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.ConstUI;
+import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.core.widget.tree.LeveledTreeNode;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.spoon.TreeSelection;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.MenuItem;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Tree;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -44,6 +48,12 @@ import java.util.function.Supplier;
 public class RunConfigurationPopupMenuExtension implements ExtensionPointInterface {
 
   private static Class<?> PKG = RunConfigurationPopupMenuExtension.class;
+  private static final String ACTION_CREATE = "create";
+  private static final String ACTION_EDIT = "edit";
+  private static final String ACTION_MOVE = "move";
+  private static final String ACTION_COPY = "copy";
+  private static final String ACTION_DUPLICATE = "duplicate";
+  private static final String ACTION_DELETE = "delete";
 
   private Supplier<Spoon> spoonSupplier = Spoon::getInstance;
   private RunConfigurationTreeItem runConfigurationTreeItem;
@@ -63,7 +73,7 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       popupMenu = createRootPopupMenu( selectionTree );
     } else if ( selection instanceof RunConfigurationTreeItem ) {
       runConfigurationTreeItem = (RunConfigurationTreeItem) selection;
-      if ( runConfigurationTreeItem.getName().equalsIgnoreCase( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
+      if ( runConfigurationTreeItem.getName().equalsIgnoreCase( RunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
         return;
       }
       popupMenu = createItemPopupMenu( selectionTree );
@@ -85,10 +95,7 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
         @Override
         public void widgetSelected( SelectionEvent selectionEvent ) {
           // new goes to the Spoon's current bowl
-          Bowl bowl = Spoon.getInstance().getManagementBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          runConfigurationDelegate.create();
+          executeWithDelegate( Spoon.getInstance().getManagementBowl(), ACTION_CREATE, RunConfigurationDelegate::create );
         }
       } );
     }
@@ -102,11 +109,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       editMenuItem.setText( BaseMessages.getString( PKG, "RunConfigurationPopupMenuExtension.MenuItem.Edit" ) );
       editMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
-          Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          // Use loadAndEdit which handles session expiry during load
-          runConfigurationDelegate.loadAndEdit( runConfigurationTreeItem.getName() );
+          executeWithDelegate( getEventBowl(), ACTION_EDIT,
+            delegate -> delegate.loadAndEdit( runConfigurationTreeItem.getName() ) );
         }
       } );
     }
@@ -122,11 +126,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
               spoonSupplier.get().getGlobalManagementBowl().getLevelDisplayName() ) );
       moveMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
-          Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
-          runConfigurationDelegate.loadAndMoveToGlobal( runConfigurationManager, runConfigurationTreeItem.getName() );
+          executeWithDelegateAndManager( getEventBowl(), ACTION_MOVE,
+            ( delegate, manager ) -> delegate.loadAndMoveToGlobal( manager, runConfigurationTreeItem.getName() ) );
         }
       } );
 
@@ -135,11 +136,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
               spoonSupplier.get().getGlobalManagementBowl().getLevelDisplayName() ) );
       copyMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
-          Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
-          runConfigurationDelegate.loadAndCopyToGlobal( runConfigurationManager, runConfigurationTreeItem.getName() );
+          executeWithDelegateAndManager( getEventBowl(), ACTION_COPY,
+            ( delegate, manager ) -> delegate.loadAndCopyToGlobal( manager, runConfigurationTreeItem.getName() ) );
         }
       } );
     }
@@ -150,22 +148,16 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       moveMenuItem.setText( BaseMessages.getString( PKG, "RunConfigurationPopupMenuExtension.MenuItem.MoveToProject" ) );
       moveMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
-          Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
-          runConfigurationDelegate.loadAndMoveToProject( runConfigurationManager, runConfigurationTreeItem.getName() );
+          executeWithDelegateAndManager( getEventBowl(), ACTION_MOVE,
+            ( delegate, manager ) -> delegate.loadAndMoveToProject( manager, runConfigurationTreeItem.getName() ) );
         }
       } );
       MenuItem copyMenuItem = new MenuItem( itemMenu, SWT.NONE );
       copyMenuItem.setText( BaseMessages.getString( PKG, "RunConfigurationPopupMenuExtension.MenuItem.CopyToProject" ) );
       copyMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
-          Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
-          runConfigurationDelegate.loadAndCopyToProject( runConfigurationManager, runConfigurationTreeItem.getName() );
+          executeWithDelegateAndManager( getEventBowl(), ACTION_COPY,
+            ( delegate, manager ) -> delegate.loadAndCopyToProject( manager, runConfigurationTreeItem.getName() ) );
         }
       } );
     }
@@ -179,10 +171,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
     }
     duplicateMenuItem.addSelectionListener( new SelectionAdapter() {
       @Override public void widgetSelected( SelectionEvent selectionEvent ) {
-        Bowl bowl = getEventBowl();
-        CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-        RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-        runConfigurationDelegate.loadAndDuplicate( runConfigurationTreeItem.getName() );
+        executeWithDelegate( getEventBowl(), ACTION_DUPLICATE,
+          delegate -> delegate.loadAndDuplicate( runConfigurationTreeItem.getName() ) );
       }
     } );
 
@@ -190,10 +180,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
     deleteMenuItem.setText( BaseMessages.getString( PKG, "RunConfigurationPopupMenuExtension.MenuItem.Delete" ) );
     deleteMenuItem.addSelectionListener( new SelectionAdapter() {
       @Override public void widgetSelected( SelectionEvent selectionEvent ) {
-        Bowl bowl = getEventBowl();
-        CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-        RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-        runConfigurationDelegate.loadAndDelete( runConfigurationTreeItem.getName() );
+        executeWithDelegate( getEventBowl(), ACTION_DELETE,
+          delegate -> delegate.loadAndDelete( runConfigurationTreeItem.getName() ) );
       }
     } );
     return itemMenu;
@@ -206,6 +194,51 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
     } else {
       return spoonSupplier.get().getManagementBowl();
     }
+  }
+
+  private RunConfigurationDelegate getRunConfigurationDelegate( Bowl bowl, String action ) {
+    try {
+      return RunConfigurationDelegate.getInstance( bowl );
+    } catch ( KettleException e ) {
+      showUiError( action, e );
+      return null;
+    }
+  }
+
+  private RunConfigurationService getRunConfigurationManager( Bowl bowl, String action ) {
+    try {
+      return bowl.getManager( RunConfigurationService.class );
+    } catch ( KettleException e ) {
+      showUiError( action, e );
+      return null;
+    }
+  }
+
+  private void executeWithDelegate( Bowl bowl, String action, Consumer<RunConfigurationDelegate> consumer ) {
+    RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl, action );
+    if ( runConfigurationDelegate == null ) {
+      return;
+    }
+
+    consumer.accept( runConfigurationDelegate );
+  }
+
+  private void executeWithDelegateAndManager( Bowl bowl, String action,
+                                              BiConsumer<RunConfigurationDelegate, RunConfigurationService> consumer ) {
+    RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl, action );
+    RunConfigurationService runConfigurationManager = getRunConfigurationManager( bowl, action );
+    if ( runConfigurationDelegate == null || runConfigurationManager == null ) {
+      return;
+    }
+
+    consumer.accept( runConfigurationDelegate, runConfigurationManager );
+  }
+
+  private void showUiError( String action, KettleException e ) {
+    Spoon spoon = spoonSupplier.get();
+    Shell shell = spoon.getShell();
+    String title = "Run Configuration Error";
+    new ErrorDialog( shell, title, "Unable to " + action + " run configuration", e );
   }
 }
 

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationPopupMenuExtension.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationPopupMenuExtension.java
@@ -25,8 +25,7 @@ import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
-import org.pentaho.di.engine.configuration.api.CheckedMetaStoreSupplier;
-import org.pentaho.di.engine.configuration.impl.RunConfigurationManager;
+import org.pentaho.di.engine.configuration.api.RunConfigurationService;
 import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.ConstUI;
@@ -86,8 +85,7 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
         public void widgetSelected( SelectionEvent selectionEvent ) {
           // new goes to the Spoon's current bowl
           Bowl bowl = Spoon.getInstance().getManagementBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
+          RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl );
           runConfigurationDelegate.create();
         }
       } );
@@ -103,9 +101,7 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       editMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
           Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          // Use loadAndEdit which handles session expiry during load
+          RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl );
           runConfigurationDelegate.loadAndEdit( runConfigurationTreeItem.getName() );
         }
       } );
@@ -123,9 +119,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       moveMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
           Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
+          RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl );
+          RunConfigurationService runConfigurationManager = getRunConfigurationManager( bowl );
           runConfigurationDelegate.loadAndMoveToGlobal( runConfigurationManager, runConfigurationTreeItem.getName() );
         }
       } );
@@ -136,9 +131,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       copyMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
           Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
+          RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl );
+          RunConfigurationService runConfigurationManager = getRunConfigurationManager( bowl );
           runConfigurationDelegate.loadAndCopyToGlobal( runConfigurationManager, runConfigurationTreeItem.getName() );
         }
       } );
@@ -151,9 +145,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       moveMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
           Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
+          RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl );
+          RunConfigurationService runConfigurationManager = getRunConfigurationManager( bowl );
           runConfigurationDelegate.loadAndMoveToProject( runConfigurationManager, runConfigurationTreeItem.getName() );
         }
       } );
@@ -162,9 +155,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       copyMenuItem.addSelectionListener( new SelectionAdapter() {
         @Override public void widgetSelected( SelectionEvent selectionEvent ) {
           Bowl bowl = getEventBowl();
-          CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-          RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-          RunConfigurationManager runConfigurationManager = RunConfigurationManager.getInstance( ms );
+          RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl );
+          RunConfigurationService runConfigurationManager = getRunConfigurationManager( bowl );
           runConfigurationDelegate.loadAndCopyToProject( runConfigurationManager, runConfigurationTreeItem.getName() );
         }
       } );
@@ -180,9 +172,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
     duplicateMenuItem.addSelectionListener( new SelectionAdapter() {
       @Override public void widgetSelected( SelectionEvent selectionEvent ) {
         Bowl bowl = getEventBowl();
-        CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-        RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-        runConfigurationDelegate.loadAndDuplicate( runConfigurationTreeItem.getName() );
+        RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl );
+      runConfigurationDelegate.loadAndDuplicate( runConfigurationTreeItem.getName() );
       }
     } );
 
@@ -191,9 +182,8 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
     deleteMenuItem.addSelectionListener( new SelectionAdapter() {
       @Override public void widgetSelected( SelectionEvent selectionEvent ) {
         Bowl bowl = getEventBowl();
-        CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-        RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
-        runConfigurationDelegate.loadAndDelete( runConfigurationTreeItem.getName() );
+        RunConfigurationDelegate runConfigurationDelegate = getRunConfigurationDelegate( bowl );
+      runConfigurationDelegate.loadAndDelete( runConfigurationTreeItem.getName() );
       }
     } );
     return itemMenu;
@@ -205,6 +195,22 @@ public class RunConfigurationPopupMenuExtension implements ExtensionPointInterfa
       return spoonSupplier.get().getGlobalManagementBowl();
     } else {
       return spoonSupplier.get().getManagementBowl();
+    }
+  }
+
+  private RunConfigurationDelegate getRunConfigurationDelegate( Bowl bowl ) {
+    try {
+      return RunConfigurationDelegate.getInstance( bowl );
+    } catch ( KettleException e ) {
+      throw new IllegalStateException( "Unable to access run configuration delegate", e );
+    }
+  }
+
+  private RunConfigurationService getRunConfigurationManager( Bowl bowl ) {
+    try {
+      return bowl.getManager( RunConfigurationService.class );
+    } catch ( KettleException e ) {
+      throw new IllegalStateException( "Unable to access run configuration manager", e );
     }
   }
 }

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationTreeDelegateExtension.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationTreeDelegateExtension.java
@@ -18,7 +18,7 @@ import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
-import org.pentaho.di.engine.configuration.impl.pentaho.DefaultRunConfigurationProvider;
+import org.pentaho.di.engine.configuration.api.RunConfigurationProvider;
 import org.pentaho.di.ui.core.widget.tree.LeveledTreeNode;
 import org.pentaho.di.ui.spoon.TreeSelection;
 import org.pentaho.di.ui.spoon.delegates.SpoonTreeDelegateExtension;
@@ -53,7 +53,7 @@ public class RunConfigurationTreeDelegateExtension implements ExtensionPointInte
             String name = LeveledTreeNode.getName( treeItem );
             LeveledTreeNode.LEVEL level = LeveledTreeNode.getLevel( treeItem );
 
-            if ( !name.equalsIgnoreCase( DefaultRunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
+            if ( !name.equalsIgnoreCase( RunConfigurationProvider.DEFAULT_CONFIG_NAME ) ) {
               object = new TreeSelection( treeItem, name, new RunConfigurationTreeItem( name, level ) );
             }
           } catch ( Exception e ) {

--- a/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationViewTreeExtension.java
+++ b/plugins/engine-configuration/impl/src/main/java/org/pentaho/di/engine/ui/RunConfigurationViewTreeExtension.java
@@ -20,7 +20,6 @@ import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.engine.configuration.api.RunConfiguration;
-import org.pentaho.di.engine.configuration.api.CheckedMetaStoreSupplier;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.widget.tree.LeveledTreeNode;
 import org.pentaho.di.ui.spoon.SelectionTreeExtension;
@@ -48,7 +47,7 @@ public class RunConfigurationViewTreeExtension implements ExtensionPointInterfac
           bowl = Spoon.getInstance().getManagementBowl();
         }
         RunConfigurationDelegate runConfigurationDelegate =
-          RunConfigurationDelegate.getInstance( () -> bowl.getMetastore() );
+          RunConfigurationDelegate.getInstance( bowl );
 
         runConfigurationDelegate.edit( runConfigurationDelegate.load( name ) );
       }
@@ -56,8 +55,7 @@ public class RunConfigurationViewTreeExtension implements ExtensionPointInterfac
       if ( selectionTreeExtension.getSelection().equals( RunConfiguration.class ) ) {
         // Create new RunConfiguration
         Bowl bowl = Spoon.getInstance().getManagementBowl();
-        CheckedMetaStoreSupplier ms = () -> bowl.getMetastore();
-        RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( ms );
+        RunConfigurationDelegate runConfigurationDelegate = RunConfigurationDelegate.getInstance( bowl );
         runConfigurationDelegate.create();
       }
     }

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/RunConfigurationManagerFactoryInitializationTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/configuration/impl/RunConfigurationManagerFactoryInitializationTest.java
@@ -1,0 +1,67 @@
+package org.pentaho.di.engine.configuration.impl;
+
+import org.pentaho.di.engine.configuration.api.RunConfigurationProvider;
+import org.pentaho.metastore.stores.memory.MemoryMetaStore;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for the Bowl-based factory initialization pattern.
+ * Verifies that factory initialization and singleton behavior work correctly.
+ */
+@RunWith( MockitoJUnitRunner.StrictStubs.class )
+public class RunConfigurationManagerFactoryInitializationTest {
+
+  private MemoryMetaStore metaStore;
+
+  @Before
+  public void setup() throws Exception {
+    metaStore = new MemoryMetaStore();
+  }
+
+  @Test
+  public void testFactoryCanBeRetrievedMultipleTimes() throws Exception {
+    // Arrange & Act - factory initialization should be idempotent
+    RunConfigurationProviderFactoryManagerImpl factory1 = RunConfigurationProviderFactoryManagerImpl.getInstance();
+    RunConfigurationProviderFactoryManagerImpl factory2 = RunConfigurationProviderFactoryManagerImpl.getInstance();
+
+    // Assert - should be the same singleton instance
+    assertNotNull( factory1 );
+    assertNotNull( factory2 );
+    assertEquals( factory1, factory2 );
+  }
+
+  @Test
+  public void testFactoryCanGenerateProvidersFromMetaStore() throws Exception {
+    // Arrange
+    RunConfigurationProviderFactoryManagerImpl factory = RunConfigurationProviderFactoryManagerImpl.getInstance();
+
+    // Act - generate providers from metastore supplier
+    var providers = factory.generateProviders( () -> metaStore );
+
+    // Assert - providers should not be null or empty
+    assertNotNull( providers );
+  }
+
+  @Test
+  public void testDefaultConfigNameConstantIsFromProvider() {
+    // Assert - verify the constant is defined in the provider interface
+    assertEquals( "Pentaho local", RunConfigurationProvider.DEFAULT_CONFIG_NAME );
+  }
+
+  @Test
+  @SuppressWarnings( "deprecation" )
+  public void testDeprecatedMethodStillFunctional() throws Exception {
+    // Arrange & Act - deprecated method should not throw exception
+    RunConfigurationManager manager = RunConfigurationManager.getInstance( () -> metaStore );
+
+    // Assert
+    assertNotNull( manager );
+  }
+}

--- a/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/ui/RunConfigurationDelegateTest.java
+++ b/plugins/engine-configuration/impl/src/test/java/org/pentaho/di/engine/ui/RunConfigurationDelegateTest.java
@@ -74,14 +74,14 @@ public class RunConfigurationDelegateTest {
   private MockedStatic<Spoon> mockedSpoon;
 
   @Before
-  public void setup() {
+  public void setup() throws KettleException {
     spoon = mock( Spoon.class );
     doReturn( mock( Shell.class ) ).when( spoon ).getShell();
 
     mockedSpoon = mockStatic( Spoon.class );
     when( Spoon.getInstance() ).thenReturn( spoon );
 
-    delegate = spy( RunConfigurationDelegate.getInstance( () -> DefaultBowl.getInstance().getMetastore() ) );
+    delegate = spy( RunConfigurationDelegate.getInstance( DefaultBowl.getInstance() ) );
     service = mock( RunConfigurationManager.class );
     delegate.setRunConfigurationManager( service );
   }
@@ -589,7 +589,7 @@ public class RunConfigurationDelegateTest {
     when( targetManager.getNames() ).thenReturn( new ArrayList<>() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.loadAndCopyToProject( srcManager, "TestConfig" );
 
@@ -630,7 +630,7 @@ public class RunConfigurationDelegateTest {
     when( targetManager.getNames() ).thenReturn( new ArrayList<>() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.loadAndMoveToGlobal( srcManager, "TestConfig" );
 
@@ -671,7 +671,7 @@ public class RunConfigurationDelegateTest {
     when( targetManager.getNames() ).thenReturn( new ArrayList<>() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.loadAndMoveToProject( srcManager, "TestConfig" );
 
@@ -792,7 +792,7 @@ public class RunConfigurationDelegateTest {
     when( targetManager.getNames() ).thenReturn( new ArrayList<>() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.copyToGlobal( srcManager, config );
 
@@ -815,7 +815,7 @@ public class RunConfigurationDelegateTest {
     when( targetManager.getNames() ).thenReturn( new ArrayList<>() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.moveToGlobal( srcManager, config );
 
@@ -841,7 +841,7 @@ public class RunConfigurationDelegateTest {
     doReturn( true ).when( delegate ).shouldOverwrite( any() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.copyToGlobal( srcManager, config );
 
@@ -867,7 +867,7 @@ public class RunConfigurationDelegateTest {
     doReturn( false ).when( delegate ).shouldOverwrite( any() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.copyToGlobal( srcManager, config );
 
@@ -890,7 +890,7 @@ public class RunConfigurationDelegateTest {
     when( targetManager.getNames() ).thenReturn( new ArrayList<>() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.copyToProject( srcManager, config );
 
@@ -913,7 +913,7 @@ public class RunConfigurationDelegateTest {
     when( targetManager.getNames() ).thenReturn( new ArrayList<>() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.moveToProject( srcManager, config );
 
@@ -957,7 +957,7 @@ public class RunConfigurationDelegateTest {
     when( targetManager.getNames() ).thenReturn( new ArrayList<>() );
 
     try ( MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class ) ) {
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.loadAndCopyToGlobal( srcManager, "TestConfig" );
 
@@ -988,7 +988,7 @@ public class RunConfigurationDelegateTest {
           MockedStatic<RunConfigurationManager> mockedRCM = mockStatic( RunConfigurationManager.class );
           MockedConstruction<ErrorDialog> mockedError = mockConstruction( ErrorDialog.class ) ) {
       repoUtils.when( () -> RepositoryExceptionUtils.isSessionExpired( sessionError ) ).thenReturn( true );
-      mockedRCM.when( () -> RunConfigurationManager.getInstance( any() ) ).thenReturn( targetManager );
+      mockedRCM.when( () -> RunConfigurationManager.getInstance( any( Bowl.class ) ) ).thenReturn( targetManager );
 
       delegate.copyToGlobal( srcManager, config );
 


### PR DESCRIPTION
- move DEFAULT_CONFIG_NAME to the api package
- switch from CheckedMetastoreSuppliers to Bowl-based factory methods to support consistent project-based managers for the new REST API.
- Use RunConfigurationService (the interface) instead of RunConfigurationManager (the implementing class) in most call sites.
- call RunConfigurationProviderFactoryManagerImpl.getInstance in Extension points to ensure the manager factory is registered, this mostly covers pan/kitchen use