### PR TITLE
chore[SP-7231]: REST Client Step KeyStore functionality is not working

### DIFF
--- a/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
@@ -13,9 +13,9 @@
 
 package org.pentaho.di.trans.steps.rest;
 
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -24,8 +24,6 @@ import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import javax.net.ssl.SSLContext;
 
 
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
@@ -40,7 +38,9 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowDataUtil;
+import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.util.Utils;
+import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
@@ -77,18 +77,11 @@ public class Rest extends BaseStep implements StepInterface {
   }
 
   protected Object[] callRest( Object[] rowData ) throws KettleException {
-
-    Client client = null;
-    try {
-      client = getClient( rowData );
-      WebTarget webResource = buildRequest( client, rowData );
-      return invokeRequest( webResource, rowData );
+    try ( Client client = getClient( rowData ) ) {
+      WebTarget target = buildRequest( client, rowData );
+      return invokeRequest( target, rowData );
     } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.CanNotReadURL", data.realUrl ), e );
-    } finally {
-      if ( client != null ) {
-        client.close();
-      }
     }
   }
 
@@ -104,11 +97,11 @@ public class Rest extends BaseStep implements StepInterface {
         throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.MethodMissing" ) );
       }
     }
-    Client client = null;
+
     if ( isDetailed() ) {
       logDetailed( BaseMessages.getString( PKG, "Rest.Log.ConnectingToURL", data.realUrl ) );
     }
-    //      // Register a custom StringMessageBodyWriter to solve PDI-17423
+    // Register a custom StringMessageBodyWriter to solve PDI-17423
     ClientBuilder clientBuilder = ClientBuilder.newBuilder();
     clientBuilder
       .withConfig( data.config )
@@ -117,7 +110,7 @@ public class Rest extends BaseStep implements StepInterface {
       clientBuilder.sslContext( data.sslContext );
       clientBuilder.hostnameVerifier( ( s1, s2 ) -> true );
     }
-    client = clientBuilder.build();
+    Client client = clientBuilder.build();
     if ( data.basicAuthentication != null ) {
       client.register( data.basicAuthentication );
     }
@@ -125,9 +118,8 @@ public class Rest extends BaseStep implements StepInterface {
   }
 
   protected WebTarget buildRequest( Client client, Object[] rowData ) throws KettleException {
-    WebTarget webResource = null;
     // create a WebResource object, which encapsulates a web resource for the client
-    webResource = client.target( data.realUrl );
+    WebTarget webResource = client.target( data.realUrl );
 
     if ( data.useMatrixParams ) {
       // Add matrix parameters
@@ -198,7 +190,7 @@ public class Rest extends BaseStep implements StepInterface {
         logDebug( BaseMessages.getString( PKG, "Rest.Log.BodyValue", entityString ) );
       }
     }
-    boolean debug = true;
+
     try {
       if ( data.method.equals( RestMeta.HTTP_METHOD_GET ) ) {
         response = invocationBuilder.get( Response.class );
@@ -206,7 +198,6 @@ public class Rest extends BaseStep implements StepInterface {
         if ( null != contentType ) {
           response = invocationBuilder.post( Entity.entity( entityString, contentType ) );
         } else {
-          //            response = builder.type( data.mediaType ).post( ClientResponse.class, entityString );
           response = invocationBuilder.post( Entity.entity( entityString, data.mediaType ) );
         }
       } else if ( data.method.equals( RestMeta.HTTP_METHOD_PUT ) ) {
@@ -327,19 +318,10 @@ public class Rest extends BaseStep implements StepInterface {
 
   protected void setSSLConfiguration(RestData data) throws KettleException {
     try {
-      SSLContext ctx;
-      FileInputStream trustStoreFileStream = null;
-      if (data.trustStoreFile != null) {
-    	  trustStoreFileStream = new FileInputStream( data.trustStoreFile );
-      }
-      
-      ctx = HttpClientManager.getSslContext(meta.isIgnoreSsl(), 
-    		  						trustStoreFileStream, 
-    		  						data.trustStorePassword);
-      data.sslContext = ctx;
-      
+      data.sslContext = HttpClientManager.getSslContext( meta.isIgnoreSsl(),
+        getInputStream( data.trustStoreFile ),
+        data.trustStorePassword );
 
-      
     } catch ( NoSuchAlgorithmException e ) {
       throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.NoSuchAlgorithm" ), e );
     } catch ( KeyStoreException e ) {
@@ -347,24 +329,42 @@ public class Rest extends BaseStep implements StepInterface {
     } catch ( CertificateException e ) {
       throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.CertificateException" ), e );
     } catch ( FileNotFoundException e ) {
-      throw new KettleException(
-        BaseMessages.getString( PKG, "Rest.Error.FileNotFound", data.trustStoreFile ), e );
+      throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.FileNotFound", data.trustStoreFile ), e );
     } catch ( IOException e ) {
       throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.IOException" ), e );
-    } catch ( KeyManagementException e ) {
+    } catch ( KeyManagementException | UnrecoverableKeyException e ) {
       throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.KeyManagementException" ), e );
-    } catch ( UnrecoverableKeyException e ) {
-	  throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.KeyManagementException" ), e );
     }
   }
   
   
 
 
+  /**
+   * Get an InputStream for the file with the given name.
+   * If the file name is empty or null, returns null.
+   *
+   * @param fileName the file name to get InputStream from
+   * @return InputStream for the given file, <code>null</code> if the given file name is empty or null
+   * @throws KettleException if any error occurs while getting the InputStream
+   */
+  protected InputStream getInputStream( String fileName ) throws KettleException {
+    InputStream inputStream = null;
+
+    if ( !StringUtil.isEmpty( fileName ) ) {
+      fileName = fileName.trim();
+      if ( !StringUtil.isEmpty( fileName ) ) {
+        inputStream = KettleVFS.getInstance( this.getTransMeta().getBowl() ).getInputStream( fileName );
+      }
+    }
+    return inputStream;
+  }
+
   protected MultivaluedMap<String, Object> searchForHeaders( Response response ) {
     return response.getHeaders();
   }
 
+  @Override
   public boolean processRow( StepMetaInterface smi, StepDataInterface sdi ) throws KettleException {
     meta = (RestMeta) smi;
     data = (RestData) sdi;
@@ -491,17 +491,13 @@ public class Rest extends BaseStep implements StepInterface {
     try {
       Object[] outputRowData = callRest( r );
       putRow( data.outputRowMeta, outputRowData ); // copy row to output rowset(s);
-      if ( checkFeedback( getLinesRead() ) ) {
-        if ( isDetailed() ) {
-          logDetailed( BaseMessages.getString( PKG, "Rest.LineNumber" ) + getLinesRead() );
-        }
+      if ( isDetailed() && checkFeedback( getLinesRead() ) ) {
+        logDetailed( BaseMessages.getString( PKG, "Rest.LineNumber" ) + getLinesRead() );
       }
     } catch ( KettleException e ) {
-      boolean sendToErrorRow = false;
-      String errorMessage = null;
       if ( getStepMeta().isDoingErrorHandling() ) {
-        sendToErrorRow = true;
-        errorMessage = e.toString();
+        // Simply add this row to the error row
+        putError( getInputRowMeta(), r, 1, e.toString(), null, "Rest001" );
       } else {
         logError( BaseMessages.getString( PKG, "Rest.ErrorInStepRunning" ) + e.getMessage() );
         setErrors( 1 );
@@ -510,14 +506,11 @@ public class Rest extends BaseStep implements StepInterface {
         setOutputDone(); // signal end to receiver(s)
         return false;
       }
-      if ( sendToErrorRow ) {
-        // Simply add this row to the error row
-        putError( getInputRowMeta(), r, 1, errorMessage, null, "Rest001" );
-      }
     }
     return true;
   }
 
+  @Override
   public boolean init( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (RestMeta) smi;
     data = (RestData) sdi;
@@ -547,26 +540,8 @@ public class Rest extends BaseStep implements StepInterface {
       data.trustStorePassword =
         Encr.decryptPasswordOptionallyEncrypted( environmentSubstitute( meta.getTrustStorePassword() ) );
 
-      String applicationType = Const.NVL( meta.getApplicationType(), "" );
-      if ( applicationType.equals( RestMeta.APPLICATION_TYPE_XML ) ) {
-        data.mediaType = MediaType.APPLICATION_XML_TYPE;
-      } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_JSON ) ) {
-        data.mediaType = MediaType.APPLICATION_JSON_TYPE;
-      } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_OCTET_STREAM ) ) {
-        data.mediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
-      } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_XHTML ) ) {
-        data.mediaType = MediaType.APPLICATION_XHTML_XML_TYPE;
-      } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_FORM_URLENCODED ) ) {
-        data.mediaType = MediaType.APPLICATION_FORM_URLENCODED_TYPE;
-      } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_ATOM_XML ) ) {
-        data.mediaType = MediaType.APPLICATION_ATOM_XML_TYPE;
-      } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_SVG_XML ) ) {
-        data.mediaType = MediaType.APPLICATION_SVG_XML_TYPE;
-      } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_TEXT_XML ) ) {
-        data.mediaType = MediaType.TEXT_XML_TYPE;
-      } else {
-        data.mediaType = MediaType.TEXT_PLAIN_TYPE;
-      }
+      calcMediaType();
+
       try {
         setConfig();
       } catch ( Exception e ) {
@@ -578,6 +553,30 @@ public class Rest extends BaseStep implements StepInterface {
     return false;
   }
 
+  private void calcMediaType() {
+    String applicationType = Const.NVL( meta.getApplicationType(), "" );
+    if ( applicationType.equals( RestMeta.APPLICATION_TYPE_XML ) ) {
+      data.mediaType = MediaType.APPLICATION_XML_TYPE;
+    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_JSON ) ) {
+      data.mediaType = MediaType.APPLICATION_JSON_TYPE;
+    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_OCTET_STREAM ) ) {
+      data.mediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
+    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_XHTML ) ) {
+      data.mediaType = MediaType.APPLICATION_XHTML_XML_TYPE;
+    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_FORM_URLENCODED ) ) {
+      data.mediaType = MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_ATOM_XML ) ) {
+      data.mediaType = MediaType.APPLICATION_ATOM_XML_TYPE;
+    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_SVG_XML ) ) {
+      data.mediaType = MediaType.APPLICATION_SVG_XML_TYPE;
+    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_TEXT_XML ) ) {
+      data.mediaType = MediaType.TEXT_XML_TYPE;
+    } else {
+      data.mediaType = MediaType.TEXT_PLAIN_TYPE;
+    }
+  }
+
+  @Override
   public void dispose( StepMetaInterface smi, StepDataInterface sdi ) {
     meta = (RestMeta) smi;
     data = (RestData) sdi;
@@ -586,6 +585,7 @@ public class Rest extends BaseStep implements StepInterface {
     data.headerNames = null;
     data.indexOfHeaderFields = null;
     data.paramNames = null;
+
     super.dispose( smi, sdi );
   }
 

--- a/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
@@ -380,8 +380,8 @@ public class Rest extends BaseStep implements StepInterface {
       throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.KeyManagementException" ), e );
     }
   }
