### PR TITLE
build[SP-7260]: update Hibernate groupId

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -59,7 +59,6 @@
     <olap4j-xmla.version>1.2.0</olap4j-xmla.version>
     <wsdl4j.version>1.6.2</wsdl4j.version>
     <wsdl4j-qname.version>1.6.1</wsdl4j-qname.version>
-    <hibernate-core.version>5.4.24.Final</hibernate-core.version>
     <hibernate-commons-annotations.version>3.2.0.Final</hibernate-commons-annotations.version>
     <hibernate-ehcache.version>5.4.24.Final</hibernate-ehcache.version>
     <jboss-logging.version>3.4.3.Final</jboss-logging.version>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -612,7 +612,7 @@
       <version>${fasterxml-jackson.non-osgi.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate-core.version}</version>
       <exclusions>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7260 - Backport of PPP-6248 - (10.2 Suite) CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/SP-7260)
- **Base Case:** [PPP-6248 - CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/PPP-6248)
- **Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10474

## Changes
- Cherry-picked PR #10474 (build[PPP-6248]: update Hibernate groupId).
- Commit: 76f5693ca55

## Conflict Resolution
- Conflict in engine/pom.xml: hibernate-jcache dependency is absent in 10.2 (branch uses hibernate-ehcache). Applied hibernate-core groupId update to org.hibernate.orm; kept hibernate-ehcache dependency unchanged. Commit 5b6009362190a704d452bbee83dd38c802e79687 caused the discrepancy due to the 10.2 branch using an older Hibernate artifact set.

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
