### PR TITLE
fix[SP-7208]: Preserve trans/job filename in Carte remote execution

### DIFF
--- a/core/src/test/java/org/pentaho/di/core/vfs/KettleVFSTest.java
+++ b/core/src/test/java/org/pentaho/di/core/vfs/KettleVFSTest.java
@@ -142,4 +142,45 @@ public class KettleVFSTest {
 
   }
 
+  @Test
+  public void testNormalizeFilePath_NullOrEmpty() {
+    assertNull( KettleVFS.normalizeFilePath( null ) );
+    assertEquals( "", KettleVFS.normalizeFilePath( "" ) );
+    assertEquals( "   ", KettleVFS.normalizeFilePath( "   " ) );
+  }
+
+  @Test
+  public void testNormalizeFilePath_WithScheme() {
+    // Paths with schemes should be returned as-is
+    String hdfsPath = "hdfs://namenode:8020/user/data/file.txt";
+    assertEquals( hdfsPath, KettleVFS.normalizeFilePath( hdfsPath ) );
+
+    String s3Path = "s3://bucket/folder/file.txt";
+    assertEquals( s3Path, KettleVFS.normalizeFilePath( s3Path ) );
+
+    // file:// paths should be preserved
+    String filePath = "file:///tmp/test.ktr";
+    assertEquals( filePath, KettleVFS.normalizeFilePath( filePath ) );
+
+    // file:// paths with URL-encoded characters should be preserved
+    String encodedFilePath = "file:///tmp/my%20folder/test.ktr";
+    assertEquals( encodedFilePath, KettleVFS.normalizeFilePath( encodedFilePath ) );
+  }
+
+  @Test
+  public void testNormalizeFilePath_WithVariables() {
+    // Paths with unresolved variables should be returned as-is
+    String pathWithVar = "${Internal.Entry.Current.Directory}/Output.ktr";
+    assertEquals( pathWithVar, KettleVFS.normalizeFilePath( pathWithVar ) );
+  }
+
+  @Test
+  public void testNormalizeFilePath_LocalPathGetsFileScheme() {
+    // Test that local paths get file:// prefix
+    String localPath = "/tmp/test/file.ktr";
+    String result = KettleVFS.normalizeFilePath( localPath );
+    assertTrue( result.startsWith( "file://" ) );
+    assertTrue( result.endsWith( "file.ktr" ) );
+  }
+
 }

--- a/engine/src/main/java/org/pentaho/di/job/JobMeta.java
+++ b/engine/src/main/java/org/pentaho/di/job/JobMeta.java
@@ -588,6 +588,10 @@ public class JobMeta extends AbstractMeta
 
     retval.append( "  " ).append( XMLHandler.addTagValue( "directory",
         ( directory != null ? directory.getPath() : RepositoryDirectory.DIRECTORY_SEPARATOR ) ) );
+
+    // Include the filename for Carte remote execution to preserve the source file path
+    retval.append( "  " ).append( XMLHandler.addTagValue( "filename", filename ) );
+
     retval.append( "  " ).append( XMLHandler.addTagValue( "created_user", createdUser ) );
     retval.append( "  " ).append( XMLHandler.addTagValue( "created_date", XMLHandler.date2string( createdDate ) ) );
     retval.append( "  " ).append( XMLHandler.addTagValue( "modified_user", modifiedUser ) );