-  
-  
+
+
 
 
   /**

--- a/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
@@ -37,6 +37,7 @@ import org.json.simple.JSONObject;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.RowDataUtil;
 import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.util.Utils;
@@ -69,6 +70,8 @@ import javax.ws.rs.core.UriBuilder;
 public class Rest extends BaseStep implements StepInterface {
   private static Class<?> PKG = RestMeta.class; // for i18n purposes, needed by Translator2!! $NON-NLS-1$
 
+  private static final String HEADER_CONTENT_TYPE = "Content-Type";
+
   private RestMeta meta;
   private RestData data;
 
@@ -90,6 +93,7 @@ public class Rest extends BaseStep implements StepInterface {
     if ( meta.isUrlInField() ) {
       data.realUrl = data.inputRowMeta.getString( rowData, data.indexOfUrlField );
     }
+
     // get dynamic method?
     if ( meta.isDynamicMethod() ) {
       data.method = data.inputRowMeta.getString( rowData, data.indexOfMethod );
@@ -101,19 +105,21 @@ public class Rest extends BaseStep implements StepInterface {
     if ( isDetailed() ) {
       logDetailed( BaseMessages.getString( PKG, "Rest.Log.ConnectingToURL", data.realUrl ) );
     }
+
     // Register a custom StringMessageBodyWriter to solve PDI-17423
     ClientBuilder clientBuilder = ClientBuilder.newBuilder();
-    clientBuilder
-      .withConfig( data.config )
-      .property( HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true );
+    clientBuilder.withConfig( data.config ).property( HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true );
+
     if ( meta.isIgnoreSsl() || !Utils.isEmpty( data.trustStoreFile ) ) {
       clientBuilder.sslContext( data.sslContext );
       clientBuilder.hostnameVerifier( ( s1, s2 ) -> true );
     }
+
     Client client = clientBuilder.build();
     if ( data.basicAuthentication != null ) {
       client.register( data.basicAuthentication );
     }
+
     return client;
   }
 
@@ -147,9 +153,11 @@ public class Rest extends BaseStep implements StepInterface {
           UriComponent.encode( value, UriComponent.Type.QUERY_PARAM_SPACE_ENCODED ) );
       }
     }
+
     if ( isDebug() ) {
       logDebug( BaseMessages.getString( PKG, "Rest.Log.ConnectingToURL", webResource.getUri() ) );
     }
+
     return webResource;
   }
 
@@ -164,24 +172,8 @@ public class Rest extends BaseStep implements StepInterface {
 
     Invocation.Builder invocationBuilder = webResource.request();
 
-    String contentType = null; // media type override, if not null
-    if ( data.useHeaders ) {
-      // Add headers
-      for ( int i = 0; i < data.nrheader; i++ ) {
-        String value = data.inputRowMeta.getString( rowData, data.indexOfHeaderFields[ i ] );
+    String contentType = calcContentType( rowData, invocationBuilder );
 
-        // unsure if an already set header will be returned to builder
-        invocationBuilder.header( data.headerNames[ i ], value );
-        if ( "Content-Type".equals( data.headerNames[ i ] ) ) {
-          contentType = value;
-        }
-        if ( isDebug() ) {
-          logDebug( BaseMessages.getString( PKG, "Rest.Log.HeaderValue", data.headerNames[ i ], value ) );
-        }
-      }
-    }
-
-    Response response;
     String entityString = "";
     if ( data.useBody ) {
       // Set Http request entity
@@ -191,43 +183,8 @@ public class Rest extends BaseStep implements StepInterface {
       }
     }
 
-    try {
-      if ( data.method.equals( RestMeta.HTTP_METHOD_GET ) ) {
-        response = invocationBuilder.get( Response.class );
-      } else if ( data.method.equals( RestMeta.HTTP_METHOD_POST ) ) {
-        if ( null != contentType ) {
-          response = invocationBuilder.post( Entity.entity( entityString, contentType ) );
-        } else {
-          response = invocationBuilder.post( Entity.entity( entityString, data.mediaType ) );
-        }
-      } else if ( data.method.equals( RestMeta.HTTP_METHOD_PUT ) ) {
-        if ( null != contentType ) {
-          response = invocationBuilder.put( Entity.entity( entityString, contentType ) );
-        } else {
-          response = invocationBuilder.put( Entity.entity( entityString, data.mediaType ) );
-        }
-      } else if ( data.method.equals( RestMeta.HTTP_METHOD_DELETE ) ) {
-        response = invocationBuilder.delete();
-      } else if ( data.method.equals( RestMeta.HTTP_METHOD_HEAD ) ) {
-        response = invocationBuilder.head();
-      } else if ( data.method.equals( RestMeta.HTTP_METHOD_OPTIONS ) ) {
-        response = invocationBuilder.options();
-      } else if ( data.method.equals( RestMeta.HTTP_METHOD_PATCH ) ) {
-        if ( null != contentType ) {
-          response =
-            invocationBuilder.method(
-                RestMeta.HTTP_METHOD_PATCH, Entity.entity( entityString, contentType ) );
-        } else {
-          response =
-            invocationBuilder.method(
-                RestMeta.HTTP_METHOD_PATCH, Entity.entity( entityString, data.mediaType ) );
-        }
-      } else {
-        throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.UnknownMethod", data.method ) );
-      }
-    } catch ( Exception e ) {
-      throw new KettleException( "Request could not be processed", e );
-    }
+    Response response = getResponse( invocationBuilder, contentType, entityString );
+
     // Get response time
     long responseTime = System.currentTimeMillis() - startTime;
     if ( isDetailed() ) {
@@ -244,25 +201,12 @@ public class Rest extends BaseStep implements StepInterface {
 
     // Get Response
     String body;
-    String headerString = null;
     try {
       body = response.readEntity( String.class );
     } catch ( Exception ex ) {
       body = "";
     }
-    // get Header
-    MultivaluedMap<String, Object> headers = searchForHeaders( response );
-    JSONObject json = new JSONObject();
-    for ( java.util.Map.Entry<String, List<Object>> entry : headers.entrySet() ) {
-      String name = entry.getKey();
-      List<Object> value = entry.getValue();
-      if ( value.size() > 1 ) {
-        json.put( name, value );
-      } else {
-        json.put( name, value.get( 0 ) );
-      }
-    }
-    headerString = json.toJSONString();
+
     // for output
     int returnFieldsOffset = data.inputRowMeta.size();
     // add response to output
@@ -284,9 +228,109 @@ public class Rest extends BaseStep implements StepInterface {
     }
     // add response header to output
     if ( !Utils.isEmpty( data.resultHeaderFieldName ) ) {
-      newRow = RowDataUtil.addValueData( newRow, returnFieldsOffset, headerString );
+      newRow = RowDataUtil.addValueData( newRow, returnFieldsOffset, getHeaderFromResponse( response ) );
     }
     return newRow;
+  }
+
+  /**
+   * Calculate content type from headers if any
+   *
+   * @param rowData
+   * @param invocationBuilder
+   * @return content type if any
+   * @throws KettleValueException
+   */
+  private String calcContentType( Object[] rowData, Invocation.Builder invocationBuilder ) throws KettleValueException {
+    String contentType = null;
+    if ( data.useHeaders ) {
+      // Add headers
+      for ( int i = 0; i < data.nrheader; i++ ) {
+        String value = data.inputRowMeta.getString( rowData, data.indexOfHeaderFields[ i ] );
+
+        // unsure if an already set header will be returned to builder
+        invocationBuilder.header( data.headerNames[ i ], value );
+        if ( HEADER_CONTENT_TYPE.equals( data.headerNames[ i ] ) ) {
+          contentType = value;
+        }
+        if ( isDebug() ) {
+          logDebug( BaseMessages.getString( PKG, "Rest.Log.HeaderValue", data.headerNames[ i ], value ) );
+        }
+      }
+    }
+    return contentType;
+  }
+
+  /**
+   * Invoke the request based on the method
+   *
+   * @param invocationBuilder
+   * @param contentType
+   * @param entityString
+   * @return the response from the server
+   * @throws KettleException in case the request could not be processed
+   */
+  private Response getResponse( Invocation.Builder invocationBuilder, String contentType, String entityString )
+    throws KettleException {
+    Response response;
+    try {
+      switch ( data.method ) {
+        case RestMeta.HTTP_METHOD_GET -> response = invocationBuilder.get( Response.class );
+        case RestMeta.HTTP_METHOD_POST -> response = invocationBuilder.post( getEntity( contentType, entityString ) );
+        case RestMeta.HTTP_METHOD_PUT -> response = invocationBuilder.put( getEntity( contentType, entityString ) );
+        case RestMeta.HTTP_METHOD_DELETE -> response = invocationBuilder.delete();
+        case RestMeta.HTTP_METHOD_HEAD -> response = invocationBuilder.head();
+        case RestMeta.HTTP_METHOD_OPTIONS -> response = invocationBuilder.options();
+        case RestMeta.HTTP_METHOD_PATCH ->
+          response = invocationBuilder.method( RestMeta.HTTP_METHOD_PATCH, getEntity( contentType, entityString ) );
+        default -> throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.UnknownMethod", data.method ) );
+      }
+    } catch ( Exception e ) {
+      throw new KettleException( "Request could not be processed", e );
+    }
+    return response;
+  }
+
+  /**
+   * Get entity for request using the given content type or the default one
+   *
+   * @param contentType  the content type
+   * @param entityString the entity string
+   * @return
+   */
+  private Entity<?> getEntity( String contentType, String entityString ) {
+    Entity<?> entity;
+
+    if ( null != contentType ) {
+      entity = Entity.entity( entityString, contentType );
+    } else {
+      entity = Entity.entity( entityString, data.mediaType );
+    }
+
+    return entity;
+  }
+
+  /**
+   * Get headers from response and return then as a json string
+   *
+   * @param response the response object from which to extract headers
+   * @return json string representing the headers of the given response
+   */
+  private String getHeaderFromResponse( Response response ) {
+    MultivaluedMap<String, Object> headers = searchForHeaders( response );
+    JSONObject json = new JSONObject();
+
+    for ( java.util.Map.Entry<String, List<Object>> entry : headers.entrySet() ) {
+      String name = entry.getKey();
+      List<Object> value = entry.getValue();
+      if ( value.size() > 1 ) {
+        json.put( name, value );
+      } else {
+        json.put( name, value.get( 0 ) );
+      }
+    }
+
+    return json.toJSONString();
   }
 
   private void setConfig() throws KettleException {
@@ -383,114 +427,29 @@ public class Rest extends BaseStep implements StepInterface {
       meta.getFields( data.outputRowMeta, getStepname(), null, null, this, repository, metaStore );
 
       // Let's set URL
-      if ( meta.isUrlInField() ) {
-        if ( Utils.isEmpty( meta.getUrlField() ) ) {
-          logError( BaseMessages.getString( PKG, "Rest.Log.NoField" ) );
-          throw new KettleException( BaseMessages.getString( PKG, "Rest.Log.NoField" ) );
-        }
-        // cache the position of the field
-        if ( data.indexOfUrlField < 0 ) {
-          String realUrlfieldName = environmentSubstitute( meta.getUrlField() );
-          data.indexOfUrlField = data.inputRowMeta.indexOfValue( realUrlfieldName );
-          if ( data.indexOfUrlField < 0 ) {
-            // The field is unreachable !
-            throw new KettleException(
-              BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", realUrlfieldName ) );
-          }
-        }
-      } else {
-        // Static URL
-        data.realUrl = environmentSubstitute( meta.getUrl() );
-      }
+      calcURL();
+
       // Check Method
-      if ( meta.isDynamicMethod() ) {
-        String field = environmentSubstitute( meta.getMethodFieldName() );
-        if ( Utils.isEmpty( field ) ) {
-          throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.MethodFieldMissing" ) );
-        }
-        data.indexOfMethod = data.inputRowMeta.indexOfValue( field );
-        if ( data.indexOfMethod < 0 ) {
-          // The field is unreachable !
-          throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
-        }
-      }
+      calcMethod();
+
+
       // set Headers
-      int nrargs = meta.getHeaderName() == null ? 0 : meta.getHeaderName().length;
-      if ( nrargs > 0 ) {
-        data.nrheader = nrargs;
-        data.indexOfHeaderFields = new int[ nrargs ];
-        data.headerNames = new String[ nrargs ];
-        for ( int i = 0; i < nrargs; i++ ) {
-          // split into body / header
-          data.headerNames[ i ] = environmentSubstitute( meta.getHeaderName()[ i ] );
-          String field = environmentSubstitute( meta.getHeaderField()[ i ] );
-          if ( Utils.isEmpty( field ) ) {
-            throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.HeaderFieldEmpty" ) );
-          }
-          data.indexOfHeaderFields[ i ] = data.inputRowMeta.indexOfValue( field );
-          if ( data.indexOfHeaderFields[ i ] < 0 ) {
-            throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
-          }
-        }
-        data.useHeaders = true;
-      }
+      calcHeaders();
 
       String substitutedMethod = environmentSubstitute( meta.getMethod() );
+      // Set Parameters
       if ( RestMeta.isActiveParameters( substitutedMethod ) ) {
-        // Parameters
-        int nrparams = meta.getParameterField() == null ? 0 : meta.getParameterField().length;
-        if ( nrparams > 0 ) {
-          data.nrParams = nrparams;
-          data.paramNames = new String[ nrparams ];
-          data.indexOfParamFields = new int[ nrparams ];
-          for ( int i = 0; i < nrparams; i++ ) {
-            data.paramNames[ i ] = environmentSubstitute( meta.getParameterName()[ i ] );
-            String field = environmentSubstitute( meta.getParameterField()[ i ] );
-            if ( Utils.isEmpty( field ) ) {
-              throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ParamFieldEmpty" ) );
-            }
-            data.indexOfParamFields[ i ] = data.inputRowMeta.indexOfValue( field );
-            if ( data.indexOfParamFields[ i ] < 0 ) {
-              throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
-            }
-          }
-          data.useParams = true;
-        }
-        int nrmatrixparams = meta.getMatrixParameterField() == null ? 0 : meta.getMatrixParameterField().length;
-        if ( nrmatrixparams > 0 ) {
-          data.nrMatrixParams = nrmatrixparams;
-          data.matrixParamNames = new String[ nrmatrixparams ];
-          data.indexOfMatrixParamFields = new int[ nrmatrixparams ];
-          for ( int i = 0; i < nrmatrixparams; i++ ) {
-            data.matrixParamNames[ i ] = environmentSubstitute( meta.getMatrixParameterName()[ i ] );
-            String field = environmentSubstitute( meta.getMatrixParameterField()[ i ] );
-            if ( Utils.isEmpty( field ) ) {
-              throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.MatrixParamFieldEmpty" ) );
-            }
-            data.indexOfMatrixParamFields[ i ] = data.inputRowMeta.indexOfValue( field );
-            if ( data.indexOfMatrixParamFields[ i ] < 0 ) {
-              throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
-            }
-          }
-          data.useMatrixParams = true;
-        }
+        calcParameters();
       }
 
       // Do we need to set body
       if ( RestMeta.isActiveBody( substitutedMethod ) ) {
-        String field = environmentSubstitute( meta.getBodyField() );
-        if ( !Utils.isEmpty( field ) ) {
-          data.indexOfBodyField = data.inputRowMeta.indexOfValue( field );
-          if ( data.indexOfBodyField < 0 ) {
-            throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
-          }
-          data.useBody = true;
-        }
+        calcBody();
       }
     } // end if first
     try {
       Object[] outputRowData = callRest( r );
-      putRow( data.outputRowMeta, outputRowData ); // copy row to output rowset(s);
+      putRow( data.outputRowMeta, outputRowData ); // copy row to output rowset(s)
       if ( isDetailed() && checkFeedback( getLinesRead() ) ) {
         logDetailed( BaseMessages.getString( PKG, "Rest.LineNumber" ) + getLinesRead() );
       }
@@ -508,6 +467,141 @@ public class Rest extends BaseStep implements StepInterface {
       }
     }
     return true;
+  }
+
+  /**
+   * Calculate URL
+   *
+   * @throws KettleException
+   */
+  private void calcURL() throws KettleException {
+    if ( meta.isUrlInField() ) {
+      if ( Utils.isEmpty( meta.getUrlField() ) ) {
+        logError( BaseMessages.getString( PKG, "Rest.Log.NoField" ) );
+        throw new KettleException( BaseMessages.getString( PKG, "Rest.Log.NoField" ) );
+      }
+      // cache the position of the field
+      if ( data.indexOfUrlField < 0 ) {
+        String realUrlfieldName = environmentSubstitute( meta.getUrlField() );
+        data.indexOfUrlField = data.inputRowMeta.indexOfValue( realUrlfieldName );
+        if ( data.indexOfUrlField < 0 ) {
+          // The field is unreachable !
+          throw new KettleException(
+            BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", realUrlfieldName ) );
+        }
+      }
+    } else {
+      // Static URL
+      data.realUrl = environmentSubstitute( meta.getUrl() );
+    }
+  }
+
+  /**
+   * Calculate method
+   *
+   * @throws KettleException
+   */
+  private void calcMethod() throws KettleException {
+    if ( meta.isDynamicMethod() ) {
+      String field = environmentSubstitute( meta.getMethodFieldName() );
+      if ( Utils.isEmpty( field ) ) {
+        throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.MethodFieldMissing" ) );
+      }
+      data.indexOfMethod = data.inputRowMeta.indexOfValue( field );
+      if ( data.indexOfMethod < 0 ) {
+        // The field is unreachable !
+        throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
+      }
+    }
+  }
+
+  /**
+   * Calculate headers
+   *
+   * @throws KettleException
+   */
+  private void calcHeaders() throws KettleException {
+    int nrArgs = meta.getHeaderName() == null ? 0 : meta.getHeaderName().length;
+    if ( nrArgs > 0 ) {
+      data.nrheader = nrArgs;
+      data.indexOfHeaderFields = new int[ nrArgs ];
+      data.headerNames = new String[ nrArgs ];
+      for ( int i = 0; i < nrArgs; i++ ) {
+        // split into body / header
+        data.headerNames[ i ] = environmentSubstitute( meta.getHeaderName()[ i ] );
+        String field = environmentSubstitute( meta.getHeaderField()[ i ] );
+        if ( Utils.isEmpty( field ) ) {
+          throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.HeaderFieldEmpty" ) );
+        }
+        data.indexOfHeaderFields[ i ] = data.inputRowMeta.indexOfValue( field );
+        if ( data.indexOfHeaderFields[ i ] < 0 ) {
+          throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
+        }
+      }
+      data.useHeaders = true;
+    }
+  }
+
+  /**
+   * Calculate the parameters
+   *
+   * @throws KettleException
+   */
+  private void calcParameters() throws KettleException {
+    // Parameters
+    int nrParams = meta.getParameterField() == null ? 0 : meta.getParameterField().length;
+    if ( nrParams > 0 ) {
+      data.nrParams = nrParams;
+      data.paramNames = new String[ nrParams ];
+      data.indexOfParamFields = new int[ nrParams ];
+      for ( int i = 0; i < nrParams; i++ ) {
+        data.paramNames[ i ] = environmentSubstitute( meta.getParameterName()[ i ] );
+        String field = environmentSubstitute( meta.getParameterField()[ i ] );
+        if ( Utils.isEmpty( field ) ) {
+          throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ParamFieldEmpty" ) );
+        }
+        data.indexOfParamFields[ i ] = data.inputRowMeta.indexOfValue( field );
+        if ( data.indexOfParamFields[ i ] < 0 ) {
+          throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
+        }
+      }
+      data.useParams = true;
+    }
+
+    int nrMatrixParams = meta.getMatrixParameterField() == null ? 0 : meta.getMatrixParameterField().length;
+    if ( nrMatrixParams > 0 ) {
+      data.nrMatrixParams = nrMatrixParams;
+      data.matrixParamNames = new String[ nrMatrixParams ];
+      data.indexOfMatrixParamFields = new int[ nrMatrixParams ];
+      for ( int i = 0; i < nrMatrixParams; i++ ) {
+        data.matrixParamNames[ i ] = environmentSubstitute( meta.getMatrixParameterName()[ i ] );
+        String field = environmentSubstitute( meta.getMatrixParameterField()[ i ] );
+        if ( Utils.isEmpty( field ) ) {
+          throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.MatrixParamFieldEmpty" ) );
+        }
+        data.indexOfMatrixParamFields[ i ] = data.inputRowMeta.indexOfValue( field );
+        if ( data.indexOfMatrixParamFields[ i ] < 0 ) {
+          throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
+        }
+      }
+      data.useMatrixParams = true;
+    }
+  }
+
+  /**
+   * Calculate body
+   *
+   * @throws KettleException
+   */
+  private void calcBody() throws KettleException {
+    String field = environmentSubstitute( meta.getBodyField() );
+    if ( !Utils.isEmpty( field ) ) {
+      data.indexOfBodyField = data.inputRowMeta.indexOfValue( field );
+      if ( data.indexOfBodyField < 0 ) {
+        throw new KettleException( BaseMessages.getString( PKG, "Rest.Exception.ErrorFindingField", field ) );
+      }
+      data.useBody = true;
+    }
   }
 
   @Override
@@ -553,26 +647,21 @@ public class Rest extends BaseStep implements StepInterface {
     return false;
   }
 
+  /**
+   * Calculate media type based on the application type
+   */
   private void calcMediaType() {
     String applicationType = Const.NVL( meta.getApplicationType(), "" );
-    if ( applicationType.equals( RestMeta.APPLICATION_TYPE_XML ) ) {
-      data.mediaType = MediaType.APPLICATION_XML_TYPE;
-    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_JSON ) ) {
-      data.mediaType = MediaType.APPLICATION_JSON_TYPE;
-    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_OCTET_STREAM ) ) {
-      data.mediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
-    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_XHTML ) ) {
-      data.mediaType = MediaType.APPLICATION_XHTML_XML_TYPE;
-    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_FORM_URLENCODED ) ) {
-      data.mediaType = MediaType.APPLICATION_FORM_URLENCODED_TYPE;
-    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_ATOM_XML ) ) {
-      data.mediaType = MediaType.APPLICATION_ATOM_XML_TYPE;
-    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_SVG_XML ) ) {
-      data.mediaType = MediaType.APPLICATION_SVG_XML_TYPE;
-    } else if ( applicationType.equals( RestMeta.APPLICATION_TYPE_TEXT_XML ) ) {
-      data.mediaType = MediaType.TEXT_XML_TYPE;
-    } else {
-      data.mediaType = MediaType.TEXT_PLAIN_TYPE;
+    switch ( applicationType ) {
+      case RestMeta.APPLICATION_TYPE_XML -> data.mediaType = MediaType.APPLICATION_XML_TYPE;
+      case RestMeta.APPLICATION_TYPE_JSON -> data.mediaType = MediaType.APPLICATION_JSON_TYPE;
+      case RestMeta.APPLICATION_TYPE_OCTET_STREAM -> data.mediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
+      case RestMeta.APPLICATION_TYPE_XHTML -> data.mediaType = MediaType.APPLICATION_XHTML_XML_TYPE;
+      case RestMeta.APPLICATION_TYPE_FORM_URLENCODED -> data.mediaType = MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+      case RestMeta.APPLICATION_TYPE_ATOM_XML -> data.mediaType = MediaType.APPLICATION_ATOM_XML_TYPE;
+      case RestMeta.APPLICATION_TYPE_SVG_XML -> data.mediaType = MediaType.APPLICATION_SVG_XML_TYPE;
+      case RestMeta.APPLICATION_TYPE_TEXT_XML -> data.mediaType = MediaType.TEXT_XML_TYPE;
+      default -> data.mediaType = MediaType.TEXT_PLAIN_TYPE;
     }
   }
 

