### PR TITLE
[BACKLOG-48250]- job step : Simple evaluation

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEval.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEval.java
@@ -32,6 +32,7 @@ import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.entry.JobEntryBase;
+import org.pentaho.di.job.entry.JobEntryHelperInterface;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
@@ -1158,6 +1159,11 @@ public class JobEntrySimpleEval extends JobEntryBase implements Cloneable, JobEn
   @Override
   public boolean evaluates() {
     return true;
+  }
+
+  @Override
+  public JobEntryHelperInterface getJobEntryHelperInterface() {
+    return new JobEntrySimpleEvalHelper();
   }
 
 }

--- a/engine/src/main/java/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEvalHelper.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEvalHelper.java
@@ -1,0 +1,150 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.simpleeval;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entry.BaseJobEntryHelper;
+
+import java.util.Map;
+
+/**
+ * Provides action handlers for the Simple Evaluation job entry dialog,
+ * exposing dropdown data for value types, field types, and field-type-specific
+ * success conditions.
+ *
+ * @see BaseJobEntryHelper
+ * @see JobEntrySimpleEval
+ */
+public class JobEntrySimpleEvalHelper extends BaseJobEntryHelper {
+
+  @VisibleForTesting
+  protected static final String METHOD_GET_SUCCESS_CONDITIONS = "getSuccessConditions";
+  @VisibleForTesting
+  protected static final String METHOD_GET_DROPDOWN_DATA = "getDropdownData";
+
+  @VisibleForTesting
+  protected static final String RESPONSE_KEY_SUCCESS_CONDITIONS = "successConditions";
+  @VisibleForTesting
+  protected static final String RESPONSE_KEY_VALUE_TYPES = "valueTypes";
+  @VisibleForTesting
+  protected static final String RESPONSE_KEY_FIELD_TYPES = "fieldTypes";
+
+  public JobEntrySimpleEvalHelper() {
+    super();
+  }
+
+  @Override
+  @SuppressWarnings( "unchecked" )
+  protected JSONObject handleJobEntryAction( String method, JobMeta jobMeta, Map<String, String> queryParams ) {
+    JSONObject response = new JSONObject();
+    if ( METHOD_GET_SUCCESS_CONDITIONS.equals( method ) ) {
+      response = getSuccessConditions( queryParams );
+    } else if ( METHOD_GET_DROPDOWN_DATA.equals( method ) ) {
+      response = getDropdownData();
+    } else {
+      response.put( ACTION_STATUS, FAILURE_METHOD_NOT_FOUND_RESPONSE );
+    }
+    return response;
+  }
+
+  /**
+   * Returns the success condition options matching the requested field type.
+   * <p>
+   * Reads the {@code fieldType} query parameter and returns the corresponding
+   * set of success conditions:
+   * <ul>
+   *   <li>{@code "string"} (default) &ndash; string-based conditions (equal, different, contains, etc.)</li>
+   *   <li>{@code "number"} or {@code "datetime"} &ndash; numeric/date conditions (equal, different, smaller, etc.)</li>
+   *   <li>{@code "boolean"} &ndash; boolean conditions (true, false)</li>
+   * </ul>
+   *
+   * @param queryParams query parameters; expects {@code fieldType}
+   * @return a {@link JSONObject} containing the matching conditions under {@value #RESPONSE_KEY_SUCCESS_CONDITIONS}
+   */
+  @VisibleForTesting
+  @SuppressWarnings( "unchecked" )
+  protected JSONObject getSuccessConditions( Map<String, String> queryParams ) {
+    String fieldType = Const.NVL( queryParams == null ? null : queryParams.get( "fieldType" ), "string" );
+    JSONArray conditions = new JSONArray();
+
+    switch ( fieldType ) {
+      case "number":
+      case "datetime":
+        for ( int i = 0; i < JobEntrySimpleEval.successNumberConditionCode.length; i++ ) {
+          JSONObject item = new JSONObject();
+          item.put( "id", JobEntrySimpleEval.successNumberConditionCode[i] );
+          item.put( "name", JobEntrySimpleEval.successNumberConditionDesc[i] );
+          conditions.add( item );
+        }
+        break;
+      case "boolean":
+        for ( int i = 0; i < JobEntrySimpleEval.successBooleanConditionCode.length; i++ ) {
+          JSONObject item = new JSONObject();
+          item.put( "id", JobEntrySimpleEval.successBooleanConditionCode[i] );
+          item.put( "name", JobEntrySimpleEval.successBooleanConditionDesc[i] );
+          conditions.add( item );
+        }
+        break;
+      case "string":
+      default:
+        for ( int i = 0; i < JobEntrySimpleEval.successConditionCode.length; i++ ) {
+          JSONObject item = new JSONObject();
+          item.put( "id", JobEntrySimpleEval.successConditionCode[i] );
+          item.put( "name", JobEntrySimpleEval.successConditionDesc[i] );
+          conditions.add( item );
+        }
+        break;
+    }
+
+    JSONObject response = new JSONObject();
+    response.put( RESPONSE_KEY_SUCCESS_CONDITIONS, conditions );
+    response.put( ACTION_STATUS, SUCCESS_RESPONSE );
+    return response;
+  }
+
+  /**
+   * Returns the static dropdown data for value types and field types.
+   *
+   * @return a {@link JSONObject} containing {@value #RESPONSE_KEY_VALUE_TYPES}
+   *         and {@value #RESPONSE_KEY_FIELD_TYPES} arrays
+   */
+  @VisibleForTesting
+  @SuppressWarnings( "unchecked" )
+  protected JSONObject getDropdownData() {
+    JSONArray valueTypes = new JSONArray();
+    for ( int i = 0; i < JobEntrySimpleEval.valueTypeCode.length; i++ ) {
+      JSONObject item = new JSONObject();
+      item.put( "id", JobEntrySimpleEval.valueTypeCode[i] );
+      item.put( "name", JobEntrySimpleEval.valueTypeDesc[i] );
+      valueTypes.add( item );
+    }
+
+    JSONArray fieldTypes = new JSONArray();
+    for ( int i = 0; i < JobEntrySimpleEval.fieldTypeCode.length; i++ ) {
+      JSONObject item = new JSONObject();
+      item.put( "id", JobEntrySimpleEval.fieldTypeCode[i] );
+      item.put( "name", JobEntrySimpleEval.fieldTypeDesc[i] );
+      fieldTypes.add( item );
+    }
+
+    JSONObject response = new JSONObject();
+    response.put( RESPONSE_KEY_VALUE_TYPES, valueTypes );
+    response.put( RESPONSE_KEY_FIELD_TYPES, fieldTypes );
+    response.put( ACTION_STATUS, SUCCESS_RESPONSE );
+    return response;
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEvalHelperTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/simpleeval/JobEntrySimpleEvalHelperTest.java
@@ -1,0 +1,207 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.simpleeval;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.job.JobMeta;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.pentaho.di.job.entry.JobEntryHelperInterface.ACTION_STATUS;
+import static org.pentaho.di.job.entry.JobEntryHelperInterface.FAILURE_METHOD_NOT_FOUND_RESPONSE;
+import static org.pentaho.di.job.entry.JobEntryHelperInterface.SUCCESS_RESPONSE;
+
+public class JobEntrySimpleEvalHelperTest {
+
+  private JobEntrySimpleEvalHelper helper;
+  private JobMeta jobMeta;
+
+  @Before
+  public void setUp() {
+    jobMeta = mock( JobMeta.class );
+    helper = new JobEntrySimpleEvalHelper();
+  }
+
+  @Test
+  public void testGetSuccessConditions_String() {
+    Map<String, String> params = new HashMap<>();
+    params.put( "fieldType", "string" );
+
+    JSONObject result = helper.getSuccessConditions( params );
+
+    assertNotNull( result );
+    assertEquals( SUCCESS_RESPONSE, result.get( ACTION_STATUS ) );
+    JSONArray conditions = (JSONArray) result.get( JobEntrySimpleEvalHelper.RESPONSE_KEY_SUCCESS_CONDITIONS );
+    assertNotNull( conditions );
+    assertEquals( JobEntrySimpleEval.successConditionCode.length, conditions.size() );
+
+    for ( int i = 0; i < conditions.size(); i++ ) {
+      JSONObject item = (JSONObject) conditions.get( i );
+      assertEquals( JobEntrySimpleEval.successConditionCode[i], item.get( "id" ) );
+      assertEquals( JobEntrySimpleEval.successConditionDesc[i], item.get( "name" ) );
+    }
+  }
+
+  @Test
+  public void testGetSuccessConditions_DefaultIsString() {
+    JSONObject result = helper.getSuccessConditions( Collections.emptyMap() );
+
+    assertNotNull( result );
+    JSONArray conditions = (JSONArray) result.get( JobEntrySimpleEvalHelper.RESPONSE_KEY_SUCCESS_CONDITIONS );
+    assertEquals( JobEntrySimpleEval.successConditionCode.length, conditions.size() );
+  }
+
+  @Test
+  public void testGetSuccessConditions_Number() {
+    Map<String, String> params = new HashMap<>();
+    params.put( "fieldType", "number" );
+
+    JSONObject result = helper.getSuccessConditions( params );
+
+    assertNotNull( result );
+    assertEquals( SUCCESS_RESPONSE, result.get( ACTION_STATUS ) );
+    JSONArray conditions = (JSONArray) result.get( JobEntrySimpleEvalHelper.RESPONSE_KEY_SUCCESS_CONDITIONS );
+    assertNotNull( conditions );
+    assertEquals( JobEntrySimpleEval.successNumberConditionCode.length, conditions.size() );
+
+    for ( int i = 0; i < conditions.size(); i++ ) {
+      JSONObject item = (JSONObject) conditions.get( i );
+      assertEquals( JobEntrySimpleEval.successNumberConditionCode[i], item.get( "id" ) );
+      assertEquals( JobEntrySimpleEval.successNumberConditionDesc[i], item.get( "name" ) );
+    }
+  }
+
+  @Test
+  public void testGetSuccessConditions_DateTime() {
+    Map<String, String> params = new HashMap<>();
+    params.put( "fieldType", "datetime" );
+
+    JSONObject result = helper.getSuccessConditions( params );
+
+    assertNotNull( result );
+    JSONArray conditions = (JSONArray) result.get( JobEntrySimpleEvalHelper.RESPONSE_KEY_SUCCESS_CONDITIONS );
+    // datetime uses the same conditions as number
+    assertEquals( JobEntrySimpleEval.successNumberConditionCode.length, conditions.size() );
+  }
+
+  @Test
+  public void testGetSuccessConditions_Boolean() {
+    Map<String, String> params = new HashMap<>();
+    params.put( "fieldType", "boolean" );
+
+    JSONObject result = helper.getSuccessConditions( params );
+
+    assertNotNull( result );
+    assertEquals( SUCCESS_RESPONSE, result.get( ACTION_STATUS ) );
+    JSONArray conditions = (JSONArray) result.get( JobEntrySimpleEvalHelper.RESPONSE_KEY_SUCCESS_CONDITIONS );
+    assertNotNull( conditions );
+    assertEquals( JobEntrySimpleEval.successBooleanConditionCode.length, conditions.size() );
+
+    for ( int i = 0; i < conditions.size(); i++ ) {
+      JSONObject item = (JSONObject) conditions.get( i );
+      assertEquals( JobEntrySimpleEval.successBooleanConditionCode[i], item.get( "id" ) );
+      assertEquals( JobEntrySimpleEval.successBooleanConditionDesc[i], item.get( "name" ) );
+    }
+  }
+
+  @Test
+  public void testGetDropdownData() {
+    JSONObject result = helper.getDropdownData();
+
+    assertNotNull( result );
+    assertEquals( SUCCESS_RESPONSE, result.get( ACTION_STATUS ) );
+
+    JSONArray valueTypes = (JSONArray) result.get( JobEntrySimpleEvalHelper.RESPONSE_KEY_VALUE_TYPES );
+    assertNotNull( valueTypes );
+    assertEquals( JobEntrySimpleEval.valueTypeCode.length, valueTypes.size() );
+
+    for ( int i = 0; i < valueTypes.size(); i++ ) {
+      JSONObject item = (JSONObject) valueTypes.get( i );
+      assertEquals( JobEntrySimpleEval.valueTypeCode[i], item.get( "id" ) );
+      assertEquals( JobEntrySimpleEval.valueTypeDesc[i], item.get( "name" ) );
+    }
+
+    JSONArray fieldTypes = (JSONArray) result.get( JobEntrySimpleEvalHelper.RESPONSE_KEY_FIELD_TYPES );
+    assertNotNull( fieldTypes );
+    assertEquals( JobEntrySimpleEval.fieldTypeCode.length, fieldTypes.size() );
+
+    for ( int i = 0; i < fieldTypes.size(); i++ ) {
+      JSONObject item = (JSONObject) fieldTypes.get( i );
+      assertEquals( JobEntrySimpleEval.fieldTypeCode[i], item.get( "id" ) );
+      assertEquals( JobEntrySimpleEval.fieldTypeDesc[i], item.get( "name" ) );
+    }
+  }
+
+  @Test
+  public void testHandleJobEntryAction_GetSuccessConditions() {
+    Map<String, String> params = new HashMap<>();
+    params.put( "fieldType", "string" );
+
+    JSONObject result = helper.handleJobEntryAction(
+      JobEntrySimpleEvalHelper.METHOD_GET_SUCCESS_CONDITIONS, jobMeta, params );
+
+    assertNotNull( result );
+    assertTrue( result.containsKey( JobEntrySimpleEvalHelper.RESPONSE_KEY_SUCCESS_CONDITIONS ) );
+  }
+
+  @Test
+  public void testHandleJobEntryAction_GetDropdownData() {
+    JSONObject result = helper.handleJobEntryAction(
+      JobEntrySimpleEvalHelper.METHOD_GET_DROPDOWN_DATA, jobMeta, Collections.emptyMap() );
+
+    assertNotNull( result );
+    assertTrue( result.containsKey( JobEntrySimpleEvalHelper.RESPONSE_KEY_VALUE_TYPES ) );
+    assertTrue( result.containsKey( JobEntrySimpleEvalHelper.RESPONSE_KEY_FIELD_TYPES ) );
+  }
+
+  @Test
+  public void testHandleJobEntryAction_InvalidMethod() {
+    JSONObject result = helper.handleJobEntryAction( "invalidMethod", jobMeta, Collections.emptyMap() );
+
+    assertNotNull( result );
+    assertEquals( FAILURE_METHOD_NOT_FOUND_RESPONSE, result.get( ACTION_STATUS ) );
+  }
+
+  @Test
+  public void testHandleJobEntryAction_NumberAndDateTimeSameConditions() {
+    Map<String, String> numberParams = new HashMap<>();
+    numberParams.put( "fieldType", "number" );
+    JSONObject numberResult = helper.getSuccessConditions( numberParams );
+
+    Map<String, String> dateTimeParams = new HashMap<>();
+    dateTimeParams.put( "fieldType", "datetime" );
+    JSONObject dateTimeResult = helper.getSuccessConditions( dateTimeParams );
+
+    JSONArray numberConditions =
+      (JSONArray) numberResult.get( JobEntrySimpleEvalHelper.RESPONSE_KEY_SUCCESS_CONDITIONS );
+    JSONArray dateTimeConditions =
+      (JSONArray) dateTimeResult.get( JobEntrySimpleEvalHelper.RESPONSE_KEY_SUCCESS_CONDITIONS );
+
+    assertEquals( numberConditions.size(), dateTimeConditions.size() );
+    for ( int i = 0; i < numberConditions.size(); i++ ) {
+      JSONObject numItem = (JSONObject) numberConditions.get( i );
+      JSONObject dtItem = (JSONObject) dateTimeConditions.get( i );
+      assertEquals( numItem.get( "id" ), dtItem.get( "id" ) );
+      assertEquals( numItem.get( "name" ), dtItem.get( "name" ) );
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new helper class to support the Simple Evaluation job entry in Pentaho, providing structured data for UI dropdowns and success conditions, and adds comprehensive unit tests for this functionality. It also updates `JobEntrySimpleEval` to expose the new helper for use in the job entry dialog.

**Simple Evaluation job entry helper integration:**

* Added a new class `JobEntrySimpleEvalHelper` that extends `BaseJobEntryHelper` and provides methods to return dropdown data for value types, field types, and context-sensitive success conditions for the Simple Evaluation job entry dialog. The helper exposes two main methods: `getSuccessConditions` (returns condition options based on field type) and `getDropdownData` (returns available value and field types).
* Updated `JobEntrySimpleEval` to implement `getJobEntryHelperInterface()`, returning an instance of the new helper, enabling the job entry dialog to retrieve dropdown and condition data dynamically. [[1]](diffhunk://#diff-954868c53fefa97ae04354bbca5f6960683f2d04f39c1adedd433247b5605450R35) [[2]](diffhunk://#diff-954868c53fefa97ae04354bbca5f6960683f2d04f39c1adedd433247b5605450R1164-R1168)

**Testing:**

* Added a new test class `JobEntrySimpleEvalHelperTest` with thorough unit tests covering all helper methods, including: verifying correct condition lists for different field types, validating dropdown data, and ensuring correct handling of invalid method requests.