### PR TITLE
fix[SP-7225]: prevent duplication and fix completion of repository path in log filenames (#10484)

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/logging/Slf4jLoggingEventListener.java
+++ b/core/src/main/java/org/pentaho/di/core/logging/Slf4jLoggingEventListener.java
@@ -124,7 +124,16 @@ public class Slf4jLoggingEventListener implements KettleLoggingEventListener {
               subjects.add( name );
             }
           } else {
-            subjects.add( path + SEPARATOR + name );
+            // If the filename already includes the repository directory path, don't prepend it again.
+            // We only treat it as 'already includes' if the filename starts with the same directory boundary.
+            final boolean startsWithRepoPath = isNotBlank( name )
+              && ( name.startsWith( path + SEPARATOR ) || name.equals( path ) );
+
+            if ( startsWithRepoPath ) {
+              subjects.add( name );
+            } else {
+              subjects.add( path + SEPARATOR + name );
+            }
           }
         } else if ( name != null && name.length() > 0 ) {
           subjects.add( name );

--- a/core/src/test/java/org/pentaho/di/core/logging/Slf4jLoggingEventListenerTest.java
+++ b/core/src/test/java/org/pentaho/di/core/logging/Slf4jLoggingEventListenerTest.java
@@ -153,4 +153,72 @@ public class Slf4jLoggingEventListenerTest {
     verify( transLogger ).info( "[" + testPath + "/TestTrans"
       + RepositoryObjectType.TRANSFORMATION.getExtension() + "]  " + msgText );
   }
+
+  @Test
+  public void testTransDoesNotDuplicateRepositoryPathWhenFilenameAlreadyIncludesIt() {
+    when( logObjProvider.apply( logChannelId ) ).thenReturn( loggingObject );
+    when( loggingObject.getObjectType() ).thenReturn( LoggingObjectType.TRANS );
+    when( message.getLevel() ).thenReturn( LogLevel.BASIC );
+
+    when( loggingObject.getRepositoryDirectory() ).thenReturn( repositoryDirectory );
+    when( repositoryDirectory.getPath() ).thenReturn( "/public" );
+
+    // Filename coming from repository execution already includes the repository directory
+    when( loggingObject.getFilename() ).thenReturn( "/public/tr_writeToLog.ktr" );
+
+    listener.eventAdded( logEvent );
+
+    verify( transLogger ).info( "[/public/tr_writeToLog.ktr]  " + msgText );
+  }
+
+  @Test
+  public void testJobDoesNotDuplicateRepositoryPathWhenFilenameAlreadyIncludesIt() {
+    when( logObjProvider.apply( logChannelId ) ).thenReturn( loggingObject );
+    when( loggingObject.getObjectType() ).thenReturn( LoggingObjectType.JOB );
+    when( message.getLevel() ).thenReturn( LogLevel.BASIC );
+
+    when( loggingObject.getRepositoryDirectory() ).thenReturn( repositoryDirectory );
+    when( repositoryDirectory.getPath() ).thenReturn( "/public" );
+
+    // Filename coming from repository execution already includes the repository directory
+    when( loggingObject.getFilename() ).thenReturn( "/public/jb_internalPath.kjb" );
+
+    listener.eventAdded( logEvent );
+
+    verify( jobLogger ).info( "[/public/jb_internalPath.kjb]  " + msgText );
+  }
+
+  @Test
+  public void testTransPreservesRepositoryPathWhenFilenameIsNotAbsoluteRepoPath() {
+    when( logObjProvider.apply( logChannelId ) ).thenReturn( loggingObject );
+    when( loggingObject.getObjectType() ).thenReturn( LoggingObjectType.TRANS );
+    when( message.getLevel() ).thenReturn( LogLevel.BASIC );
+
+    when( loggingObject.getRepositoryDirectory() ).thenReturn( repositoryDirectory );
+    when( repositoryDirectory.getPath() ).thenReturn( "/public" );
+
+    // Filename without leading '/' should still get repository path prepended
+    when( loggingObject.getFilename() ).thenReturn( "jb_internalPath.ktr" );
+
+    listener.eventAdded( logEvent );
+
+    verify( transLogger ).info( "[/public/jb_internalPath.ktr]  " + msgText );
+  }
+
+  @Test
+  public void testJobPreservesRepositoryPathWhenFilenameIsNotAbsoluteRepoPath() {
+    when( logObjProvider.apply( logChannelId ) ).thenReturn( loggingObject );
+    when( loggingObject.getObjectType() ).thenReturn( LoggingObjectType.JOB );
+    when( message.getLevel() ).thenReturn( LogLevel.BASIC );
+
+    when( loggingObject.getRepositoryDirectory() ).thenReturn( repositoryDirectory );
+    when( repositoryDirectory.getPath() ).thenReturn( "/public" );
+
+    // Filename without leading '/' should still get repository path prepended
+    when( loggingObject.getFilename() ).thenReturn( "jb_internalPath.kjb" );
+
+    listener.eventAdded( logEvent );
+
+    verify( jobLogger ).info( "[/public/jb_internalPath.kjb]  " + msgText );
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
+++ b/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
@@ -267,12 +267,46 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
       }
 
       cacheMeta( idContainer[ 0 ], theMeta );
+      // Re-seed the internal directory variables on the returned meta from the freshly resolved tmpSpace.
+      // The cache may return an instance whose internal vars were last set in a different context
+      // (e.g. from a step loader using getVarSpaceOnlyWithRequiredParentVars, or with rep==null),
+      // which would otherwise leak the wrong Internal.Entry.Current.Directory into the child execution.
+      reseedInternalDirectoryVars( theMeta, tmpSpace );
       return theMeta;
     } catch ( final KettleException ke ) {
       // if we get a KettleException, simply re-throw it
       throw ke;
     } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( persistentClass, "JobTrans.Exception.MetaDataLoad" ), e );