--- a/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
@@ -265,8 +265,8 @@ public class Rest extends BaseStep implements StepInterface {
    * Invoke the request based on the method
    *
    * @param invocationBuilder
-   * @param contentType
-   * @param entityString
+   * @param contentType  the content type
+   * @param entityString the entity string
    * @return the response from the server
    * @throws KettleException in case the request could not be processed
    */
@@ -296,7 +296,7 @@ public class Rest extends BaseStep implements StepInterface {
    *
    * @param contentType  the content type
    * @param entityString the entity string
-   * @return
+   * @return the request entity built using the given content type or the default media type
    */
   private Entity<?> getEntity( String contentType, String entityString ) {
     Entity<?> entity;

--- a/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/Rest.java
@@ -13,6 +13,21 @@
 
 package org.pentaho.di.trans.steps.rest;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+
+
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
@@ -36,29 +51,15 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.di.util.HttpClientManager;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
-import java.util.List;
 
 /**
  * @author Samatar
@@ -319,36 +320,26 @@ public class Rest extends BaseStep implements StepInterface {
         }
       }
       // SSL TRUST STORE CONFIGURATION
-      if ( !Utils.isEmpty( data.trustStoreFile ) && !meta.isIgnoreSsl() ) {
-        setTrustStoreFile();
-      }
-      if ( meta.isIgnoreSsl() ) {
-        setTrustAll();
-      }
+      setSSLConfiguration( data );
 
     }
   }
 
-  private void setTrustAll() throws KettleException {
+  protected void setSSLConfiguration(RestData data) throws KettleException {
     try {
-      SSLContext ctx = HttpClientManager.getTrustAllSslContext();
-
+      SSLContext ctx;
+      FileInputStream trustStoreFileStream = null;
+      if (data.trustStoreFile != null) {
+    	  trustStoreFileStream = new FileInputStream( data.trustStoreFile );
+      }
+      
+      ctx = HttpClientManager.getSslContext(meta.isIgnoreSsl(), 
+    		  						trustStoreFileStream, 
+    		  						data.trustStorePassword);
       data.sslContext = ctx;
-    } catch ( NoSuchAlgorithmException e ) {
-      throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.NoSuchAlgorithm" ), e );
-    } catch ( KeyManagementException e ) {
-      throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.KeyManagementException" ), e );
-    }
-  }
+      
 
-  private void setTrustStoreFile() throws KettleException {
-    try ( FileInputStream trustFileStream = new FileInputStream( data.trustStoreFile ) ) {
-
-      SSLContext ctx =
-        HttpClientManager.getSslContextWithTrustStoreFile(
-          trustFileStream, data.trustStorePassword );
-
-      data.sslContext = ctx;
+      
     } catch ( NoSuchAlgorithmException e ) {
       throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.NoSuchAlgorithm" ), e );
     } catch ( KeyStoreException e ) {
@@ -362,40 +353,13 @@ public class Rest extends BaseStep implements StepInterface {
       throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.IOException" ), e );
     } catch ( KeyManagementException e ) {
       throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.KeyManagementException" ), e );
+    } catch ( UnrecoverableKeyException e ) {
+	  throw new KettleException( BaseMessages.getString( PKG, "Rest.Error.KeyManagementException" ), e );
     }
   }
+  
+  
 
-  protected SSLContext getSslContext( String trustFile, String trustStorePassword )
-    throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException, KeyManagementException,
-    UnrecoverableKeyException {
-
-    try ( FileInputStream trustFileStream = new FileInputStream( trustFile );
-          FileInputStream keyStoreFileStream = new FileInputStream( trustFile ) ) {
-
-
-      TrustManagerFactory tmf = TrustManagerFactory.getInstance( TrustManagerFactory.getDefaultAlgorithm() );
-      // Using null here initialises the TMF with the default trust store.
-      tmf.init( (KeyStore) null );
-
-      // Load the trustStore which needs to be imported
-      KeyStore trustStore = KeyStore.getInstance( KeyStore.getDefaultType() );
-      trustStore.load( trustFileStream, trustStorePassword.toCharArray() );
-
-      tmf = TrustManagerFactory.getInstance( TrustManagerFactory.getDefaultAlgorithm() );
-      tmf.init( trustStore );
-
-      KeyStore identityKeyStore = KeyStore.getInstance( KeyStore.getDefaultType() );
-      identityKeyStore.load( keyStoreFileStream, trustStorePassword.toCharArray() );
-      KeyManagerFactory kmf = KeyManagerFactory.getInstance( KeyManagerFactory.getDefaultAlgorithm() );
-      kmf.init( identityKeyStore, trustStorePassword.toCharArray() );
-
-
-      SSLContext sslContext = SSLContext.getInstance( "TLSv1.2" );
-      sslContext.init( kmf.getKeyManagers(), tmf.getTrustManagers(), null );
-
-      return sslContext;
-    }
-  }
 
   protected MultivaluedMap<String, Object> searchForHeaders( Response response ) {
     return response.getHeaders();

--- a/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/RestMeta.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/RestMeta.java
@@ -412,7 +412,7 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
    *
    * @param nrHeaders    number of headers
    * @param nrParameters number of parameters
-   * @deprecated use #allocate(int nrHeaders, int nrParameters, int nrMatrixParameters) instead
+   * @deprecated use {@link RestMeta#allocate(int, int, int)} instead
    */
   @Deprecated
   public void allocate( int nrHeaders, int nrParameters ) {

--- a/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/RestMeta.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/trans/steps/rest/RestMeta.java
@@ -16,6 +16,8 @@ package org.pentaho.di.trans.steps.rest;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.annotations.Step;
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.encryption.Encr;
 import org.pentaho.di.core.exception.KettleException;
@@ -31,7 +33,6 @@ import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
-import org.pentaho.di.shared.SharedObjectInterface;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
@@ -40,7 +41,6 @@ import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
 import org.pentaho.metastore.api.IMetaStore;
-import org.pentaho.di.core.annotations.Step;
 import org.w3c.dom.Node;
 
 import java.util.List;
@@ -56,8 +56,46 @@ import java.util.List;
 public class RestMeta extends BaseStepMeta implements StepMetaInterface {
   private static Class<?> PKG = RestMeta.class; // for i18n purposes, needed by Translator2!!
 
-  public static final String[] APPLICATION_TYPES = new String[] {
-    "TEXT PLAIN", "XML", "JSON", "OCTET STREAM", "XHTML", "FORM URLENCODED", "ATOM XML", "SVG XML", "TEXT XML" };
+  private static final String TAG_APPLICATION_TYPE = "applicationType";
+  private static final String TAG_BODY_FIELD = "bodyField";
+  private static final String TAG_CODE = "code";
+  private static final String TAG_DYNAMIC_METHOD = "dynamicMethod";
+  private static final String TAG_FIELD = "field";
+  private static final String TAG_HEADER = "header";
+  private static final String TAG_HEADER_FIELD = "header_field";
+  private static final String TAG_HEADER_NAME = "header_name";
+  private static final String TAG_HEADERS = "headers";
+  private static final String TAG_HTTP_LOGIN = "httpLogin";
+  private static final String TAG_HTTP_PASSWORD = "httpPassword";
+  private static final String TAG_IGNORE_SSL = "ignoreSsl";
+  private static final String TAG_MATRIX_PARAMETER = "matrixParameter";
+  private static final String TAG_MATRIX_PARAMETER_FIELD = "matrix_parameter_field";
+  private static final String TAG_MATRIX_PARAMETER_NAME = "matrix_parameter_name";
+  private static final String TAG_MATRIX_PARAMETERS = "matrixParameters";
+  private static final String TAG_METHOD = "method";
+  private static final String TAG_METHOD_FIELD_NAME = "methodFieldName";
+  private static final String TAG_NAME = "name";
+  private static final String TAG_PARAMETER = "parameter";
+  private static final String TAG_PARAMETER_FIELD = "parameter_field";
+  private static final String TAG_PARAMETER_NAME = "parameter_name";
+  private static final String TAG_PARAMETERS = "parameters";
+  private static final String TAG_PREEMPTIVE = "preemptive";
+  private static final String TAG_PROXY_HOST = "proxyHost";
+  private static final String TAG_PROXY_PORT = "proxyPort";
+  private static final String TAG_RESPONSE_HEADER = "response_header";
+  private static final String TAG_RESPONSE_TIME = "response_time";
+  private static final String TAG_RESULT = "result";
+  private static final String TAG_RESULT_CODE = "result_code";
+  private static final String TAG_RESULT_NAME = "result_name";
+  private static final String TAG_TRUST_STORE_FILE = "trustStoreFile";
+  private static final String TAG_TRUST_STORE_PASSWORD = "trustStorePassword";
+  private static final String TAG_URL = "url";
+  private static final String TAG_URL_FIELD = "urlField";
+  private static final String TAG_URL_IN_FIELD = "urlInField";
+  private static final String TAG_SPACES8 = "        ";
+  private static final String TAG_SPACES6 = "      ";
+  private static final String TAG_SPACES4 = "    ";
+
   public static final String APPLICATION_TYPE_TEXT_PLAIN = "TEXT PLAIN";
   public static final String APPLICATION_TYPE_XML = "XML";
   public static final String APPLICATION_TYPE_JSON = "JSON";
@@ -67,10 +105,12 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
   public static final String APPLICATION_TYPE_ATOM_XML = "ATOM XML";
   public static final String APPLICATION_TYPE_SVG_XML = "SVG XML";
   public static final String APPLICATION_TYPE_TEXT_XML = "TEXT XML";
+  public static final String[] APPLICATION_TYPES =
+    new String[] { APPLICATION_TYPE_TEXT_PLAIN, APPLICATION_TYPE_XML, APPLICATION_TYPE_JSON,
+      APPLICATION_TYPE_OCTET_STREAM, APPLICATION_TYPE_XHTML, APPLICATION_TYPE_FORM_URLENCODED,
+      APPLICATION_TYPE_ATOM_XML, APPLICATION_TYPE_SVG_XML, APPLICATION_TYPE_TEXT_XML };
 
   private String applicationType;
-
-  public static final String[] HTTP_METHODS = new String[] { "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"};
 
   public static final String HTTP_METHOD_GET = "GET";
   public static final String HTTP_METHOD_POST = "POST";
@@ -79,6 +119,9 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
   public static final String HTTP_METHOD_HEAD = "HEAD";
   public static final String HTTP_METHOD_OPTIONS = "OPTIONS";
   public static final String HTTP_METHOD_PATCH = "PATCH";
+  public static final String[] HTTP_METHODS =
+    new String[] { HTTP_METHOD_GET, HTTP_METHOD_POST, HTTP_METHOD_PUT, HTTP_METHOD_DELETE, HTTP_METHOD_HEAD,
+      HTTP_METHOD_OPTIONS, HTTP_METHOD_PATCH };
 
   /** URL / service to be called */
   private String url;
@@ -364,35 +407,49 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
     readData( stepnode, databases );
   }
 
+  /**
+   * Allocate internal structures according to the number of headers and parameters.
+   *
+   * @param nrHeaders    number of headers
+   * @param nrParameters number of parameters
+   * @deprecated use #allocate(int nrHeaders, int nrParameters, int nrMatrixParameters) instead
+   */
   @Deprecated
-  public void allocate( int nrheaders, int nrparamers ) {
-    allocate( nrheaders, nrparamers, 0 );
+  public void allocate( int nrHeaders, int nrParameters ) {
+    allocate( nrHeaders, nrParameters, 0 );
   }
 
-  public void allocate( int nrheaders, int nrparamers, int nrmatrixparameters ) {
-    headerField = new String[nrheaders];
-    headerName = new String[nrheaders];
-    parameterField = new String[nrparamers];
-    parameterName = new String[nrparamers];
-    matrixParameterField = new String[nrmatrixparameters];
-    matrixParameterName = new String[nrmatrixparameters];
+  /**
+   * Allocate internal structures according to the given components' sizes
+   *
+   * @param nrHeaders number of headers
+   * @param nrParameters number of parameters
+   * @param nrMatrixParameters number of matrix parameters
+   */
+  public void allocate( int nrHeaders, int nrParameters, int nrMatrixParameters ) {
+    headerField = new String[ nrHeaders ];
+    headerName = new String[ nrHeaders ];
+    parameterField = new String[ nrParameters ];
+    parameterName = new String[ nrParameters ];
+    matrixParameterField = new String[ nrMatrixParameters ];
+    matrixParameterName = new String[ nrMatrixParameters ];
   }
 
   @Override
   public Object clone() {
     RestMeta retval = (RestMeta) super.clone();
 
-    int nrheaders = headerName.length;
-    int nrparameters = parameterField.length;
-    int nrmatrixparameters = matrixParameterField.length;
+    int nrHeaders = headerName.length;
+    int nrParameters = parameterField.length;
+    int nrMatrixParameters = matrixParameterField.length;
 
-    retval.allocate( nrheaders, nrparameters, nrmatrixparameters );
-    System.arraycopy( headerField, 0, retval.headerField, 0, nrheaders );
-    System.arraycopy( headerName, 0, retval.headerName, 0, nrheaders );
-    System.arraycopy( parameterField, 0, retval.parameterField, 0, nrparameters );
-    System.arraycopy( parameterName, 0, retval.parameterName, 0, nrparameters );
-    System.arraycopy( matrixParameterField, 0, retval.matrixParameterField, 0, nrmatrixparameters );
-    System.arraycopy( matrixParameterName, 0, retval.matrixParameterName, 0, nrmatrixparameters );
+    retval.allocate( nrHeaders, nrParameters, nrMatrixParameters );
+    System.arraycopy( headerField, 0, retval.headerField, 0, nrHeaders );
+    System.arraycopy( headerName, 0, retval.headerName, 0, nrHeaders );
+    System.arraycopy( parameterField, 0, retval.parameterField, 0, nrParameters );
+    System.arraycopy( parameterName, 0, retval.parameterName, 0, nrParameters );
+    System.arraycopy( matrixParameterField, 0, retval.matrixParameterField, 0, nrMatrixParameters );
+    System.arraycopy( matrixParameterName, 0, retval.matrixParameterName, 0, nrMatrixParameters );
 
     return retval;
   }
@@ -447,33 +504,33 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
   @Override
   public String getXML() {
     StringBuilder retval = new StringBuilder();
-    retval.append( "    " ).append( XMLHandler.addTagValue( "applicationType", applicationType ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "method", method ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "url", url ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "urlInField", urlInField ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "dynamicMethod", dynamicMethod ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "methodFieldName", methodFieldName ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_APPLICATION_TYPE, applicationType ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_METHOD, method ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_URL, url ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_URL_IN_FIELD, urlInField ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_DYNAMIC_METHOD, dynamicMethod ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_METHOD_FIELD_NAME, methodFieldName ) );
 
-    retval.append( "    " ).append( XMLHandler.addTagValue( "urlField", urlField ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "bodyField", bodyField ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "httpLogin", httpLogin ) );
-    retval.append( "    " ).append(
-        XMLHandler.addTagValue( "httpPassword", Encr.encryptPasswordIfNotUsingVariables( httpPassword ) ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_URL_FIELD, urlField ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_BODY_FIELD, bodyField ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_HTTP_LOGIN, httpLogin ) );
+    retval.append( TAG_SPACES4 ).append(
+        XMLHandler.addTagValue( TAG_HTTP_PASSWORD, Encr.encryptPasswordIfNotUsingVariables( httpPassword ) ) );
 
-    retval.append( "    " ).append( XMLHandler.addTagValue( "proxyHost", proxyHost ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "proxyPort", proxyPort ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "preemptive", preemptive ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_PROXY_HOST, proxyHost ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_PROXY_PORT, proxyPort ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_PREEMPTIVE, preemptive ) );
 
-    retval.append( "    " ).append( XMLHandler.addTagValue( "trustStoreFile", trustStoreFile ) );
-    retval.append( "    " ).append( XMLHandler.addTagValue( "ignoreSsl", ignoreSsl ) );
-    retval.append( "    " ).append(
-        XMLHandler.addTagValue( "trustStorePassword", Encr.encryptPasswordIfNotUsingVariables( trustStorePassword ) ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_TRUST_STORE_FILE, trustStoreFile ) );
+    retval.append( TAG_SPACES4 ).append( XMLHandler.addTagValue( TAG_IGNORE_SSL, ignoreSsl ) );
+    retval.append( TAG_SPACES4 ).append(
+        XMLHandler.addTagValue( TAG_TRUST_STORE_PASSWORD, Encr.encryptPasswordIfNotUsingVariables( trustStorePassword ) ) );
 
     retval.append( "    <headers>" ).append( Const.CR );
     for ( int i = 0, len = ( headerName != null ? headerName.length : 0 ); i < len; i++ ) {
       retval.append( "      <header>" ).append( Const.CR );
-      retval.append( "        " ).append( XMLHandler.addTagValue( "field", headerField[i] ) );
-      retval.append( "        " ).append( XMLHandler.addTagValue( "name", headerName[i] ) );
+      retval.append( TAG_SPACES8 ).append( XMLHandler.addTagValue( TAG_FIELD, headerField[i] ) );
+      retval.append( TAG_SPACES8 ).append( XMLHandler.addTagValue( TAG_NAME, headerName[i] ) );
       retval.append( "        </header>" ).append( Const.CR );
     }
     retval.append( "      </headers>" ).append( Const.CR );
@@ -481,8 +538,8 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
     retval.append( "    <parameters>" ).append( Const.CR );
     for ( int i = 0, len = ( parameterName != null ? parameterName.length : 0 ); i < len; i++ ) {
       retval.append( "      <parameter>" ).append( Const.CR );
-      retval.append( "        " ).append( XMLHandler.addTagValue( "field", parameterField[i] ) );
-      retval.append( "        " ).append( XMLHandler.addTagValue( "name", parameterName[i] ) );
+      retval.append( TAG_SPACES8 ).append( XMLHandler.addTagValue( TAG_FIELD, parameterField[i] ) );
+      retval.append( TAG_SPACES8 ).append( XMLHandler.addTagValue( TAG_NAME, parameterName[i] ) );
       retval.append( "        </parameter>" ).append( Const.CR );
     }
     retval.append( "      </parameters>" ).append( Const.CR );
@@ -490,17 +547,17 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
     retval.append( "    <matrixParameters>" ).append( Const.CR );
     for ( int i = 0, len = ( matrixParameterName != null ? matrixParameterName.length : 0 ); i < len; i++ ) {
       retval.append( "      <matrixParameter>" ).append( Const.CR );
-      retval.append( "        " ).append( XMLHandler.addTagValue( "field", matrixParameterField[i] ) );
-      retval.append( "        " ).append( XMLHandler.addTagValue( "name", matrixParameterName[i] ) );
+      retval.append( TAG_SPACES8 ).append( XMLHandler.addTagValue( TAG_FIELD, matrixParameterField[i] ) );
+      retval.append( TAG_SPACES8 ).append( XMLHandler.addTagValue( TAG_NAME, matrixParameterName[i] ) );
       retval.append( "        </matrixParameter>" ).append( Const.CR );
     }
     retval.append( "      </matrixParameters>" ).append( Const.CR );
 
     retval.append( "    <result>" ).append( Const.CR );
-    retval.append( "      " ).append( XMLHandler.addTagValue( "name", fieldName ) );
-    retval.append( "      " ).append( XMLHandler.addTagValue( "code", resultCodeFieldName ) );
-    retval.append( "      " ).append( XMLHandler.addTagValue( "response_time", responseTimeFieldName ) );
-    retval.append( "      " ).append( XMLHandler.addTagValue( "response_header", responseHeaderFieldName ) );
+    retval.append( TAG_SPACES6 ).append( XMLHandler.addTagValue( TAG_NAME, fieldName ) );
+    retval.append( TAG_SPACES6 ).append( XMLHandler.addTagValue( TAG_CODE, resultCodeFieldName ) );
+    retval.append( TAG_SPACES6 ).append( XMLHandler.addTagValue( TAG_RESPONSE_TIME, responseTimeFieldName ) );
+    retval.append( TAG_SPACES6 ).append( XMLHandler.addTagValue( TAG_RESPONSE_HEADER, responseHeaderFieldName ) );
     retval.append( "      </result>" ).append( Const.CR );
 
     return retval.toString();
@@ -508,107 +565,107 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
 
   private void readData( Node stepnode, List<? extends SharedObjectInterface> databases ) throws KettleXMLException {
     try {
-      applicationType = XMLHandler.getTagValue( stepnode, "applicationType" );
-      method = XMLHandler.getTagValue( stepnode, "method" );
-      url = XMLHandler.getTagValue( stepnode, "url" );
-      urlInField = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, "urlInField" ) );
-      methodFieldName = XMLHandler.getTagValue( stepnode, "methodFieldName" );
+      applicationType = XMLHandler.getTagValue( stepnode, TAG_APPLICATION_TYPE );
+      method = XMLHandler.getTagValue( stepnode, TAG_METHOD );
+      url = XMLHandler.getTagValue( stepnode, TAG_URL );
+      urlInField = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, TAG_URL_IN_FIELD ) );
+      methodFieldName = XMLHandler.getTagValue( stepnode, TAG_METHOD_FIELD_NAME );
 
-      dynamicMethod = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, "dynamicMethod" ) );
-      urlField = XMLHandler.getTagValue( stepnode, "urlField" );
-      bodyField = XMLHandler.getTagValue( stepnode, "bodyField" );
-      httpLogin = XMLHandler.getTagValue( stepnode, "httpLogin" );
-      httpPassword = Encr.decryptPasswordOptionallyEncrypted( XMLHandler.getTagValue( stepnode, "httpPassword" ) );
+      dynamicMethod = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, TAG_DYNAMIC_METHOD ) );
+      urlField = XMLHandler.getTagValue( stepnode, TAG_URL_FIELD );
+      bodyField = XMLHandler.getTagValue( stepnode, TAG_BODY_FIELD );
+      httpLogin = XMLHandler.getTagValue( stepnode, TAG_HTTP_LOGIN );
+      httpPassword = Encr.decryptPasswordOptionallyEncrypted( XMLHandler.getTagValue( stepnode, TAG_HTTP_PASSWORD ) );
 
-      proxyHost = XMLHandler.getTagValue( stepnode, "proxyHost" );
-      proxyPort = XMLHandler.getTagValue( stepnode, "proxyPort" );
-      preemptive = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, "preemptive" ) );
+      proxyHost = XMLHandler.getTagValue( stepnode, TAG_PROXY_HOST );
+      proxyPort = XMLHandler.getTagValue( stepnode, TAG_PROXY_PORT );
+      preemptive = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, TAG_PREEMPTIVE ) );
 
