### PR TITLE
[BISERVER-15647] - performance improvements

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/xml/XMLHandler.java
+++ b/core/src/main/java/org/pentaho/di/core/xml/XMLHandler.java
@@ -89,6 +89,26 @@ public class XMLHandler {
     new SimpleTimestampFormat( ValueMeta.DEFAULT_TIMESTAMP_FORMAT_MASK );
   public static final int DEFAULT_RETRY_ATTEMPTS = 2;
 
+  /**
+   * ThreadLocal cache for DocumentBuilder instances with standard configuration:
+   * namespaceAware=false, deferNodeExpansion=true
+   *
+   * Uses ThreadLocal to provide each thread with its own DocumentBuilder instance.
+   * DocumentBuilder is not thread-safe (has mutable internal state during parsing),
+   * so each thread maintains its own instance to avoid synchronization overhead.
+   * This eliminates expensive DocumentBuilderFactory creation (~60% overhead reduction).
+   *
+   * @see #getDefaultDocumentBuilder()
+   */
+  private static final ThreadLocal<DocumentBuilder> DEFAULT_BUILDER_CACHE = ThreadLocal.withInitial( () -> {
+    try {
+      return createDocumentBuilder( false, true );
+    } catch ( KettleXMLException e ) {
+      throw new DocumentBuilderInitializationException(
+        "Failed to initialize default DocumentBuilder for XML parsing", e );
+    }
+  } );
+
   private XMLHandler() {
   }
 
@@ -706,16 +726,18 @@ public class XMLHandler {
   }
 
   /**
-   * Calls loadXMLString with deferNodeExpansion = TRUE
+   * Load a String into an XML document using the cached default DocumentBuilder.
+   * Uses ThreadLocal-cached DocumentBuilder to avoid expensive factory creation (~60% overhead reduction).
+   * This is the most common path for XML string parsing.
    *
-   * @param string
-   * @return
-   * @throws KettleXMLException
+   * Configuration: namespaceAware=false, deferNodeExpansion=true
+   *
+   * @param string The XML text to load into a document
+   * @return the parsed Document
+   * @throws KettleXMLException if parsing fails
    */
   public static Document loadXMLString( String string ) throws KettleXMLException {
-
-    return loadXMLString( string, Boolean.FALSE, Boolean.TRUE );
-
+    return loadXMLString( DEFAULT_BUILDER_CACHE.get(), string );
   }
 
   /**
@@ -732,14 +754,23 @@ public class XMLHandler {
   }
 
   /**
-   * Load a String into an XML document
+   * Load a String into an XML document with specified configuration.
+  * Uses ThreadLocal-cached DocumentBuilder for default configuration,
+  * creates a new one for all other configs.
    *
    * @param string             The XML text to load into a document
-   * @param deferNodeExpansion true to defer node expansion, false to not defer.
-   * @return the Document if all went well, null if an error occurred!
+   * @param namespaceAware     true to support XML namespaces, false otherwise
+   * @param deferNodeExpansion true to defer node expansion, false to not defer
+   * @return the parsed Document
+   * @throws KettleXMLException if parsing fails
    */
   public static Document loadXMLString( String string, Boolean namespaceAware, Boolean deferNodeExpansion )
     throws KettleXMLException {
+    // Use cached builders for common configurations to avoid DocumentBuilderFactory creation overhead
+    if ( Boolean.TRUE.equals( deferNodeExpansion ) && ! Boolean.TRUE.equals( namespaceAware ) ) {
+      return loadXMLString( DEFAULT_BUILDER_CACHE.get(), string );
+    }
+    // For non-default configurations, create a one-off builder
     DocumentBuilder db = createDocumentBuilder( namespaceAware, deferNodeExpansion );
     return loadXMLString( db, string );
   }
@@ -756,6 +787,7 @@ public class XMLHandler {
       } catch ( IOException ef ) {
         throw new KettleXMLException( "Error parsing XML", ef );
       } finally {
+        resetDocumentBuilder( db );
         stringReader.close();
       }
 
@@ -774,6 +806,23 @@ public class XMLHandler {
       return dbf.newDocumentBuilder();
     } catch ( ParserConfigurationException e ) {
       throw new KettleXMLException( e );
+    }
+  }
+
+  private static void resetDocumentBuilder( DocumentBuilder db ) {
+    // ThreadLocal-cached builders are reused, so reset parser state between invocations.
+    try {
+      db.reset();
+    } catch ( UnsupportedOperationException ignored ) {
+      // Some parser implementations may not support reset; continue safely.
+    }
+  }
+
+  private static class DocumentBuilderInitializationException extends IllegalStateException {
+    private static final long serialVersionUID = -5273507582858574646L;
+
+    private DocumentBuilderInitializationException( String message, Throwable cause ) {
+      super( message, cause );
     }
   }
 

--- a/core/src/test/java/org/pentaho/di/core/xml/XMLHandlerUnitTest.java
+++ b/core/src/test/java/org/pentaho/di/core/xml/XMLHandlerUnitTest.java
@@ -347,4 +347,160 @@ public class XMLHandlerUnitTest {
     assertNotNull( subNode );
     assertEquals( "3", subNode.getTextContent() );
   }
+
+  /**
+   * Test that the default cached DocumentBuilder parses XML correctly.
+   * Verifies ThreadLocal caching of builders works and produces valid Documents.
+   */
+  @Test
+  public void cachedDefaultBuilderParsesXmlCorrectly() throws Exception {
+    String simpleXml = "<?xml version=\"1.0\"?><root><item>test</item></root>";
+    Document doc = XMLHandler.loadXMLString( simpleXml );
+    assertNotNull( "Document should not be null", doc );
+    assertNotNull( "Root element should exist", doc.getDocumentElement() );
+    assertEquals( "Root element name", "root", doc.getDocumentElement().getNodeName() );
+  }
+
+  /**
+   * Test that the namespace-aware cached DocumentBuilder works correctly.
+   */
+  @Test
+  public void cachedNamespaceAwareBuilderParsesXmlCorrectly() throws Exception {
+    String nsXml = "<?xml version=\"1.0\"?><root xmlns=\"http://example.com\"><item>test</item></root>";
+    Document doc = XMLHandler.loadXMLString( nsXml, true, true );
+    assertNotNull( "Document should not be null", doc );
+    assertNotNull( "Root element should exist", doc.getDocumentElement() );
+    assertEquals( "Root element local name", "root", doc.getDocumentElement().getLocalName() );
+  }
+
+  /**
+   * Test that cached builders produce the same results as fresh builders.
+   * This ensures ThreadLocal caching is functionally equivalent.
+   */
+  @Test
+  public void cachedBuilderProducesIdenticalResultsAsNewBuilder() throws Exception {
+    String testXml = "<?xml version=\"1.0\"?><root attr=\"value\"><child>text</child></root>";
+    
+    // Parse with cached builder
+    Document cachedDoc = XMLHandler.loadXMLString( testXml );
+    
+    // Parse with new builder
+    DocumentBuilder freshBuilder = XMLHandler.createDocumentBuilder( false, true );
+    Document freshDoc = XMLHandler.loadXMLString( freshBuilder, testXml );
+    
+    assertNotNull( "Cached document", cachedDoc );
+    assertNotNull( "Fresh document", freshDoc );
+    assertEquals( "Root element names match",
+      cachedDoc.getDocumentElement().getNodeName(),
+      freshDoc.getDocumentElement().getNodeName() );
+    assertEquals( "Child node count",
+      cachedDoc.getDocumentElement().getChildNodes().getLength(),
+      freshDoc.getDocumentElement().getChildNodes().getLength() );
+  }
+
+  /**
+   * Test that non-standard configurations work (creates fresh builder, not cached).
+   */
+  @Test
+  public void nonStandardConfigurationCreatesFreshBuilder() throws Exception {
+    String testXml = "<?xml version=\"1.0\"?><root><item>test</item></root>";
+    Document doc = XMLHandler.loadXMLString( testXml, true, false );
+    assertNotNull( "Non-standard config should parse", doc );
+    assertEquals( "Root element name", "root", doc.getDocumentElement().getNodeName() );
+  }
+
+  /**
+   * Test concurrent access to cached builders.
+   * Each thread gets its own DocumentBuilder via ThreadLocal, so no synchronization issues.
+   */
+  @Test
+  public void concurrentAccessToCachedBuilders() throws Exception {
+    String testXml = "<?xml version=\"1.0\"?><root><data>concurrent test</data></root>";
+    final int threadCount = 10;
+    final int iterationsPerThread = 20;
+    
+    Thread[] threads = new Thread[threadCount];
+    final Exception[] exceptions = new Exception[threadCount];
+    
+    for ( int i = 0; i < threadCount; i++ ) {
+      final int threadIndex = i;
+      threads[i] = new Thread( () -> {
+        try {
+          for ( int j = 0; j < iterationsPerThread; j++ ) {
+            // Each thread uses ThreadLocal cached builders
+            Document doc1 = XMLHandler.loadXMLString( testXml );
+            assertNotNull( "Thread " + threadIndex + " iteration " + j, doc1 );
+            
+            Document doc2 = XMLHandler.loadXMLString( testXml, true, true );
+            assertNotNull( "Thread " + threadIndex + " iteration " + j + " (NS aware)", doc2 );
+          }
+        } catch ( Exception e ) {
+          exceptions[threadIndex] = e;
+        }
+      } );
+    }
+    
+    // Start all threads
+    for ( Thread thread : threads ) {
+      thread.start();
+    }
+    
+    // Wait for all threads to complete
+    for ( Thread thread : threads ) {
+      thread.join();
+    }
+    
+    // Check for exceptions
+    for ( int i = 0; i < threadCount; i++ ) {
+      assertNull( "Thread " + i + " should not throw exception", exceptions[i] );
+    }
+  }
+
+  /**
+   * Test rapid repeated parsing with cached builders.
+   * Simulates repeated parsing scenarios and verifies functional correctness.
+   */
+  @Test
+  public void cachedBuilderHandlesRapidRepeatParsing() throws Exception {
+    String testXml = "<?xml version=\"1.0\"?><root><item>test</item></root>";
+
+    // Rapid repeated parsing (similar to addOrReplaceSlaveServer loop)
+    for ( int i = 0; i < 1000; i++ ) {
+      Document doc = XMLHandler.loadXMLString( testXml );
+      assertNotNull( doc );
+      assertNotNull( doc.getDocumentElement() );
+      assertEquals( "root", doc.getDocumentElement().getNodeName() );
+    }
+  }
+
+  /**
+   * Test that complex XML with mixed namespaces parses correctly with cached builder.
+   */
+  @Test
+  public void complexXmlWithMixedContentParsesCorrectly() throws Exception {
+    String complexXml = "<?xml version=\"1.0\"?>\n"
+      + "<root xmlns=\"http://default.example.com\" xmlns:custom=\"http://custom.example.com\">\n"
+      + "  <item>Default namespace</item>\n"
+      + "  <custom:item>Custom namespace</custom:item>\n"
+      + "</root>";
+    
+    Document doc = XMLHandler.loadXMLString( complexXml, true, true );
+    assertNotNull( "Complex document should parse", doc );
+    assertNotNull( "Root element should exist", doc.getDocumentElement() );
+  }
+
+  /**
+   * Test entity reference handling with cached builders.
+   */
+  @Test
+  public void entityReferencesHandledCorrectlyWithCachedBuilder() throws Exception {
+    String xmlWithEntities = "<?xml version=\"1.0\"?><root attr=\"value &amp; more\">"
+      + "<item>&lt;test&gt;</item></root>";
+    
+    Document doc = XMLHandler.loadXMLString( xmlWithEntities );
+    assertNotNull( "Document with entities should parse", doc );
+    
+    String text = doc.getDocumentElement().getFirstChild().getTextContent();
+    assertEquals( "Entity references should be expanded", "<test>", text );
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
+++ b/engine/src/main/java/org/pentaho/di/base/AbstractMeta.java
@@ -442,9 +442,6 @@ public abstract class AbstractMeta implements ChangedFlagInterface, UndoInterfac
    */
   public void setBowl( Bowl bowl ) {
     this.bowl = Objects.requireNonNull( bowl );
-    // clearing cache just before loading shared objects ensures that the loaded file will have the 
-    // most recent config. 
-    bowl.clearCache();
     initializeNonLocalSharedObjects();
     // now that the bowl has changed, make sure we have up-to-date DatabaseMetas.
     allDatabasesUpdated();

--- a/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
+++ b/engine/src/main/java/org/pentaho/di/cluster/SlaveServer.java
@@ -144,7 +144,7 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
     }
   }
 
