### PR TITLE
build[SP-7261]: update Hibernate groupId

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -595,12 +595,12 @@
       <version>${fasterxml-jackson.non-osgi.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate-core.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-jcache</artifactId>
       <version>${hibernate-jcache.version}</version>
       <exclusions>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7261 - Backport of PPP-6248 - (11.0 Suite) CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/SP-7261)
- **Base Case:** [PPP-6248 - CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/PPP-6248)
- **Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10474

## Changes
- Cherry-picked PR #10474 (build[PPP-6248]: update Hibernate groupId).
- Commit: 5b6009362190a704d452bbee83dd38c802e79687

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