-      ignoreSsl = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, "ignoreSsl" ) );
-      trustStoreFile = XMLHandler.getTagValue( stepnode, "trustStoreFile" );
+      ignoreSsl = "Y".equalsIgnoreCase( XMLHandler.getTagValue( stepnode, TAG_IGNORE_SSL ) );
+      trustStoreFile = XMLHandler.getTagValue( stepnode, TAG_TRUST_STORE_FILE );
       trustStorePassword =
-          Encr.decryptPasswordOptionallyEncrypted( XMLHandler.getTagValue( stepnode, "trustStorePassword" ) );
+          Encr.decryptPasswordOptionallyEncrypted( XMLHandler.getTagValue( stepnode, TAG_TRUST_STORE_PASSWORD ) );
 
-      Node headernode = XMLHandler.getSubNode( stepnode, "headers" );
-      int nrheaders = XMLHandler.countNodes( headernode, "header" );
-      Node paramnode = XMLHandler.getSubNode( stepnode, "parameters" );
-      int nrparameters = XMLHandler.countNodes( paramnode, "parameter" );
-      Node matrixparamnode = XMLHandler.getSubNode( stepnode, "matrixParameters" );
-      int nrmatrixparameters = XMLHandler.countNodes( matrixparamnode, "matrixParameter" );
+      Node headerNode = XMLHandler.getSubNode( stepnode, TAG_HEADERS );
+      int nrHeaders = XMLHandler.countNodes( headerNode, TAG_HEADER );
+      Node paramNode = XMLHandler.getSubNode( stepnode, TAG_PARAMETERS );
+      int nrParameters = XMLHandler.countNodes( paramNode, TAG_PARAMETER );
+      Node matrixParametersNode = XMLHandler.getSubNode( stepnode, TAG_MATRIX_PARAMETERS );
+      int nrMatrixParameters = XMLHandler.countNodes( matrixParametersNode, TAG_MATRIX_PARAMETER );
 
-      allocate( nrheaders, nrparameters, nrmatrixparameters );
-      for ( int i = 0; i < nrheaders; i++ ) {
-        Node anode = XMLHandler.getSubNodeByNr( headernode, "header", i );
-        headerField[i] = XMLHandler.getTagValue( anode, "field" );
-        headerName[i] = XMLHandler.getTagValue( anode, "name" );
+      allocate( nrHeaders, nrParameters, nrMatrixParameters );
+      for ( int i = 0; i < nrHeaders; i++ ) {
+        Node anode = XMLHandler.getSubNodeByNr( headerNode, TAG_HEADER, i );
+        headerField[i] = XMLHandler.getTagValue( anode, TAG_FIELD );
+        headerName[i] = XMLHandler.getTagValue( anode, TAG_NAME );
       }
-      for ( int i = 0; i < nrparameters; i++ ) {
-        Node anode = XMLHandler.getSubNodeByNr( paramnode, "parameter", i );
-        parameterField[i] = XMLHandler.getTagValue( anode, "field" );
-        parameterName[i] = XMLHandler.getTagValue( anode, "name" );
+      for ( int i = 0; i < nrParameters; i++ ) {
+        Node anode = XMLHandler.getSubNodeByNr( paramNode, TAG_PARAMETER, i );
+        parameterField[i] = XMLHandler.getTagValue( anode, TAG_FIELD );
+        parameterName[i] = XMLHandler.getTagValue( anode, TAG_NAME );
       }
-      for ( int i = 0; i < nrmatrixparameters; i++ ) {
-        Node anode = XMLHandler.getSubNodeByNr( matrixparamnode, "matrixParameter", i );
-        matrixParameterField[i] = XMLHandler.getTagValue( anode, "field" );
-        matrixParameterName[i] = XMLHandler.getTagValue( anode, "name" );
+      for ( int i = 0; i < nrMatrixParameters; i++ ) {
+        Node anode = XMLHandler.getSubNodeByNr( matrixParametersNode, TAG_MATRIX_PARAMETER, i );
+        matrixParameterField[i] = XMLHandler.getTagValue( anode, TAG_FIELD );
+        matrixParameterName[i] = XMLHandler.getTagValue( anode, TAG_NAME );
       }
 
-      fieldName = XMLHandler.getTagValue( stepnode, "result", "name" ); // Optional, can be null
-      resultCodeFieldName = XMLHandler.getTagValue( stepnode, "result", "code" ); // Optional, can be null
-      responseTimeFieldName = XMLHandler.getTagValue( stepnode, "result", "response_time" ); // Optional, can be null
-      responseHeaderFieldName = XMLHandler.getTagValue( stepnode, "result", "response_header" ); // Optional, can be null
+      fieldName = XMLHandler.getTagValue( stepnode, TAG_RESULT, TAG_NAME ); // Optional, can be null
+      resultCodeFieldName = XMLHandler.getTagValue( stepnode, TAG_RESULT, TAG_CODE ); // Optional, can be null
+      responseTimeFieldName = XMLHandler.getTagValue( stepnode, TAG_RESULT, TAG_RESPONSE_TIME ); // Optional, can be null
+      responseHeaderFieldName = XMLHandler.getTagValue( stepnode, TAG_RESULT, TAG_RESPONSE_HEADER ); // Optional, can be null
     } catch ( Exception e ) {
       throw new KettleXMLException( BaseMessages.getString( PKG, "RestMeta.Exception.UnableToReadStepInfo" ), e );
     }
   }
 
   @Override
-  public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases ) throws KettleException {
+  public void readRep( Repository rep, IMetaStore metaStore, ObjectId idStep, List<DatabaseMeta> databases ) throws KettleException {
     try {
-      applicationType = rep.getStepAttributeString( id_step, "applicationType" );
-      method = rep.getStepAttributeString( id_step, "method" );
-      url = rep.getStepAttributeString( id_step, "url" );
-      urlInField = rep.getStepAttributeBoolean( id_step, "urlInField" );
+      applicationType = rep.getStepAttributeString( idStep, TAG_APPLICATION_TYPE );
+      method = rep.getStepAttributeString( idStep, TAG_METHOD );
+      url = rep.getStepAttributeString( idStep, TAG_URL );
+      urlInField = rep.getStepAttributeBoolean( idStep, TAG_URL_IN_FIELD );
 
-      methodFieldName = rep.getStepAttributeString( id_step, "methodFieldName" );
-      dynamicMethod = rep.getStepAttributeBoolean( id_step, "dynamicMethod" );
-      urlField = rep.getStepAttributeString( id_step, "urlField" );
-      bodyField = rep.getStepAttributeString( id_step, "bodyField" );
-      httpLogin = rep.getStepAttributeString( id_step, "httpLogin" );
+      methodFieldName = rep.getStepAttributeString( idStep, TAG_METHOD_FIELD_NAME );
+      dynamicMethod = rep.getStepAttributeBoolean( idStep, TAG_DYNAMIC_METHOD );
+      urlField = rep.getStepAttributeString( idStep, TAG_URL_FIELD );
+      bodyField = rep.getStepAttributeString( idStep, TAG_BODY_FIELD );
+      httpLogin = rep.getStepAttributeString( idStep, TAG_HTTP_LOGIN );
       httpPassword =
-        Encr.decryptPasswordOptionallyEncrypted( rep.getStepAttributeString( id_step, "httpPassword" ) );
+        Encr.decryptPasswordOptionallyEncrypted( rep.getStepAttributeString( idStep, TAG_HTTP_PASSWORD ) );
 
-      proxyHost = rep.getStepAttributeString( id_step, "proxyHost" );
-      proxyPort = rep.getStepAttributeString( id_step, "proxyPort" );
+      proxyHost = rep.getStepAttributeString( idStep, TAG_PROXY_HOST );
+      proxyPort = rep.getStepAttributeString( idStep, TAG_PROXY_PORT );
 
-      trustStoreFile = rep.getStepAttributeString( id_step, "trustStoreFile" );
-      ignoreSsl = "Y".equalsIgnoreCase( rep.getStepAttributeString( id_step, "ignoreSsl") );
+      trustStoreFile = rep.getStepAttributeString( idStep, TAG_TRUST_STORE_FILE );
+      ignoreSsl = "Y".equalsIgnoreCase( rep.getStepAttributeString( idStep, TAG_IGNORE_SSL ) );
       trustStorePassword =
-          Encr.decryptPasswordOptionallyEncrypted( rep.getStepAttributeString( id_step, "trustStorePassword" ) );
+          Encr.decryptPasswordOptionallyEncrypted( rep.getStepAttributeString( idStep, TAG_TRUST_STORE_PASSWORD ) );
 
-      preemptive = rep.getStepAttributeBoolean( id_step, "preemptive" );
-      int nrheaders = rep.countNrStepAttributes( id_step, "header_field" );
-      int nrparams = rep.countNrStepAttributes( id_step, "parameter_field" );
-      int nrmatrixparams = rep.countNrStepAttributes( id_step, "matrix_parameter_field" );
-      allocate( nrheaders, nrparams, nrmatrixparams );
+      preemptive = rep.getStepAttributeBoolean( idStep, TAG_PREEMPTIVE );
+      int nrHeaders = rep.countNrStepAttributes( idStep, TAG_HEADER_FIELD );
+      int nrParams = rep.countNrStepAttributes( idStep, TAG_PARAMETER_FIELD );
+      int nrMatrixParams = rep.countNrStepAttributes( idStep, TAG_MATRIX_PARAMETER_FIELD );
+      allocate( nrHeaders, nrParams, nrMatrixParams );
 
-      for ( int i = 0; i < nrheaders; i++ ) {
-        headerField[i] = rep.getStepAttributeString( id_step, i, "header_field" );
-        headerName[i] = rep.getStepAttributeString( id_step, i, "header_name" );
+      for ( int i = 0; i < nrHeaders; i++ ) {
+        headerField[i] = rep.getStepAttributeString( idStep, i, TAG_HEADER_FIELD );
+        headerName[i] = rep.getStepAttributeString( idStep, i, TAG_HEADER_NAME );
       }
-      for ( int i = 0; i < nrparams; i++ ) {
-        parameterField[i] = rep.getStepAttributeString( id_step, i, "parameter_field" );
-        parameterName[i] = rep.getStepAttributeString( id_step, i, "parameter_name" );
+      for ( int i = 0; i < nrParams; i++ ) {
+        parameterField[i] = rep.getStepAttributeString( idStep, i, TAG_PARAMETER_FIELD );
+        parameterName[i] = rep.getStepAttributeString( idStep, i, TAG_PARAMETER_NAME );
       }
-      for ( int i = 0; i < nrmatrixparams; i++ ) {
-        matrixParameterField[i] = rep.getStepAttributeString( id_step, i, "matrix_parameter_field" );
-        matrixParameterName[i] = rep.getStepAttributeString( id_step, i, "matrix_parameter_name" );
+      for ( int i = 0; i < nrMatrixParams; i++ ) {
+        matrixParameterField[i] = rep.getStepAttributeString( idStep, i, TAG_MATRIX_PARAMETER_FIELD );
+        matrixParameterName[i] = rep.getStepAttributeString( idStep, i, TAG_MATRIX_PARAMETER_NAME );
       }
 
-      fieldName = rep.getStepAttributeString( id_step, "result_name" );
-      resultCodeFieldName = rep.getStepAttributeString( id_step, "result_code" );
-      responseTimeFieldName = rep.getStepAttributeString( id_step, "response_time" );
-      responseHeaderFieldName = rep.getStepAttributeString( id_step, "response_header" );
+      fieldName = rep.getStepAttributeString( idStep, TAG_RESULT_NAME );
+      resultCodeFieldName = rep.getStepAttributeString( idStep, TAG_RESULT_CODE );
+      responseTimeFieldName = rep.getStepAttributeString( idStep, TAG_RESPONSE_TIME );
+      responseHeaderFieldName = rep.getStepAttributeString( idStep, TAG_RESPONSE_HEADER );
     } catch ( Exception e ) {
       throw new KettleException(
         BaseMessages.getString( PKG, "RestMeta.Exception.UnexpectedErrorReadingStepInfo" ), e );
@@ -616,49 +673,49 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   @Override
-  public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
+  public void saveRep( Repository rep, IMetaStore metaStore, ObjectId idTransformation, ObjectId idStep ) throws KettleException {
     try {
-      rep.saveStepAttribute( id_transformation, id_step, "applicationType", applicationType );
-      rep.saveStepAttribute( id_transformation, id_step, "method", method );
-      rep.saveStepAttribute( id_transformation, id_step, "url", url );
-      rep.saveStepAttribute( id_transformation, id_step, "methodFieldName", methodFieldName );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_APPLICATION_TYPE, applicationType );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_METHOD, method );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_URL, url );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_METHOD_FIELD_NAME, methodFieldName );
 
-      rep.saveStepAttribute( id_transformation, id_step, "dynamicMethod", dynamicMethod );
-      rep.saveStepAttribute( id_transformation, id_step, "urlInField", urlInField );
-      rep.saveStepAttribute( id_transformation, id_step, "urlField", urlField );
-      rep.saveStepAttribute( id_transformation, id_step, "bodyField", bodyField );
-      rep.saveStepAttribute( id_transformation, id_step, "httpLogin", httpLogin );
-      rep.saveStepAttribute( id_transformation, id_step, "httpPassword", Encr
+      rep.saveStepAttribute( idTransformation, idStep, TAG_DYNAMIC_METHOD, dynamicMethod );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_URL_IN_FIELD, urlInField );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_URL_FIELD, urlField );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_BODY_FIELD, bodyField );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_HTTP_LOGIN, httpLogin );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_HTTP_PASSWORD, Encr
         .encryptPasswordIfNotUsingVariables( httpPassword ) );
 