+    }
+  }
+
+  /**
+   * Force the four internal directory variables on the loaded meta to the values resolved by
+   * {@link CurrentDirectoryResolver} for *this* job-entry invocation. Without this, a cached
+   * TransMeta/JobMeta returned from a previous load can carry stale Internal.Entry.Current.Directory
+   * (and friends) inherited from whatever space was active during that earlier load.
+   */
+  private void reseedInternalDirectoryVars( T theMeta, VariableSpace tmpSpace ) {
+    if ( theMeta == null || tmpSpace == null || !( theMeta instanceof org.pentaho.di.base.AbstractMeta ) ) {
+      return;
+    }
+    org.pentaho.di.base.AbstractMeta meta = (org.pentaho.di.base.AbstractMeta) theMeta;
+    String entryDir = tmpSpace.getVariable( INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY );
+    if ( entryDir != null ) {
+      meta.setVariable( INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, entryDir );
+    }
+    String jobDir = tmpSpace.getVariable( INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY );
+    if ( jobDir != null ) {
+      meta.setVariable( INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY, jobDir );
+    }
+    String transDir = tmpSpace.getVariable( INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY );
+    if ( transDir != null ) {
+      meta.setVariable( INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, transDir );
+    }
+    String jobName = tmpSpace.getVariable( INTERNAL_VARIABLE_JOB_FILENAME_NAME );
+    if ( jobName != null ) {
+      meta.setVariable( INTERNAL_VARIABLE_JOB_FILENAME_NAME, jobName );
     }
   }
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/trans/JobEntryTrans.java
@@ -1321,21 +1321,28 @@ public class JobEntryTrans extends JobEntryBase implements Cloneable, JobEntryIn
       TransMeta transMeta = metaFileLoader.getMetaForEntry( parentJobMeta.getBowl(), rep, metaStore, space );
 
       if ( transMeta != null ) {
-        // set Internal.Entry.Current.Directory again because it was changed
-        transMeta.setInternalKettleVariables();
+        // Pass repository and metastore references first.
+        //
+        transMeta.setRepository( rep );
+        transMeta.setMetaStore( metaStore );
+
+        // NOTE: do NOT call transMeta.setInternalKettleVariables() here.
+        // MetaFileLoaderImpl.getMetaForEntry has already seeded Internal.Entry.Current.Directory (and
+        // friends) on the loaded meta from the freshly resolved tmpSpace for *this* job-entry invocation.
+        // Calling setInternalKettleVariables() at this point would recompute those vars from the meta's
+        // own (potentially stale or context-mismatched) directory/filename fields and clobber the
+        // correct value -- this was the root cause of Internal.Entry.Current.Directory resolving to the
+        // parent directory (e.g. "/public" instead of "/public/test") when a transformation is invoked
+        // from a job entry.
+
         //  When the child parameter does exist in the parent parameters, overwrite the child parameter by the
         // parent parameter.
-
         StepWithMappingMeta.replaceVariableValues( transMeta, space, "Trans" );
         if ( isPassingAllParameters() ) {
           // All other parent parameters need to get copied into the child parameters  (when the 'Inherit all
           // variables from the transformation?' option is checked)
           StepWithMappingMeta.addMissingVariables( transMeta, space );
         }
-        // Pass repository and metastore references
-        //
-        transMeta.setRepository( rep );
-        transMeta.setMetaStore( metaStore );
       }
 
       return transMeta;


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
**SP Issue:** [SP-7225 - Backport of PDI-20828 - (11.0 Suite) Internal.Entry.Current.Directory not resolving properly when used on the Pentaho Server](https://hv-eng.atlassian.net/browse/SP-7225)
**Base Case:** [PDI-20828 - Internal.Entry.Current.Directory not resolving properly when used on the Pentaho Server](https://hv-eng.atlassian.net/browse/PDI-20828)
**Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10484

## Changes
- fix: prevent duplication and fix completion of repository path in log filenames
- Commit: aacdc9db5d91d57d86c251d053068b27cf43c610

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
- **Code Freeze Status:** Detected (SP2026 - 11.0 (11.0.0.2)), but backport only to maintenance branch per policy
