### PR TITLE
[BACKLOG-48247]- Job step - Columns Exist in Table

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExist.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExist.java
@@ -33,6 +33,7 @@ import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryBase;
+import org.pentaho.di.job.entry.JobEntryHelperInterface;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
@@ -212,6 +213,11 @@ public class JobEntryColumnsExist extends JobEntryBase implements Cloneable, Job
 
   public boolean isUnconditional() {
     return false;
+  }
+
+  @Override
+  public JobEntryHelperInterface getJobEntryHelperInterface() {
+    return new JobEntryColumnsExistHelper();
   }
 
   public Result execute( Result previousResult, int nr ) {

--- a/engine/src/main/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExistHelper.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExistHelper.java
@@ -1,0 +1,127 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.columnsexist;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.database.Database;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entry.BaseJobEntryHelper;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Provides action handlers for the Columns Exist job entry dialog.
+ * Exposes {@code getTableColumns} to fetch column names from the specified
+ * database table, enabling the "Get columns" button in the UI.
+ *
+ * @see BaseJobEntryHelper
+ * @see JobEntryColumnsExist
+ */
+public class JobEntryColumnsExistHelper extends BaseJobEntryHelper {
+
+  private static final Class<?> PKG = JobEntryColumnsExist.class;
+
+  private static final String METHOD_GET_TABLE_COLUMNS = "getTableColumns";
+  private static final String RESPONSE_KEY_COLUMNS = "columns";
+  private static final String RESPONSE_KEY_MESSAGE = "message";
+
+  public JobEntryColumnsExistHelper() {
+    super();
+  }
+
+  @Override
+  @SuppressWarnings( "unchecked" )
+  protected JSONObject handleJobEntryAction( String method, JobMeta jobMeta, Map<String, String> queryParams ) {
+    JSONObject response = new JSONObject();
+    try {
+      if ( METHOD_GET_TABLE_COLUMNS.equals( method ) ) {
+        response = getTableColumns( jobMeta, queryParams );
+      } else {
+        response.put( ACTION_STATUS, FAILURE_METHOD_NOT_FOUND_RESPONSE );
+      }
+    } catch ( Exception ex ) {
+      response.put( ACTION_STATUS, FAILURE_RESPONSE );
+      log.logError( "Error executing job entry action '" + method + "'", ex );
+    }
+    return response;
+  }
+
+  /**
+   * Fetches the column names for the specified table from the database.
+   *
+   * @param jobMeta     the job metadata used for variable substitution and database lookup
+   * @param queryParams expects {@code connection}, {@code schemaname}, {@code tablename}
+   * @return a {@link JSONObject} with {@code columns} (array of column name strings) on success,
+   *         or an error status on failure
+   */
+  @SuppressWarnings( "unchecked" )
+  public JSONObject getTableColumns( JobMeta jobMeta, Map<String, String> queryParams ) {
+    JSONObject response = new JSONObject();
+    if ( jobMeta == null ) {
+      response.put( ACTION_STATUS, FAILURE_RESPONSE );
+      response.put( RESPONSE_KEY_MESSAGE, BaseMessages.getString( PKG, "JobEntryColumnsExist.Error.NoDbConnection" ) );
+      return response;
+    }
+    JSONArray columns = new JSONArray();
+
+    Map<String, String> safeParams = queryParams == null ? Collections.emptyMap() : queryParams;
+    String connectionName = Const.NVL( safeParams.get( "connection" ), "" );
+    String schemaName = Const.NVL( safeParams.get( "schemaname" ), "" );
+    String tableName = Const.NVL( safeParams.get( "tablename" ), "" );
+
+    DatabaseMeta databaseMeta = jobMeta.findDatabase( connectionName );
+    if ( databaseMeta == null ) {
+      response.put( ACTION_STATUS, FAILURE_RESPONSE );
+      response.put( RESPONSE_KEY_MESSAGE, BaseMessages.getString( PKG, "JobEntryColumnsExist.Error.NoDbConnection" ) );
+      return response;
+    }
+
+    Database database = createDatabase( jobMeta, databaseMeta );
+    database.shareVariablesWith( jobMeta );
+    try {
+      database.connect();
+
+      String resolvedSchema = jobMeta.environmentSubstitute( schemaName );
+      String resolvedTable = jobMeta.environmentSubstitute( tableName );
+
+      RowMetaInterface row = database.getTableFieldsMeta( resolvedSchema, resolvedTable );
+      if ( row != null ) {
+        String[] fieldNames = row.getFieldNames();
+        Collections.addAll( columns, fieldNames );
+        response.put( RESPONSE_KEY_COLUMNS, columns );
+        response.put( ACTION_STATUS, SUCCESS_RESPONSE );
+      } else {
+        response.put( ACTION_STATUS, FAILURE_RESPONSE );
+        response.put( RESPONSE_KEY_MESSAGE, BaseMessages.getString( PKG, "JobEntryColumnsExist.GetListColumsNoRow.DialogMessage" ) );
+      }
+    } catch ( Exception e ) {
+      log.logError( BaseMessages.getString( PKG, "JobEntryColumnsExist.ConnectionError2.DialogMessage", tableName ), e );
+      response.put( ACTION_STATUS, FAILURE_RESPONSE );
+      response.put( RESPONSE_KEY_MESSAGE, BaseMessages.getString( PKG, "JobEntryColumnsExist.ConnectionError2.DialogMessage", tableName ) );
+    } finally {
+      database.disconnect();
+    }
+
+    return response;
+  }
+
+  protected Database createDatabase( JobMeta jobMeta, DatabaseMeta databaseMeta ) {
+    return new Database( jobMeta, databaseMeta );
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExistHelperTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExistHelperTest.java
@@ -1,0 +1,169 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.columnsexist;
+
+import org.json.simple.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.database.Database;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.job.JobMeta;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.pentaho.di.job.entry.JobEntryHelperInterface.ACTION_STATUS;
+import static org.pentaho.di.job.entry.JobEntryHelperInterface.FAILURE_METHOD_NOT_FOUND_RESPONSE;
+import static org.pentaho.di.job.entry.JobEntryHelperInterface.FAILURE_RESPONSE;
+
+public class JobEntryColumnsExistHelperTest {
+
+  private JobEntryColumnsExistHelper helper;
+  private JobMeta jobMeta;
+
+  @BeforeClass
+  public static void setUpClass() {
+    KettleLogStore.init();
+  }
+
+  @Before
+  public void setUp() {
+    jobMeta = mock( JobMeta.class );
+    helper = new JobEntryColumnsExistHelper();
+  }
+
+  // ---- handleJobEntryAction dispatch ----
+
+  @Test
+  public void testHandleJobEntryAction_ValidMethod() {
+    DatabaseMeta databaseMeta = mock( DatabaseMeta.class );
+    when( jobMeta.findDatabase( anyString() ) ).thenReturn( databaseMeta );
+    when( jobMeta.environmentSubstitute( anyString() ) ).thenAnswer( inv -> inv.getArgument( 0 ) );
+
+    Map<String, String> params = new HashMap<>();
+    params.put( "connection", "testConn" );
+    params.put( "schemaname", "testSchema" );
+    params.put( "tablename", "testTable" );
+
+    // The method dispatches to getTableColumns; result will be FAILURE_RESPONSE due to DB connect
+    // but it must NOT return FAILURE_METHOD_NOT_FOUND_RESPONSE
+    JSONObject response = helper.handleJobEntryAction( "getTableColumns", jobMeta, params );
+
+    assertNotNull( response );
+    Object status = response.get( ACTION_STATUS );
+    assertNotNull( status );
+    // Must not be the "method not found" failure
+    assertEquals( false, FAILURE_METHOD_NOT_FOUND_RESPONSE.equals( status ) );
+  }
+
+  @Test
+  public void testHandleJobEntryAction_UnknownMethod() {
+    JSONObject response = helper.handleJobEntryAction( "unknownMethod", jobMeta, new HashMap<>() );
+
+    assertNotNull( response );
+    assertEquals( FAILURE_METHOD_NOT_FOUND_RESPONSE, response.get( ACTION_STATUS ) );
+  }
+
+  @Test
+  public void testHandleJobEntryAction_ExceptionDuringDispatch() {
+    // Pass null jobMeta to trigger an exception inside the method
+    JSONObject response = helper.handleJobEntryAction( "getTableColumns", null, new HashMap<>() );
+
+    assertNotNull( response );
+    assertEquals( FAILURE_RESPONSE, response.get( ACTION_STATUS ) );
+  }
+
+  // ---- getTableColumns ----
+
+  @Test
+  public void testGetTableColumns_NullJobMeta() {
+    JSONObject response = helper.getTableColumns( null, new HashMap<>() );
+
+    assertNotNull( response );
+    assertEquals( FAILURE_RESPONSE, response.get( ACTION_STATUS ) );
+    assertNotNull( response.get( "message" ) );
+  }
+
+  @Test
+  public void testGetTableColumns_NoDatabaseConnection() {
+    when( jobMeta.findDatabase( anyString() ) ).thenReturn( null );
+
+    Map<String, String> params = new HashMap<>();
+    params.put( "connection", "missingConn" );
+    params.put( "schemaname", "" );
+    params.put( "tablename", "employees" );
+
+    JSONObject response = helper.getTableColumns( jobMeta, params );
+
+    assertNotNull( response );
+    assertEquals( FAILURE_RESPONSE, response.get( ACTION_STATUS ) );
+    assertNotNull( response.get( "message" ) );
+  }
+
+  @Test
+  public void testGetTableColumns_NullRow() throws Exception {
+    DatabaseMeta databaseMeta = mock( DatabaseMeta.class );
+    Database mockDatabase = mock( Database.class );
+    RowMetaInterface mockRow = null; // simulate getTableFieldsMeta returning null
+
+    when( jobMeta.findDatabase( anyString() ) ).thenReturn( databaseMeta );
+    when( jobMeta.environmentSubstitute( anyString() ) ).thenAnswer( inv -> inv.getArgument( 0 ) );
+    when( mockDatabase.getTableFieldsMeta( anyString(), anyString() ) ).thenReturn( mockRow );
+
+    // Use factory method override to inject the mock Database
+    JobEntryColumnsExistHelper helperWithMockDb = new JobEntryColumnsExistHelper() {
+      @Override
+      protected Database createDatabase( JobMeta jm, DatabaseMeta dm ) {
+        return mockDatabase;
+      }
+    };
+
+    Map<String, String> params = new HashMap<>();
+    params.put( "connection", "testConn" );
+    params.put( "schemaname", "testSchema" );
+    params.put( "tablename", "testTable" );
+
+    JSONObject response = helperWithMockDb.getTableColumns( jobMeta, params );
+
+    assertNotNull( response );
+    assertEquals( FAILURE_RESPONSE, response.get( ACTION_STATUS ) );
+    assertNotNull( response.get( "message" ) );
+  }
+
+  @Test
+  public void testGetTableColumns_DatabaseConnectException() {
+    DatabaseMeta databaseMeta = mock( DatabaseMeta.class );
+    when( jobMeta.findDatabase( anyString() ) ).thenReturn( databaseMeta );
+    when( jobMeta.environmentSubstitute( anyString() ) ).thenAnswer( inv -> inv.getArgument( 0 ) );
+
+    // No actual DB — connect() will throw; we expect a FAILURE_RESPONSE
+    Map<String, String> params = new HashMap<>();
+    params.put( "connection", "testConn" );
+    params.put( "schemaname", "" );
+    params.put( "tablename", "employees" );
+
+    JSONObject response = helper.getTableColumns( jobMeta, params );
+
+    assertNotNull( response );
+    assertEquals( FAILURE_RESPONSE, response.get( ACTION_STATUS ) );
+    assertNotNull( response.get( "message" ) );
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExistTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExistTest.java
@@ -27,11 +27,13 @@ import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entry.JobEntryCopy;
+import org.pentaho.di.job.entry.JobEntryHelperInterface;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doNothing;
@@ -88,7 +90,7 @@ public class JobEntryColumnsExistTest {
   }
 
   @Test
-  public void jobFail_tableNameIsEmpty() throws KettleException {
+  public void jobFail_tableNameIsEmpty() {
     jobEntry.setTablename( null );
     final Result result = jobEntry.execute( new Result(), 0 );
     assertEquals( "Should be error", 1, result.getNrErrors() );
@@ -96,7 +98,7 @@ public class JobEntryColumnsExistTest {
   }
 
   @Test
-  public void jobFail_columnsArrayIsEmpty() throws KettleException {
+  public void jobFail_columnsArrayIsEmpty() {
     jobEntry.setArguments( null );
     final Result result = jobEntry.execute( new Result(), 0 );
     assertEquals( "Should be error", 1, result.getNrErrors() );
@@ -104,7 +106,7 @@ public class JobEntryColumnsExistTest {
   }
 
   @Test
-  public void jobFail_connectionIsNull() throws KettleException {
+  public void jobFail_connectionIsNull() {
     jobEntry.setDatabase( null );
     final Result result = jobEntry.execute( new Result(), 0 );
     assertEquals( "Should be error", 1, result.getNrErrors() );
@@ -146,5 +148,12 @@ public class JobEntryColumnsExistTest {
     assertTrue( "Result should be true", result.getResult() );
     assertEquals( "Lines written", COLUMNS.length, result.getNrLinesWritten() );
     verify( db, atLeastOnce() ).disconnect();
+  }
+
+  @Test
+  public void testGetJobEntryHelperInterface() {
+    JobEntryHelperInterface helper = jobEntry.getJobEntryHelperInterface();
+    assertNotNull( helper );
+    assertTrue( helper instanceof JobEntryColumnsExistHelper );
   }
 }

--- a/ui/src/main/java/org/pentaho/di/ui/job/entries/columnsexist/JobEntryColumnsExistDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/entries/columnsexist/JobEntryColumnsExistDialog.java
@@ -37,10 +37,14 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.database.Database;
 import org.pentaho.di.core.database.DatabaseMeta;
-import org.pentaho.di.core.row.RowMetaInterface;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import java.util.HashMap;
+import java.util.Map;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.columnsexist.JobEntryColumnsExist;
+import org.pentaho.di.job.entries.columnsexist.JobEntryColumnsExistHelper;
 import org.pentaho.di.job.entry.JobEntryDialogInterface;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.repository.Repository;
@@ -65,6 +69,8 @@ import org.pentaho.di.ui.trans.step.BaseStepDialog;
 
 public class JobEntryColumnsExistDialog extends JobEntryDialog implements JobEntryDialogInterface {
   private static Class<?> PKG = JobEntryColumnsExist.class; // for i18n purposes, needed by Translator2!!
+
+  private static final String SYSTEM_DIALOG_ERROR_TITLE = "System.Dialog.Error.Title";
 
   private Label wlName;
 
@@ -384,7 +390,7 @@ public class JobEntryColumnsExistDialog extends JobEntryDialog implements JobEnt
     } else {
       MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
       mb.setMessage( BaseMessages.getString( PKG, "JobEntryColumnsExist.ConnectionError.DialogMessage" ) );
-      mb.setText( BaseMessages.getString( PKG, "System.Dialog.Error.Title" ) );
+      mb.setText( BaseMessages.getString( PKG, SYSTEM_DIALOG_ERROR_TITLE ) );
       mb.open();
     }
 
@@ -466,43 +472,48 @@ public class JobEntryColumnsExistDialog extends JobEntryDialog implements JobEnt
   }
 
   /**
-   * Get a list of columns
+   * Get a list of columns by delegating to {@link JobEntryColumnsExistHelper}.
    */
-  private void getListColumns() {
+  void getListColumns() {
     if ( !Utils.isEmpty( wTablename.getText() ) ) {
-      DatabaseMeta databaseMeta = jobMeta.findDatabase( wConnection.getText() );
-      if ( databaseMeta != null ) {
-        Database database = new Database( loggingObject, databaseMeta );
-        database.shareVariablesWith( jobMeta );
-        try {
-          database.connect();
-          RowMetaInterface row =
-            database.getTableFieldsMeta(
-              jobMeta.environmentSubstitute( wSchemaname.getText() ),
-              jobMeta.environmentSubstitute( wTablename.getText() ) );
-          if ( row != null ) {
-            String[] available = row.getFieldNames();
+      JobEntryColumnsExistHelper helper = createColumnsExistHelper();
+      Map<String, String> params = new HashMap<>();
+      params.put( "connection", wConnection.getText() );
+      params.put( "schemaname", wSchemaname.getText() );
+      params.put( "tablename", wTablename.getText() );
 
-            wFields.removeAll();
-            for ( int i = 0; i < available.length; i++ ) {
-              wFields.add( available[i] );
-            }
-            wFields.removeEmptyRows();
-            wFields.setRowNums();
-          } else {
-            MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
-            mb.setMessage( BaseMessages.getString( PKG, "JobEntryColumnsExist.GetListColumsNoRow.DialogMessage" ) );
-            mb.setText( BaseMessages.getString( PKG, "System.Dialog.Error.Title" ) );
-            mb.open();
+      JSONObject result = helper.getTableColumns( jobMeta, params );
+
+      if ( !helper.isFailedResponse( result ) ) {
+        JSONArray columns = (JSONArray) result.get( "columns" );
+        if ( columns != null ) {
+          wFields.removeAll();
+          for ( Object col : columns ) {
+            wFields.add( col.toString() );
           }
-        } catch ( Exception e ) {
-          new ErrorDialog( shell, BaseMessages.getString( PKG, "System.Dialog.Error.Title" ), BaseMessages
-            .getString( PKG, "JobEntryColumnsExist.ConnectionError2.DialogMessage", wTablename.getText() ), e );
-        } finally {
-          database.disconnect();
+          wFields.removeEmptyRows();
+          wFields.setRowNums();
+        } else {
+          showErrorDialog( BaseMessages.getString( PKG, "JobEntryColumnsExist.GetListColumsNoRow.DialogMessage" ) );
         }
+      } else {
+        String helperMsg = (String) result.get( "message" );
+        String displayMsg = helperMsg != null ? helperMsg
+          : BaseMessages.getString( PKG, "JobEntryColumnsExist.ConnectionError2.DialogMessage", wTablename.getText() );
+        showErrorDialog( displayMsg );
       }
     }
+  }
+
+  protected JobEntryColumnsExistHelper createColumnsExistHelper() {
+    return new JobEntryColumnsExistHelper();
+  }
+
+  protected void showErrorDialog( String message ) {
+    MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_ERROR );
+    mb.setText( BaseMessages.getString( PKG, SYSTEM_DIALOG_ERROR_TITLE ) );
+    mb.setMessage( message );
+    mb.open();
   }
 
   private void getSchemaNames() {
@@ -534,13 +545,10 @@ public class JobEntryColumnsExistDialog extends JobEntryDialog implements JobEnt
           mb.open();
         }
       } catch ( Exception e ) {
-        new ErrorDialog( shell, BaseMessages.getString( PKG, "System.Dialog.Error.Title" ), BaseMessages
+        new ErrorDialog( shell, BaseMessages.getString( PKG, SYSTEM_DIALOG_ERROR_TITLE ), BaseMessages
           .getString( PKG, "System.Dialog.AvailableSchemas.ConnectionError" ), e );
       } finally {
-        if ( database != null ) {
-          database.disconnect();
-          database = null;
-        }
+        database.disconnect();
       }
     }
   }

--- a/ui/src/test/java/org/pentaho/di/ui/job/entries/columnsexist/JobEntryColumnsExistDialogTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/job/entries/columnsexist/JobEntryColumnsExistDialogTest.java
@@ -1,0 +1,216 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.ui.job.entries.columnsexist;
+
+import org.eclipse.swt.custom.CCombo;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import org.pentaho.di.ui.core.widget.TextVar;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.job.entries.columnsexist.JobEntryColumnsExistHelper;
+import org.pentaho.di.ui.core.widget.TableView;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.reflect.Whitebox.setInternalState;
+import static org.pentaho.di.job.entry.JobEntryHelperInterface.ACTION_STATUS;
+import static org.pentaho.di.job.entry.JobEntryHelperInterface.FAILURE_RESPONSE;
+import static org.pentaho.di.job.entry.JobEntryHelperInterface.SUCCESS_RESPONSE;
+
+@SuppressWarnings( "unchecked" )
+public class JobEntryColumnsExistDialogTest {
+
+  @Test
+  public void testGetListColumns_EmptyTablename_DoesNothing() {
+    JobEntryColumnsExistDialog dialog = mock( JobEntryColumnsExistDialog.class );
+    doCallRealMethod().when( dialog ).getListColumns();
+
+    TextVar wTablename = mock( TextVar.class );
+    when( wTablename.getText() ).thenReturn( "" );
+    setInternalState( dialog, "wTablename", wTablename );
+
+    dialog.getListColumns();
+
+    verify( dialog, never() ).createColumnsExistHelper();
+  }
+
+  @Test
+  public void testGetListColumns_SuccessWithColumns() {
+    JobEntryColumnsExistDialog dialog = mock( JobEntryColumnsExistDialog.class );
+    doCallRealMethod().when( dialog ).getListColumns();
+    doNothing().when( dialog ).showErrorDialog( anyString() );
+
+    TextVar wTablename = mock( TextVar.class );
+    when( wTablename.getText() ).thenReturn( "employees" );
+
+    CCombo wConnection = mock( CCombo.class );
+    when( wConnection.getText() ).thenReturn( "testConn" );
+
+    TextVar wSchemaname = mock( TextVar.class );
+    when( wSchemaname.getText() ).thenReturn( "testSchema" );
+
+    TableView wFields = mock( TableView.class );
+
+    JobMeta jobMeta = mock( JobMeta.class );
+
+    JSONArray columns = new JSONArray();
+    columns.add( "COL1" );
+    columns.add( "COL2" );
+
+    JSONObject successResponse = new JSONObject();
+    successResponse.put( ACTION_STATUS, SUCCESS_RESPONSE );
+    successResponse.put( "columns", columns );
+
+    JobEntryColumnsExistHelper helper = mock( JobEntryColumnsExistHelper.class );
+    when( helper.getTableColumns( any( JobMeta.class ), anyMap() ) )
+      .thenReturn( successResponse );
+    when( helper.isFailedResponse( successResponse ) ).thenReturn( false );
+    when( dialog.createColumnsExistHelper() ).thenReturn( helper );
+
+    setInternalState( dialog, "wTablename", wTablename );
+    setInternalState( dialog, "wConnection", wConnection );
+    setInternalState( dialog, "wSchemaname", wSchemaname );
+    setInternalState( dialog, "wFields", wFields );
+    setInternalState( dialog, "jobMeta", jobMeta );
+
+    dialog.getListColumns();
+
+    verify( wFields ).removeAll();
+    verify( wFields ).add( "COL1" );
+    verify( wFields ).add( "COL2" );
+    verify( wFields ).removeEmptyRows();
+    verify( wFields ).setRowNums();
+    verify( dialog, never() ).showErrorDialog( anyString() );
+  }
+
+  @Test
+  public void testGetListColumns_NullColumns_ShowsError() {
+    JobEntryColumnsExistDialog dialog = mock( JobEntryColumnsExistDialog.class );
+    doCallRealMethod().when( dialog ).getListColumns();
+    doNothing().when( dialog ).showErrorDialog( anyString() );
+
+    TextVar wTablename = mock( TextVar.class );
+    when( wTablename.getText() ).thenReturn( "employees" );
+
+    CCombo wConnection = mock( CCombo.class );
+    when( wConnection.getText() ).thenReturn( "testConn" );
+
+    TextVar wSchemaname = mock( TextVar.class );
+    when( wSchemaname.getText() ).thenReturn( "" );
+
+    TableView wFields = mock( TableView.class );
+    JobMeta jobMeta = mock( JobMeta.class );
+
+    JSONObject successResponse = new JSONObject();
+    successResponse.put( ACTION_STATUS, SUCCESS_RESPONSE );
+    // no "columns" key → null columns
+
+    JobEntryColumnsExistHelper helper = mock( JobEntryColumnsExistHelper.class );
+    when( helper.getTableColumns( any(), anyMap() ) )
+      .thenReturn( successResponse );
+    when( helper.isFailedResponse( successResponse ) ).thenReturn( false );
+    when( dialog.createColumnsExistHelper() ).thenReturn( helper );
+
+    setInternalState( dialog, "wTablename", wTablename );
+    setInternalState( dialog, "wConnection", wConnection );
+    setInternalState( dialog, "wSchemaname", wSchemaname );
+    setInternalState( dialog, "wFields", wFields );
+    setInternalState( dialog, "jobMeta", jobMeta );
+
+    dialog.getListColumns();
+
+    verify( dialog ).showErrorDialog( anyString() );
+    verify( wFields, never() ).removeAll();
+  }
+
+  @Test
+  public void testGetListColumns_HelperFailure_ShowsError() {
+    JobEntryColumnsExistDialog dialog = mock( JobEntryColumnsExistDialog.class );
+    doCallRealMethod().when( dialog ).getListColumns();
+    doNothing().when( dialog ).showErrorDialog( anyString() );
+
+    TextVar wTablename = mock( TextVar.class );
+    when( wTablename.getText() ).thenReturn( "employees" );
+
+    CCombo wConnection = mock( CCombo.class );
+    when( wConnection.getText() ).thenReturn( "testConn" );
+
+    TextVar wSchemaname = mock( TextVar.class );
+    when( wSchemaname.getText() ).thenReturn( "" );
+
+    TableView wFields = mock( TableView.class );
+    JobMeta jobMeta = mock( JobMeta.class );
+
+    JSONObject failureResponse = new JSONObject();
+    failureResponse.put( ACTION_STATUS, FAILURE_RESPONSE );
+    failureResponse.put( "message", "Connection failed" );
+
+    JobEntryColumnsExistHelper helper = mock( JobEntryColumnsExistHelper.class );
+    when( helper.getTableColumns( any(), anyMap() ) )
+      .thenReturn( failureResponse );
+    when( helper.isFailedResponse( failureResponse ) ).thenReturn( true );
+    when( dialog.createColumnsExistHelper() ).thenReturn( helper );
+
+    setInternalState( dialog, "wTablename", wTablename );
+    setInternalState( dialog, "wConnection", wConnection );
+    setInternalState( dialog, "wSchemaname", wSchemaname );
+    setInternalState( dialog, "wFields", wFields );
+    setInternalState( dialog, "jobMeta", jobMeta );
+
+    dialog.getListColumns();
+
+    verify( dialog ).showErrorDialog( "Connection failed" );
+    verify( wFields, never() ).removeAll();
+  }
+
+  @Test
+  public void testCreateColumnsExistHelper_ReturnsNewInstance() {
+    JobEntryColumnsExistDialog dialog = mock( JobEntryColumnsExistDialog.class );
+    doCallRealMethod().when( dialog ).createColumnsExistHelper();
+
+    JobEntryColumnsExistHelper result = dialog.createColumnsExistHelper();
+
+    assertNotNull( result );
+    assertTrue( result instanceof JobEntryColumnsExistHelper );
+  }
+
+  @Test
+  public void testShowErrorDialog_SetsTextAndMessageAndOpens() {
+    JobEntryColumnsExistDialog dialog = mock( JobEntryColumnsExistDialog.class );
+    doCallRealMethod().when( dialog ).showErrorDialog( anyString() );
+    setInternalState( dialog, "shell", mock( Shell.class ) );
+
+    try ( var mb = mockConstruction( MessageBox.class ) ) {
+      dialog.showErrorDialog( "Something went wrong" );
+
+      assertNotNull( mb.constructed() );
+      MessageBox constructed = mb.constructed().get( 0 );
+      verify( constructed ).setText( anyString() );
+      verify( constructed ).setMessage( "Something went wrong" );
+      verify( constructed ).open();
+    }
+  }
+}


### PR DESCRIPTION
This pull request refactors and improves the "Columns Exist" job entry in Pentaho Data Integration by introducing a new helper class to handle the retrieval of table columns, and updates the UI dialog to use this helper. The main goal is to centralize and standardize the logic for fetching column names from a database, making it easier to maintain and extend.

**Backend logic extraction and reuse:**

* Added a new class `JobEntryColumnsExistHelper` in `engine/src/main/java/org/pentaho/di/job/entries/columnsexist/JobEntryColumnsExistHelper.java` that encapsulates the logic for fetching column names from a database table, returning results as JSON. This class extends `BaseJobEntryHelper` and exposes the `getTableColumns` method for use by UI and other consumers.
* Updated `JobEntryColumnsExist` to implement `getJobEntryHelperInterface()`, returning an instance of the new helper class, enabling consistent helper usage across the codebase. [[1]](diffhunk://#diff-f856e16c61a9823861156d918c64f532c5791c5dd916f7d6f405e9cc8aed89e3R36) [[2]](diffhunk://#diff-f856e16c61a9823861156d918c64f532c5791c5dd916f7d6f405e9cc8aed89e3R218-R222)

**UI dialog refactor:**

* Refactored the `JobEntryColumnsExistDialog` UI class to delegate the retrieval of table columns to the new `JobEntryColumnsExistHelper`, replacing the previous direct database access logic. This improves separation of concerns and code reuse. [[1]](diffhunk://#diff-6a53658db5fb6e52a09206d7f35d97d89d6eca6689877d82f0253d2d7acd00e4R41-R48) [[2]](diffhunk://#diff-6a53658db5fb6e52a09206d7f35d97d89d6eca6689877d82f0253d2d7acd00e4L469-R491)
* Updated error handling in the UI dialog to use the error messages provided by the helper's JSON response, resulting in clearer and more consistent error dialogs for users.