-      rep.saveStepAttribute( id_transformation, id_step, "proxyHost", proxyHost );
-      rep.saveStepAttribute( id_transformation, id_step, "proxyPort", proxyPort );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_PROXY_HOST, proxyHost );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_PROXY_PORT, proxyPort );
 
-      rep.saveStepAttribute( id_transformation, id_step, "ignoreSsl", ignoreSsl );
-      rep.saveStepAttribute( id_transformation, id_step, "trustStoreFile", trustStoreFile );
-      rep.saveStepAttribute( id_transformation, id_step, "trustStorePassword", Encr
+      rep.saveStepAttribute( idTransformation, idStep, TAG_IGNORE_SSL, ignoreSsl );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_TRUST_STORE_FILE, trustStoreFile );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_TRUST_STORE_PASSWORD, Encr
           .encryptPasswordIfNotUsingVariables( trustStorePassword ) );
 
-      rep.saveStepAttribute( id_transformation, id_step, "preemptive", preemptive );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_PREEMPTIVE, preemptive );
       for ( int i = 0; i < headerName.length; i++ ) {
-        rep.saveStepAttribute( id_transformation, id_step, i, "header_field", headerField[i] );
-        rep.saveStepAttribute( id_transformation, id_step, i, "header_name", headerName[i] );
+        rep.saveStepAttribute( idTransformation, idStep, i, TAG_HEADER_FIELD, headerField[i] );
+        rep.saveStepAttribute( idTransformation, idStep, i, TAG_HEADER_NAME, headerName[i] );
       }
       for ( int i = 0; i < parameterField.length; i++ ) {
-        rep.saveStepAttribute( id_transformation, id_step, i, "parameter_field", parameterField[i] );
-        rep.saveStepAttribute( id_transformation, id_step, i, "parameter_name", parameterName[i] );
+        rep.saveStepAttribute( idTransformation, idStep, i, TAG_PARAMETER_FIELD, parameterField[i] );
+        rep.saveStepAttribute( idTransformation, idStep, i, TAG_PARAMETER_NAME, parameterName[i] );
       }
       for ( int i = 0; i < matrixParameterField.length; i++ ) {
-        rep.saveStepAttribute( id_transformation, id_step, i, "matrix_parameter_field", matrixParameterField[i] );
-        rep.saveStepAttribute( id_transformation, id_step, i, "matrix_parameter_name", matrixParameterName[i] );
+        rep.saveStepAttribute( idTransformation, idStep, i, TAG_MATRIX_PARAMETER_FIELD, matrixParameterField[i] );
+        rep.saveStepAttribute( idTransformation, idStep, i, TAG_MATRIX_PARAMETER_NAME, matrixParameterName[i] );
       }
-      rep.saveStepAttribute( id_transformation, id_step, "result_name", fieldName );
-      rep.saveStepAttribute( id_transformation, id_step, "result_code", resultCodeFieldName );
-      rep.saveStepAttribute( id_transformation, id_step, "response_time", responseTimeFieldName );
-      rep.saveStepAttribute( id_transformation, id_step, "response_header", responseHeaderFieldName );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_RESULT_NAME, fieldName );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_RESULT_CODE, resultCodeFieldName );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_RESPONSE_TIME, responseTimeFieldName );
+      rep.saveStepAttribute( idTransformation, idStep, TAG_RESPONSE_HEADER, responseHeaderFieldName );
     } catch ( Exception e ) {
       throw new KettleException( BaseMessages.getString( PKG, "RestMeta.Exception.UnableToSaveStepInfo" )
-        + id_step, e );
+        + idStep, e );
     }
   }
 
