### PR TITLE
build[SP-7278]: build[PPP-6390][PPP-6391]: use maven-parent-pom bouncycastle managed version

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -501,12 +501,10 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.xml</groupId>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7278 - Backport of PPP-6391 - (11.0 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7278)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (11.0 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10501

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-kettle/pull/10501
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
