### PR TITLE
build[PPP-6390][PPP-6391]: use maven-parent-pom bouncycastle managed version

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -502,12 +502,10 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.xml</groupId>


### PR DESCRIPTION
This pull request makes a minor update to `pom.xml` files to use the `bouncycastle` version declared in `maven-parent-poms` `dependencyManagement`: https://github.com/pentaho/maven-parent-poms/pull/843