@@ -671,11 +728,11 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
     // See if we have input streams leading to this step!
     if ( input.length > 0 ) {
       cr =
-        new CheckResult( CheckResult.TYPE_RESULT_OK, BaseMessages.getString(
+        new CheckResult( CheckResultInterface.TYPE_RESULT_OK, BaseMessages.getString(
           PKG, "RestMeta.CheckResult.ReceivingInfoFromOtherSteps" ), stepMeta );
     } else {
       cr =
-        new CheckResult( CheckResult.TYPE_RESULT_ERROR, BaseMessages.getString(
+        new CheckResult( CheckResultInterface.TYPE_RESULT_ERROR, BaseMessages.getString(
           PKG, "RestMeta.CheckResult.NoInpuReceived" ), stepMeta );
     }
     remarks.add( cr );
@@ -684,22 +741,22 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
     if ( urlInField ) {
       if ( Utils.isEmpty( urlField ) ) {
         cr =
-          new CheckResult( CheckResult.TYPE_RESULT_ERROR, BaseMessages.getString(
+          new CheckResult( CheckResultInterface.TYPE_RESULT_ERROR, BaseMessages.getString(
             PKG, "RestMeta.CheckResult.UrlfieldMissing" ), stepMeta );
       } else {
         cr =
-          new CheckResult( CheckResult.TYPE_RESULT_OK, BaseMessages.getString(
+          new CheckResult( CheckResultInterface.TYPE_RESULT_OK, BaseMessages.getString(
             PKG, "RestMeta.CheckResult.UrlfieldOk" ), stepMeta );
       }
 
     } else {
       if ( Utils.isEmpty( url ) ) {
         cr =
-          new CheckResult( CheckResult.TYPE_RESULT_ERROR, BaseMessages.getString(
+          new CheckResult( CheckResultInterface.TYPE_RESULT_ERROR, BaseMessages.getString(
             PKG, "RestMeta.CheckResult.UrlMissing" ), stepMeta );
       } else {
         cr =
-          new CheckResult( CheckResult.TYPE_RESULT_OK, BaseMessages
+          new CheckResult( CheckResultInterface.TYPE_RESULT_OK, BaseMessages
             .getString( PKG, "RestMeta.CheckResult.UrlOk" ), stepMeta );
       }
     }
@@ -709,22 +766,22 @@ public class RestMeta extends BaseStepMeta implements StepMetaInterface {
     if ( dynamicMethod ) {
       if ( Utils.isEmpty( methodFieldName ) ) {
         cr =
-          new CheckResult( CheckResult.TYPE_RESULT_ERROR, BaseMessages.getString(
+          new CheckResult( CheckResultInterface.TYPE_RESULT_ERROR, BaseMessages.getString(
             PKG, "RestMeta.CheckResult.MethodFieldMissing" ), stepMeta );
       } else {
         cr =
-          new CheckResult( CheckResult.TYPE_RESULT_ERROR, BaseMessages.getString(
+          new CheckResult( CheckResultInterface.TYPE_RESULT_ERROR, BaseMessages.getString(
             PKG, "RestMeta.CheckResult.MethodFieldOk" ), stepMeta );
       }
 
     } else {
       if ( Utils.isEmpty( method ) ) {
         cr =
-          new CheckResult( CheckResult.TYPE_RESULT_ERROR, BaseMessages.getString(
+          new CheckResult( CheckResultInterface.TYPE_RESULT_ERROR, BaseMessages.getString(
             PKG, "RestMeta.CheckResult.MethodMissing" ), stepMeta );
       } else {
         cr =
-          new CheckResult( CheckResult.TYPE_RESULT_OK, BaseMessages.getString(
+          new CheckResult( CheckResultInterface.TYPE_RESULT_OK, BaseMessages.getString(
             PKG, "RestMeta.CheckResult.MethodOk" ), stepMeta );
       }
     }

--- a/plugins/rest/core/src/main/java/org/pentaho/di/ui/trans/steps/rest/RestDialog.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/ui/trans/steps/rest/RestDialog.java
@@ -277,10 +277,12 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     fdUrlField.right = new FormAttachment( 100, -margin );
     wUrlField.setLayoutData( fdUrlField );
     wUrlField.addFocusListener( new FocusListener() {
+      @Override
       public void focusLost( org.eclipse.swt.events.FocusEvent e ) {
         // Nothing to do
       }
 
+      @Override
       public void focusGained( org.eclipse.swt.events.FocusEvent e ) {
         Cursor busy = new Cursor( shell.getDisplay(), SWT.CURSOR_WAIT );
         shell.setCursor( busy );
@@ -361,10 +363,12 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     fdMethodField.right = new FormAttachment( 100, -margin );
     wMethodField.setLayoutData( fdMethodField );
     wMethodField.addFocusListener( new FocusListener() {
+      @Override
       public void focusLost( org.eclipse.swt.events.FocusEvent e ) {
         // Nothing to do
       }
 
+      @Override
       public void focusGained( org.eclipse.swt.events.FocusEvent e ) {
         Cursor busy = new Cursor( shell.getDisplay(), SWT.CURSOR_WAIT );
         shell.setCursor( busy );
@@ -394,10 +398,12 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     fdBody.right = new FormAttachment( 100, -margin );
     wBody.setLayoutData( fdBody );
     wBody.addFocusListener( new FocusListener() {
+      @Override
       public void focusLost( org.eclipse.swt.events.FocusEvent e ) {
         // Nothing to do
       }
 
+      @Override
       public void focusGained( org.eclipse.swt.events.FocusEvent e ) {
         Cursor busy = new Cursor( shell.getDisplay(), SWT.CURSOR_WAIT );
         shell.setCursor( busy );
@@ -1030,6 +1036,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     //
 
     final Runnable runnable = new Runnable() {
+      @Override
       public void run() {
         StepMeta stepMeta = transMeta.findStep( stepname );
         if ( stepMeta != null ) {

--- a/plugins/rest/core/src/main/java/org/pentaho/di/ui/trans/steps/rest/RestDialog.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/ui/trans/steps/rest/RestDialog.java
@@ -17,7 +17,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.events.FocusListener;
-import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -31,10 +30,8 @@ import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
@@ -70,49 +67,31 @@ import java.util.Set;
 public class RestDialog extends BaseStepDialog implements StepDialogInterface {
   private static Class<?> PKG = RestMeta.class; // for i18n purposes, needed by Translator2!!
 
-  private Label wlApplicationType;
   private ComboVar wApplicationType;
-  private FormData fdlApplicationType, fdApplicationType;
 
   private Label wlMethod;
   private ComboVar wMethod;
-  private FormData fdlMethod, fdMethod;
 
   private Label wlUrl;
   private TextVar wUrl;
-  private FormData fdlUrl, fdUrl;
 
-  private Label wlResult;
   private TextVar wResult;
-  private FormData fdlResult, fdResult;
 
-  private Label wlResultCode;
   private TextVar wResultCode;
-  private FormData fdlResultCode, fdResultCode;
 
-  private Label wlFields;
   private TableView wFields;
-  private FormData fdlFields, fdFields;
 
-  private Label wlUrlInField;
   private Button wUrlInField;
-  private FormData fdlUrlInField, fdUrlInField;
 
   private Label wlUrlField;
   private ComboVar wUrlField;
-  private FormData fdlUrlField, fdUrlField;
 
-  private Label wlMethodInField;
   private Button wMethodInField;
-  private FormData fdlMethodInField, fdMethodInField;
 
-  private Label wlPreemptive;
   private Button wPreemptive;
-  private FormData fdlPreemptive, fdPreemptive;
 
   private Label wlMethodField;
   private ComboVar wMethodField;
-  private FormData fdlMethodField, fdMethodField;
 
   private RestMeta input;
 
@@ -120,78 +99,51 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
   private Label wlBody;
   private ComboVar wBody;
-  private FormData fdlBody, fdBody;
 
-  private Button wGetHeaders;
-
-  private ColumnInfo[] colinf, colinfoparams;
+  private ColumnInfo[] colInf;
+  private ColumnInfo[] colInfoParams;
 
   private String[] fieldNames;
 
-  private Label wlHttpLogin;
   private TextVar wHttpLogin;
 
-  private Label wlHttpPassword;
   private TextVar wHttpPassword;
 
-  private Label wlProxyHost;
   private TextVar wProxyHost;
 
-  private Label wlProxyPort;
   private TextVar wProxyPort;
 
   protected CTabFolder wTabFolder;
 
-  private CTabItem wGeneralTab, wAdditionalTab, wParametersTab, wMatrixParametersTab, wAuthTab;
   protected CTabItem wSSLTab;
-  private FormData fdTabFolder;
-
-  private Composite wGeneralComp, wAdditionalComp;
-  private FormData fdGeneralComp, fdAdditionalComp;
-
-  private Composite wParametersComp, wMatrixParametersComp;
-  private FormData fdParametersComp, fdMatrixParametersComp;
-
-  private Composite wAuthComp;
-  private FormData fdAuthComp;
 
   protected Composite wSSLComp;
-  private FormData fdSSLComp;
 
-  private Label wlParameters, wlMatrixParameters;
-  private TableView wParameters, wMatrixParameters;
-  private FormData fdlParameters, fdlMatrixParameters, fdParameters, fdMatrixParameters;
+  private Label wlParameters;
+  private Label wlMatrixParameters;
+  private TableView wParameters;
+  private TableView wMatrixParameters;
 
-  private Label wlResponseTime;
   private TextVar wResponseTime;
-  private FormData fdlResponseTime, fdResponseTime;
-  private Label wlResponseHeader;
   private TextVar wResponseHeader;
-  private FormData fdlResponseHeader, fdResponseHeader;
 
-  private Label wlTrustStorePassword;
   private TextVar wTrustStorePassword;
-  private FormData fdlTrustStorePassword, fdTrustStorePassword;
 
-  private Label wlTrustStoreFile;
   private TextVar wTrustStoreFile;
   private Button wbTrustStoreFile;
-  private FormData fdbTrustStoreFile;
-  private FormData fdlTrustStoreFile, fdTrustStoreFile;
   private Button wIgnoreSSL;
 
   private boolean gotPreviousFields = false;
 
   private Button wMatrixGet;
-  private Listener lsMatrixGet;
 
   protected Group gSSLTrustStore;
 
 
-  public RestDialog( Shell parent, Object in, TransMeta transMeta, String sname ) {
-    super( parent, (BaseStepMeta) in, transMeta, sname );
+  public RestDialog( Shell parent, Object in, TransMeta transMeta, String sName ) {
+    super( parent, (BaseStepMeta) in, transMeta, sName );
     input = (RestMeta) in;
-    inputFields = new HashMap<String, Integer>();
+    inputFields = new HashMap<>();
   }
 
   public String open() {
@@ -202,11 +154,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     props.setLook( shell );
     setShellImage( shell, input );
 
-    ModifyListener lsMod = new ModifyListener() {
-      public void modifyText( ModifyEvent e ) {
-        input.setChanged();
-      }
-    };
+    ModifyListener lsMod = e -> input.setChanged();
 
     changed = input.hasChanged();
 
@@ -224,20 +172,20 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wlStepname = new Label( shell, SWT.RIGHT );
     wlStepname.setText( BaseMessages.getString( PKG, "RestDialog.Stepname.Label" ) );
     props.setLook( wlStepname );
-    fdlStepname = new FormData();
-    fdlStepname.left = new FormAttachment( 0, 0 );
-    fdlStepname.right = new FormAttachment( middle, -margin );
-    fdlStepname.top = new FormAttachment( 0, margin );
-    wlStepname.setLayoutData( fdlStepname );
+    FormData fdlStepName = new FormData();
+    fdlStepName.left = new FormAttachment( 0, 0 );
+    fdlStepName.right = new FormAttachment( middle, -margin );
+    fdlStepName.top = new FormAttachment( 0, margin );
+    wlStepname.setLayoutData( fdlStepName );
     wStepname = new Text( shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wStepname.setText( stepname );
     props.setLook( wStepname );
     wStepname.addModifyListener( lsMod );
-    fdStepname = new FormData();
-    fdStepname.left = new FormAttachment( middle, 0 );
-    fdStepname.top = new FormAttachment( 0, margin );
-    fdStepname.right = new FormAttachment( 100, 0 );
-    wStepname.setLayoutData( fdStepname );
+    FormData fdStepName = new FormData();
+    fdStepName.left = new FormAttachment( middle, 0 );
+    fdStepName.top = new FormAttachment( 0, margin );
+    fdStepName.right = new FormAttachment( 100, 0 );
+    wStepname.setLayoutData( fdStepName );
 
     wTabFolder = new CTabFolder( shell, SWT.BORDER );
     props.setLook( wTabFolder, PropsUI.WIDGET_STYLE_TAB );
@@ -245,10 +193,10 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     // ////////////////////////
     // START OF GENERAL TAB ///
     // ////////////////////////
-    wGeneralTab = new CTabItem( wTabFolder, SWT.NONE );
+    CTabItem wGeneralTab = new CTabItem( wTabFolder, SWT.NONE );
     wGeneralTab.setText( BaseMessages.getString( PKG, "RestDialog.GeneralTab.Title" ) );
 
-    wGeneralComp = new Composite( wTabFolder, SWT.NONE );
+    Composite wGeneralComp = new Composite( wTabFolder, SWT.NONE );
     props.setLook( wGeneralComp );
 
     FormLayout fileLayout = new FormLayout();
@@ -261,16 +209,16 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     Group gSettings = new Group( wGeneralComp, SWT.SHADOW_ETCHED_IN );
     gSettings.setText( BaseMessages.getString( PKG, "RestDialog.SettingsGroup.Label" ) );
-    FormLayout SettingsLayout = new FormLayout();
-    SettingsLayout.marginWidth = 3;
-    SettingsLayout.marginHeight = 3;
-    gSettings.setLayout( SettingsLayout );
+    FormLayout settingsLayout = new FormLayout();
+    settingsLayout.marginWidth = 3;
+    settingsLayout.marginHeight = 3;
+    gSettings.setLayout( settingsLayout );
     props.setLook( gSettings );
 
     wlUrl = new Label( gSettings, SWT.RIGHT );
     wlUrl.setText( BaseMessages.getString( PKG, "RestDialog.URL.Label" ) );
     props.setLook( wlUrl );
-    fdlUrl = new FormData();
+    FormData fdlUrl = new FormData();
     fdlUrl.left = new FormAttachment( 0, 0 );
     fdlUrl.right = new FormAttachment( middle, -margin );
     fdlUrl.top = new FormAttachment( wGeneralComp, margin * 2 );
@@ -279,29 +227,30 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wUrl = new TextVar( transMeta, gSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wUrl );
     wUrl.addModifyListener( lsMod );
-    fdUrl = new FormData();
+    FormData fdUrl = new FormData();
     fdUrl.left = new FormAttachment( middle, 0 );
     fdUrl.top = new FormAttachment( wGeneralComp, margin * 2 );
     fdUrl.right = new FormAttachment( 100, 0 );
     wUrl.setLayoutData( fdUrl );
 
     // UrlInField line
-    wlUrlInField = new Label( gSettings, SWT.RIGHT );
+    Label wlUrlInField = new Label( gSettings, SWT.RIGHT );
     wlUrlInField.setText( BaseMessages.getString( PKG, "RestDialog.UrlInField.Label" ) );
     props.setLook( wlUrlInField );
-    fdlUrlInField = new FormData();
+    FormData fdlUrlInField = new FormData();
     fdlUrlInField.left = new FormAttachment( 0, 0 );
     fdlUrlInField.top = new FormAttachment( wUrl, margin );
     fdlUrlInField.right = new FormAttachment( middle, -margin );
     wlUrlInField.setLayoutData( fdlUrlInField );
     wUrlInField = new Button( gSettings, SWT.CHECK );
     props.setLook( wUrlInField );
-    fdUrlInField = new FormData();
+    FormData fdUrlInField = new FormData();
     fdUrlInField.left = new FormAttachment( middle, 0 );
     fdUrlInField.top = new FormAttachment( wUrl, margin );
     fdUrlInField.right = new FormAttachment( 100, 0 );
     wUrlInField.setLayoutData( fdUrlInField );
     wUrlInField.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         input.setChanged();
         activeUrlInfield();
@@ -312,7 +261,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wlUrlField = new Label( gSettings, SWT.RIGHT );
     wlUrlField.setText( BaseMessages.getString( PKG, "RestDialog.UrlField.Label" ) );
     props.setLook( wlUrlField );
-    fdlUrlField = new FormData();
+    FormData fdlUrlField = new FormData();
     fdlUrlField.left = new FormAttachment( 0, 0 );
     fdlUrlField.right = new FormAttachment( middle, -margin );
     fdlUrlField.top = new FormAttachment( wUrlInField, margin );
@@ -322,13 +271,14 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wUrlField.setEditable( true );
     props.setLook( wUrlField );
     wUrlField.addModifyListener( lsMod );
-    fdUrlField = new FormData();
+    FormData fdUrlField = new FormData();
     fdUrlField.left = new FormAttachment( middle, 0 );
     fdUrlField.top = new FormAttachment( wUrlInField, margin );
     fdUrlField.right = new FormAttachment( 100, -margin );
     wUrlField.setLayoutData( fdUrlField );
     wUrlField.addFocusListener( new FocusListener() {
       public void focusLost( org.eclipse.swt.events.FocusEvent e ) {
+        // Nothing to do
       }
 
       public void focusGained( org.eclipse.swt.events.FocusEvent e ) {
@@ -344,7 +294,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wlMethod = new Label( gSettings, SWT.RIGHT );
     wlMethod.setText( BaseMessages.getString( PKG, "RestDialog.Method.Label" ) );
     props.setLook( wlMethod );
-    fdlMethod = new FormData();
+    FormData fdlMethod = new FormData();
     fdlMethod.left = new FormAttachment( 0, 0 );
     fdlMethod.right = new FormAttachment( middle, -margin );
     fdlMethod.top = new FormAttachment( wUrlField, 2 * margin );
@@ -354,36 +304,37 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wMethod.setEditable( true );
     props.setLook( wMethod );
     wMethod.addModifyListener( lsMod );
-    fdMethod = new FormData();
+    FormData fdMethod = new FormData();
     fdMethod.left = new FormAttachment( middle, 0 );
     fdMethod.top = new FormAttachment( wUrlField, 2 * margin );
     fdMethod.right = new FormAttachment( 100, -margin );
     wMethod.setLayoutData( fdMethod );
     wMethod.setItems( RestMeta.HTTP_METHODS );
     wMethod.addSelectionListener( new SelectionAdapter() {
-
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         setMethod();
       }
     } );
 
     // MethodInField line
-    wlMethodInField = new Label( gSettings, SWT.RIGHT );
+    Label wlMethodInField = new Label( gSettings, SWT.RIGHT );
     wlMethodInField.setText( BaseMessages.getString( PKG, "RestDialog.MethodInField.Label" ) );
     props.setLook( wlMethodInField );
-    fdlMethodInField = new FormData();
+    FormData fdlMethodInField = new FormData();
     fdlMethodInField.left = new FormAttachment( 0, 0 );
     fdlMethodInField.top = new FormAttachment( wMethod, margin );
     fdlMethodInField.right = new FormAttachment( middle, -margin );
     wlMethodInField.setLayoutData( fdlMethodInField );
     wMethodInField = new Button( gSettings, SWT.CHECK );
     props.setLook( wMethodInField );
-    fdMethodInField = new FormData();
+    FormData fdMethodInField = new FormData();
     fdMethodInField.left = new FormAttachment( middle, 0 );
     fdMethodInField.top = new FormAttachment( wMethod, margin );
     fdMethodInField.right = new FormAttachment( 100, 0 );
     wMethodInField.setLayoutData( fdMethodInField );
     wMethodInField.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         input.setChanged();
         activeMethodInfield();
@@ -394,7 +345,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wlMethodField = new Label( gSettings, SWT.RIGHT );
     wlMethodField.setText( BaseMessages.getString( PKG, "RestDialog.MethodField.Label" ) );
     props.setLook( wlMethodField );
-    fdlMethodField = new FormData();
+    FormData fdlMethodField = new FormData();
     fdlMethodField.left = new FormAttachment( 0, 0 );
     fdlMethodField.right = new FormAttachment( middle, -margin );
     fdlMethodField.top = new FormAttachment( wMethodInField, margin );
@@ -404,13 +355,14 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wMethodField.setEditable( true );
     props.setLook( wMethodField );
     wMethodField.addModifyListener( lsMod );
-    fdMethodField = new FormData();
+    FormData fdMethodField = new FormData();
     fdMethodField.left = new FormAttachment( middle, 0 );
     fdMethodField.top = new FormAttachment( wMethodInField, margin );
     fdMethodField.right = new FormAttachment( 100, -margin );
     wMethodField.setLayoutData( fdMethodField );
     wMethodField.addFocusListener( new FocusListener() {
       public void focusLost( org.eclipse.swt.events.FocusEvent e ) {
+        // Nothing to do
       }
 
       public void focusGained( org.eclipse.swt.events.FocusEvent e ) {
@@ -426,7 +378,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wlBody = new Label( gSettings, SWT.RIGHT );
     wlBody.setText( BaseMessages.getString( PKG, "RestDialog.Body.Label" ) );
     props.setLook( wlBody );
-    fdlBody = new FormData();
+    FormData fdlBody = new FormData();
     fdlBody.left = new FormAttachment( 0, 0 );
     fdlBody.right = new FormAttachment( middle, -margin );
     fdlBody.top = new FormAttachment( wMethodField, 2 * margin );
@@ -436,13 +388,14 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wBody.setEditable( true );
     props.setLook( wBody );
     wBody.addModifyListener( lsMod );
-    fdBody = new FormData();
+    FormData fdBody = new FormData();
     fdBody.left = new FormAttachment( middle, 0 );
     fdBody.top = new FormAttachment( wMethodField, 2 * margin );
     fdBody.right = new FormAttachment( 100, -margin );
     wBody.setLayoutData( fdBody );
     wBody.addFocusListener( new FocusListener() {
       public void focusLost( org.eclipse.swt.events.FocusEvent e ) {
+        // Nothing to do
       }
 
       public void focusGained( org.eclipse.swt.events.FocusEvent e ) {
@@ -455,10 +408,10 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     } );
 
     // ApplicationType Line
-    wlApplicationType = new Label( gSettings, SWT.RIGHT );
+    Label wlApplicationType = new Label( gSettings, SWT.RIGHT );
     wlApplicationType.setText( BaseMessages.getString( PKG, "RestDialog.ApplicationType.Label" ) );
     props.setLook( wlApplicationType );
-    fdlApplicationType = new FormData();
+    FormData fdlApplicationType = new FormData();
     fdlApplicationType.left = new FormAttachment( 0, 0 );
     fdlApplicationType.right = new FormAttachment( middle, -margin );
     fdlApplicationType.top = new FormAttachment( wBody, 2 * margin );
@@ -468,14 +421,14 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wApplicationType.setEditable( true );
     props.setLook( wApplicationType );
     wApplicationType.addModifyListener( lsMod );
-    fdApplicationType = new FormData();
+    FormData fdApplicationType = new FormData();
     fdApplicationType.left = new FormAttachment( middle, 0 );
     fdApplicationType.top = new FormAttachment( wBody, 2 * margin );
     fdApplicationType.right = new FormAttachment( 100, -margin );
     wApplicationType.setLayoutData( fdApplicationType );
     wApplicationType.setItems( RestMeta.APPLICATION_TYPES );
     wApplicationType.addSelectionListener( new SelectionAdapter() {
-
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         input.setChanged();
       }
@@ -495,17 +448,17 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     Group gOutputFields = new Group( wGeneralComp, SWT.SHADOW_ETCHED_IN );
     gOutputFields.setText( BaseMessages.getString( PKG, "RestDialog.OutputFieldsGroup.Label" ) );
-    FormLayout OutputFieldsLayout = new FormLayout();
-    OutputFieldsLayout.marginWidth = 3;
-    OutputFieldsLayout.marginHeight = 3;
-    gOutputFields.setLayout( OutputFieldsLayout );
+    FormLayout outputFieldsLayout = new FormLayout();
+    outputFieldsLayout.marginWidth = 3;
+    outputFieldsLayout.marginHeight = 3;
+    gOutputFields.setLayout( outputFieldsLayout );
     props.setLook( gOutputFields );
 
     // Result line...
-    wlResult = new Label( gOutputFields, SWT.RIGHT );
+    Label wlResult = new Label( gOutputFields, SWT.RIGHT );
     wlResult.setText( BaseMessages.getString( PKG, "RestDialog.Result.Label" ) );
     props.setLook( wlResult );
-    fdlResult = new FormData();
+    FormData fdlResult = new FormData();
     fdlResult.left = new FormAttachment( 0, 0 );
     fdlResult.right = new FormAttachment( middle, -margin );
     fdlResult.top = new FormAttachment( gSettings, margin );
@@ -513,17 +466,17 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wResult = new TextVar( transMeta, gOutputFields, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wResult );
     wResult.addModifyListener( lsMod );
-    fdResult = new FormData();
+    FormData fdResult = new FormData();
     fdResult.left = new FormAttachment( middle, 0 );
     fdResult.top = new FormAttachment( gSettings, margin * 2 );
     fdResult.right = new FormAttachment( 100, -margin );
     wResult.setLayoutData( fdResult );
 
     // Resultcode line...
-    wlResultCode = new Label( gOutputFields, SWT.RIGHT );
+    Label wlResultCode = new Label( gOutputFields, SWT.RIGHT );
     wlResultCode.setText( BaseMessages.getString( PKG, "RestDialog.ResultCode.Label" ) );
     props.setLook( wlResultCode );
-    fdlResultCode = new FormData();
+    FormData fdlResultCode = new FormData();
     fdlResultCode.left = new FormAttachment( 0, 0 );
     fdlResultCode.right = new FormAttachment( middle, -margin );
     fdlResultCode.top = new FormAttachment( wResult, margin );
@@ -531,17 +484,17 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wResultCode = new TextVar( transMeta, gOutputFields, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wResultCode );
     wResultCode.addModifyListener( lsMod );
-    fdResultCode = new FormData();
+    FormData fdResultCode = new FormData();
     fdResultCode.left = new FormAttachment( middle, 0 );
     fdResultCode.top = new FormAttachment( wResult, margin );
     fdResultCode.right = new FormAttachment( 100, -margin );
     wResultCode.setLayoutData( fdResultCode );
 
     // Response time line...
-    wlResponseTime = new Label( gOutputFields, SWT.RIGHT );
+    Label wlResponseTime = new Label( gOutputFields, SWT.RIGHT );
     wlResponseTime.setText( BaseMessages.getString( PKG, "RestDialog.ResponseTime.Label" ) );
     props.setLook( wlResponseTime );
-    fdlResponseTime = new FormData();
+    FormData fdlResponseTime = new FormData();
     fdlResponseTime.left = new FormAttachment( 0, 0 );
     fdlResponseTime.right = new FormAttachment( middle, -margin );
     fdlResponseTime.top = new FormAttachment( wResultCode, margin );
@@ -549,16 +502,16 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wResponseTime = new TextVar( transMeta, gOutputFields, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wResponseTime );
     wResponseTime.addModifyListener( lsMod );
-    fdResponseTime = new FormData();
+    FormData fdResponseTime = new FormData();
     fdResponseTime.left = new FormAttachment( middle, 0 );
     fdResponseTime.top = new FormAttachment( wResultCode, margin );
     fdResponseTime.right = new FormAttachment( 100, 0 );
     wResponseTime.setLayoutData( fdResponseTime );
     // Response header line...
-    wlResponseHeader = new Label( gOutputFields, SWT.RIGHT );
+    Label wlResponseHeader = new Label( gOutputFields, SWT.RIGHT );
     wlResponseHeader.setText( BaseMessages.getString( PKG, "RestDialog.ResponseHeader.Label" ) );
     props.setLook( wlResponseHeader );
-    fdlResponseHeader = new FormData();
+    FormData fdlResponseHeader = new FormData();
     fdlResponseHeader.left = new FormAttachment( 0, 0 );
     fdlResponseHeader.right = new FormAttachment( middle, -margin );
     fdlResponseHeader.top = new FormAttachment( wResponseTime, margin );
@@ -566,7 +519,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wResponseHeader = new TextVar( transMeta, gOutputFields, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wResponseHeader );
     wResponseHeader.addModifyListener( lsMod );
-    fdResponseHeader = new FormData();
+    FormData fdResponseHeader = new FormData();
     fdResponseHeader.left = new FormAttachment( middle, 0 );
     fdResponseHeader.top = new FormAttachment( wResponseTime, margin );
     fdResponseHeader.right = new FormAttachment( 100, 0 );
@@ -581,7 +534,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     // END Output Fields GROUP
     // ////////////////////////
 
-    fdGeneralComp = new FormData();
+    FormData fdGeneralComp = new FormData();
     fdGeneralComp.left = new FormAttachment( 0, 0 );
     fdGeneralComp.top = new FormAttachment( wStepname, margin );
     fdGeneralComp.right = new FormAttachment( 100, 0 );
@@ -597,14 +550,14 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     // Auth tab...
     //
-    wAuthTab = new CTabItem( wTabFolder, SWT.NONE );
+    CTabItem wAuthTab = new CTabItem( wTabFolder, SWT.NONE );
     wAuthTab.setText( BaseMessages.getString( PKG, "RestDialog.Auth.Title" ) );
 
     FormLayout alayout = new FormLayout();
     alayout.marginWidth = Const.FORM_MARGIN;
     alayout.marginHeight = Const.FORM_MARGIN;
 
-    wAuthComp = new Composite( wTabFolder, SWT.NONE );
+    Composite wAuthComp = new Composite( wTabFolder, SWT.NONE );
     wAuthComp.setLayout( alayout );
     props.setLook( wAuthComp );
 
@@ -620,7 +573,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     props.setLook( gHttpAuth );
 
     // HTTP Login
-    wlHttpLogin = new Label( gHttpAuth, SWT.RIGHT );
+    Label wlHttpLogin = new Label( gHttpAuth, SWT.RIGHT );
     wlHttpLogin.setText( BaseMessages.getString( PKG, "RestDialog.HttpLogin.Label" ) );
     props.setLook( wlHttpLogin );
     FormData fdlHttpLogin = new FormData();
@@ -639,7 +592,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wHttpLogin.setLayoutData( fdHttpLogin );
 
     // HTTP Password
-    wlHttpPassword = new Label( gHttpAuth, SWT.RIGHT );
+    Label wlHttpPassword = new Label( gHttpAuth, SWT.RIGHT );
     wlHttpPassword.setText( BaseMessages.getString( PKG, "RestDialog.HttpPassword.Label" ) );
     props.setLook( wlHttpPassword );
     FormData fdlHttpPassword = new FormData();
@@ -658,22 +611,23 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wHttpPassword.setLayoutData( fdHttpPassword );
 
     // Preemptive line
-    wlPreemptive = new Label( gHttpAuth, SWT.RIGHT );
+    Label wlPreemptive = new Label( gHttpAuth, SWT.RIGHT );
     wlPreemptive.setText( BaseMessages.getString( PKG, "RestDialog.Preemptive.Label" ) );
     props.setLook( wlPreemptive );
-    fdlPreemptive = new FormData();
+    FormData fdlPreemptive = new FormData();
     fdlPreemptive.left = new FormAttachment( 0, 0 );
     fdlPreemptive.top = new FormAttachment( wHttpPassword, margin );
     fdlPreemptive.right = new FormAttachment( middle, -margin );
     wlPreemptive.setLayoutData( fdlPreemptive );
     wPreemptive = new Button( gHttpAuth, SWT.CHECK );
     props.setLook( wPreemptive );
-    fdPreemptive = new FormData();
+    FormData fdPreemptive = new FormData();
     fdPreemptive.left = new FormAttachment( middle, 0 );
     fdPreemptive.top = new FormAttachment( wHttpPassword, margin );
     fdPreemptive.right = new FormAttachment( 100, 0 );
     wPreemptive.setLayoutData( fdPreemptive );
     wPreemptive.addSelectionListener( new SelectionAdapter() {
+      @Override
       public void widgetSelected( SelectionEvent e ) {
         input.setChanged();
       }
@@ -700,7 +654,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     props.setLook( gProxy );
 
     // HTTP Login
-    wlProxyHost = new Label( gProxy, SWT.RIGHT );
+    Label wlProxyHost = new Label( gProxy, SWT.RIGHT );
     wlProxyHost.setText( BaseMessages.getString( PKG, "RestDialog.ProxyHost.Label" ) );
     props.setLook( wlProxyHost );
     FormData fdlProxyHost = new FormData();
@@ -719,7 +673,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wProxyHost.setLayoutData( fdProxyHost );
 
     // HTTP Password
-    wlProxyPort = new Label( gProxy, SWT.RIGHT );
+    Label wlProxyPort = new Label( gProxy, SWT.RIGHT );
     wlProxyPort.setText( BaseMessages.getString( PKG, "RestDialog.ProxyPort.Label" ) );
     props.setLook( wlProxyPort );
     FormData fdlProxyPort = new FormData();
@@ -746,7 +700,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     // END HTTP AUTH GROUP
     // ////////////////////////
 
-    fdAuthComp = new FormData();
+    FormData fdAuthComp = new FormData();
     fdAuthComp.left = new FormAttachment( 0, 0 );
     fdAuthComp.top = new FormAttachment( wStepname, margin );
     fdAuthComp.right = new FormAttachment( 100, 0 );
@@ -775,17 +729,17 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     gSSLTrustStore = new Group( wSSLComp, SWT.SHADOW_ETCHED_IN );
     gSSLTrustStore.setText( BaseMessages.getString( PKG, "RestDialog.SSLTrustStoreGroup.Label" ) );
-    FormLayout SSLTrustStoreLayout = new FormLayout();
-    SSLTrustStoreLayout.marginWidth = 3;
-    SSLTrustStoreLayout.marginHeight = 3;
-    gSSLTrustStore.setLayout( SSLTrustStoreLayout );
+    FormLayout sslTrustStoreLayout = new FormLayout();
+    sslTrustStoreLayout.marginWidth = 3;
+    sslTrustStoreLayout.marginHeight = 3;
+    gSSLTrustStore.setLayout( sslTrustStoreLayout );
     props.setLook( gSSLTrustStore );
 
     // TrustStoreFile line
-    wlTrustStoreFile = new Label( gSSLTrustStore, SWT.RIGHT );
+    Label wlTrustStoreFile = new Label( gSSLTrustStore, SWT.RIGHT );
     wlTrustStoreFile.setText( BaseMessages.getString( PKG, "RestDialog.TrustStoreFile.Label" ) );
     props.setLook( wlTrustStoreFile );
-    fdlTrustStoreFile = new FormData();
+    FormData fdlTrustStoreFile = new FormData();
     fdlTrustStoreFile.left = new FormAttachment( 0, 0 );
     fdlTrustStoreFile.top = new FormAttachment( 0, margin );
     fdlTrustStoreFile.right = new FormAttachment( middle, -margin );
@@ -794,7 +748,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wbTrustStoreFile = new Button( gSSLTrustStore, SWT.PUSH | SWT.CENTER );
     props.setLook( wbTrustStoreFile );
     wbTrustStoreFile.setText( BaseMessages.getString( PKG, "System.Button.Browse" ) );
-    fdbTrustStoreFile = new FormData();
+    FormData fdbTrustStoreFile = new FormData();
     fdbTrustStoreFile.right = new FormAttachment( 100, 0 );
     fdbTrustStoreFile.top = new FormAttachment( 0, 0 );
     wbTrustStoreFile.setLayoutData( fdbTrustStoreFile );
@@ -803,7 +757,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wTrustStoreFile = new TextVar( transMeta, gSSLTrustStore, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wTrustStoreFile );
     wTrustStoreFile.addModifyListener( lsMod );
-    fdTrustStoreFile = new FormData();
+    FormData fdTrustStoreFile = new FormData();
     fdTrustStoreFile.left = new FormAttachment( middle, 0 );
     fdTrustStoreFile.top = new FormAttachment( 0, margin );
     fdTrustStoreFile.right = new FormAttachment( wbTrustStoreFile, -margin );
@@ -814,10 +768,10 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
         new FilterType[] { FilterType.ALL }, FilterType.ALL ) ) );
 
     // TrustStorePassword line
-    wlTrustStorePassword = new Label( gSSLTrustStore, SWT.RIGHT );
+    Label wlTrustStorePassword = new Label( gSSLTrustStore, SWT.RIGHT );
     wlTrustStorePassword.setText( BaseMessages.getString( PKG, "RestDialog.TrustStorePassword.Label" ) );
     props.setLook( wlTrustStorePassword );
-    fdlTrustStorePassword = new FormData();
+    FormData fdlTrustStorePassword = new FormData();
     fdlTrustStorePassword.left = new FormAttachment( 0, 0 );
     fdlTrustStorePassword.top = new FormAttachment( wbTrustStoreFile, margin );
     fdlTrustStorePassword.right = new FormAttachment( middle, -margin );
@@ -826,7 +780,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
       new PasswordTextVar( transMeta, gSSLTrustStore, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wTrustStorePassword );
     wTrustStorePassword.addModifyListener( lsMod );
-    fdTrustStorePassword = new FormData();
+    FormData fdTrustStorePassword = new FormData();
     fdTrustStorePassword.left = new FormAttachment( middle, 0 );
     fdTrustStorePassword.top = new FormAttachment( wbTrustStoreFile, margin );
     fdTrustStorePassword.right = new FormAttachment( 100, 0 );
@@ -865,10 +819,10 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     // END HTTP AUTH GROUP
     // ////////////////////////
 
-    // TODO
+    // Allow additional SSL UI changes
     additionalSSLUiChanges();
 
-    fdSSLComp = new FormData();
+    FormData fdSSLComp = new FormData();
     fdSSLComp.left = new FormAttachment( 0, 0 );
     fdSSLComp.top = new FormAttachment( wStepname, margin );
     fdSSLComp.right = new FormAttachment( 100, 0 );
@@ -881,26 +835,26 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     // Additional tab...
     //
-    wAdditionalTab = new CTabItem( wTabFolder, SWT.NONE );
+    CTabItem wAdditionalTab = new CTabItem( wTabFolder, SWT.NONE );
     wAdditionalTab.setText( BaseMessages.getString( PKG, "RestDialog.Headers.Title" ) );
 
     FormLayout addLayout = new FormLayout();
     addLayout.marginWidth = Const.FORM_MARGIN;
     addLayout.marginHeight = Const.FORM_MARGIN;
 
-    wAdditionalComp = new Composite( wTabFolder, SWT.NONE );
+    Composite wAdditionalComp = new Composite( wTabFolder, SWT.NONE );
     wAdditionalComp.setLayout( addLayout );
     props.setLook( wAdditionalComp );
 
-    wlFields = new Label( wAdditionalComp, SWT.NONE );
+    Label wlFields = new Label( wAdditionalComp, SWT.NONE );
     wlFields.setText( BaseMessages.getString( PKG, "RestDialog.Headers.Label" ) );
     props.setLook( wlFields );
-    fdlFields = new FormData();
+    FormData fdlFields = new FormData();
     fdlFields.left = new FormAttachment( 0, 0 );
     fdlFields.top = new FormAttachment( wStepname, margin );
     wlFields.setLayoutData( fdlFields );
 
-    wGetHeaders = new Button( wAdditionalComp, SWT.PUSH );
+    Button wGetHeaders = new Button( wAdditionalComp, SWT.PUSH );
     wGetHeaders.setText( BaseMessages.getString( PKG, "RestDialog.GetHeaders.Button" ) );
     FormData fdGetHeaders = new FormData();
     fdGetHeaders.top = new FormAttachment( wlFields, margin );
@@ -909,7 +863,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     final int FieldsRows = input.getHeaderName().length;
 
-    colinf =
+    colInf =
       new ColumnInfo[] {
         new ColumnInfo(
           BaseMessages.getString( PKG, "RestDialog.ColumnInfo.Field" ), ColumnInfo.COLUMN_TYPE_CCOMBO,
@@ -917,20 +871,20 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
         new ColumnInfo(
           BaseMessages.getString( PKG, "RestDialog.ColumnInfo.Name" ), ColumnInfo.COLUMN_TYPE_TEXT, false ) };
 
-    colinf[ 1 ].setUsingVariables( true );
+    colInf[ 1 ].setUsingVariables( true );
     wFields =
       new TableView(
-        transMeta, wAdditionalComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod,
+        transMeta, wAdditionalComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colInf, FieldsRows, lsMod,
         props );
 
-    fdFields = new FormData();
+    FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );
     fdFields.top = new FormAttachment( wlFields, margin );
     fdFields.right = new FormAttachment( wGetHeaders, -margin );
     fdFields.bottom = new FormAttachment( 100, -margin );
     wFields.setLayoutData( fdFields );
 
-    fdAdditionalComp = new FormData();
+    FormData fdAdditionalComp = new FormData();
     fdAdditionalComp.left = new FormAttachment( 0, 0 );
     fdAdditionalComp.top = new FormAttachment( wStepname, margin );
     fdAdditionalComp.right = new FormAttachment( 100, -margin );
@@ -943,21 +897,21 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     // Query Parameters tab...
     //
-    wParametersTab = new CTabItem( wTabFolder, SWT.NONE );
+    CTabItem wParametersTab = new CTabItem( wTabFolder, SWT.NONE );
     wParametersTab.setText( BaseMessages.getString( PKG, "RestDialog.Parameters.Title" ) );
 
     FormLayout playout = new FormLayout();
     playout.marginWidth = Const.FORM_MARGIN;
     playout.marginHeight = Const.FORM_MARGIN;
 
-    wParametersComp = new Composite( wTabFolder, SWT.NONE );
+    Composite wParametersComp = new Composite( wTabFolder, SWT.NONE );
     wParametersComp.setLayout( playout );
     props.setLook( wParametersComp );
 
     wlParameters = new Label( wParametersComp, SWT.NONE );
     wlParameters.setText( BaseMessages.getString( PKG, "RestDialog.Parameters.Label" ) );
     props.setLook( wlParameters );
-    fdlParameters = new FormData();
+    FormData fdlParameters = new FormData();
     fdlParameters.left = new FormAttachment( 0, 0 );
     fdlParameters.top = new FormAttachment( wStepname, margin );
     wlParameters.setLayoutData( fdlParameters );
@@ -971,7 +925,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     final int ParametersRows = input.getParameterField().length;
 
-    colinfoparams =
+    colInfoParams =
       new ColumnInfo[] {
         new ColumnInfo(
           BaseMessages.getString( PKG, "RestDialog.ColumnInfo.ParameterField" ),
@@ -982,17 +936,17 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     wParameters =
       new TableView(
-        transMeta, wParametersComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinfoparams,
+        transMeta, wParametersComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colInfoParams,
         ParametersRows, lsMod, props );
 
-    fdParameters = new FormData();
+    FormData fdParameters = new FormData();
     fdParameters.left = new FormAttachment( 0, 0 );
     fdParameters.top = new FormAttachment( wlParameters, margin );
     fdParameters.right = new FormAttachment( wGet, -margin );
     fdParameters.bottom = new FormAttachment( 100, -margin );
     wParameters.setLayoutData( fdParameters );
 
-    fdParametersComp = new FormData();
+    FormData fdParametersComp = new FormData();
     fdParametersComp.left = new FormAttachment( 0, 0 );
     fdParametersComp.top = new FormAttachment( wStepname, margin );
     fdParametersComp.right = new FormAttachment( 100, 0 );
@@ -1004,21 +958,21 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     // ////// END of Query Parameters Tab
 
     // Matrix Parameters tab
-    wMatrixParametersTab = new CTabItem( wTabFolder, SWT.NONE );
+    CTabItem wMatrixParametersTab = new CTabItem( wTabFolder, SWT.NONE );
     wMatrixParametersTab.setText( BaseMessages.getString( PKG, "RestDialog.MatrixParameters.Title" ) );
 
     FormLayout pl = new FormLayout();
     pl.marginWidth = Const.FORM_MARGIN;
     pl.marginHeight = Const.FORM_MARGIN;
 
-    wMatrixParametersComp = new Composite( wTabFolder, SWT.NONE );
+    Composite wMatrixParametersComp = new Composite( wTabFolder, SWT.NONE );
     wMatrixParametersComp.setLayout( pl );
     props.setLook( wMatrixParametersComp );
 
     wlMatrixParameters = new Label( wMatrixParametersComp, SWT.NONE );
     wlMatrixParameters.setText( BaseMessages.getString( PKG, "RestDialog.Parameters.Label" ) );
     props.setLook( wlMatrixParameters );
-    fdlMatrixParameters = new FormData();
+    FormData fdlMatrixParameters = new FormData();
     fdlMatrixParameters.left = new FormAttachment( 0, 0 );
     fdlMatrixParameters.top = new FormAttachment( wStepname, margin );
     wlMatrixParameters.setLayoutData( fdlMatrixParameters );
@@ -1032,7 +986,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     int matrixParametersRows = input.getMatrixParameterField().length;
 
-    colinfoparams =
+    colInfoParams =
       new ColumnInfo[] {
         new ColumnInfo(
           BaseMessages.getString( PKG, "RestDialog.ColumnInfo.ParameterField" ),
@@ -1043,17 +997,17 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     wMatrixParameters =
       new TableView(
-        transMeta, wMatrixParametersComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinfoparams,
+        transMeta, wMatrixParametersComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colInfoParams,
         matrixParametersRows, lsMod, props );
 
-    fdMatrixParameters = new FormData();
+    FormData fdMatrixParameters = new FormData();
     fdMatrixParameters.left = new FormAttachment( 0, 0 );
     fdMatrixParameters.top = new FormAttachment( wlMatrixParameters, margin );
     fdMatrixParameters.right = new FormAttachment( wMatrixGet, -margin );
     fdMatrixParameters.bottom = new FormAttachment( 100, -margin );
     wMatrixParameters.setLayoutData( fdMatrixParameters );
 
-    fdMatrixParametersComp = new FormData();
+    FormData fdMatrixParametersComp = new FormData();
     fdMatrixParametersComp.left = new FormAttachment( 0, 0 );
     fdMatrixParametersComp.top = new FormAttachment( wStepname, margin );
     fdMatrixParametersComp.right = new FormAttachment( 100, 0 );
@@ -1064,7 +1018,7 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     wMatrixParametersTab.setControl( wMatrixParametersComp );
     //END of Matrix Parameters Tab
 
-    fdTabFolder = new FormData();
+    FormData fdTabFolder = new FormData();
     fdTabFolder.left = new FormAttachment( 0, 0 );
     fdTabFolder.top = new FormAttachment( wStepname, margin );
     fdTabFolder.right = new FormAttachment( 100, 0 );
@@ -1105,39 +1059,18 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
     setButtonPositions( new Button[] { wOK, wCancel }, margin, wTabFolder );
 
     // Add listeners
-    lsOK = new Listener() {
-      public void handleEvent( Event e ) {
-        ok();
-      }
-    };
-    lsCancel = new Listener() {
-      public void handleEvent( Event e ) {
-        cancel();
-      }
-    };
-    lsGet = new Listener() {
-      public void handleEvent( Event e ) {
-        getParametersFields( wParameters );
-      }
-    };
-    lsMatrixGet = new Listener() {
-      public void handleEvent( Event e ) {
-        getParametersFields( wMatrixParameters );
-      }
-    };
-    Listener lsGetHeaders = new Listener() {
-      public void handleEvent( Event e ) {
-        getHeaders();
-      }
-    };
+    lsOK = e -> ok();
+    lsCancel = e -> cancel();
+    lsGet = e -> getParametersFields( wParameters );
 
     wOK.addListener( SWT.Selection, lsOK );
     wGet.addListener( SWT.Selection, lsGet );
-    wMatrixGet.addListener( SWT.Selection, lsMatrixGet );
-    wGetHeaders.addListener( SWT.Selection, lsGetHeaders );
+    wMatrixGet.addListener( SWT.Selection, e1 -> getParametersFields( wMatrixParameters ) );
+    wGetHeaders.addListener( SWT.Selection, e -> getHeaders() );
     wCancel.addListener( SWT.Selection, lsCancel );
 
     lsDef = new SelectionAdapter() {
+      @Override
       public void widgetDefaultSelected( SelectionEvent e ) {
         ok();
       }
@@ -1151,21 +1084,19 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
 
     // Detect X or ALT-F4 or something that kills this window...
     shell.addShellListener( new ShellAdapter() {
+      @Override
       public void shellClosed( ShellEvent e ) {
         cancel();
       }
     } );
 
-    lsResize = new Listener() {
-      public void handleEvent( Event event ) {
-        Point size = shell.getSize();
-        wFields.setSize( size.x - 10, size.y - 50 );
-        wFields.table.setSize( size.x - 10, size.y - 50 );
-        wFields.redraw();
-      }
+    lsResize = event -> {
+      Point size = shell.getSize();
+      wFields.setSize( size.x - 10, size.y - 50 );
+      wFields.table.setSize( size.x - 10, size.y - 50 );
+      wFields.redraw();
     };
     shell.addListener( SWT.Resize, lsResize );
-
 
     // Set the shell size, based upon previous time...
     setSize();
@@ -1212,24 +1143,24 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
   protected void setComboBoxes() {
     // Something was changed in the row.
     //
-    final Map<String, Integer> fields = new HashMap<String, Integer>();
+    final Map<String, Integer> fields = new HashMap<>();
 
     // Add the currentMeta fields...
     fields.putAll( inputFields );
 
     Set<String> keySet = fields.keySet();
-    List<String> entries = new ArrayList<String>( keySet );
+    List<String> entries = new ArrayList<>( keySet );
 
-    fieldNames = entries.toArray( new String[ entries.size() ] );
+    fieldNames = entries.toArray( new String[ 0 ] );
 
     Const.sortStrings( fieldNames );
-    colinfoparams[ 0 ].setComboValues( fieldNames );
-    colinf[ 0 ].setComboValues( fieldNames );
+    colInfoParams[ 0 ].setComboValues( fieldNames );
+    colInf[ 0 ].setComboValues( fieldNames );
   }
 
   private void setStreamFields() {
     if ( !gotPreviousFields ) {
-      String urlfield = wUrlField.getText();
+      String urlField = wUrlField.getText();
       String body = wBody.getText();
       String method = wMethodField.getText();
 
@@ -1244,8 +1175,8 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
           wMethodField.setItems( fieldNames );
         }
       } finally {
-        if ( urlfield != null ) {
-          wUrlField.setText( urlfield );
+        if ( urlField != null ) {
+          wUrlField.setText( urlField );
         }
         if ( body != null ) {
           wBody.setText( body );
@@ -1379,26 +1310,28 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
       return;
     }
 
-    int nrheaders = wFields.nrNonEmpty();
-    int nrparams = wParameters.nrNonEmpty();
-    int nrmatrixparams = wMatrixParameters.nrNonEmpty();
-    input.allocate( nrheaders, nrparams, nrmatrixparams );
+    int nrHeaders = wFields.nrNonEmpty();
+    int nrParams = wParameters.nrNonEmpty();
+    int nrMatrixParams = wMatrixParameters.nrNonEmpty();
+    input.allocate( nrHeaders, nrParams, nrMatrixParams );
 
     if ( isDebug() ) {
-      logDebug( BaseMessages.getString( PKG, "RestDialog.Log.FoundArguments", String.valueOf( nrheaders ) ) );
+      logDebug( BaseMessages.getString( PKG, "RestDialog.Log.FoundArguments", String.valueOf( nrHeaders ) ) );
     }
-    for ( int i = 0; i < nrheaders; i++ ) {
+
+    for ( int i = 0; i < nrHeaders; i++ ) {
       TableItem item = wFields.getNonEmpty( i );
       input.getHeaderField()[ i ] = item.getText( 1 );
       input.getHeaderName()[ i ] = item.getText( 2 );
     }
-    for ( int i = 0; i < nrparams; i++ ) {
+
+    for ( int i = 0; i < nrParams; i++ ) {
       TableItem item = wParameters.getNonEmpty( i );
       input.getParameterField()[ i ] = item.getText( 1 );
       input.getParameterName()[ i ] = item.getText( 2 );
     }
 
-    for ( int i = 0; i < nrmatrixparams; i++ ) {
+    for ( int i = 0; i < nrMatrixParams; i++ ) {
       TableItem item = wMatrixParameters.getNonEmpty( i );
       input.getMatrixParameterField()[ i ] = item.getText( 1 );
       input.getMatrixParameterName()[ i ] = item.getText( 2 );
@@ -1444,7 +1377,6 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
         shell, BaseMessages.getString( PKG, "RestDialog.FailedToGetFields.DialogTitle" ), BaseMessages
         .getString( PKG, "RestDialog.FailedToGetFields.DialogMessage" ), ke );
     }
-
   }
 
   private void getHeaders() {
@@ -1458,7 +1390,6 @@ public class RestDialog extends BaseStepDialog implements StepDialogInterface {
         shell, BaseMessages.getString( PKG, "RestDialog.FailedToGetHeaders.DialogTitle" ), BaseMessages
         .getString( PKG, "RestDialog.FailedToGetHeaders.DialogMessage" ), ke );
     }
-
   }
 
   private void activeMethodInfield() {

--- a/plugins/rest/core/src/main/java/org/pentaho/di/util/HttpClientManager.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/util/HttpClientManager.java
@@ -40,8 +40,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -85,9 +85,9 @@ public class HttpClientManager {
     private int socketTimeout;
     private HttpHost proxy;
     private boolean ignoreSsl;
-    private FileInputStream trustStoreStream;
+    private InputStream trustStoreStream;
     private String trustStorePassword;
-    private FileInputStream keyStoreStream;
+    private InputStream keyStoreStream;
     private String keyStorePassword;
     private String keyPassword;
 
@@ -103,10 +103,9 @@ public class HttpClientManager {
 
     public HttpClientBuilderFacade setCredentials(
       String user, String password, AuthScope authScope ) {
-      CredentialsProvider provider = new BasicCredentialsProvider();
-      UsernamePasswordCredentials credentials = new UsernamePasswordCredentials( user, password );
-      provider.setCredentials( authScope, credentials );
-      this.provider = provider;
+      CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+      credentialsProvider.setCredentials( authScope, new UsernamePasswordCredentials( user, password ) );
+      this.provider = credentialsProvider;
       return this;
     }
 
@@ -133,13 +132,14 @@ public class HttpClientManager {
       this.ignoreSsl = ignoreSsl;
     }
 
-    public HttpClientBuilderFacade setTrustStore(FileInputStream trustStoreStream, String trustStorePassword) {
+    public HttpClientBuilderFacade setTrustStore( InputStream trustStoreStream, String trustStorePassword ) {
       this.trustStoreStream = trustStoreStream;
       this.trustStorePassword = trustStorePassword;
       return this;
     }
 
-    public HttpClientBuilderFacade setKeyStore(FileInputStream keyStoreStream, String keyStorePassword, String keyPassword) {
+    public HttpClientBuilderFacade setKeyStore( InputStream keyStoreStream, String keyStorePassword,
+                                                String keyPassword ) {
       this.keyStoreStream = keyStoreStream;
       this.keyStorePassword = keyStorePassword;
       this.keyPassword = keyPassword;
@@ -183,17 +183,20 @@ public class HttpClientManager {
   }
 
 
-  public static SSLContext getSslContext(boolean ignoreSSLValidation, FileInputStream trustFileStream, String trustStorePassword)
-	      throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException, KeyManagementException, UnrecoverableKeyException {
-	  return getSslContext(ignoreSSLValidation,trustFileStream,trustStorePassword,null,null,null);
+  public static SSLContext getSslContext( boolean ignoreSSLValidation, InputStream trustFileStream,
+                                          String trustStorePassword )
+    throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException, KeyManagementException,
+    UnrecoverableKeyException {
+    return getSslContext( ignoreSSLValidation, trustFileStream, trustStorePassword, null, null, null );
   }
 
-  
-  public static SSLContext getSslContext(boolean ignoreSSLValidation, FileInputStream trustFileStream, String trustStorePassword,
-      FileInputStream keyStoreFileStream, String keyStorePassword, String keyPassword)
-      throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException, KeyManagementException, UnrecoverableKeyException {
+  public static SSLContext getSslContext( boolean ignoreSSLValidation, InputStream trustFileStream,
+                                          String trustStorePassword, InputStream keyStoreFileStream,
+                                          String keyStorePassword, String keyPassword )
+    throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException, KeyManagementException,
+    UnrecoverableKeyException {
 
-    String SSLContextProtocol = ignoreSSLValidation ? "SSL" : "TLSv1.2";
+    String sslContextProtocol = ignoreSSLValidation ? "SSL" : "TLSv1.2";
     TrustManager[] trustManagers = null;
     KeyManager[] keyManagers = null;
 
@@ -258,15 +261,15 @@ public class HttpClientManager {
       keyManagers = kmf.getKeyManagers();
     }
 
-    SSLContext sslContext = SSLContext.getInstance(SSLContextProtocol);
-    sslContext.init(keyManagers, trustManagers, new java.security.SecureRandom());
+    SSLContext sslContext = SSLContext.getInstance( sslContextProtocol );
+    sslContext.init( keyManagers, trustManagers, new java.security.SecureRandom() );
 
     return sslContext;
   }
 
   /**
-   * @deprecated This method is deprecated because is replaced by getSSLContext. 
-   *             Use {@link #getSslContext(boolean, FileInputStream, String)} instead.
+   * @deprecated This method is deprecated because is replaced by getSSLContext.
+   * Use {@link #getSslContext(boolean, InputStream, String)} instead.
    */
   @Deprecated
   public static SSLContext getTrustAllSslContext() throws NoSuchAlgorithmException, KeyManagementException {
@@ -279,13 +282,12 @@ public class HttpClientManager {
   }
 
   /**
-   * @deprecated This method is deprecated because is replaced by getSSLContext. 
-   *             Use {@link #getSslContext(boolean, FileInputStream, String)} instead.
+   * @deprecated This method is deprecated because is replaced by getSSLContext.
+   * Use {@link #getSslContext(boolean, InputStream, String)} instead.
    */
   @Deprecated
-  public static SSLContext getSslContextWithTrustStoreFile( FileInputStream trustFileStream, String trustStorePassword)
-    throws NoSuchAlgorithmException, KeyStoreException,
-    IOException, CertificateException, KeyManagementException {
+  public static SSLContext getSslContextWithTrustStoreFile( InputStream trustFileStream, String trustStorePassword )
+    throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException, KeyManagementException {
     try {
       return getSslContext( false,trustFileStream, trustStorePassword);
     } catch ( UnrecoverableKeyException e ) {

--- a/plugins/rest/core/src/main/java/org/pentaho/di/util/HttpClientManager.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/util/HttpClientManager.java
@@ -54,19 +54,15 @@ public class HttpClientManager {
   private static final int CONNECTIONS_PER_ROUTE = 100;
   private static final int TOTAL_CONNECTIONS = 200;
 
-  private static HttpClientManager httpClientManager;
-  private static PoolingHttpClientConnectionManager manager;
+  private static final HttpClientManager httpClientManager = new HttpClientManager();
+  private final PoolingHttpClientConnectionManager manager = new PoolingHttpClientConnectionManager();
 
   private HttpClientManager() {
-    manager = new PoolingHttpClientConnectionManager();
     manager.setDefaultMaxPerRoute( CONNECTIONS_PER_ROUTE );
     manager.setMaxTotal( TOTAL_CONNECTIONS );
   }
 
   public static HttpClientManager getInstance() {
-    if ( httpClientManager == null ) {
-      httpClientManager = new HttpClientManager();
-    }
     return httpClientManager;
   }
 
@@ -128,8 +124,9 @@ public class HttpClientManager {
       return this;
     }
 
-    public void ignoreSsl( boolean ignoreSsl ) {
+    public HttpClientBuilderFacade ignoreSsl( boolean ignoreSsl ) {
       this.ignoreSsl = ignoreSsl;
+      return this;
     }
 
     public HttpClientBuilderFacade setTrustStore( InputStream trustStoreStream, String trustStorePassword ) {
@@ -155,7 +152,7 @@ public class HttpClientManager {
         requestConfigBuilder.setSocketTimeout( socketTimeout );
       }
       if ( connectionTimeout > 0 ) {
-        requestConfigBuilder.setConnectTimeout( socketTimeout );
+        requestConfigBuilder.setConnectTimeout( connectionTimeout );
       }
       if ( proxy != null ) {
         requestConfigBuilder.setProxy( proxy );
@@ -196,7 +193,7 @@ public class HttpClientManager {
     throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException, KeyManagementException,
     UnrecoverableKeyException {
 
-    String sslContextProtocol = ignoreSSLValidation ? "SSL" : "TLSv1.2";
+    String sslContextProtocol = ignoreSSLValidation ? "SSL" : "TLS";
     TrustManager[] trustManagers = null;
     KeyManager[] keyManagers = null;
 

--- a/plugins/rest/core/src/main/java/org/pentaho/di/util/HttpClientManager.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/util/HttpClientManager.java
@@ -275,7 +275,7 @@ public class HttpClientManager {
     } catch (UnrecoverableKeyException | IOException | CertificateException | KeyStoreException e) {
       // This should never happen since we're passing null for keystore parameters
       throw new KeyManagementException("Unexpected error: " + e.getMessage(), e );
-    }  
+    }
   }
 
   /**

--- a/plugins/rest/core/src/main/java/org/pentaho/di/util/HttpClientManager.java
+++ b/plugins/rest/core/src/main/java/org/pentaho/di/util/HttpClientManager.java
@@ -265,7 +265,7 @@ public class HttpClientManager {
   }
 
   /**
-   * @deprecated This method is deprecated because is replaced by getSSLContext.
+   * @deprecated This method is deprecated because is replaced by getSslContext.
    * Use {@link #getSslContext(boolean, InputStream, String)} instead.
    */
   @Deprecated
@@ -279,7 +279,7 @@ public class HttpClientManager {
   }
 
   /**
-   * @deprecated This method is deprecated because is replaced by getSSLContext.
+   * @deprecated This method is deprecated because is replaced by getSslContext.
    * Use {@link #getSslContext(boolean, InputStream, String)} instead.
    */
   @Deprecated

--- a/plugins/rest/core/src/test/java/org/pentaho/di/trans/steps/rest/RestMetaTest.java
+++ b/plugins/rest/core/src/test/java/org/pentaho/di/trans/steps/rest/RestMetaTest.java
@@ -69,12 +69,11 @@ public class RestMetaTest {
         "parameterName", "matrixParameterField", "matrixParameterName", "fieldName", "resultCodeFieldName",
         "responseTimeFieldName", "responseHeaderFieldName" );
 
-    Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorAttributeMap =
-      new HashMap<String, FieldLoadSaveValidator<?>>();
+    Map<String, FieldLoadSaveValidator<?>> fieldLoadSaveValidatorAttributeMap = new HashMap<>();
 
     // Arrays need to be consistent length
     FieldLoadSaveValidator<String[]> stringArrayLoadSaveValidator =
-      new ArrayLoadSaveValidator<String>( new StringLoadSaveValidator(), 25 );
+      new ArrayLoadSaveValidator<>( new StringLoadSaveValidator(), 25 );
     fieldLoadSaveValidatorAttributeMap.put( "headerField", stringArrayLoadSaveValidator );
     fieldLoadSaveValidatorAttributeMap.put( "headerName", stringArrayLoadSaveValidator );
     fieldLoadSaveValidatorAttributeMap.put( "parameterField", stringArrayLoadSaveValidator );
@@ -83,9 +82,9 @@ public class RestMetaTest {
     fieldLoadSaveValidatorAttributeMap.put( "matrixParameterName", stringArrayLoadSaveValidator );
 
     LoadSaveTester<RestMeta> loadSaveTester =
-      new LoadSaveTester<RestMeta>( RestMeta.class, attributes, new HashMap<String, String>(),
-        new HashMap<String, String>(), fieldLoadSaveValidatorAttributeMap,
-        new HashMap<String, FieldLoadSaveValidator<?>>() );
+      new LoadSaveTester<>( RestMeta.class, attributes, new HashMap<>(),
+        new HashMap<>(), fieldLoadSaveValidatorAttributeMap,
+        new HashMap<>() );
 
     loadSaveTester.testSerialization();
   }
@@ -93,7 +92,7 @@ public class RestMetaTest {
   @Test
   public void testStepChecks() {
     RestMeta meta = new RestMeta();
-    List<CheckResultInterface> remarks = new ArrayList<CheckResultInterface>();
+    List<CheckResultInterface> remarks = new ArrayList<>();
     TransMeta transMeta = new TransMeta();
     StepMeta step = new StepMeta();
     RowMetaInterface prev = new RowMeta();


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information

- **SP Issue:** [SP-7231](https://jira.pentaho.com/browse/SP-7231)
- **Base Case:** [PDI-20531](https://jira.pentaho.com/browse/PDI-20531)
- **Original master PR:** [pentaho/pentaho-kettle#10226](https://github.com/pentaho/pentaho-kettle/pull/10226)

## Changes

Cherry-picked from https://github.com/pentaho/pentaho-kettle/pull/10226 onto target branch `10.2`.

Commits applied (oldest → newest):

- `ea4b65c6225` — `[PDI-20531] - REST Client Step KeyStore functionality is not working`
- `0a56de52dd6` — `Fix file access and some Sonar suggestions`
- `0a542a8f514` — `Implement Sonar suggestions`
- `4d0a04f1da1` — `Claude Sonnet suggestions`
- `c1b89a5b257` — `fix[SP-7231]: Remove trailing whitespace introduced by cherry-pick`
- `1ce94cf2f27` — `Implement Sonar suggestions SP-7231`
- `657f29f2c4c` — `Sonar suggestions SP-7231`

> **Reviewer note:** The original PR 10226 also included a "Fix code style" commit (`d19e9c7ac70`) that reorganized imports to use `jakarta.ws.rs.*`. This import namespace is incompatible with the `10.2` maintenance branch (which uses `javax.ws.rs.*`), so that commit resolved to an empty change and was skipped. The functional behaviour is fully preserved.

## Conflict Resolution

- Conflict at `0407a78eda1` (`Implement Sonar suggestions`): conflict in `RestMeta.java` — resolved automatically by Conflict Resolver agent, preserving the full Sonar refactoring on the 10.2 code base.
- Conflict at `436226f7ef2` (`Implement Sonar suggestions`): conflict in `RestMeta.java` — duplicate `@Step` import (already added earlier in the file by this same commit), resolved by removing the duplicate.
- Conflict at `d19e9c7ac70` (`Fix code style`): `jakarta.ws.rs.*` import migration incompatible with 10.2; resolved by accepting HEAD (javax namespace). Resulting commit was empty — skipped.

## Target

- **Target branch:** `10.2`
- **Code freeze status (informational):** Target Fix Version field indicates `SP2026 - 10.2 (10.2.0.x)`. Code freeze may be in effect. Backport still targets the maintenance branch `10.2` only per policy.


[SP-7231]: https://hv-eng.atlassian.net/browse/SP-7231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PDI-20531]: https://hv-eng.atlassian.net/browse/PDI-20531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PDI-20531]: https://hv-eng.atlassian.net/browse/PDI-20531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