@@ -907,7 +911,7 @@ public class JobMeta extends AbstractMeta
       // If we are not using a repository, we are getting the job from a file
       // Set the filename here so it can be used in variables for ALL aspects of the job FIX: PDI-8890
       if ( null == rep ) {
-        setFilename( fname );
+        setFilename( KettleVFS.normalizeFilePath( fname ) );
       }  else {
         // Set the repository here so it can be used in variables for ALL aspects of the job FIX: PDI-16441
         setRepository( rep );
@@ -941,6 +945,15 @@ public class JobMeta extends AbstractMeta
 
       // job status
       jobStatus = Const.toInt( XMLHandler.getTagValue( jobnode, "job_status" ), -1 );
+
+      // If filename was not set during construction (e.g. when loading from XML Node for Carte execution),
+      // try to read it from the XML. This ensures the filename is preserved during remote execution.
+      if ( Utils.isEmpty( filename ) ) {
+        String xmlFilename = XMLHandler.getTagValue( jobnode, "filename" );
+        if ( !Utils.isEmpty( xmlFilename ) ) {
+          setFilename( xmlFilename );
+        }
+      }
 
       // Created user/date
       createdUser = XMLHandler.getTagValue( jobnode, "created_user" );

--- a/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/TransMeta.java
@@ -2427,6 +2427,8 @@ public class TransMeta extends AbstractMeta
     retval.append( "    " ).append( XMLHandler.addTagValue( "directory",
             directory != null ? directory.getPath() : RepositoryDirectory.DIRECTORY_SEPARATOR ) );
 
+    // Include the filename for Carte remote execution to preserve the source file path
+    retval.append( "    " ).append( XMLHandler.addTagValue( "filename", filename ) );
 
     if ( includeNamedParameters ) {
       retval.append( "    " ).append( XMLHandler.openTag( XML_TAG_PARAMETERS ) ).append( Const.CR );
@@ -2996,7 +2998,7 @@ public class TransMeta extends AbstractMeta
         // If we are not using a repository, we are getting the transformation from a file
         // Set the filename here so it can be used in variables for ALL aspects of the transformation FIX: PDI-8890
         if ( null == rep ) {
-          setFilename( fname );
+          setFilename( KettleVFS.normalizeFilePath( fname ) );
         } else {
           // Set the repository here so it can be used in variables for ALL aspects of the job FIX: PDI-16441
           setRepository( rep );
@@ -3171,6 +3173,15 @@ public class TransMeta extends AbstractMeta
 
         String transTypeCode = XMLHandler.getTagValue( infonode, "trans_type" );
         transformationType = TransformationType.getTransformationTypeByCode( transTypeCode );
+
+        // If filename was not set during construction (e.g. when loading from XML Node for Carte execution),
+        // try to read it from the XML. This ensures the filename is preserved during remote execution.
+        if ( Utils.isEmpty( filename ) ) {
+          String xmlFilename = XMLHandler.getTagValue( infonode, "filename" );
+          if ( !Utils.isEmpty( xmlFilename ) ) {
+            setFilename( xmlFilename );
+          }
+        }
 
         // Optionally load the repository directory...
         //

--- a/engine/src/test/java/org/pentaho/di/job/JobMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/JobMetaTest.java
@@ -39,6 +39,7 @@ import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.resource.ResourceDefinition;
 import org.pentaho.di.resource.ResourceNamingInterface;
+import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -50,6 +51,7 @@ import java.util.HashMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.same;
@@ -515,6 +517,92 @@ public class JobMetaTest {
     assertTrue( jobMetaTest.isGatheringMetrics() );
     jobMetaTest.setGatheringMetrics( false );
     assertFalse( jobMetaTest.isGatheringMetrics() );
+  }
+
+  /**
+   * Tests that the filename is preserved during XML serialization and deserialization.
+   * This is critical for Carte remote execution where JobMeta is serialized to XML,
+   * sent to a slave server, and deserialized. The filename must be preserved so that
+   * lineage tracking and other features can identify the source job file.
+   */
+  @Test
+  public void testFilenamePreservedInXmlSerialization() throws Exception {
+    // Create a JobMeta with a filename set
+    JobMeta originalJobMeta = new JobMeta();
+    originalJobMeta.setName( "TestJob" );
+    String testFilename = "/path/to/test/job.kjb";
+    originalJobMeta.setFilename( testFilename );
+
+    // Serialize to XML
+    String xml = originalJobMeta.getXML();
+
+    // Verify the filename is in the XML
+    assertTrue( "Filename should be included in XML", xml.contains( "<filename>" + testFilename + "</filename>" ) );
+
+    // Deserialize from XML (simulating Carte receiving the job)
+    org.w3c.dom.Document doc = XMLHandler.loadXMLString( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + xml );
+    Node jobNode = XMLHandler.getSubNode( doc, JobMeta.XML_TAG );
+
+    JobMeta deserializedJobMeta = new JobMeta();
+    deserializedJobMeta.loadXML( jobNode, null, null );
+
+    // Verify the filename is preserved after deserialization
+    assertEquals( "Filename should be preserved after XML deserialization", testFilename, deserializedJobMeta.getFilename() );
+  }
+
+  /**
+   * Tests that when loadXML is called, the filename is loaded from the XML.
+   * This is the expected behavior when JobMeta is deserialized on a Carte server.
+   */
+  @Test
+  public void testFilenameLoadedFromXmlOnLoadXML() throws Exception {
+    // Create a JobMeta with a filename set via XML
+    JobMeta sourceJobMeta = new JobMeta();
+    sourceJobMeta.setName( "TestJob" );
+    String originalFilename = "/original/path/job.kjb";
+    sourceJobMeta.setFilename( originalFilename );
+
+    // Serialize to XML
+    String xml = sourceJobMeta.getXML();
+    org.w3c.dom.Document doc = XMLHandler.loadXMLString( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + xml );
+    Node jobNode = XMLHandler.getSubNode( doc, JobMeta.XML_TAG );
+
+    // Create a new JobMeta and load the XML (simulating Carte receiving the job)
+    JobMeta targetJobMeta = new JobMeta();
+
+    // Load XML into the JobMeta - this should load the filename from XML
+    targetJobMeta.loadXML( jobNode, null, null );
+
+    // The filename from XML should be loaded
+    assertEquals( "Filename should be loaded from XML", originalFilename, targetJobMeta.getFilename() );
+  }
+
+  /**
+   * Tests that null filename doesn't cause issues in XML serialization.
+   */
+  @Test
+  public void testNullFilenameInXmlSerialization() throws Exception {
+    JobMeta jobMetaWithNullFilename = new JobMeta();
+    jobMetaWithNullFilename.setName( "TestJob" );
+    // Filename is null by default
+    assertNull( jobMetaWithNullFilename.getFilename() );
+
+    // Serialize to XML - should not throw exception
+    String xml = jobMetaWithNullFilename.getXML();
+
+    // Should have empty filename tag
+    assertTrue( "XML should contain filename tag even when null", xml.contains( "<filename/>" ) || xml.contains( "<filename></filename>" ) );
+
+    // Deserialize and verify
+    org.w3c.dom.Document doc = XMLHandler.loadXMLString( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + xml );
+    Node jobNode = XMLHandler.getSubNode( doc, JobMeta.XML_TAG );
+
+    JobMeta deserializedJobMeta = new JobMeta();
+    deserializedJobMeta.loadXML( jobNode, null, null );
+
+    // Filename should still be null/empty after deserialization
+    assertTrue( "Null filename should result in null or empty after deserialization",
+        deserializedJobMeta.getFilename() == null || deserializedJobMeta.getFilename().isEmpty() );
   }
 
 }

--- a/engine/src/test/java/org/pentaho/di/job/JobMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/JobMetaTest.java
@@ -591,7 +591,8 @@ public class JobMetaTest {
     String xml = jobMetaWithNullFilename.getXML();
 
     // Should have empty filename tag
-    assertTrue( "XML should contain filename tag even when null", xml.contains( "<filename/>" ) || xml.contains( "<filename></filename>" ) );
+    assertTrue( "XML should contain filename tag even when null",
+      xml.contains( "<filename/>" ) || xml.contains( "<filename />" ) || xml.contains( "<filename></filename>" ) );
 
     // Deserialize and verify
     org.w3c.dom.Document doc = XMLHandler.loadXMLString( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + xml );

--- a/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
@@ -927,7 +927,8 @@ public class TransMetaTest {
     String xml = transMetaWithNullFilename.getXML();
 
     // Should have empty filename tag
-    assertTrue( "XML should contain filename tag even when null", xml.contains( "<filename/>" ) || xml.contains( "<filename></filename>" ) );
+    assertTrue( "XML should contain filename tag even when null",
+      xml.contains( "<filename/>" ) || xml.contains( "<filename />" ) || xml.contains( "<filename></filename>" ) );
 
     // Deserialize and verify
     org.w3c.dom.Document doc = XMLHandler.loadXMLString( xml );

--- a/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/TransMetaTest.java
@@ -51,6 +51,7 @@ import org.pentaho.di.trans.steps.textfileoutput.TextFileOutputMeta;
 import org.pentaho.di.trans.steps.userdefinedjavaclass.InfoStepDefinition;
 import org.pentaho.di.trans.steps.userdefinedjavaclass.UserDefinedJavaClassDef;
 import org.pentaho.di.trans.steps.userdefinedjavaclass.UserDefinedJavaClassMeta;
+import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.stores.memory.MemoryMetaStore;
 import org.w3c.dom.Node;
@@ -850,5 +851,92 @@ public class TransMetaTest {
     transMetaTest.setInternalEntryCurrentDirectory();
 
     assertEquals( "Original value defined at run execution", transMetaTest.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
+  }
+
+  /**
+   * Tests that the filename is preserved during XML serialization and deserialization.
+   * This is critical for Carte remote execution where TransMeta is serialized to XML,
+   * sent to a slave server, and deserialized. The filename must be preserved so that
+   * lineage tracking and other features can identify the source transformation file.
+   */
+  @Test
+  public void testFilenamePreservedInXmlSerialization() throws Exception {
+    // Create a TransMeta with a filename set
+    TransMeta originalTransMeta = new TransMeta();
+    originalTransMeta.setName( "TestTransformation" );
+    String testFilename = "/path/to/test/transformation.ktr";
+    originalTransMeta.setFilename( testFilename );
+
+    // Serialize to XML
+    String xml = originalTransMeta.getXML();
+
+    // Verify the filename is in the XML
+    assertTrue( "Filename should be included in XML", xml.contains( "<filename>" + testFilename + "</filename>" ) );
+
+    // Deserialize from XML (simulating Carte receiving the transformation)
+    // When loading from Node (not from file), filename should be read from XML
+    org.w3c.dom.Document doc = XMLHandler.loadXMLString( xml );
+    Node transNode = XMLHandler.getSubNode( doc, TransMeta.XML_TAG );
+ 
+    TransMeta deserializedTransMeta = new TransMeta( transNode, null );
+
+    // Verify the filename is preserved after deserialization
+    assertEquals( "Filename should be preserved after XML deserialization", testFilename, deserializedTransMeta.getFilename() );
+  }
+
+  /**
+   * Tests that when loadXML is called, the filename is loaded from the XML.
+   * This is the expected behavior when TransMeta is deserialized on a Carte server.
+   * Note: loadXML calls clear() first, so any pre-existing filename will be cleared
+   * before the XML content is loaded.
+   */
+  @Test
+  public void testFilenameLoadedFromXmlOnLoadXML() throws Exception {
+    // Create a TransMeta with a filename set via XML
+    TransMeta sourceTransMeta = new TransMeta();
+    sourceTransMeta.setName( "TestTransformation" );
+    String originalFilename = "/original/path/transformation.ktr";
+    sourceTransMeta.setFilename( originalFilename );
+
+    // Serialize to XML
+    String xml = sourceTransMeta.getXML();
+    org.w3c.dom.Document doc = XMLHandler.loadXMLString( xml );
+    Node transNode = XMLHandler.getSubNode( doc, TransMeta.XML_TAG );
+
+    // Create a new TransMeta and load the XML (simulating Carte receiving the transformation)
+    TransMeta targetTransMeta = new TransMeta();
+
+    // Load XML into the TransMeta - this should load the filename from XML
+    targetTransMeta.loadXML( transNode, null, false );
+
+    // The filename from XML should be loaded
+    assertEquals( "Filename should be loaded from XML", originalFilename, targetTransMeta.getFilename() );
+  }
+
+  /**
+   * Tests that null filename doesn't cause issues in XML serialization.
+   */
+  @Test
+  public void testNullFilenameInXmlSerialization() throws Exception {
+    TransMeta transMetaWithNullFilename = new TransMeta();
+    transMetaWithNullFilename.setName( "TestTransformation" );
+    // Filename is null by default
+    assertNull( transMetaWithNullFilename.getFilename() );
+
+    // Serialize to XML - should not throw exception
+    String xml = transMetaWithNullFilename.getXML();
+
+    // Should have empty filename tag
+    assertTrue( "XML should contain filename tag even when null", xml.contains( "<filename/>" ) || xml.contains( "<filename></filename>" ) );
+
+    // Deserialize and verify
+    org.w3c.dom.Document doc = XMLHandler.loadXMLString( xml );
+    Node transNode = XMLHandler.getSubNode( doc, TransMeta.XML_TAG );
+
+    TransMeta deserializedTransMeta = new TransMeta( transNode, null );
+
+    // Filename should still be null/empty after deserialization
+    assertTrue( "Null filename should result in null or empty after deserialization",
+        deserializedTransMeta.getFilename() == null || deserializedTransMeta.getFilename().isEmpty() );
   }
 }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
@@ -20,6 +20,7 @@ import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPointHandler;
 import org.pentaho.di.core.extension.KettleExtensionPoint;
+import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.job.JobEntryJob;
@@ -79,7 +80,7 @@ public class JobFileListener implements FileListener, ConnectionListener {
         jobMeta.clearChanged();
       }
 
-      jobMeta.setFilename( fname );
+      jobMeta.setFilename( KettleVFS.normalizeFilePath( fname ) );
       spoon.delegates.jobs.addJobGraph( jobMeta );
 
       // Call extension point(s) now that the file has been opened

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/TransFileListener.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/TransFileListener.java
@@ -24,6 +24,7 @@ import org.pentaho.di.core.extension.ExtensionPointHandler;
 import org.pentaho.di.core.extension.KettleExtensionPoint;
 import org.pentaho.di.core.gui.OverwritePrompter;
 import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
@@ -106,7 +107,7 @@ public class TransFileListener implements FileListener, ConnectionListener {
         transMeta.clearChanged();
       }
 
-      transMeta.setFilename( fname );
+      transMeta.setFilename( KettleVFS.normalizeFilePath( fname ) );
       spoon.addTransGraph( transMeta );
       spoon.sharedObjectsFileMap.put( transMeta.getSharedObjects().getFilename(), transMeta.getSharedObjects() );
 


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7208 - Backport of PDI-20600 - (10.2 Suite) Null filename when consulting TransformationMeta in Carte and other inconsistencies](https://hv-eng.atlassian.net/browse/SP-7208)
- **Base Case:** [PDI-20600 - Backport of PDI-20600 - (10.2 Suite) Null filename when consulting TransformationMeta in Carte and other inconsistencies](https://hv-eng.atlassian.net/browse/PDI-20600)
- **Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10365

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-kettle/pull/10365
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