-  private LogChannelInterface log;
+  private static LogChannelInterface log = new LogChannel( STRING_SLAVESERVER );
 
   private String name;
 
@@ -187,9 +187,7 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
   private ReadWriteLock lock;
 
   public SlaveServer() {
-    initializeVariablesFrom( null );
     id = null;
-    this.log = new LogChannel( STRING_SLAVESERVER );
     this.changedDate = new Date();
     lock = new ReentrantReadWriteLock();
   }
@@ -218,8 +216,6 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
 
     this.master = master;
     this.sslMode = ssl;
-    initializeVariablesFrom( null );
-    this.log = new LogChannel( this );
   }
 
   public SlaveServer( Node slaveNode ) {
@@ -237,8 +233,6 @@ public class SlaveServer extends ChangedFlag implements Cloneable, SharedObjectI
     this.overrideExistingProperties =
       "Y".equalsIgnoreCase( XMLHandler.getTagValue( slaveNode, "override_existing_properties" ) );
     this.master = "Y".equalsIgnoreCase( XMLHandler.getTagValue( slaveNode, "master" ) );
-    initializeVariablesFrom( null );
-    this.log = new LogChannel( this );
     readObjectId( slaveNode );
 
     setSslMode( "Y".equalsIgnoreCase( XMLHandler.getTagValue( slaveNode, SSL_MODE_TAG ) ) );

--- a/engine/src/main/java/org/pentaho/di/repository/AbstractRepository.java
+++ b/engine/src/main/java/org/pentaho/di/repository/AbstractRepository.java
@@ -26,7 +26,15 @@ import java.util.List;
  */
 public abstract class AbstractRepository implements Repository {
 
-  private final Bowl bowl = new RepositoryBowl( this );
+  private final Bowl bowl;
+
+  protected AbstractRepository() {
+    bowl = new RepositoryBowl( this );
+  }
+
+  protected AbstractRepository( Bowl bowl ) {
+    this.bowl = bowl;
+  }
 
   @Override
   public long getJobEntryAttributeInteger( ObjectId id_jobentry, String code ) throws KettleException {

--- a/engine/src/main/java/org/pentaho/di/shared/PassthroughManager.java
+++ b/engine/src/main/java/org/pentaho/di/shared/PassthroughManager.java
@@ -1,4 +1,5 @@
-/*! ******************************************************************************
+/*
+ * ! ******************************************************************************
  *
  * Pentaho
  *
@@ -25,7 +26,7 @@ import org.w3c.dom.Node;
 /**
  * This Manager that does not cache anything. Complete passthrough to the provided SharedObjectsIO instance.
  *
-*/
+ */
 public abstract class PassthroughManager<T extends SharedObjectInterface<T> & RepositoryElementInterface>
   implements SharedObjectsManagementInterface<T> {
 
@@ -40,6 +41,7 @@ public abstract class PassthroughManager<T extends SharedObjectInterface<T> & Re
   /**
    * This method is used to create concrete SharedObjectInterface implementation class. This will be implemented by
    * subclasses.
+   * 
    * @param node
    * @return
    * @throws KettleException
@@ -59,7 +61,7 @@ public abstract class PassthroughManager<T extends SharedObjectInterface<T> & Re
   }
 
   @Override
-  public T get( String name) throws KettleException {
+  public T get( String name ) throws KettleException {
     try {
       sharedObjectsIO.lock();
       Node node = sharedObjectsIO.getSharedObject( type, name );
@@ -74,24 +76,23 @@ public abstract class PassthroughManager<T extends SharedObjectInterface<T> & Re
   }
 
   @Override
-  public List<T> getAll( ) throws KettleException {
+  public List<T> getAll() throws KettleException {
     try {
       sharedObjectsIO.lock();
-    
-    Map<String, Node> nodeMap = sharedObjectsIO.getSharedObjects( type );
-    List<T> result = new ArrayList<>( nodeMap.size() );
+      Map<String, Node> nodeMap = sharedObjectsIO.getSharedObjects( type );
+      List<T> result = new ArrayList<>( nodeMap.size() );
 
-    for ( Node node : nodeMap.values() ) {
-      result.add( createSharedObjectUsingNode( node ) );
-    }
-    return result;
+      for ( Node node : nodeMap.values() ) {
+        result.add( createSharedObjectUsingNode( node ) );
+      }
+      return result;
     } finally {
       sharedObjectsIO.unlock();
     }
   }
 
   @Override
-  public void clear( ) throws KettleException {
+  public void clear() throws KettleException {
     sharedObjectsIO.clear( type );
   }
 
@@ -101,7 +102,7 @@ public abstract class PassthroughManager<T extends SharedObjectInterface<T> & Re
   }
 
   @Override
-  public void remove( String name) throws KettleException {
+  public void remove( String name ) throws KettleException {
     sharedObjectsIO.delete( type, name );
   }
 

--- a/engine/src/main/java/org/pentaho/di/shared/RepositorySharedObjectsIO.java
+++ b/engine/src/main/java/org/pentaho/di/shared/RepositorySharedObjectsIO.java
@@ -31,97 +31,129 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import org.w3c.dom.Node;
 
 /**
- * An implementation of SharedObjectsIO that backs to a Repository.
+ * An implementation of SharedObjectsIO that backs to a Repository with a write-through cache.
  * <p>
- * This class does not cache anything. Note that PurRepository does its own caching, but only through the
- * RepositoryExtended interface, which this class makes use of.
- *
+ * Reads are served from the in-memory cache after the first load for each type; writes go to both the
+ * backing repository and the cache. Call {@link #clearCache()} to evict all locally cached entries so
+ * that the next read fetches fresh data from the backing repository.
+ * <p>
+ * Note that PurRepository does its own caching through the RepositoryExtended interface, which this
+ * class also makes use of when available.
  */
 public class RepositorySharedObjectsIO implements SharedObjectsIO {
 
   private final Repository repository;
   private final SlaveServersSupplier slaveServerSupplier;
+  private final Map<String, Map<String, Node>> cache = new HashMap<>();
+  // Guards cache map reads/writes and repository cache invalidation calls.
+  private final ReentrantLock cacheLock = new ReentrantLock();
+  // Implements SharedObjectsIO Node-access lock contract.
+  private final ReentrantLock nodeLock = new ReentrantLock();
 
   public RepositorySharedObjectsIO( Repository repository, SlaveServersSupplier slaveServerSupplier ) {
     this.repository = Objects.requireNonNull( repository );
     this.slaveServerSupplier = slaveServerSupplier;
   }
 
-  @Override
+  @SuppressWarnings( "deprecation" ) @Override
   public Map<String, Node> getSharedObjects( String type ) throws KettleException {
-    SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
-    List<? extends SharedObjectInterface<?>> objects = null;
-    if ( repository instanceof RepositoryExtended ) {
-      // use the methods that support caching
-      RepositoryExtended extended = (RepositoryExtended) repository;
-      switch ( objectType ) {
-        case CONNECTION:
-          objects = extended.getConnections( true );
-          break;
-        case SLAVESERVER:
-          objects = extended.getSlaveServers( true );
-          break;
-        case PARTITIONSCHEMA:
-          objects = extended.getPartitions( true );
-          break;
-        case CLUSTERSCHEMA:
-          objects = extended.getClusters( true );
-          break;
+    try {
+      cacheLock.lock();
+      SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
+      Map<String, Node> cached = cache.get( objectType.getName() );
+      if ( cached != null ) {
+        return new HashMap<>( cached );
       }
-    } else {
-      switch ( objectType ) {
-        case CONNECTION:
-          objects = repository.readDatabases();
-          break;
-        case SLAVESERVER:
-          objects = repository.getSlaveServers();
-          break;
-        case PARTITIONSCHEMA:
-          ObjectId[] psids = repository.getPartitionSchemaIDs( false );
-          List<PartitionSchema> pss = new ArrayList<>();
-          if ( psids != null ) {
-            for ( ObjectId id : psids ) {
-              pss.add( repository.loadPartitionSchema( id, null ) );
-            }
-          }
-          objects = pss;
-          break;
-        case CLUSTERSCHEMA:
-          ObjectId[] csids = repository.getClusterIDs( false );
-          List<ClusterSchema> css = new ArrayList<>();
-          if ( csids != null ) {
-            List<SlaveServer> sss = slaveServerSupplier.get();
-            for ( ObjectId id : csids ) {
-              css.add( repository.loadClusterSchema( id, sss, null ) );
-            }
-          }
-          objects = css;
-          break;
-      }
-    }
-    if ( objects != null ) {
+      List<? extends SharedObjectInterface<?>> objects = repository instanceof RepositoryExtended
+        ? loadFromExtendedRepository( (RepositoryExtended) repository, objectType )
+        : loadFromRepository( objectType );
       Map<String, Node> result = new HashMap<>();
-      for ( SharedObjectInterface<?> object : objects ) {
-        result.put( object.getName(), object.toNode() );
+      if ( objects != null ) {
+        for ( SharedObjectInterface<?> object : objects ) {
+          result.put( object.getName(), object.toNode() );
+        }
       }
-      return result;
+      cache.put( objectType.getName(), result );
+      return new HashMap<>( result );
+    } finally {
+      cacheLock.unlock();
     }
-    return Collections.emptyMap();
+  }
+
+  private List<? extends SharedObjectInterface<?>> loadFromExtendedRepository(
+      @SuppressWarnings( "deprecation" ) RepositoryExtended extended, SharedObjectType objectType ) throws KettleException {
+    switch ( objectType ) {
+      case CONNECTION:
+        return extended.getConnections( true );
+      case SLAVESERVER:
+        return extended.getSlaveServers( true );
+      case PARTITIONSCHEMA:
+        return extended.getPartitions( true );
+      case CLUSTERSCHEMA:
+        return extended.getClusters( true );
+      default:
+        return Collections.emptyList();
+    }
+  }
+
+  private List<? extends SharedObjectInterface<?>> loadFromRepository( SharedObjectType objectType )
+      throws KettleException {
+    switch ( objectType ) {
+      case CONNECTION:
+        return repository.readDatabases();
+      case SLAVESERVER:
+        return repository.getSlaveServers();
+      case PARTITIONSCHEMA:
+        return loadPartitionSchemas();
+      case CLUSTERSCHEMA:
+        return loadClusterSchemas();
+      default:
+        return Collections.emptyList();
+    }
+  }
+
+  private List<PartitionSchema> loadPartitionSchemas() throws KettleException {
+    ObjectId[] psids = repository.getPartitionSchemaIDs( false );
+    List<PartitionSchema> pss = new ArrayList<>();
+    if ( psids != null ) {
+      for ( ObjectId id : psids ) {
+        pss.add( repository.loadPartitionSchema( id, null ) );
+      }
+    }
+    return pss;
+  }
+
+  private List<ClusterSchema> loadClusterSchemas() throws KettleException {
+    ObjectId[] csids = repository.getClusterIDs( false );
+    List<ClusterSchema> css = new ArrayList<>();
+    if ( csids != null ) {
+      List<SlaveServer> sss = slaveServerSupplier.get();
+      for ( ObjectId id : csids ) {
+        css.add( repository.loadClusterSchema( id, sss, null ) );
+      }
+    }
+    return css;
   }
 
   @Override
   public Node getSharedObject( String type, String name ) throws KettleException {
-    Map<String, Node> nodeMap = getSharedObjects( type );
-    return nodeMap.get( SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap.keySet() ) );
+    try {
+      cacheLock.lock();
+      Map<String, Node> nodeMap = getSharedObjects( type );
+      return nodeMap.get( SharedObjectsIO.findSharedObjectIgnoreCase( name, nodeMap.keySet() ) );
+    } finally {
+      cacheLock.unlock();
+    }
   }
 
   @Override
   public void clear( String type ) throws KettleException {
     try {
-      lock();
+      cacheLock.lock();
       SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
       ObjectId[] ids = null;
       switch ( objectType ) {
@@ -150,15 +182,16 @@ public class RepositorySharedObjectsIO implements SharedObjectsIO {
           }
           break;
       }
+      cache.remove( objectType.getName() );
     } finally {
-      unlock();
+      cacheLock.unlock();
     }
   }
 
   @Override
   public void delete( String type, String name ) throws KettleException {
     try {
-      lock();
+      cacheLock.lock();
       SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
 
       Map<String, Node> nodeMap = getSharedObjects( type );
@@ -169,10 +202,11 @@ public class RepositorySharedObjectsIO implements SharedObjectsIO {
 
       deleteInner( objectType, existingName );
     } finally {
-      unlock();
+      cacheLock.unlock();
     }
   }
 
+  // Must be called with cacheLock held.
   private void deleteInner( SharedObjectType objectType, String existingName ) throws KettleException {
     ObjectId id;
     switch ( objectType ) {
@@ -198,50 +232,74 @@ public class RepositorySharedObjectsIO implements SharedObjectsIO {
         }
         break;
     }
+    Map<String, Node> typeCache = cache.get( objectType.getName() );
+    if ( typeCache != null ) {
+      typeCache.remove( existingName );
+    }
   }
 
   @Override
   public void saveSharedObject( String type, String name, Node node ) throws KettleException {
-    SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
+    try {
+      cacheLock.lock();
+      SharedObjectType objectType = SharedObjectType.valueOf( type.toUpperCase() );
 
-    RepositoryElementInterface repoElement = null;
-    switch ( objectType ) {
-      case CONNECTION:
-        repoElement = new DatabaseMeta( node );
-        break;
-      case SLAVESERVER:
-        repoElement = new SlaveServer( node );
-        break;
-      case PARTITIONSCHEMA:
-        repoElement = new PartitionSchema( node );
-        break;
-      case CLUSTERSCHEMA:
-        repoElement = new ClusterSchema( node, slaveServerSupplier.get() );
-        break;
+      RepositoryElementInterface repoElement = null;
+      switch ( objectType ) {
+        case CONNECTION:
+          repoElement = new DatabaseMeta( node );
+          break;
+        case SLAVESERVER:
+          repoElement = new SlaveServer( node );
+          break;
+        case PARTITIONSCHEMA:
+          repoElement = new PartitionSchema( node );
+          break;
+        case CLUSTERSCHEMA:
+          repoElement = new ClusterSchema( node, slaveServerSupplier.get() );
+          break;
+      }
+      if ( repoElement != null ) {
+        repository.save( repoElement, Const.VERSION_COMMENT_EDIT_VERSION, null );
+        updateCache( objectType.getName(), name, (SharedObjectInterface<?>) repoElement );
+      }
+    } finally {
+      cacheLock.unlock();
     }
-    if ( repoElement != null ) {
-      repository.save( repoElement, Const.VERSION_COMMENT_EDIT_VERSION, null );
+  }
+
+  // Must be called with cacheLock held.
+  private void updateCache( String type, String oldName, SharedObjectInterface<?> element ) throws KettleException {
+    Map<String, Node> typeCache = cache.get( type );
+    if ( typeCache == null ) {
+      return;
     }
+    String existingKey = SharedObjectsIO.findSharedObjectIgnoreCase( oldName, typeCache.keySet() );
+    if ( existingKey != null ) {
+      typeCache.remove( existingKey );
+    }
+    typeCache.put( element.getName(), element.toNode() );
   }
 
   @Override
   public void clearCache() {
     try {
-      lock();
+      cacheLock.lock();
+      cache.clear();
       repository.clearSharedObjectCache();
     } finally {
-      unlock();
+      cacheLock.unlock();
     }
   }
 
   @Override
   public void lock() {
-    // because this class creates new Nodes for every operation, we don't actually need to lock. 
+    nodeLock.lock();
   }
 
   @Override
   public void unlock() {
-    // no locking needed
+    nodeLock.unlock();
   }
 }
 

--- a/engine/src/main/java/org/pentaho/di/shared/SharedObjectUtil.java
+++ b/engine/src/main/java/org/pentaho/di/shared/SharedObjectUtil.java
@@ -119,6 +119,9 @@ public class SharedObjectUtil {
   /**
    * Copies shared objects from the source bowl to the target AbstractMeta if they aren't already there. If onlyUsedDbs
    * is true, the only database connections that will be copied will be those used by the target meta.
+    *
+    * Copied objects have their ObjectIds cleared before they are added to the target, so this method is suitable for
+    * export/serialization flows that should not preserve repository identity.
    *
    *
    * @param sourceBowl
@@ -127,17 +130,17 @@ public class SharedObjectUtil {
   public static void copySharedObjects( Bowl sourceBowl, AbstractMeta targetMeta, boolean onlyUsedDbs )
       throws KettleException {
     copyAll( sourceBowl.getManager( ClusterSchemaManagementInterface.class ),
-             targetMeta.getSharedObjectManager( ClusterSchemaManagementInterface.class ), false );
+             targetMeta.getSharedObjectManager( ClusterSchemaManagementInterface.class ), false, true );
     copyAll( sourceBowl.getManager( PartitionSchemaManagementInterface.class ),
-             targetMeta.getSharedObjectManager( PartitionSchemaManagementInterface.class ), false );
+             targetMeta.getSharedObjectManager( PartitionSchemaManagementInterface.class ), false, true );
     copyAll( sourceBowl.getManager( SlaveServerManagementInterface.class ),
-             targetMeta.getSharedObjectManager( SlaveServerManagementInterface.class ), false );
+             targetMeta.getSharedObjectManager( SlaveServerManagementInterface.class ), false, true );
 
     if ( onlyUsedDbs ) {
-      copyUsedDbConnections( sourceBowl, targetMeta );
+      copyUsedDbConnections( sourceBowl, targetMeta, true );
     } else {
       copyAll( sourceBowl.getManager( DatabaseManagementInterface.class ),
-               targetMeta.getSharedObjectManager( DatabaseManagementInterface.class ), false );
+               targetMeta.getSharedObjectManager( DatabaseManagementInterface.class ), false, true );
     }
   }
 
@@ -162,7 +165,9 @@ public class SharedObjectUtil {
   /**
    * Copies all the shared objects from the source manager to the target manager. If overwrite is true, copy will
    * happen whether or not the target manager already has the object (case insensitive). If overwrite is false, copy
-   * will not happen if the target manager already has the object
+    * will not happen if the target manager already has the object.
+    *
+    * This overload preserves ObjectIds.
    *
    *
    * @param sourceManager
@@ -172,16 +177,49 @@ public class SharedObjectUtil {
   public static <T extends SharedObjectInterface<T> & RepositoryElementInterface>
     void copyAll( SharedObjectsManagementInterface<T> sourceManager, SharedObjectsManagementInterface<T> targetManager,
       boolean overwrite ) throws KettleException {
+    copyAll( sourceManager, targetManager, overwrite, false );
+  }
+
+  /**
+   * Copies all shared objects from source manager to target manager.
+   *
+   * @param sourceManager source manager
+   * @param targetManager target manager
+   * @param overwrite true to overwrite existing objects in target manager
+   * @param clearObjectIds true to clear each copied object's ObjectId before add
+   * @param <T> shared object type
+   */
+  public static <T extends SharedObjectInterface<T> & RepositoryElementInterface>
+    void copyAll( SharedObjectsManagementInterface<T> sourceManager, SharedObjectsManagementInterface<T> targetManager,
+      boolean overwrite, boolean clearObjectIds ) throws KettleException {
     if ( sourceManager != null && targetManager != null ) {
       for ( T object : sourceManager.getAll() ) {
         if ( overwrite || targetManager.get( object.getName() ) == null ) {
+          if ( clearObjectIds && object.getObjectId() != null ) {
+            object.setObjectId( null );
+          }
           targetManager.add( object );
         }
       }
     }
   }
 
+  /**
+   * Copies only used database connections from source bowl to target meta and preserves ObjectIds.
+   */
   public static void copyUsedDbConnections( Bowl sourceBowl, AbstractMeta targetMeta ) throws KettleException {
+    copyUsedDbConnections( sourceBowl, targetMeta, false );
+  }
+
+  /**
+   * Copies only used database connections from source bowl to target meta.
+   *
+   * @param sourceBowl source bowl
+   * @param targetMeta target meta
+   * @param clearObjectIds true to clear each copied database ObjectId before add
+   */
+  public static void copyUsedDbConnections( Bowl sourceBowl, AbstractMeta targetMeta, boolean clearObjectIds )
+      throws KettleException {
     DatabaseManagementInterface sourceManager = sourceBowl.getManager( DatabaseManagementInterface.class );
     DatabaseManagementInterface targetManager = targetMeta.getSharedObjectManager( DatabaseManagementInterface.class );
 
@@ -189,6 +227,9 @@ public class SharedObjectUtil {
     for ( String name : usedNames ) {
       DatabaseMeta db = sourceManager.get( name );
       if ( db != null && targetManager.get( name ) == null ) {
+        if ( clearObjectIds && db.getObjectId() != null ) {
+          db.setObjectId( null );
+        }
         targetManager.add( db );
         targetMeta.databaseUpdated( name );
       }
@@ -212,7 +253,9 @@ public class SharedObjectUtil {
 
   /**
    * Remove ObjectIds from all the Local objects. Use before serializing to some format that should not contain object
-   * ids from the repository.
+    * ids from the repository.
+    *
+    * This remains useful for objects introduced through paths other than copySharedObjects.
    *
    *
    * @param meta
@@ -231,8 +274,10 @@ public class SharedObjectUtil {
     }
     List<T> all = manager.getAll();
     for ( T object : all ) {
-      object.setObjectId( null );
-      manager.add( object );
+      if ( object.getObjectId() != null ) {
+        object.setObjectId( null );
+        manager.add( object );
+      }
     }
   }
 

--- a/engine/src/main/java/org/pentaho/di/www/AddTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/AddTransServlet.java
@@ -234,6 +234,7 @@ public class AddTransServlet extends BaseHttpServlet implements CartePluginInter
       // If there was a repository, we know about it at this point in time.
       //
       final Repository repository = transExecutionConfiguration.getRepository();
+      clearBowlCache( repository );
 
       String carteObjectId = UUID.randomUUID().toString();
       SimpleLoggingObject servletLoggingObject =

--- a/engine/src/main/java/org/pentaho/di/www/BaseHttpServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/BaseHttpServlet.java
@@ -22,9 +22,12 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.repository.Repository;
 
 
 public class BaseHttpServlet extends HttpServlet {
@@ -195,6 +198,16 @@ public class BaseHttpServlet extends HttpServlet {
       variableSpace.setVariable( parameter, values != null && values.length > 0 ? values[0] : "" );
     }
     return variableSpace;
+  }
+
+  protected void clearBowlCache( Repository repository ) {
+    clearBowlCache( repository == null ? DefaultBowl.getInstance() : repository.getBowl() );
+  }
+
+  protected void clearBowlCache( Bowl bowl ) {
+    if ( bowl != null ) {
+      bowl.clearCache();
+    }
   }
 
 }

--- a/engine/src/main/java/org/pentaho/di/www/BaseJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/BaseJobServlet.java
@@ -59,6 +59,7 @@ public abstract class BaseJobServlet extends BodyHttpServlet {
     JobExecutionConfiguration jobExecutionConfiguration = jobConfiguration.getJobExecutionConfiguration();
 
     JobMeta jobMeta = jobConfiguration.getJobMeta();
+    servlet.clearBowlCache( jobMeta.getBowl() );
     jobMeta.setLogLevel( jobExecutionConfiguration.getLogLevel() );
     jobMeta.injectVariables( jobExecutionConfiguration.getVariables() );
 
@@ -116,6 +117,7 @@ public abstract class BaseJobServlet extends BodyHttpServlet {
   protected Trans createTrans( TransConfiguration transConfiguration ) throws UnknownParamException {
     TransMeta transMeta = transConfiguration.getTransMeta();
     TransExecutionConfiguration transExecutionConfiguration = transConfiguration.getTransExecutionConfiguration();
+    clearBowlCache( transMeta.getBowl() );
     transMeta.setLogLevel( transExecutionConfiguration.getLogLevel() );
     transMeta.injectVariables( transExecutionConfiguration.getVariables() );
 

--- a/engine/src/main/java/org/pentaho/di/www/ExecuteJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/ExecuteJobServlet.java
@@ -198,6 +198,7 @@ public class ExecuteJobServlet extends BaseHttpServlet implements CartePluginInt
     Repository repository;
     try {
       repository = openRepository( repOption, userOption, passOption );
+      clearBowlCache( repository );
     } catch ( KettleRepositoryNotFoundException krnfe ) {
       // Repository not found.
       response.setStatus( HttpServletResponse.SC_NOT_FOUND );

--- a/engine/src/main/java/org/pentaho/di/www/ExecuteTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/ExecuteTransServlet.java
@@ -253,6 +253,7 @@ public class ExecuteTransServlet extends BaseHttpServlet implements CartePluginI
     try {
 
       final Repository repository = openRepository( repOption, userOption, passOption );
+      clearBowlCache( repository );
       final TransMeta transMeta = loadTransformation( repository, transOption, getPopulatedVariableSpaceFromRequest( request, new Variables() ) );
 
       // Set the servlet parameters as variables in the transformation

--- a/engine/src/main/java/org/pentaho/di/www/RunTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RunTransServlet.java
@@ -165,6 +165,7 @@ public class RunTransServlet extends BaseHttpServlet implements CartePluginInter
     try {
 
       final Repository repository = transformationMap.getSlaveServerConfig().getRepository();
+      clearBowlCache( repository );
       final TransMeta transMeta = loadTrans( repository, transOption, getPopulatedVariableSpaceFromRequest( request, new Variables() ) );
 
       // Set the servlet parameters as variables in the transformation

--- a/engine/src/main/java/org/pentaho/di/www/StartTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StartTransServlet.java
@@ -235,6 +235,9 @@ public class StartTransServlet extends BaseHttpServlet implements CartePluginInt
         servletLoggingObject.setLogLevel( trans.getLogLevel() );
         trans.setParent( servletLoggingObject );
 
+        trans.getTransMeta().getBowl().clearCache();
+        trans.getTransMeta().allDatabasesUpdated();
+
         executeTrans( trans );
 
         String message = BaseMessages.getString( PKG, "StartTransServlet.Log.TransStarted", transName );

--- a/engine/src/main/java/org/pentaho/di/www/jaxrs/TransformationResource.java
+++ b/engine/src/main/java/org/pentaho/di/www/jaxrs/TransformationResource.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.LoggingObjectType;
@@ -205,6 +206,7 @@ public class TransformationResource {
     try {
       transConfiguration = TransConfiguration.fromXML( xml.toString() );
       TransMeta transMeta = transConfiguration.getTransMeta();
+      clearBowlCache( transMeta.getBowl() );
       TransExecutionConfiguration transExecutionConfiguration =
         transConfiguration.getTransExecutionConfiguration();
       transMeta.setLogLevel( transExecutionConfiguration.getLogLevel() );
@@ -259,6 +261,12 @@ public class TransformationResource {
       e.printStackTrace();
     }
     return null;
+  }
+
+  private void clearBowlCache( Bowl bowl ) {
+    if ( bowl != null ) {
+      bowl.clearCache();
+    }
   }
 
 }

--- a/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/AbstractMetaTest.java
@@ -18,9 +18,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.bowl.BaseBowl;
@@ -268,7 +266,7 @@ public class AbstractMetaTest {
   }
 
   @Test
-  public void testBowlClearCache() throws Exception {
+  public void testSetBowlDoesNotClearCache() throws Exception {
     MemorySharedObjectsIO sharedObjectsIO = new MemorySharedObjectsIO();
 
     Bowl bowl = mock( BaseBowl.class );
@@ -279,28 +277,11 @@ public class AbstractMetaTest {
     List<DatabaseMeta> databases = meta.getDatabases();
     assertEquals( 0, databases.size() );
 
-    doAnswer( new Answer<Void>() {
-      public Void answer( InvocationOnMock invocation ) {
-        // write directly to the SharedObjectsIO to simulate another process having done the write
-        DatabaseMeta dbMeta = new DatabaseMeta();
-        dbMeta.setName( "foo" );
-        try {
-          sharedObjectsIO.lock();
-          sharedObjectsIO.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), "foo",
-            dbMeta.toNode());
-        } catch ( KettleException e ) {
-          throw new RuntimeException( e );
-        } finally {
-          sharedObjectsIO.unlock();
-        }
-        return null;
-      }
-    } ).when( bowl ).clearCache();
-
     AbstractMetaStub meta2 = new AbstractMetaStub();
     meta2.setBowl( bowl );
     List<DatabaseMeta> databases2 = meta2.getDatabases();
-    assertEquals( 1, databases2.size() );
+    assertEquals( 0, databases2.size() );
+    verify( bowl, never() ).clearCache();
   }
 
   @Test

--- a/engine/src/test/java/org/pentaho/di/base/MetaFileLoaderImplTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/MetaFileLoaderImplTest.java
@@ -75,7 +75,10 @@ public class MetaFileLoaderImplTest {
   @After
   public void tearDown() {
     System.setProperty( Const.KETTLE_USE_META_FILE_CACHE, null == oldSystemParam ? "" : oldSystemParam );
-    KettleClientEnvironment.reset();
+    // NOTE: Removed KettleClientEnvironment.reset() as this is a pure unit test for file loading, not global initialization.
+    // Calling reset() causes PluginRegistry to be cleared globally, which corrupts extension-point type registration 
+    // for subsequent tests in the same JVM (e.g., PanCommandExecutorTest). Since this test only calls init() in setUp,
+    // no cleanup is necessary.
   }
 
   @Test

--- a/engine/src/test/java/org/pentaho/di/shared/RepositorySharedObjectsIOCacheTest.java
+++ b/engine/src/test/java/org/pentaho/di/shared/RepositorySharedObjectsIOCacheTest.java
@@ -1,0 +1,257 @@
+package org.pentaho.di.shared;
+
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.trans.steps.loadsave.MemoryRepository;
+import org.pentaho.di.trans.steps.loadsave.MemoryRepositoryExtended;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.w3c.dom.Node;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests that verify the write-through cache in {@link RepositorySharedObjectsIO}.
+ * <p>
+ * Parameterized over both plain {@link MemoryRepository} and {@link MemoryRepositoryExtended} so that
+ * both the standard-repository and RepositoryExtended code paths are exercised.
+ * <p>
+ * A fresh repository instance is created before each test to guarantee full isolation.
+ */
+@RunWith( Parameterized.class )
+public class RepositorySharedObjectsIOCacheTest {
+
+  /**
+   * Class of the repository to instantiate for each test. Using a class reference rather than a
+   * pre-built instance ensures every {@code @Before} gets a brand-new, clean repository.
+   */
+  private final Class<? extends MemoryRepository> repClass;
+  private MemoryRepository rep;
+  private RepositorySharedObjectsIO shared;
+
+  public RepositorySharedObjectsIOCacheTest( Class<? extends MemoryRepository> repClass ) {
+    this.repClass = repClass;
+  }
+
+  @Parameterized.Parameters
+  public static List<Object[]> repositories() {
+    ArrayList<Object[]> reps = new ArrayList<>();
+    reps.add( new Object[] { MemoryRepository.class } );
+    reps.add( new Object[] { MemoryRepositoryExtended.class } );
+    return reps;
+  }
+
+  @BeforeClass
+  public static void init() throws Exception {
+    KettleClientEnvironment.init();
+  }
+
+  @Before
+  public void setup() throws Exception {
+    rep = repClass.getDeclaredConstructor().newInstance();
+    shared = new RepositorySharedObjectsIO( rep, Collections::emptyList );
+  }
+
+  // region Cache hit on repeated reads
+
+  /**
+   * Verifies that once the cache is populated, subsequent reads are served from the cache and do
+   * not reflect changes made directly to the backing repository.
+   */
+  @Test
+  public void testCacheIsUsedOnRepeatedReads() throws Exception {
+    // First read – populates the cache (empty repository)
+    Map<String, Node> firstRead = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertEquals( 0, firstRead.size() );
+
+    // Add a database directly to the backing repository, bypassing the cache
+    DatabaseMeta directDb = buildDb( "directDb", "directSchema" );
+    rep.save( directDb, null, null );
+
+    // Second read – should return the stale cached result, not the new repository entry
+    Map<String, Node> secondRead = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertEquals( "Cache should be used; directly-added entry must not be visible", 0, secondRead.size() );
+  }
+
+  // endregion
+
+  // region Cache updated on save
+
+  /**
+   * Verifies that after a save via {@link RepositorySharedObjectsIO#saveSharedObject}, the cached result
+   * immediately reflects the saved object without requiring another round-trip to the repository.
+   */
+  @Test
+  public void testSaveUpdatesCache() throws Exception {
+    // Warm up the cache with an empty read
+    shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+
+    // Save through the IO layer – should update the cache
+    DatabaseMeta db = buildDb( "myDb", "mySchema" );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+
+    // Add a second database directly to the backing repository (bypassing cache)
+    DatabaseMeta directDb = buildDb( "directDb", "directSchema" );
+    rep.save( directDb, null, null );
+
+    // Read – should see only the saved object (from cache), not the directly-added one
+    Map<String, Node> result = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertEquals( "Only the write-through entry should be visible", 1, result.size() );
+    assertNotNull( result.get( "myDb" ) );
+    assertNull( "Directly-added entry should not be visible via cached read", result.get( "directDb" ) );
+  }
+
+  /**
+   * Verifies that re-saving an existing object (update) replaces the old cache entry.
+   */
+  @Test
+  public void testSaveUpdatesCacheOnUpdate() throws Exception {
+    // Warm up cache
+    shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+
+    DatabaseMeta db = buildDb( "myDb", "originalSchema" );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+
+    // Update the same object
+    db.setDBName( "updatedSchema" );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+
+    Map<String, Node> result = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertEquals( 1, result.size() );
+    DatabaseMeta readBack = new DatabaseMeta( result.get( "myDb" ) );
+    assertEquals( "Cache should reflect the updated value", "updatedSchema", readBack.getDatabaseName() );
+  }
+
+  // endregion
+
+  // region Cache updated on delete
+
+  /**
+   * Verifies that after a delete, the cached result no longer contains the deleted entry.
+   */
+  @Test
+  public void testDeleteUpdatesCache() throws Exception {
+    // Warm up cache
+    shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+
+    DatabaseMeta db = buildDb( "myDb", "mySchema" );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+
+    // Confirm it is visible
+    assertNotNull( shared.getSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), "myDb" ) );
+
+    // Delete through the IO layer
+    shared.delete( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), "myDb" );
+
+    // Re-add the same object directly to the backing repository (bypassing cache)
+    rep.save( db, null, null );
+
+    // Read – cache should reflect the delete and not expose the directly-added entry
+    Map<String, Node> result = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertEquals( "Deleted entry must not be present in cache", 0, result.size() );
+  }
+
+  // endregion
+
+  // region clearCache
+
+  /**
+   * Verifies that {@link RepositorySharedObjectsIO#clearCache()} evicts all local cache entries so that
+   * the next read reflects the current state of the backing repository.
+   */
+  @Test
+  public void testClearCacheAllowsFreshReadsFromRepo() throws Exception {
+    // Warm up the cache (empty)
+    shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+
+    // Add a database directly to the backing repository (bypassing the cache)
+    DatabaseMeta directDb = buildDb( "directDb", "directSchema" );
+    rep.save( directDb, null, null );
+
+    // Before clearCache: directly-added entry is not visible
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() ).size() );
+
+    // Clear the local cache
+    shared.clearCache();
+
+    // After clearCache: next read re-fetches from the repository and sees the new entry
+    Map<String, Node> result = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertEquals( "After clearCache a fresh repository read should be performed", 1, result.size() );
+    assertNotNull( result.get( "directDb" ) );
+  }
+
+  /**
+   * Verifies that {@link RepositorySharedObjectsIO#clearCache()} evicts all types, not just one.
+   */
+  @Test
+  public void testClearCacheEvictsAllTypes() throws Exception {
+    // Warm up the cache for multiple types
+    shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    shared.getSharedObjects( SharedObjectsIO.SharedObjectType.SLAVESERVER.getName() );
+
+    // Directly add to both types in the backing repository
+    DatabaseMeta directDb = buildDb( "directDb", "directSchema" );
+    rep.save( directDb, null, null );
+
+    // Before clearCache: changes not visible
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() ).size() );
+    assertEquals( 0, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.SLAVESERVER.getName() ).size() );
+
+    shared.clearCache();
+
+    // After clearCache: both types re-fetched from repository
+    assertEquals( 1, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() ).size() );
+  }
+
+  // endregion
+
+  // region clear(type)
+
+  /**
+   * Verifies that {@link RepositorySharedObjectsIO#clear(String)} removes the cache entry for the
+   * given type so that a subsequent direct repository addition becomes visible on the next read.
+   */
+  @Test
+  public void testClearTypeInvalidatesCacheForThatType() throws Exception {
+    // Warm up cache and save an entry
+    shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    DatabaseMeta db = buildDb( "myDb", "mySchema" );
+    shared.saveSharedObject( SharedObjectsIO.SharedObjectType.CONNECTION.getName(), db.getName(), db.toNode() );
+    assertEquals( 1, shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() ).size() );
+
+    // clear() removes from the backing store and the cache
+    shared.clear( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+
+    // Directly add a new database to the repository (bypassing cache)
+    DatabaseMeta newDb = buildDb( "newDb", "newSchema" );
+    rep.save( newDb, null, null );
+
+    // The next read should miss the (now-absent) cache entry and fetch fresh from the repository
+    Map<String, Node> result = shared.getSharedObjects( SharedObjectsIO.SharedObjectType.CONNECTION.getName() );
+    assertEquals( "Cache for CONNECTION should have been invalidated by clear()", 1, result.size() );
+    assertNotNull( result.get( "newDb" ) );
+  }
+
+  // endregion
+
+  // region helpers
+
+  private static DatabaseMeta buildDb( String name, String dbName ) {
+    DatabaseMeta db = new DatabaseMeta();
+    db.setName( name );
+    db.setDBName( dbName );
+    return db;
+  }
+
+  // endregion
+}

--- a/engine/src/test/java/org/pentaho/di/shared/SharedObjectUtilTest.java
+++ b/engine/src/test/java/org/pentaho/di/shared/SharedObjectUtilTest.java
@@ -32,6 +32,7 @@ import org.pentaho.di.partition.PartitionSchema;
 import org.pentaho.di.partition.PartitionSchemaManagementInterface;
 import org.pentaho.di.repository.IRepositoryImporter;
 import org.pentaho.di.repository.RepositoryImporter;
+import org.pentaho.di.repository.StringObjectId;
 import org.pentaho.di.shared.SharedObjectsIO.SharedObjectType;
 import org.pentaho.di.shared.SharedObjectUtil.ComparedState;
 import org.pentaho.di.trans.TransMeta;
@@ -40,6 +41,7 @@ import org.pentaho.metastore.api.IMetaStore;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -129,6 +131,120 @@ public class SharedObjectUtilTest {
     Assert.assertNotNull( ssChanges );
     Assert.assertEquals( 1, ssChanges.size() );
     Assert.assertEquals( ComparedState.NEW, ssChanges.get( "new" ) );
+  }
+
+  @Test
+  public void testCopySharedObjectsClearsObjectIdsOnCopiedObjects() throws Exception {
+    DatabaseMeta sourceDb = new DatabaseMeta();
+    sourceDb.setName( "db" );
+    sourceDb.setObjectId( new StringObjectId( "db-id" ) );
+
+    SlaveServer sourceSlave = new SlaveServer();
+    sourceSlave.setName( "slave" );
+    sourceSlave.setObjectId( new StringObjectId( "slave-id" ) );
+
+    PartitionSchema sourcePartition = new PartitionSchema();
+    sourcePartition.setName( "partition" );
+    sourcePartition.setObjectId( new StringObjectId( "partition-id" ) );
+
+    MemorySharedObjectsIO sharedIO = new MemorySharedObjectsIO();
+    Bowl bowl = new BaseBowl() {
+      @Override
+      public SharedObjectsIO getSharedObjectsIO() {
+        return sharedIO;
+      }
+
+      @Override
+      public IMetaStore getMetastore() throws MetaStoreException {
+        throw new UnsupportedOperationException( "should be unused" );
+      }
+
+      @Override
+      public VariableSpace getADefaultVariableSpace() {
+        throw new UnsupportedOperationException( "should be unused" );
+      }
+    };
+
+    bowl.getManager( DatabaseManagementInterface.class ).add( sourceDb );
+    bowl.getManager( PartitionSchemaManagementInterface.class ).add( sourcePartition );
+    bowl.getManager( SlaveServerManagementInterface.class ).add( sourceSlave );
+
+    TransMeta targetMeta = new TransMeta();
+    SharedObjectUtil.copySharedObjects( bowl, targetMeta, false );
+
+    Assert.assertNull( targetMeta.getSharedObjectManager( DatabaseManagementInterface.class ).get( "db" ).getObjectId() );
+    Assert.assertNull( targetMeta.getSharedObjectManager( PartitionSchemaManagementInterface.class ).get( "partition" )
+      .getObjectId() );
+    Assert.assertNull( targetMeta.getSharedObjectManager( SlaveServerManagementInterface.class ).get( "slave" )
+      .getObjectId() );
+
+    // The source object in the bowl keeps its repository identity.
+    Assert.assertNotNull( bowl.getManager( DatabaseManagementInterface.class ).get( "db" ).getObjectId() );
+  }
+
+  @Test
+  public void testCopyAllDefaultContractKeepsObjectIds() throws Exception {
+    TransMeta sourceMeta = new TransMeta();
+    DatabaseMeta sourceDb = new DatabaseMeta();
+    sourceDb.setName( "db" );
+    sourceDb.setObjectId( new StringObjectId( "db-id" ) );
+    sourceMeta.getSharedObjectManager( DatabaseManagementInterface.class ).add( sourceDb );
+
+    TransMeta targetMeta = new TransMeta();
+    SharedObjectUtil.copyAll( sourceMeta.getSharedObjectManager( DatabaseManagementInterface.class ),
+      targetMeta.getSharedObjectManager( DatabaseManagementInterface.class ), false );
+
+    Assert.assertEquals( "db-id",
+      targetMeta.getSharedObjectManager( DatabaseManagementInterface.class ).get( "db" ).getObjectId().toString() );
+  }
+
+  @Test
+  public void testCopyUsedDbConnectionsDefaultAndClearObjectIdContracts() throws Exception {
+    DatabaseMeta sourceDb = new DatabaseMeta();
+    sourceDb.setName( "used-db" );
+    sourceDb.setObjectId( new StringObjectId( "used-db-id" ) );
+
+    MemorySharedObjectsIO sharedIO = new MemorySharedObjectsIO();
+    Bowl bowl = new BaseBowl() {
+      @Override
+      public SharedObjectsIO getSharedObjectsIO() {
+        return sharedIO;
+      }
+
+      @Override
+      public IMetaStore getMetastore() throws MetaStoreException {
+        throw new UnsupportedOperationException( "should be unused" );
+      }
+
+      @Override
+      public VariableSpace getADefaultVariableSpace() {
+        throw new UnsupportedOperationException( "should be unused" );
+      }
+    };
+    bowl.getManager( DatabaseManagementInterface.class ).add( sourceDb );
+
+    TransMeta legacyTarget = new TransMeta() {
+      @Override
+      public Set<String> getUsedDatabaseConnectionNames() {
+        return Set.of( "used-db" );
+      }
+    };
+
+    SharedObjectUtil.copyUsedDbConnections( bowl, legacyTarget );
+    Assert.assertEquals( "used-db-id",
+      legacyTarget.getSharedObjectManager( DatabaseManagementInterface.class ).get( "used-db" ).getObjectId()
+        .toString() );
+
+    TransMeta clearIdTarget = new TransMeta() {
+      @Override
+      public Set<String> getUsedDatabaseConnectionNames() {
+        return Set.of( "used-db" );
+      }
+    };
+
+    SharedObjectUtil.copyUsedDbConnections( bowl, clearIdTarget, true );
+    Assert.assertNull( clearIdTarget.getSharedObjectManager( DatabaseManagementInterface.class ).get( "used-db" )
+      .getObjectId() );
   }
 
 

--- a/engine/src/test/java/org/pentaho/di/www/ExecuteJobServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/ExecuteJobServletTest.java
@@ -45,11 +45,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.pentaho.di.core.util.Assert.assertTrue;
 
 public class ExecuteJobServletTest {
@@ -96,6 +99,7 @@ public class ExecuteJobServletTest {
       doReturn( LEVEL ).when( mockHttpServletRequest ).getParameter( "level" );
 
       doReturn( repository ).when( spyExecuteJobServlet ).openRepository( REPOSITORY_NAME, AUTHORIZED_USER, PASSWORD );
+      doNothing().when( spyExecuteJobServlet ).clearBowlCache( same( repository ) );
 
       JobMeta jobMeta = buildJobMeta();
 
@@ -113,6 +117,7 @@ public class ExecuteJobServletTest {
 
       assertTrue( out.toString().contains( WebResult.STRING_OK ) );
       assertTrue( out.toString().contains( "Job started" ) );
+      verify( spyExecuteJobServlet ).clearBowlCache( same( repository ) );
     }
   }
 

--- a/engine/src/test/java/org/pentaho/di/www/RegisterJobServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/RegisterJobServletTest.java
@@ -15,6 +15,7 @@ package org.pentaho.di.www;
 
 import jakarta.servlet.ReadListener;
 import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobConfiguration;
@@ -33,8 +34,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.pentaho.di.core.util.Assert.assertFalse;
 import static org.pentaho.di.core.util.Assert.assertTrue;
@@ -64,6 +67,28 @@ public class RegisterJobServletTest {
   @Test
   public void createJobGatheringMetricsFalseTest() throws Exception {
     assertFalse( createJob( false ).isGatheringMetrics() );
+  }
+
+  @Test
+  public void createJobClearsBowlCacheTest() throws Exception {
+    RegisterJobServlet jobServlet = spy( new RegisterJobServlet() );
+    JobMap jobMap = mock( JobMap.class );
+    jobServlet.setup( new TransformationMap(), jobMap, new SocketRepository( new LogChannel( "test" ) ), new ArrayList<>() );
+    JobConfiguration conf = mock( JobConfiguration.class );
+    JobExecutionConfiguration execConf = mock( JobExecutionConfiguration.class );
+    JobMeta jobMeta = mock( JobMeta.class );
+    SlaveServerConfig slaveServerConfig = mock( SlaveServerConfig.class );
+    Bowl bowl = mock( Bowl.class );
+    when( conf.getJobExecutionConfiguration() ).thenReturn( execConf );
+    when( conf.getJobMeta() ).thenReturn( jobMeta );
+    when( jobMap.getSlaveServerConfig() ).thenReturn( slaveServerConfig );
+    when( jobMeta.listParameters() ).thenReturn( new String[] {} );
+    when( jobMeta.getBowl() ).thenReturn( bowl );
+    doNothing().when( jobServlet ).clearBowlCache( bowl );
+
+    jobServlet.createJob( conf );
+
+    verify( jobServlet ).clearBowlCache( bowl );
   }
 
   private Job createJob( boolean gatheringMetrics ) throws Exception {

--- a/engine/src/test/java/org/pentaho/di/www/RunTransServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/RunTransServletTest.java
@@ -41,8 +41,11 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -154,6 +157,7 @@ public class RunTransServletTest {
 
     RunTransServlet runTransServlet = Mockito.mock( RunTransServlet.class );
     Mockito.doCallRealMethod().when( runTransServlet ).doGet( any(), any() );
+    doNothing().when( runTransServlet ).clearBowlCache( same( repository ) );
 
     Trans trans =
       new Trans( transMeta, new SimpleLoggingObject( RunTransServlet.CONTEXT_PATH, LoggingObjectType.CARTE, null ) );
@@ -166,5 +170,6 @@ public class RunTransServletTest {
 
     runTransServlet.doGet( request, response );
     Assert.assertEquals( testValue, trans.getParameterValue( testParameter ) );
+    verify( runTransServlet ).clearBowlCache( same( repository ) );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/www/StartTransServletTest.java
+++ b/engine/src/test/java/org/pentaho/di/www/StartTransServletTest.java
@@ -17,6 +17,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.owasp.encoder.Encode;
+
+import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.gui.Point;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
@@ -90,6 +92,7 @@ public class StartTransServletTest {
       when( mockTrans.getLogChannelId() ).thenReturn( "test" );
       when( mockTrans.getTransMeta() ).thenReturn( mockTransMeta );
       when( mockTransMeta.getMaximum() ).thenReturn( new Point( 10, 10 ) );
+      when( mockTransMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
 
       startTransServlet.doGet( mockHttpServletRequest, mockHttpServletResponse );
       assertFalse( ServletTestUtils.hasBadText( ServletTestUtils.getInsideOfTag( "H1", out.toString() ) ) );

--- a/plugins/export-repository/impl/src/main/java/org/pentaho/di/job/entries/exportrepository/JobEntryExportRepository.java
+++ b/plugins/export-repository/impl/src/main/java/org/pentaho/di/job/entries/exportrepository/JobEntryExportRepository.java
@@ -27,6 +27,7 @@ import org.apache.commons.vfs2.FileType;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.Props;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.ResultFile;
@@ -453,6 +454,11 @@ public class JobEntryExportRepository extends JobEntryBase implements Cloneable,
       || export_type.equals( Export_Jobs ) || export_type.equals( Export_Trans )
       || export_type.equals( Export_One_Folder ) ) {
       realoutfilename = buildFilename( realoutfilename );
+    }
+
+    if ( !Props.isInitialized() ) {
+      // For export specifically, initialize props to honor "only used db connections" setting
+      Props.init( Props.TYPE_PROPERTIES_SPOON );
     }
 
     NrErrors = 0;

--- a/plugins/kafka/core/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaProducerOutputTest.java
+++ b/plugins/kafka/core/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaProducerOutputTest.java
@@ -15,6 +15,7 @@ package org.pentaho.big.data.kettle.plugins.kafka;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +25,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.Props;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.logging.LogChannelFactory;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.StepPluginType;
 import org.pentaho.di.trans.Trans;
@@ -41,6 +44,12 @@ import static org.mockito.Mockito.when;
 public class KafkaProducerOutputTest {
   @Mock KafkaProducer<Object, Object> kafkaProducer;
   @Mock KafkaFactory kafkaFactory;
+
+  @Before
+  public void setUpEachTest() {
+    // Reset static logging factory to a concrete implementation to avoid cross-test leakage.
+    KettleLogStore.setLogChannelInterfaceFactory( new LogChannelFactory() );
+  }
 
   @BeforeClass
   public static void setUp() throws Exception {

--- a/plugins/pur/core/src/main/java/com/pentaho/repository/importexport/StreamToJobNodeConverter.java
+++ b/plugins/pur/core/src/main/java/com/pentaho/repository/importexport/StreamToJobNodeConverter.java
@@ -115,7 +115,6 @@ public class StreamToJobNodeConverter implements Converter {
       return null;
     }
     SharedObjectUtil.copySharedObjects( repository.getBowl(), jobMeta, true );
-    SharedObjectUtil.stripObjectIds( jobMeta );
     String xml = XMLHandler.getXMLHeader() + jobMeta.getXML();
     return new ByteArrayInputStream( xml.getBytes( StandardCharsets.UTF_8 ) );
   }

--- a/plugins/pur/core/src/main/java/com/pentaho/repository/importexport/StreamToTransNodeConverter.java
+++ b/plugins/pur/core/src/main/java/com/pentaho/repository/importexport/StreamToTransNodeConverter.java
@@ -112,7 +112,6 @@ public class StreamToTransNodeConverter implements Converter {
       return null;
     }
     SharedObjectUtil.copySharedObjects( repository.getBowl(), transMeta, true );
-    SharedObjectUtil.stripObjectIds( transMeta );
     String xml = XMLHandler.getXMLHeader() + transMeta.getXML();
     return new ByteArrayInputStream( xml.getBytes( StandardCharsets.UTF_8 ) );
   }

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryExporter.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepositoryExporter.java
@@ -227,7 +227,6 @@ public class PurRepositoryExporter implements IRepositoryExporter, java.io.Seria
             // Copy the config objects in transMeta
             SharedObjectUtil.copySharedObjects( repository.getBowl(), trans,
                     Props.getInstance().areOnlyUsedConnectionsSavedToXML() );
-            SharedObjectUtil.stripObjectIds( trans );
             writer.write( trans.getXML() + Const.CR );
           }
         } catch ( Exception ex ) {
@@ -285,7 +284,6 @@ public class PurRepositoryExporter implements IRepositoryExporter, java.io.Seria
             // Copy the config objects in meta
             SharedObjectUtil.copySharedObjects( repository.getBowl(), meta,
                     Props.getInstance().areOnlyUsedConnectionsSavedToXML() );
-            SharedObjectUtil.stripObjectIds( meta );
             writer.write( meta.getXML() + Const.CR );
           }
         } catch ( Exception ex ) {

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/RepositoryProxy.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/RepositoryProxy.java
@@ -79,7 +79,7 @@ public class RepositoryProxy extends AbstractRepository implements ILockService,
   }
 
   public RepositoryProxy( final DataNode node, Repository parentRep ) {
-    super();
+    super( parentRep.getBowl() );
     this.node = node;
     this.parentRep = parentRep;
   }

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/TransDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/TransDelegate.java
@@ -256,6 +256,8 @@ public class TransDelegate extends AbstractDelegate implements ITransformer, ISh
     throws KettleException {
     TransMeta transMeta = (TransMeta) element;
 
+    // just load these once, and only if needed by a step
+    List<ClusterSchema> clusterSchemas = null;
     // read the steps...
     //
     DataNode stepsNode = rootNode.getNode( NODE_STEPS );
@@ -349,9 +351,13 @@ public class TransDelegate extends AbstractDelegate implements ITransformer, ISh
       // Get the cluster schema name
       String clusterSchemaName = getString( stepNode, PROP_CLUSTER_SCHEMA );
       stepMeta.setClusterSchemaName( clusterSchemaName );
-      if ( clusterSchemaName != null && transMeta.getClusterSchemas() != null ) {
+      if ( clusterSchemaName != null) {
+        if ( clusterSchemas == null ) {
+          // only load these if they are used. 
+          clusterSchemas = transMeta.getClusterSchemas();
+        }
         // Get the cluster schema from the given name
-        for ( ClusterSchema clusterSchema : transMeta.getClusterSchemas() ) {
+        for ( ClusterSchema clusterSchema : clusterSchemas ) {
           if ( clusterSchema.getName().equals( clusterSchemaName ) ) {
             stepMeta.setClusterSchema( clusterSchema );
             break;

--- a/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/JobDelegateTest.java
+++ b/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/JobDelegateTest.java
@@ -62,7 +62,7 @@ public class JobDelegateTest {
   @Mock private JobLogTable mockJobLogTable;
   @Mock private JobEntryCopy mockJobEntryCopy;
 
-  private JobDelegate jobDelegate = new JobDelegate( mockPurRepository, mockUnifiedRepository );
+  private JobDelegate jobDelegate;
   private Map<String, Map<String, String>> attributes = new HashMap<>();
   private Map<String, String> group = new HashMap<>();
 
@@ -79,6 +79,8 @@ public class JobDelegateTest {
 
   @Before
   public void setup() {
+    jobDelegate = new JobDelegate( mockPurRepository, mockUnifiedRepository );
+    when( mockPurRepository.getBowl() ).thenReturn( DefaultBowl.getInstance() );
     when( mockJobMeta.listParameters() ).thenReturn( new String[] {} );
     when( mockJobMeta.getJobLogTable() ).thenReturn( mockJobLogTable );
     when( mockJobMeta.nrJobEntries() ).thenReturn( 1 );

--- a/plugins/repositories/core/src/test/java/org/pentaho/di/ui/repo/dialog/PentahoEnterpriseRepoFormCompositeTest.java
+++ b/plugins/repositories/core/src/test/java/org/pentaho/di/ui/repo/dialog/PentahoEnterpriseRepoFormCompositeTest.java
@@ -14,6 +14,7 @@ package org.pentaho.di.ui.repo.dialog;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Display;
@@ -81,7 +82,7 @@ public class PentahoEnterpriseRepoFormCompositeTest {
 
     try {
       display = new Display();
-    } catch ( SWTError e ) {
+    } catch ( SWTError | SWTException | UnsatisfiedLinkError | NoClassDefFoundError e ) {
       Assume.assumeNoException( "No display available; skipping SWT UI tests in this environment.", e );
     }
   }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/JobFileListener.java
@@ -183,7 +183,6 @@ public class JobFileListener implements FileListener, ConnectionListener {
         lmeta = jmeta;
         SharedObjectUtil.copySharedObjects( spoon.getGlobalManagementBowl(), jmeta,
           Props.getInstance().areOnlyUsedConnectionsSavedToXML() );
-        SharedObjectUtil.stripObjectIds( jmeta );
       } else {
         lmeta = meta;
       }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -4446,6 +4446,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
   public void loadObjectFromRepository(
       ObjectId objectId, RepositoryObjectType objectType, String revision ) throws Exception {
     // Try to open the selected transformation.
+    clearBowlCaches();
     if ( objectType.equals( RepositoryObjectType.TRANSFORMATION ) ) {
       try {
         TransLoadProgressDialog progressDialog = new TransLoadProgressDialog( shell, rep, objectId, revision );
@@ -5225,6 +5226,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     // does the file exist? If not, show an error dialog
     boolean fileExists = false;
     boolean loaded = false;
+    clearBowlCaches();
 
     if ( rep != null && !importFile && !forceLocalFile ) {
       // load from the repository
@@ -5417,6 +5419,8 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     //
     setTransMetaVariables( transMeta );
 
+    clearBowlCaches();
+
     // Pass repository information
     //
     transMeta.setRepository( rep );
@@ -5475,6 +5479,8 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       // the transformation metadata too.
       //
       setJobMetaVariables( jobMeta );
+
+      clearBowlCaches();
 
       // Pass repository information
       //
@@ -5980,7 +5986,6 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
           SharedObjectUtil.moveAllSharedObjects( ameta, rep.getBowl() );
         }
         // refresh the dbs in the meta
-        ameta.allDatabasesUpdated();
         forceRefreshTree( true);
       }
 
@@ -6389,7 +6394,8 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         return false;
       }
     }
-
+    // make sure we export the latest config
+    clearBowlCaches();
     RepositoryExportProgressDialog repd =
       new RepositoryExportProgressDialog( shell, rep, directoryToExport, filename, importRules );
     repd.open();
@@ -6467,6 +6473,9 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         versionOk = true;
       }
     }
+
+    // make sure any config import decisions are based on the latest state. 
+    clearBowlCaches();
 
     String[] filenames = dialog.getFileNames();
     if ( filenames.length > 0 ) {
@@ -6982,6 +6991,25 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     addDragSourceToTree( selectionTree );
   }
 
+  // This full thing may not be needed every time. 
+  // Generally, we want to clear these caches whenever a user-initiated action 
+  // opens, saves, or executes a file. 
+  public void clearBowlCaches() {
+    globalManagementBowl.clearCache();
+    managementBowl.clearCache();
+    executionBowl.clearCache();
+
+    // update open metas so they match the new cache state.
+    List<TransMeta> transList = delegates.trans.getTransformationList();
+    List<JobMeta> jobList = delegates.jobs.getJobList();
+    for ( TransMeta transMeta : transList ) {
+      transMeta.allDatabasesUpdated();
+    }
+    for ( JobMeta jobMeta : jobList ) {
+      jobMeta.allDatabasesUpdated();
+    }
+  }
+
   public void forceRefreshTree() {
     forceRefreshTree( true ); 
   } 
@@ -6990,9 +7018,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     try {
       // refresh underlying data
       if ( clearCaches ) {
-        globalManagementBowl.clearCache();
-        managementBowl.clearCache();
-        executionBowl.clearCache();
+        clearBowlCaches();
       }
 
       if ( selectionTreeManager != null ) {

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/TransFileListener.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/TransFileListener.java
@@ -184,7 +184,6 @@ public class TransFileListener implements FileListener, ConnectionListener {
         lmeta = tmeta;
         SharedObjectUtil.copySharedObjects( spoon.getGlobalManagementBowl(), tmeta,
           Props.getInstance().areOnlyUsedConnectionsSavedToXML() );
-        SharedObjectUtil.stripObjectIds( tmeta );
       } else {
         lmeta = meta;
       }

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/job/JobGraph.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/job/JobGraph.java
@@ -3491,6 +3491,7 @@ public class JobGraph extends AbstractGraph implements XulEventHandler, Redrawab
             }
 
             JobMeta runJobMeta;
+            spoon.clearBowlCaches();
 
             if ( spoon.rep != null ) {
               runJobMeta = spoon.rep.loadJob( jobMeta.getName(), jobMeta.getRepositoryDirectory(), null, null );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGraph.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGraph.java
@@ -3843,6 +3843,9 @@ public class TransGraph extends AbstractGraph implements XulEventHandler, Redraw
           // memory
           // To be able to completely test this, we need to run it as we would normally do in pan
           //
+          // clear caches before loading the new meta
+          spoon.clearBowlCaches();
+
           trans = DefaultTransFactoryManager.getInstance().getTransFactory( executionConfiguration.getRunConfiguration() )
             .create( transMeta, spoon.rep, transMeta.getName(), transMeta.getRepositoryDirectory().getPath(),
             transMeta.getFilename(), transMeta );
@@ -3993,6 +3996,8 @@ public class TransGraph extends AbstractGraph implements XulEventHandler, Redraw
 
         // Create a new transformation to execution
         //
+        // clear caches before beginning execution
+        spoon.clearBowlCaches();
         trans = new Trans( transMeta );
         trans.setSafeModeEnabled( executionConfiguration.isSafeModeEnabled() );
         trans.setPreview( true );
@@ -4252,7 +4257,6 @@ public class TransGraph extends AbstractGraph implements XulEventHandler, Redraw
       @Override
       public void run() {
         try {
-
           trans.setInitialLogBufferStartLine();
           trans.prepareExecution( args );
 


### PR DESCRIPTION
- ThreadLocal DocumentBuilder cache. DocumentBuilder construction was a significant (40+%) cost of exporting the repository, and isn't thread safe.
- Removed bowl.clearCache() from AbstractMeta. This was being called for each object in large exports, which was causing considerable cache churn. Removing this means our cache invalidation strategy has signficantly changed. The new goal is that cache invalidation happens at user-file level operations, like opening, exporting, executing a file or multiple files.
- cache objects in the RepositorySharedObjectsIO. Even though the Repository itself caches shared objects, copying them into XML nodes in this class was a significant cost.
- combine copying shared objects with clearing object ids. This reduces a lot of xml overhead from doing this twice for export use cases.
- carte APIs: invalidate caches before executing files.
- MetaFileLoaderImplTest: cleanup. This was interfering with other tests.
- TransDelegate: load clusterSchemas once, rather than once per step.
- Spoon UI code: clear bowl caches before user initiated file operations