### PR TITLE
test:[BACKLOG-49854] Updated the unit tests to avoid calling

### DIFF
--- a/dbdialog/pom.xml
+++ b/dbdialog/pom.xml
@@ -49,6 +49,13 @@
 
     <!-- Test dependencies -->
     <dependency>
+      <groupId>pentaho-kettle</groupId>
+      <artifactId>kettle-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-core</artifactId>
       <version>${powermock.version}</version>

--- a/dbdialog/src/test/java/org/pentaho/ui/database/event/DataHandlerTest.java
+++ b/dbdialog/src/test/java/org/pentaho/ui/database/event/DataHandlerTest.java
@@ -15,15 +15,16 @@ package org.pentaho.ui.database.event;
 import java.util.Properties;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.pentaho.di.core.database.BaseDatabaseMeta;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
-import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.plugins.DatabasePluginType;
 import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.junit.rules.RestorePDIEnvironment;
 import org.pentaho.ui.util.Launch;
 import org.pentaho.ui.util.Launch.Status;
 import org.pentaho.ui.xul.XulComponent;
@@ -58,6 +59,9 @@ import static org.mockito.Mockito.when;
  */
 public class DataHandlerTest {
 
+  @ClassRule
+  public static RestorePDIEnvironment env = new RestorePDIEnvironment();
+
   DataHandler dataHandler;
   Document document;
   XulDomContainer xulDomContainer;
@@ -78,9 +82,13 @@ public class DataHandlerTest {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    PluginRegistry.addPluginType( DatabasePluginType.getInstance() );
-    PluginRegistry.init();
-    KettleLogStore.init();
+    // Use a targeted plugin search instead of PluginRegistry.init() to avoid triggering a full
+    // classpath scan. PluginRegistry.init() loads PluginRegistryExtension implementations, one of
+    // which (from commons-xul-swt) initialises SWT's GTK native library and throws
+    // UnsatisfiedLinkError on headless CI agents that lack GTK. searchPlugins() registers only
+    // database plugins without that broader scan. KettleLogStore is initialised by
+    // RestorePDIEnvironment via KettleClientEnvironment.init().
+    DatabasePluginType.getInstance().searchPlugins();
   }
 
   @Before

--- a/dbdialog/src/test/java/org/pentaho/ui/database/event/FragmentHandlerTest.java
+++ b/dbdialog/src/test/java/org/pentaho/ui/database/event/FragmentHandlerTest.java
@@ -14,11 +14,11 @@ package org.pentaho.ui.database.event;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.pentaho.di.core.database.DatabaseInterface;
-import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.plugins.DatabasePluginType;
-import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.junit.rules.RestorePDIEnvironment;
 import org.pentaho.ui.xul.XulComponent;
 import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.XulException;
@@ -39,15 +39,22 @@ import static org.mockito.Mockito.when;
  */
 public class FragmentHandlerTest {
 
+  @ClassRule
+  public static RestorePDIEnvironment env = new RestorePDIEnvironment();
+
   FragmentHandler fragmentHandler;
   Document document;
   XulDomContainer xulDomContainer;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    PluginRegistry.addPluginType( DatabasePluginType.getInstance() );
-    PluginRegistry.init();
-    KettleLogStore.init();
+    // Use a targeted plugin search instead of PluginRegistry.init() to avoid triggering a full
+    // classpath scan. PluginRegistry.init() loads PluginRegistryExtension implementations, one of
+    // which (from commons-xul-swt) initialises SWT's GTK native library and throws
+    // UnsatisfiedLinkError on headless CI agents that lack GTK. searchPlugins() registers only
+    // database plugins without that broader scan. KettleLogStore is initialised by
+    // RestorePDIEnvironment via KettleClientEnvironment.init().
+    DatabasePluginType.getInstance().searchPlugins();
   }
 
   @Before


### PR DESCRIPTION
PluginRegistry.init() which was causing something to load the UI libraries or access a non-existent display on the headless Jenkins environment.  Tests were passing locally before and after the fix. This may not be sufficient and we may also need to update the test container to include the libgtk libraries.