### PR TITLE
chore[SP-7196]: add missing dependency for wizard-core (#10414)

### DIFF
--- a/plugins/pentaho-reporting/assemblies/plugin/pom.xml
+++ b/plugins/pentaho-reporting/assemblies/plugin/pom.xml
@@ -98,6 +98,11 @@
       <artifactId>classic-extensions-sampledata</artifactId>
       <version>${pentaho-reporting.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho.reporting.engine</groupId>
+      <artifactId>wizard-core</artifactId>
+      <version>${pentaho-reporting.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -137,6 +142,7 @@
                 classic-extensions-scripting,
                 classic-extensions-toc,
                 classic-extensions-xpath,
+                wizard-core,
                 commons-database-model,
                 commons-digester,
                 commons-lang3,


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
**SP Issue:** [SP-7196 - Backport of PDI-19902 - (11.0 Suite) Pentaho Reporting Output step fails in 9.4 and 9.5 if "Wizard Processor" preprocessor is selected in the report. Failed to instantiate the specified preprocessor](https://hv-eng.atlassian.net/browse/SP-7196)
**Base Case:** [PDI-19902 - Pentaho Reporting Output step fails in 9.4 and 9.5 if "Wizard Processor" preprocessor is selected in the report. Failed to instantiate the specified preprocessor](https://hv-eng.atlassian.net/browse/PDI-19902)
**Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10414

## Changes
- Backported master PR #10414 to 11.0 for SP-7196
- Cherry-picked commit 58658cc8d2109eb0a26135f260bd0476eb13e654
- Commit: 58658cc8d2109eb0a26135f260bd0476eb13e654

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
- **Code Freeze Status:** Detected (SP2026 - 11.0 (11.0.0.2)), but backport only to maintenance branch per policy
