### PR TITLE
[BACKLOG-500157]  :Cancel existing auth flow and release callback port before initiating new browser login to prevent "Address already in use" BindException

### DIFF
--- a/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/dialog/RepositoryManagerDialog.java
+++ b/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/dialog/RepositoryManagerDialog.java
@@ -68,6 +68,7 @@ import org.pentaho.di.ui.core.PropsUI;
 import org.pentaho.di.ui.core.gui.GUIResource;
 import org.pentaho.di.ui.repo.controller.RepositoryConnectController;
 import org.pentaho.di.ui.repo.service.BrowserAuthenticationService;
+import org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper;
 import org.pentaho.di.ui.repo.util.PurRepositoryUtils;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.spoon.session.AuthenticationContext;
@@ -926,12 +927,14 @@ public class RepositoryManagerDialog extends Dialog {
     }
 
     try {
+      BrowserAuthenticationService authService = getBrowserAuthService();
+      if ( !BrowserAuthDialogHelper.confirmCancelExistingLoginIfNeeded( Spoon.getInstance().getShell(), authService ) ) {
+        return;
+      }
+
       if ( dialog != null && !dialog.isDisposed() ) {
         dialog.close();
       }
-
-      BrowserAuthenticationService authService =
-          new BrowserAuthenticationService();
 
       CompletableFuture<BrowserAuthenticationService.SessionInfo>
           future = authService.authenticate( serverUrl, authorizationUri );
@@ -964,6 +967,10 @@ public class RepositoryManagerDialog extends Dialog {
           }
         } )
       ).exceptionally( error -> {
+        if ( BrowserAuthenticationService.isUserInitiatedCancellation( error ) ) {
+          log.logBasic( "Previous browser login was cancelled to start a new login; skipping error dialog." );
+          return null;
+        }
         log.logError( "Browser authentication failed", error );
         Display.getDefault().asyncExec( () -> showErrorDialog(
           BaseMessages.getString( PKG, "repositories.error.authenticationFailed.title" ),
@@ -1005,5 +1012,9 @@ public class RepositoryManagerDialog extends Dialog {
       current = current.getCause();
     }
     return current;
+  }
+
+  BrowserAuthenticationService getBrowserAuthService() {
+    return BrowserAuthenticationService.getInstance();
   }
 }

--- a/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/menu/RepositoryConnectMenu.java
+++ b/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/menu/RepositoryConnectMenu.java
@@ -35,6 +35,7 @@ import org.pentaho.di.ui.repo.dialog.RepositoryConnectionDialog;
 import org.pentaho.di.ui.repo.dialog.RepositoryManagerDialog;
 import org.pentaho.di.ui.repo.service.BrowserAuthenticationService;
 import org.pentaho.di.ui.repo.service.BrowserAuthenticationService.SessionInfo;
+import org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper;
 import org.pentaho.di.ui.repo.util.PurRepositoryUtils;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.spoon.session.AuthenticationContext;
@@ -290,7 +291,12 @@ public class RepositoryConnectMenu {
    */
   private void openBrowserLogin( String repoName, String serverUrl, String authorizationUri ) {
     try {
-      BrowserAuthenticationService authService = new BrowserAuthenticationService();
+      BrowserAuthenticationService authService = getBrowserAuthService();
+
+      if ( !BrowserAuthDialogHelper.confirmCancelExistingLoginIfNeeded( spoon.getShell(), authService ) ) {
+        return;
+      }
+
       CompletableFuture<SessionInfo> future = authService.authenticate( serverUrl, authorizationUri );
 
       future.thenAccept( sessionInfo ->
@@ -323,6 +329,10 @@ public class RepositoryConnectMenu {
           }
         } )
       ).exceptionally( ex -> {
+        if ( BrowserAuthenticationService.isUserInitiatedCancellation( ex ) ) {
+          log.logBasic( "Previous browser login was cancelled to start a new login; skipping error dialog." );
+          return null;
+        }
         log.logError( BaseMessages.getString( PKG, "RepositoryConnectMenu.ErrorBrowserAuthFailed" ), ex );
         spoon.getDisplay().asyncExec( () ->
           showErrorDialog(
@@ -368,5 +378,9 @@ public class RepositoryConnectMenu {
       current = current.getCause();
     }
     return current;
+  }
+
+  BrowserAuthenticationService getBrowserAuthService() {
+    return BrowserAuthenticationService.getInstance();
   }
 }

--- a/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/timeout/SessionTimeoutHandler.java
+++ b/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/timeout/SessionTimeoutHandler.java
@@ -388,7 +388,7 @@ public class SessionTimeoutHandler {
   }
 
   BrowserAuthenticationService createBrowserAuthenticationService() {
-    return new BrowserAuthenticationService();
+    return BrowserAuthenticationService.getInstance();
   }
 
   /**

--- a/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/util/BrowserAuthDialogHelper.java
+++ b/plugins/repositories/core/src/main/java/org/pentaho/di/ui/repo/util/BrowserAuthDialogHelper.java
@@ -1,0 +1,53 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.ui.repo.util;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
+import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.ui.repo.service.BrowserAuthenticationService;
+
+/**
+ * Shared UI helper for browser-authentication dialogs.
+ */
+public final class BrowserAuthDialogHelper {
+
+  private static final Class<?> PKG = BrowserAuthDialogHelper.class;
+
+  private BrowserAuthDialogHelper() {
+  }
+
+  /**
+   * Ensures there is no active browser-authentication flow before starting a new one.
+   *
+   * @return true if caller should continue and start authentication; false to keep waiting for existing flow.
+   */
+  public static boolean confirmCancelExistingLoginIfNeeded( Shell parentShell,
+                                                             BrowserAuthenticationService authService ) {
+    if ( !authService.isAuthInProgress() ) {
+      return true;
+    }
+
+    MessageBox mb = new MessageBox( parentShell, SWT.YES | SWT.NO | SWT.ICON_WARNING );
+    mb.setText( BaseMessages.getString( PKG, "BrowserAuthDialogHelper.LoginInProgressTitle" ) );
+    mb.setMessage( BaseMessages.getString( PKG, "BrowserAuthDialogHelper.LoginInProgressMessage" ) );
+
+    if ( mb.open() == SWT.YES ) {
+      authService.cancelCurrentAuth();
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/plugins/repositories/core/src/main/resources/org/pentaho/di/ui/repo/util/messages/messages_en_US.properties
+++ b/plugins/repositories/core/src/main/resources/org/pentaho/di/ui/repo/util/messages/messages_en_US.properties
@@ -1,0 +1,2 @@
+BrowserAuthDialogHelper.LoginInProgressTitle=Login Already In Progress
+BrowserAuthDialogHelper.LoginInProgressMessage=A browser login is already in progress.\n\nDo you want to cancel it and start a new login?\nClick 'No' to continue waiting for the existing login.

--- a/plugins/repositories/core/src/test/java/org/pentaho/di/ui/repo/dialog/RepositoryManagerDialogTest.java
+++ b/plugins/repositories/core/src/test/java/org/pentaho/di/ui/repo/dialog/RepositoryManagerDialogTest.java
@@ -69,6 +69,7 @@ public class RepositoryManagerDialogTest {
   private Shell mockDialogShell;
   private LogChannelInterface mockLog;
   private Display mockDisplay;
+  private BrowserAuthenticationService mockAuthService;
 
   @BeforeClass
   public static void setUpClass() throws Exception {
@@ -120,6 +121,11 @@ public class RepositoryManagerDialogTest {
     setField( dialogInstance, "dialog", mockDialogShell );
     setField( dialogInstance, "log", mockLog );
 
+    // Create mock auth service and spy the dialog to return it
+    mockAuthService = mock( BrowserAuthenticationService.class );
+    dialogInstance = org.mockito.Mockito.spy( dialogInstance );
+    doAnswer( inv -> mockAuthService ).when( dialogInstance ).getBrowserAuthService();
+
     when( mockDialogShell.isDisposed() ).thenReturn( false );
   }
 
@@ -134,28 +140,26 @@ public class RepositoryManagerDialogTest {
       .thenReturn( mockAuthContext );
 
     RepositoryConnectController mockController = mock( RepositoryConnectController.class );
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getShell() ).thenReturn( mockShell );
+
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( completedFuture );
 
     try ( MockedStatic<SpoonSessionManager> sessionMock = mockStatic( SpoonSessionManager.class );
           MockedStatic<Display> displayMock = mockStatic( Display.class );
           MockedStatic<RepositoryConnectController> ctrlMock = mockStatic( RepositoryConnectController.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( completedFuture ) ) ) {
+          MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class ) ) {
 
       sessionMock.when( SpoonSessionManager::getInstance ).thenReturn( mockSessionMgr );
       displayMock.when( Display::getDefault ).thenReturn( mockDisplay );
       ctrlMock.when( RepositoryConnectController::getInstance ).thenReturn( mockController );
+      spoonMock.when( Spoon::getInstance ).thenReturn( mockSpoon );
 
       dialogInstance.openBrowserLogin( "myRepo", "http://localhost:8080/pentaho",
         new RepositoriesMeta(), null );
 
-      // Verify dialog was closed
       verify( mockDialogShell ).close();
-
-      // Verify session was stored
       verify( mockAuthContext ).storeJSessionId( "JSESS123" );
-
-      // Verify connectToRepository was called with correct arguments
       verify( mockController ).connectToRepository(
         "myRepo",
         "adminUser",
@@ -171,12 +175,10 @@ public class RepositoryManagerDialogTest {
 
     Spoon mockSpoon = mock( Spoon.class );
     when( mockSpoon.getShell() ).thenReturn( mockShell );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( failedFuture );
 
     try ( MockedStatic<Display> displayMock = mockStatic( Display.class );
           MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( failedFuture ) );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -186,10 +188,8 @@ public class RepositoryManagerDialogTest {
       dialogInstance.openBrowserLogin( "myRepo", "http://localhost:8080/pentaho",
         new RepositoriesMeta(), null );
 
-      // Verify error was logged
       verify( mockLog ).logError( eq( "Browser authentication failed" ), any( Throwable.class ) );
 
-      // Verify error dialog was shown
       org.eclipse.swt.widgets.MessageBox msgBox = mbMock.constructed().get( 0 );
       verify( msgBox ).setText( anyString() );
       verify( msgBox ).open();
@@ -203,12 +203,10 @@ public class RepositoryManagerDialogTest {
 
     Spoon mockSpoon = mock( Spoon.class );
     when( mockSpoon.getShell() ).thenReturn( mockShell );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( timedOutFuture );
 
     try ( MockedStatic<Display> displayMock = mockStatic( Display.class );
           MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( timedOutFuture ) );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -218,7 +216,6 @@ public class RepositoryManagerDialogTest {
       dialogInstance.openBrowserLogin( "myRepo", "http://localhost:8080/pentaho",
         new RepositoriesMeta(), null );
 
-      // Verify error dialog was shown
       org.eclipse.swt.widgets.MessageBox msgBox = mbMock.constructed().get( 0 );
       verify( msgBox ).setText( anyString() );
       verify( msgBox ).open();
@@ -229,12 +226,10 @@ public class RepositoryManagerDialogTest {
   public void openBrowserLogin_AuthenticateThrows_ShowsError() {
     Spoon mockSpoon = mock( Spoon.class );
     when( mockSpoon.getShell() ).thenReturn( mockShell );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenThrow(
+      new RuntimeException( "Port already in use" ) );
 
     try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenThrow(
-                new RuntimeException( "Port already in use" ) ) );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -243,7 +238,6 @@ public class RepositoryManagerDialogTest {
       dialogInstance.openBrowserLogin( "myRepo", "http://localhost:8080/pentaho",
         new RepositoriesMeta(), null );
 
-      // Verify error dialog was shown
       org.eclipse.swt.widgets.MessageBox msgBox = mbMock.constructed().get( 0 );
       verify( msgBox ).setText( anyString() );
       verify( msgBox ).open();
@@ -253,17 +247,17 @@ public class RepositoryManagerDialogTest {
   @Test
   public void openBrowserLogin_DialogAlreadyDisposed_SkipsClose() {
     when( mockDialogShell.isDisposed() ).thenReturn( true );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
 
-    CompletableFuture<SessionInfo> pending = new CompletableFuture<>();
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getShell() ).thenReturn( mockShell );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( pending ) ) ) {
+    try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class ) ) {
+      spoonMock.when( Spoon::getInstance ).thenReturn( mockSpoon );
 
       dialogInstance.openBrowserLogin( "myRepo", "http://localhost:8080/pentaho",
         new RepositoriesMeta(), null );
 
-      // dialog.close() should NOT have been called since it's already disposed
       verify( mockDialogShell, never() ).close();
     }
   }
@@ -271,16 +265,17 @@ public class RepositoryManagerDialogTest {
   @Test
   public void openBrowserLogin_PassesCorrectServerUrl() {
     String serverUrl = "https://secure-server:443/pentaho";
-    CompletableFuture<SessionInfo> pending = new CompletableFuture<>();
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( pending ) ) ) {
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getShell() ).thenReturn( mockShell );
+
+    try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class ) ) {
+      spoonMock.when( Spoon::getInstance ).thenReturn( mockSpoon );
 
       dialogInstance.openBrowserLogin( "myRepo", serverUrl, new RepositoriesMeta(), null );
 
-      BrowserAuthenticationService constructed = authMock.constructed().get( 0 );
-      verify( constructed ).authenticate( "https://secure-server:443/pentaho", null );
+      verify( mockAuthService ).authenticate( "https://secure-server:443/pentaho", null );
     }
   }
 
@@ -288,16 +283,17 @@ public class RepositoryManagerDialogTest {
   public void openBrowserLogin_PassesAuthorizationUri() {
     String serverUrl = "http://server:8080/pentaho";
     String authUri = "https://idp.example.com/authorize";
-    CompletableFuture<SessionInfo> pending = new CompletableFuture<>();
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( pending ) ) ) {
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getShell() ).thenReturn( mockShell );
+
+    try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class ) ) {
+      spoonMock.when( Spoon::getInstance ).thenReturn( mockSpoon );
 
       dialogInstance.openBrowserLogin( "myRepo", serverUrl, new RepositoriesMeta(), authUri );
 
-      BrowserAuthenticationService constructed = authMock.constructed().get( 0 );
-      verify( constructed ).authenticate( serverUrl, authUri );
+      verify( mockAuthService ).authenticate( serverUrl, authUri );
     }
   }
 
@@ -458,13 +454,12 @@ public class RepositoryManagerDialogTest {
     Spoon mockSpoon = mock( Spoon.class );
     when( mockSpoon.getShell() ).thenReturn( mockShell );
 
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( completedFuture );
+
     try ( MockedStatic<SpoonSessionManager> sessionMock = mockStatic( SpoonSessionManager.class );
           MockedStatic<Display> displayMock = mockStatic( Display.class );
           MockedStatic<RepositoryConnectController> ctrlMock = mockStatic( RepositoryConnectController.class );
           MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( completedFuture ) );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -493,12 +488,10 @@ public class RepositoryManagerDialogTest {
 
     Spoon mockSpoon = mock( Spoon.class );
     when( mockSpoon.getShell() ).thenReturn( mockShell );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( failedFuture );
 
     try ( MockedStatic<Display> displayMock = mockStatic( Display.class );
           MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( failedFuture ) );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -522,8 +515,6 @@ public class RepositoryManagerDialogTest {
     when( mockSpoon.getShell() ).thenReturn( mockShell );
 
     try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -532,8 +523,7 @@ public class RepositoryManagerDialogTest {
       dialogInstance.openBrowserLogin( "myRepo", "not a valid url :// %%",
         new RepositoriesMeta(), null );
 
-      assertTrue( "No BrowserAuthenticationService should have been created",
-        authMock.constructed().isEmpty() );
+      verify( mockAuthService, never() ).authenticate( anyString(), any() );
       verify( mockDialogShell, never() ).close();
       verify( mockLog ).logError( eq( "Invalid server URL for browser login: not a valid url :// %%" ),
         any( java.net.URISyntaxException.class ) );
@@ -550,8 +540,6 @@ public class RepositoryManagerDialogTest {
     when( mockSpoon.getShell() ).thenReturn( mockShell );
 
     try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -560,8 +548,7 @@ public class RepositoryManagerDialogTest {
       dialogInstance.openBrowserLogin( "myRepo", "file:///local/path",
         new RepositoriesMeta(), null );
 
-      assertTrue( "No BrowserAuthenticationService should have been created",
-        authMock.constructed().isEmpty() );
+      verify( mockAuthService, never() ).authenticate( anyString(), any() );
       verify( mockDialogShell, never() ).close();
       verify( mockLog ).logError( eq( "Invalid server URL for browser login: file:///local/path" ),
         any( java.net.URISyntaxException.class ) );
@@ -578,8 +565,6 @@ public class RepositoryManagerDialogTest {
     when( mockSpoon.getShell() ).thenReturn( mockShell );
 
     try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -588,7 +573,7 @@ public class RepositoryManagerDialogTest {
       dialogInstance.openBrowserLogin( "myRepo", "mailto:user@example.com",
         new RepositoriesMeta(), null );
 
-      assertTrue( authMock.constructed().isEmpty() );
+      verify( mockAuthService, never() ).authenticate( anyString(), any() );
       verify( mockDialogShell, never() ).close();
 
       org.eclipse.swt.widgets.MessageBox msgBox = mbMock.constructed().get( 0 );
@@ -611,13 +596,12 @@ public class RepositoryManagerDialogTest {
 
     RepositoryConnectController mockController = mock( RepositoryConnectController.class );
 
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( completedFuture );
+
     try ( MockedStatic<SpoonSessionManager> sessionMock = mockStatic( SpoonSessionManager.class );
           MockedStatic<Display> displayMock = mockStatic( Display.class );
           MockedStatic<RepositoryConnectController> ctrlMock = mockStatic( RepositoryConnectController.class );
           MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( completedFuture ) );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -642,18 +626,18 @@ public class RepositoryManagerDialogTest {
 
   @Test
   public void openBrowserLogin_ValidHttpsUrl_ProceedsToBrowserAuth() {
-    CompletableFuture<SessionInfo> pending = new CompletableFuture<>();
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( pending ) ) ) {
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getShell() ).thenReturn( mockShell );
+
+    try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class ) ) {
+      spoonMock.when( Spoon::getInstance ).thenReturn( mockSpoon );
 
       dialogInstance.openBrowserLogin( "myRepo", "https://secure.example.com:443/pentaho",
         new RepositoriesMeta(), "https://idp.example.com/auth" );
 
-      assertEquals( 1, authMock.constructed().size() );
-      BrowserAuthenticationService constructed = authMock.constructed().get( 0 );
-      verify( constructed ).authenticate( "https://secure.example.com:443/pentaho",
+      verify( mockAuthService ).authenticate( "https://secure.example.com:443/pentaho",
         "https://idp.example.com/auth" );
     }
   }
@@ -664,8 +648,6 @@ public class RepositoryManagerDialogTest {
     when( mockSpoon.getShell() ).thenReturn( mockShell );
 
     try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -674,7 +656,7 @@ public class RepositoryManagerDialogTest {
       dialogInstance.openBrowserLogin( "myRepo", "   ",
         new RepositoriesMeta(), null );
 
-      assertTrue( authMock.constructed().isEmpty() );
+      verify( mockAuthService, never() ).authenticate( anyString(), any() );
       verify( mockDialogShell, never() ).close();
 
       org.eclipse.swt.widgets.MessageBox msgBox = mbMock.constructed().get( 0 );
@@ -685,34 +667,37 @@ public class RepositoryManagerDialogTest {
 
   @Test
   public void openBrowserLogin_ValidUrlWithPortNoPath_ProceedsToBrowserAuth() {
-    CompletableFuture<SessionInfo> pending = new CompletableFuture<>();
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( pending ) ) ) {
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getShell() ).thenReturn( mockShell );
+
+    try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class ) ) {
+      spoonMock.when( Spoon::getInstance ).thenReturn( mockSpoon );
 
       dialogInstance.openBrowserLogin( "myRepo", "http://myserver:9090",
         new RepositoriesMeta(), null );
 
-      assertEquals( 1, authMock.constructed().size() );
       verify( mockDialogShell ).close();
-      verify( authMock.constructed().get( 0 ) ).authenticate( "http://myserver:9090", null );
+      verify( mockAuthService ).authenticate( "http://myserver:9090", null );
     }
   }
 
   @Test
   public void openBrowserLogin_NullDialogField_ValidUrl_ProceedsWithoutClose() throws Exception {
     setField( dialogInstance, "dialog", null );
-    CompletableFuture<SessionInfo> pending = new CompletableFuture<>();
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( pending ) ) ) {
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getShell() ).thenReturn( mockShell );
+
+    try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class ) ) {
+      spoonMock.when( Spoon::getInstance ).thenReturn( mockSpoon );
 
       dialogInstance.openBrowserLogin( "myRepo", "http://valid-host:8080/pentaho",
         new RepositoriesMeta(), null );
 
-      assertEquals( 1, authMock.constructed().size() );
+      verify( mockAuthService ).authenticate( "http://valid-host:8080/pentaho", null );
     }
   }
 
@@ -732,13 +717,12 @@ public class RepositoryManagerDialogTest {
 
     RepositoryConnectController mockController = mock( RepositoryConnectController.class );
 
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( completedFuture );
+
     try ( MockedStatic<SpoonSessionManager> sessionMock = mockStatic( SpoonSessionManager.class );
           MockedStatic<Display> displayMock = mockStatic( Display.class );
           MockedStatic<RepositoryConnectController> ctrlMock = mockStatic( RepositoryConnectController.class );
           MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( completedFuture ) );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -766,8 +750,6 @@ public class RepositoryManagerDialogTest {
     when( mockSpoon.getShell() ).thenReturn( mockShell );
 
     try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -808,6 +790,51 @@ public class RepositoryManagerDialogTest {
         throw (Exception) e.getCause();
       }
       throw e;
+    }
+  }
+
+  @Test
+  public void openBrowserLogin_ConfirmCancelReturnsFalse_DoesNotAuthenticate() {
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getShell() ).thenReturn( mockShell );
+
+    try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
+          MockedStatic<org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper> helperMock =
+            mockStatic( org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper.class ) ) {
+
+      spoonMock.when( Spoon::getInstance ).thenReturn( mockSpoon );
+      helperMock.when( () -> org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper
+        .confirmCancelExistingLoginIfNeeded( any( Shell.class ), any( BrowserAuthenticationService.class ) ) )
+        .thenReturn( false );
+
+      dialogInstance.openBrowserLogin( "myRepo", "http://localhost:8080/pentaho",
+        new RepositoriesMeta(), null );
+
+      verify( mockAuthService, never() ).authenticate( anyString(), any() );
+      verify( mockDialogShell, never() ).close();
+    }
+  }
+
+  @Test
+  public void openBrowserLogin_ConfirmCancelReturnsTrue_ProceedsToAuthenticate() {
+    Spoon mockSpoon = mock( Spoon.class );
+    when( mockSpoon.getShell() ).thenReturn( mockShell );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
+
+    try ( MockedStatic<Spoon> spoonMock = mockStatic( Spoon.class );
+          MockedStatic<org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper> helperMock =
+            mockStatic( org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper.class ) ) {
+
+      spoonMock.when( Spoon::getInstance ).thenReturn( mockSpoon );
+      helperMock.when( () -> org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper
+        .confirmCancelExistingLoginIfNeeded( any( Shell.class ), any( BrowserAuthenticationService.class ) ) )
+        .thenReturn( true );
+
+      dialogInstance.openBrowserLogin( "myRepo", "http://localhost:8080/pentaho",
+        new RepositoriesMeta(), null );
+
+      verify( mockAuthService ).authenticate( "http://localhost:8080/pentaho", null );
+      verify( mockDialogShell ).close();
     }
   }
 

--- a/plugins/repositories/core/src/test/java/org/pentaho/di/ui/repo/menu/RepositoryConnectMenuTest.java
+++ b/plugins/repositories/core/src/test/java/org/pentaho/di/ui/repo/menu/RepositoryConnectMenuTest.java
@@ -70,6 +70,7 @@ public class RepositoryConnectMenuTest {
   private RepositoryConnectController repoController;
   private Shell mockShell;
   private Display mockDisplay;
+  private BrowserAuthenticationService mockAuthService;
 
   @BeforeClass
   public static void setUpClass() throws Exception {
@@ -121,6 +122,11 @@ public class RepositoryConnectMenuTest {
     // Build menu object via reflection to avoid constructor side-effects
     // (constructor calls getRepoControllerInstance() and addListener())
     menu = createMenuWithReflection( spoon, repoController );
+
+    // Create a mock BrowserAuthenticationService and make the menu return it
+    mockAuthService = mock( BrowserAuthenticationService.class );
+    menu = spy( menu );
+    doAnswer( inv -> mockAuthService ).when( menu ).getBrowserAuthService();
   }
 
   private RepositoryConnectMenu createMenuWithReflection( Spoon spoon,
@@ -146,12 +152,9 @@ public class RepositoryConnectMenuTest {
     RepositoryMeta repoMeta = mock( RepositoryMeta.class );
     String serverUrl = "http://localhost:8080/pentaho";
 
-    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) -> {
-              CompletableFuture<SessionInfo> pending = new CompletableFuture<>();
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( pending );
-            } ) ) {
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
+
+    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class ) ) {
 
       purUtils.when( () -> PurRepositoryUtils.supportsBrowserAuth( repoMeta ) ).thenReturn( true );
       purUtils.when( () -> PurRepositoryUtils.getAuthMethod( repoMeta ) ).thenReturn( "SSO" );
@@ -159,9 +162,7 @@ public class RepositoryConnectMenuTest {
 
       invokeConnectBasedOnAuthMethod( "myRepo", repoMeta );
 
-      // BrowserAuthenticationService should have been constructed and authenticate called
-      BrowserAuthenticationService constructed = authMock.constructed().get( 0 );
-      verify( constructed ).authenticate( serverUrl, null );
+      verify( mockAuthService ).authenticate( serverUrl, null );
     }
   }
 
@@ -176,11 +177,9 @@ public class RepositoryConnectMenuTest {
     AuthenticationContext mockAuthContext = mock( AuthenticationContext.class );
     SpoonSessionManager mockSessionMgr = mock( SpoonSessionManager.class );
     when( mockSessionMgr.getAuthenticationContext( serverUrl ) ).thenReturn( mockAuthContext );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( completedFuture );
 
-    try ( MockedStatic<SpoonSessionManager> sessionMock = mockStatic( SpoonSessionManager.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( completedFuture ) ) ) {
+    try ( MockedStatic<SpoonSessionManager> sessionMock = mockStatic( SpoonSessionManager.class ) ) {
 
       sessionMock.when( SpoonSessionManager::getInstance ).thenReturn( mockSessionMgr );
 
@@ -211,11 +210,9 @@ public class RepositoryConnectMenuTest {
     when( mockSessionMgr.getAuthenticationContext( serverUrl ) ).thenReturn( mockAuthContext );
     doThrow( new RuntimeException( "Connection refused" ) )
       .when( repoController ).connectToRepository( anyString(), anyString(), anyString() );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( completedFuture );
 
     try ( MockedStatic<SpoonSessionManager> sessionMock = mockStatic( SpoonSessionManager.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( completedFuture ) );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -236,11 +233,9 @@ public class RepositoryConnectMenuTest {
 
     CompletableFuture<SessionInfo> failedFuture = new CompletableFuture<>();
     failedFuture.completeExceptionally( new RuntimeException( "Server unreachable" ) );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( failedFuture );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( failedFuture ) );
-          MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
+    try ( MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
       invokeOpenBrowserLogin( "myRepo", serverUrl );
@@ -261,11 +256,9 @@ public class RepositoryConnectMenuTest {
 
     CompletableFuture<SessionInfo> timedOutFuture = new CompletableFuture<>();
     timedOutFuture.completeExceptionally( new TimeoutException( "Timed out" ) );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( timedOutFuture );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( timedOutFuture ) );
-          MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
+    try ( MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
       invokeOpenBrowserLogin( "myRepo", serverUrl );
@@ -280,11 +273,10 @@ public class RepositoryConnectMenuTest {
   public void testOpenBrowserLogin_AuthenticateThrows_ShowsError() throws Exception {
     String serverUrl = "http://localhost:8080/pentaho";
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenThrow(
-                new RuntimeException( "Port already in use" ) ) );
-          MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenThrow(
+      new RuntimeException( "Port already in use" ) );
+
+    try ( MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
       invokeOpenBrowserLogin( "myRepo", serverUrl );
@@ -303,17 +295,11 @@ public class RepositoryConnectMenuTest {
   public void testOpenBrowserLogin_PassesCorrectServerUrl() throws Exception {
     String serverUrl = "https://secure-server:443/pentaho";
 
-    CompletableFuture<SessionInfo> pending = new CompletableFuture<>();
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( pending ) ) ) {
+    invokeOpenBrowserLogin( "myRepo", serverUrl );
 
-      invokeOpenBrowserLogin( "myRepo", serverUrl );
-
-      BrowserAuthenticationService constructed = authMock.constructed().get( 0 );
-      verify( constructed ).authenticate( "https://secure-server:443/pentaho", null );
-    }
+    verify( mockAuthService ).authenticate( "https://secure-server:443/pentaho", null );
   }
 
   @Test
@@ -321,11 +307,9 @@ public class RepositoryConnectMenuTest {
     RepositoryMeta repoMeta = mock( RepositoryMeta.class );
     String serverUrl = "http://localhost:8080/pentaho";
 
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenThrow( new RuntimeException( "Fatal error" ) );
+
     try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) -> {
-              when( mock.authenticate( anyString(), any() ) ).thenThrow( new RuntimeException( "Fatal error" ) );
-            } );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
@@ -348,9 +332,7 @@ public class RepositoryConnectMenuTest {
   public void testConnectBasedOnAuthMethod_SSO_NullServerUrl_LogsErrorAndSkipsBrowserLogin() throws Exception {
     RepositoryMeta repoMeta = mock( RepositoryMeta.class );
 
-    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class ) ) {
+    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class ) ) {
 
       purUtils.when( () -> PurRepositoryUtils.getAuthMethod( repoMeta ) ).thenReturn( "SSO" );
       purUtils.when( () -> PurRepositoryUtils.getServerUrl( repoMeta ) ).thenReturn( null );
@@ -358,8 +340,8 @@ public class RepositoryConnectMenuTest {
 
       invokeConnectBasedOnAuthMethod( "myRepo", repoMeta );
 
-      // BrowserAuthenticationService should never be constructed
-      assertTrue( authMock.constructed().isEmpty() );
+      // authenticate should never be called when serverUrl is null
+      verify( mockAuthService, never() ).authenticate( anyString(), any() );
     }
   }
 
@@ -367,9 +349,7 @@ public class RepositoryConnectMenuTest {
   public void testConnectBasedOnAuthMethod_SSO_EmptyServerUrl_LogsErrorAndSkipsBrowserLogin() throws Exception {
     RepositoryMeta repoMeta = mock( RepositoryMeta.class );
 
-    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class ) ) {
+    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class ) ) {
 
       purUtils.when( () -> PurRepositoryUtils.getAuthMethod( repoMeta ) ).thenReturn( "SSO" );
       purUtils.when( () -> PurRepositoryUtils.getServerUrl( repoMeta ) ).thenReturn( "   " );
@@ -377,7 +357,7 @@ public class RepositoryConnectMenuTest {
 
       invokeConnectBasedOnAuthMethod( "myRepo", repoMeta );
 
-      assertTrue( authMock.constructed().isEmpty() );
+      verify( mockAuthService, never() ).authenticate( anyString(), any() );
     }
   }
 
@@ -387,11 +367,9 @@ public class RepositoryConnectMenuTest {
     String serverUrl = "http://localhost:8080/pentaho";
     String authUri = "https://auth.example.com/oauth2/authorize";
 
-    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) -> {
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
-            } ) ) {
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
+
+    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class ) ) {
 
       purUtils.when( () -> PurRepositoryUtils.getAuthMethod( repoMeta ) ).thenReturn( "SSO" );
       purUtils.when( () -> PurRepositoryUtils.getServerUrl( repoMeta ) ).thenReturn( serverUrl );
@@ -399,8 +377,7 @@ public class RepositoryConnectMenuTest {
 
       invokeConnectBasedOnAuthMethod( "myRepo", repoMeta );
 
-      BrowserAuthenticationService constructed = authMock.constructed().get( 0 );
-      verify( constructed ).authenticate( serverUrl, authUri );
+      verify( mockAuthService ).authenticate( serverUrl, authUri );
     }
   }
 
@@ -446,12 +423,9 @@ public class RepositoryConnectMenuTest {
     RepositoryMeta repoMeta = mock( RepositoryMeta.class );
     String serverUrl = "http://localhost:8080/pentaho";
 
-    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) -> {
-              CompletableFuture<SessionInfo> pending = new CompletableFuture<>();
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( pending );
-            } ) ) {
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
+
+    try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class ) ) {
 
       purUtils.when( () -> PurRepositoryUtils.getAuthMethod( repoMeta ) ).thenReturn( "SSO" );
       purUtils.when( () -> PurRepositoryUtils.getServerUrl( repoMeta ) ).thenReturn( serverUrl );
@@ -460,8 +434,7 @@ public class RepositoryConnectMenuTest {
 
       invokeConnectBasedOnAuthMethod( "myRepo", repoMeta );
 
-      BrowserAuthenticationService constructed = authMock.constructed().get( 0 );
-      verify( constructed ).authenticate( serverUrl, "   " );
+      verify( mockAuthService ).authenticate( serverUrl, "   " );
     }
   }
 
@@ -471,14 +444,9 @@ public class RepositoryConnectMenuTest {
     RepositoryMeta repoMeta = mock( RepositoryMeta.class );
     String serverUrl = "http://localhost:8080/pentaho";
 
-    // The BrowserAuthenticationService constructor throws, which is caught inside openBrowserLogin.
-    // Then showErrorDialog is called which throws a second exception — this propagates to the
-    // outer catch at line 275-276 in connectBasedOnAuthMethod.
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenThrow( new RuntimeException( "auth init failed" ) );
+
     try ( MockedStatic<PurRepositoryUtils> purUtils = mockStatic( PurRepositoryUtils.class );
-          MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) -> {
-              when( mock.authenticate( anyString(), any() ) ).thenThrow( new RuntimeException( "auth init failed" ) );
-            } );
           MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class, ( mock, ctx ) -> {
               // Make open() throw so the exception escapes openBrowserLogin's catch block
@@ -497,6 +465,42 @@ public class RepositoryConnectMenuTest {
     }
   }
 
+  @Test
+  public void testOpenBrowserLogin_ConfirmCancelReceivesCorrectShell() throws Exception {
+    String serverUrl = "http://localhost:8080/pentaho";
+
+    try ( MockedStatic<org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper> helperMock =
+            mockStatic( org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper.class ) ) {
+
+      helperMock.when( () -> org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper
+        .confirmCancelExistingLoginIfNeeded( any( Shell.class ), any( BrowserAuthenticationService.class ) ) )
+        .thenReturn( false );
+
+      invokeOpenBrowserLogin( "myRepo", serverUrl );
+
+      helperMock.verify( () -> org.pentaho.di.ui.repo.util.BrowserAuthDialogHelper
+        .confirmCancelExistingLoginIfNeeded( mockShell, mockAuthService ) );
+    }
+  }
+
+  @Test
+  public void testOpenBrowserLogin_NonUserCancelledException_ShowsErrorDialog() throws Exception {
+    String serverUrl = "http://localhost:8080/pentaho";
+
+    CompletableFuture<SessionInfo> failedFuture = new CompletableFuture<>();
+    failedFuture.completeExceptionally( new RuntimeException( "Server unreachable" ) );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( failedFuture );
+
+    try ( MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
+            mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
+
+      invokeOpenBrowserLogin( "myRepo", serverUrl );
+
+      org.eclipse.swt.widgets.MessageBox msgBox = mbMock.constructed().get( 0 );
+      verify( msgBox ).setText( "Authentication Failed" );
+      verify( msgBox ).open();
+    }
+  }
   // ── openBrowserLogin — additional branches ────────────────────────────────
 
   @Test
@@ -504,14 +508,11 @@ public class RepositoryConnectMenuTest {
     String serverUrl = "http://localhost:8080/pentaho";
     String authUri = "https://auth.example.com/oauth2/authorize";
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() ) ) ) {
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( new CompletableFuture<>() );
 
-      invokeOpenBrowserLogin( "myRepo", serverUrl, authUri );
+    invokeOpenBrowserLogin( "myRepo", serverUrl, authUri );
 
-      verify( authMock.constructed().get( 0 ) ).authenticate( serverUrl, authUri );
-    }
+    verify( mockAuthService ).authenticate( serverUrl, authUri );
   }
 
   @Test
@@ -522,11 +523,9 @@ public class RepositoryConnectMenuTest {
       new java.util.concurrent.CompletionException( new RuntimeException( "inner cause" ) );
     CompletableFuture<SessionInfo> failedFuture = new CompletableFuture<>();
     failedFuture.completeExceptionally( wrappedEx );
+    when( mockAuthService.authenticate( anyString(), any() ) ).thenReturn( failedFuture );
 
-    try ( MockedConstruction<BrowserAuthenticationService> authMock =
-            mockConstruction( BrowserAuthenticationService.class, ( mock, ctx ) ->
-              when( mock.authenticate( anyString(), any() ) ).thenReturn( failedFuture ) );
-          MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
+    try ( MockedConstruction<org.eclipse.swt.widgets.MessageBox> mbMock =
             mockConstruction( org.eclipse.swt.widgets.MessageBox.class ) ) {
 
       invokeOpenBrowserLogin( "myRepo", serverUrl, null );
@@ -617,20 +616,6 @@ public class RepositoryConnectMenuTest {
       "RepositoryConnectMenu.Dialog.BrowserAuthGenericError" ), result );
   }
 
-  @Test
-  public void testFormatBrowserAuthErrorMessage_CompletionExceptionWithNullCause_ReturnsGenericMessage()
-    throws Exception {
-    // CompletionException with null cause — unwrapRootCause loop terminates immediately
-    java.util.concurrent.CompletionException ce = new java.util.concurrent.CompletionException( null );
-
-    String result = invokeFormatBrowserAuthErrorMessage( ce );
-
-    // Root cause is the CompletionException itself (cause is null, loop stops)
-    // getMessage() on CompletionException with null cause is null
-    assertEquals( BaseMessages.getString( RepositoryConnectMenu.class,
-      "RepositoryConnectMenu.Dialog.BrowserAuthGenericError" ), result );
-  }
-
   // ── unwrapRootCause ──────────────────────────────────────────────────────
 
   @Test
@@ -704,9 +689,7 @@ public class RepositoryConnectMenuTest {
     // Create a SelectionEvent with the mock widget
     Event event = new Event();
     event.widget = mockWidget;
-    // Use a spy on the menu to verify connectBasedOnAuthMethod is called
-    RepositoryConnectMenu spyMenu = spy( menu );
-    setField( spyMenu, "repositoriesMeta", reposMeta );
+    // menu is already a spy from setUp
 
     // Stub connectBasedOnAuthMethod to do nothing (it's private, use doAnswer on the spy)
     // Since connectBasedOnAuthMethod is private, we invoke the callback logic directly:
@@ -729,7 +712,7 @@ public class RepositoryConnectMenuTest {
       // repositoryMeta.getId() is NOT "KettleFileRepository" so the else branch executes
       // This is exactly what lines 185-187 do
       assertNotEquals( "KettleFileRepository", repoMeta.getId() );
-      connectMethod.invoke( spyMenu, repoName, repoMeta );
+      connectMethod.invoke( menu, repoName, repoMeta );
 
       // Verify RepositoryConnectionDialog was created (USERNAME_PASSWORD falls through to else branch)
       org.pentaho.di.ui.repo.dialog.RepositoryConnectionDialog dlg = dlgMock.constructed().get( 0 );

--- a/plugins/repositories/core/src/test/java/org/pentaho/di/ui/repo/util/BrowserAuthDialogHelperTest.java
+++ b/plugins/repositories/core/src/test/java/org/pentaho/di/ui/repo/util/BrowserAuthDialogHelperTest.java
@@ -1,0 +1,120 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.ui.repo.util;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.pentaho.di.ui.repo.service.BrowserAuthenticationService;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BrowserAuthDialogHelperTest {
+
+  @Test
+  public void returnsTrueImmediatelyWhenNoAuthInProgress() {
+    Shell shell = mock( Shell.class );
+    BrowserAuthenticationService authService = mock( BrowserAuthenticationService.class );
+    when( authService.isAuthInProgress() ).thenReturn( false );
+
+    boolean result = BrowserAuthDialogHelper.confirmCancelExistingLoginIfNeeded( shell, authService );
+
+    assertTrue( result );
+    verify( authService, never() ).cancelCurrentAuth();
+  }
+
+  @Test
+  public void returnsTrueAndCancelsWhenUserConfirmsYes() {
+    Shell shell = mock( Shell.class );
+    BrowserAuthenticationService authService = mock( BrowserAuthenticationService.class );
+    when( authService.isAuthInProgress() ).thenReturn( true );
+
+    try ( MockedConstruction<MessageBox> mocked = mockConstruction( MessageBox.class,
+      ( mb, context ) -> when( mb.open() ).thenReturn( SWT.YES ) ) ) {
+
+      boolean result = BrowserAuthDialogHelper.confirmCancelExistingLoginIfNeeded( shell, authService );
+
+      assertTrue( result );
+      verify( authService ).cancelCurrentAuth();
+    }
+  }
+
+  @Test
+  public void returnsFalseWhenUserDeclinesNo() {
+    Shell shell = mock( Shell.class );
+    BrowserAuthenticationService authService = mock( BrowserAuthenticationService.class );
+    when( authService.isAuthInProgress() ).thenReturn( true );
+
+    try ( MockedConstruction<MessageBox> mocked = mockConstruction( MessageBox.class,
+      ( mb, context ) -> when( mb.open() ).thenReturn( SWT.NO ) ) ) {
+
+      boolean result = BrowserAuthDialogHelper.confirmCancelExistingLoginIfNeeded( shell, authService );
+
+      assertFalse( result );
+      verify( authService, never() ).cancelCurrentAuth();
+    }
+  }
+
+  @Test
+  public void doesNotCancelAuthWhenNoAuthInProgress() {
+    Shell shell = mock( Shell.class );
+    BrowserAuthenticationService authService = mock( BrowserAuthenticationService.class );
+    when( authService.isAuthInProgress() ).thenReturn( false );
+
+    BrowserAuthDialogHelper.confirmCancelExistingLoginIfNeeded( shell, authService );
+
+    verify( authService, never() ).cancelCurrentAuth();
+  }
+
+  @Test
+  public void setsMessageBoxTextAndMessageWhenAuthInProgress() {
+    Shell shell = mock( Shell.class );
+    BrowserAuthenticationService authService = mock( BrowserAuthenticationService.class );
+    when( authService.isAuthInProgress() ).thenReturn( true );
+
+    try ( MockedConstruction<MessageBox> mocked = mockConstruction( MessageBox.class,
+      ( mb, context ) -> when( mb.open() ).thenReturn( SWT.NO ) ) ) {
+
+      BrowserAuthDialogHelper.confirmCancelExistingLoginIfNeeded( shell, authService );
+
+      MessageBox mb = mocked.constructed().get( 0 );
+      verify( mb ).setText( org.mockito.ArgumentMatchers.anyString() );
+      verify( mb ).setMessage( org.mockito.ArgumentMatchers.anyString() );
+    }
+  }
+
+  @Test
+  public void returnsFalseWhenUserClosesDialogWithoutSelectingYes() {
+    Shell shell = mock( Shell.class );
+    BrowserAuthenticationService authService = mock( BrowserAuthenticationService.class );
+    when( authService.isAuthInProgress() ).thenReturn( true );
+
+    try ( MockedConstruction<MessageBox> mocked = mockConstruction( MessageBox.class,
+      ( mb, context ) -> when( mb.open() ).thenReturn( SWT.CANCEL ) ) ) {
+
+      boolean result = BrowserAuthDialogHelper.confirmCancelExistingLoginIfNeeded( shell, authService );
+
+      assertFalse( result );
+      verify( authService, never() ).cancelCurrentAuth();
+    }
+  }
+}
+

--- a/ui/src/main/java/org/pentaho/di/ui/repo/service/BrowserAuthenticationService.java
+++ b/ui/src/main/java/org/pentaho/di/ui/repo/service/BrowserAuthenticationService.java
@@ -21,29 +21,57 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import java.awt.*;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * HTTP callback authentication service for Pentaho Repository.
  * Opens system browser, starts local HTTP callback server, captures JSESSIONID.
  */
+@SuppressWarnings( "java:S6548" ) // Singleton is intentional — shared auth state prevents concurrent flows
 public class BrowserAuthenticationService {
 
   private static final LogChannelInterface log = new LogChannel( "BrowserAuthenticationService" );
   static final int CALLBACK_PORT = 8282;
   private static final int TIMEOUT_SECONDS = 300; // 5 minutes
+  private static final int SERVER_START_MAX_RETRIES = 5;
+  private static final long SERVER_START_RETRY_DELAY_MS = 150L;
   static final String PARAM_AUTHORIZATION_URI = "authorizationUri";
+
+  // Singleton is required: authInProgress, authGeneration, and callbackServer state must be shared
+  // across all callers to prevent concurrent authentication flows on the same callback port.
+  @SuppressWarnings( "java:S6548" ) // Singleton pattern is intentional and necessary here
+  private static class InstanceHolder {
+    private static final BrowserAuthenticationService INSTANCE = new BrowserAuthenticationService();
+  }
+
+  public static BrowserAuthenticationService getInstance() {
+    return InstanceHolder.INSTANCE;
+  }
 
   private HttpServer callbackServer;
   private CompletableFuture<SessionInfo> sessionFuture;
+
+  /** Tracks whether a browser-auth flow is currently active. */
+  private final AtomicBoolean authInProgress = new AtomicBoolean( false );
+
+  /**
+   * Incremented each time a new auth flow starts so that whenComplete callbacks
+   * from a cancelled/stale flow never stop the newly started server.
+   */
+  private final AtomicInteger authGeneration = new AtomicInteger( 0 );
 
   /**
    * Initiates HTTP callback authentication flow.
@@ -56,10 +84,20 @@ public class BrowserAuthenticationService {
   }
 
   public CompletableFuture<SessionInfo> authenticate( String serverUrl, String authorizationUri ) {
+
+    // Guard: caller must check isAuthInProgress() and call cancelCurrentAuth() if needed
+    // before calling this method. Do NOT start a new server if one is already bound.
+    if ( authInProgress.get() ) {
+      log.logBasic( "authenticate() called while auth already in progress — returning existing future." );
+      return sessionFuture;
+    }
+
+    authInProgress.set( true );
+    final int myGeneration = authGeneration.incrementAndGet();
     sessionFuture = new CompletableFuture<>();
 
     try {
-      startCallbackServer();
+      startCallbackServerWithRetry();
       String authUrl = buildAuthenticationUrl( serverUrl, authorizationUri );
       openSystemBrowser( authUrl );
 
@@ -67,8 +105,11 @@ public class BrowserAuthenticationService {
 
       return sessionFuture.orTimeout( TIMEOUT_SECONDS, TimeUnit.SECONDS )
         .whenComplete( ( result, error ) -> {
-          stopCallbackServer();
-          if ( error != null ) {
+          if ( authGeneration.get() == myGeneration ) {
+            authInProgress.set( false );
+            stopCallbackServer();
+          }
+          if ( error != null && !isUserInitiatedCancellation( error ) ) {
             log.logError( "HTTP callback authentication failed or timed out", error );
           }
         } );
@@ -76,10 +117,59 @@ public class BrowserAuthenticationService {
     } catch ( Exception e ) {
       log.logError( "Failed to initiate HTTP callback authentication", e );
       sessionFuture.completeExceptionally( e );
-      stopCallbackServer();
+      if ( authGeneration.get() == myGeneration ) {
+        authInProgress.set( false );
+        stopCallbackServer();
+      }
       return sessionFuture;
     }
   }
+
+  /**
+   * Returns whether a browser authentication flow is currently active.
+   */
+  public boolean isAuthInProgress() {
+    return authInProgress.get();
+  }
+
+  /**
+   * Cancels the currently running auth flow — stops the callback server and
+   * completes the existing future exceptionally so any pending listeners are notified.
+   * Call this before starting a new login when {@link #isAuthInProgress()} returns true.
+   */
+  public void cancelCurrentAuth() {
+    // Bump generation FIRST so any in-flight whenComplete sees a stale value
+    // and skips cleanup — preventing it from stopping the new server we are about to start.
+    authGeneration.incrementAndGet();
+    if ( sessionFuture != null && !sessionFuture.isDone() ) {
+      sessionFuture.completeExceptionally(
+        new UserCancelledAuthException( "Login cancelled by user to start a new login." ) );
+    }
+    stopCallbackServer();
+    authInProgress.set( false );
+  }
+
+  public static boolean isUserInitiatedCancellation( Throwable throwable ) {
+    Throwable current = throwable;
+    while ( current != null ) {
+      if ( current instanceof UserCancelledAuthException ) {
+        return true;
+      }
+      if ( current instanceof CompletionException && current.getCause() != null ) {
+        current = current.getCause();
+        continue;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  public static class UserCancelledAuthException extends Exception {
+    public UserCancelledAuthException( String message ) {
+      super( message );
+    }
+  }
+
 
   /**
    * Starts the local HTTP callback server.
@@ -89,6 +179,47 @@ public class BrowserAuthenticationService {
     callbackServer.createContext( "/pentaho/auth/callback", new CallbackHandler() );
     callbackServer.setExecutor( null );
     callbackServer.start();
+  }
+
+  void startCallbackServerWithRetry() throws IOException {
+    IOException lastException = null;
+    for ( int attempt = 1; attempt <= SERVER_START_MAX_RETRIES; attempt++ ) {
+      try {
+        startCallbackServer();
+        return;
+      } catch ( IOException e ) {
+        lastException = e;
+        if ( !isAddressAlreadyInUse( e ) || attempt == SERVER_START_MAX_RETRIES ) {
+          throw e;
+        }
+        log.logBasic( "Callback port still busy; retrying callback server start (attempt "
+          + attempt + "/" + SERVER_START_MAX_RETRIES + ")" );
+        try {
+          Thread.sleep( SERVER_START_RETRY_DELAY_MS );
+        } catch ( InterruptedException interrupted ) {
+          Thread.currentThread().interrupt();
+          throw new IOException( "Interrupted while waiting to retry callback server startup", interrupted );
+        }
+      }
+    }
+    if ( lastException != null ) {
+      throw lastException;
+    }
+  }
+
+  boolean isAddressAlreadyInUse( Throwable throwable ) {
+    Throwable current = throwable;
+    while ( current != null ) {
+      if ( current instanceof BindException ) {
+        return true;
+      }
+      String message = current.getMessage();
+      if ( message != null && message.toLowerCase( Locale.ROOT ).contains( "address already in use" ) ) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 
   /**

--- a/ui/src/test/java/org/pentaho/di/ui/repo/service/BrowserAuthenticationServiceTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/repo/service/BrowserAuthenticationServiceTest.java
@@ -28,10 +28,12 @@ import java.awt.Desktop;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.BindException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
@@ -39,6 +41,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -392,6 +395,332 @@ public class BrowserAuthenticationServiceTest {
   }
 
   @Test
+  public void authenticateReturnsExistingFutureWhenAuthAlreadyInProgress() throws Exception {
+    BrowserAuthenticationService noopService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        // no-op
+      }
+    };
+
+    CompletableFuture<BrowserAuthenticationService.SessionInfo> first =
+      noopService.authenticate( "http://server:8080/pentaho" );
+    CompletableFuture<BrowserAuthenticationService.SessionInfo> second =
+      noopService.authenticate( "http://server:8080/pentaho" );
+
+    // Both futures should resolve to the same result when the callback completes
+    BrowserAuthenticationService.CallbackHandler handler = noopService.new CallbackHandler();
+    HttpExchange exchange = mockExchangeWithQuery( "jsessionid=SHARED&username=admin" );
+    handler.handle( exchange );
+
+    assertEquals( "SHARED", first.get().getJsessionId() );
+    assertEquals( "SHARED", second.get().getJsessionId() );
+    noopService.stopCallbackServer();
+  }
+
+  @Test
+  public void authenticateSetsAuthInProgressToTrue() {
+    BrowserAuthenticationService noopService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        // no-op
+      }
+    };
+
+    assertFalse( noopService.isAuthInProgress() );
+
+    noopService.authenticate( "http://server:8080/pentaho" );
+
+    assertTrue( noopService.isAuthInProgress() );
+    noopService.stopCallbackServer();
+  }
+
+  @Test
+  public void authenticateClearsAuthInProgressOnServerStartFailure() {
+    BrowserAuthenticationService failingService = new BrowserAuthenticationService() {
+      @Override HttpServer createHttpServer( int port ) throws IOException {
+        throw new IOException( "port in use" );
+      }
+    };
+
+    failingService.authenticate( "http://localhost:8080/pentaho" );
+
+    assertFalse( failingService.isAuthInProgress() );
+  }
+
+  @Test
+  public void authenticateClearsAuthInProgressOnBrowserOpenFailure() {
+    BrowserAuthenticationService failingService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) throws IOException {
+        throw new IOException( "no browser" );
+      }
+    };
+
+    failingService.authenticate( "http://localhost:8080/pentaho" );
+
+    assertFalse( failingService.isAuthInProgress() );
+  }
+
+  @Test
+  public void authenticatePassesAuthorizationUriToBuildUrl() {
+    final String[] capturedUrl = { null };
+    BrowserAuthenticationService capturingService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        capturedUrl[0] = url;
+      }
+    };
+
+    capturingService.authenticate( "http://localhost:8080/pentaho", "oauth2/authorization/azure" );
+
+    assertNotNull( capturedUrl[0] );
+    assertTrue( capturedUrl[0].contains( "authorizationUri=oauth2%2Fauthorization%2Fazure" ) );
+    capturingService.stopCallbackServer();
+  }
+
+  @Test
+  public void authenticateWithoutAuthorizationUriDoesNotIncludeParam() {
+    final String[] capturedUrl = { null };
+    BrowserAuthenticationService capturingService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        capturedUrl[0] = url;
+      }
+    };
+
+    capturingService.authenticate( "http://localhost:8080/pentaho" );
+
+    assertNotNull( capturedUrl[0] );
+    assertFalse( capturedUrl[0].contains( "authorizationUri" ) );
+    capturingService.stopCallbackServer();
+  }
+
+  @Test
+  public void cancelCurrentAuthClearsAuthInProgress() {
+    BrowserAuthenticationService noopService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        // no-op
+      }
+    };
+
+    noopService.authenticate( "http://server:8080/pentaho" );
+    assertTrue( noopService.isAuthInProgress() );
+
+    noopService.cancelCurrentAuth();
+
+    assertFalse( noopService.isAuthInProgress() );
+  }
+
+  @Test
+  public void cancelCurrentAuthCompletesExistingFutureExceptionally() {
+    BrowserAuthenticationService noopService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        // no-op
+      }
+    };
+
+    CompletableFuture<BrowserAuthenticationService.SessionInfo> future =
+      noopService.authenticate( "http://server:8080/pentaho" );
+
+    noopService.cancelCurrentAuth();
+
+    assertTrue( future.isCompletedExceptionally() );
+  }
+
+  @Test
+  public void cancelCurrentAuthAllowsNewAuthFlowToStart() {
+    BrowserAuthenticationService noopService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        // no-op
+      }
+    };
+
+    CompletableFuture<BrowserAuthenticationService.SessionInfo> first =
+      noopService.authenticate( "http://server:8080/pentaho" );
+
+    noopService.cancelCurrentAuth();
+
+    CompletableFuture<BrowserAuthenticationService.SessionInfo> second =
+      noopService.authenticate( "http://server:8080/pentaho" );
+
+    assertNotSame( first, second );
+    assertFalse( second.isDone() );
+    noopService.stopCallbackServer();
+  }
+
+  @Test
+  public void cancelCurrentAuthIsIdempotentWhenNoAuthInProgress() {
+    BrowserAuthenticationService noopService = new BrowserAuthenticationService();
+
+    assertFalse( noopService.isAuthInProgress() );
+
+    noopService.cancelCurrentAuth();
+
+    assertFalse( noopService.isAuthInProgress() );
+  }
+
+  @Test
+  public void cancelCurrentAuthStopsCallbackServer() {
+    final boolean[] serverStopped = { false };
+    BrowserAuthenticationService trackingService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        // no-op
+      }
+      @Override void stopCallbackServer() {
+        serverStopped[0] = true;
+        super.stopCallbackServer();
+      }
+    };
+
+    trackingService.authenticate( "http://server:8080/pentaho" );
+
+    trackingService.cancelCurrentAuth();
+
+    assertTrue( serverStopped[0] );
+  }
+
+  @Test
+  public void cancelCurrentAuthExceptionIsUserCancelledAuthException() throws Exception {
+    BrowserAuthenticationService noopService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        // no-op
+      }
+    };
+
+    CompletableFuture<BrowserAuthenticationService.SessionInfo> future =
+      noopService.authenticate( "http://server:8080/pentaho" );
+
+    noopService.cancelCurrentAuth();
+
+    try {
+      future.get();
+      fail( "Expected ExecutionException" );
+    } catch ( ExecutionException e ) {
+      assertTrue( e.getCause() instanceof BrowserAuthenticationService.UserCancelledAuthException );
+      assertTrue( e.getCause().getMessage().contains( "cancelled" ) );
+    }
+  }
+
+  @Test
+  public void cancelCurrentAuthDoesNotAffectAlreadyCompletedFuture() throws Exception {
+    BrowserAuthenticationService noopService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        // no-op
+      }
+    };
+
+    CompletableFuture<BrowserAuthenticationService.SessionInfo> future =
+      noopService.authenticate( "http://server:8080/pentaho" );
+
+    // Simulate successful callback completion before cancel
+    BrowserAuthenticationService.CallbackHandler handler = noopService.new CallbackHandler();
+    HttpExchange exchange = mockExchangeWithQuery( "jsessionid=SESSION_OK&username=admin" );
+    handler.handle( exchange );
+
+    assertFalse( future.isCompletedExceptionally() );
+
+    noopService.cancelCurrentAuth();
+
+    // Future should remain successfully completed — cancel does not overwrite
+    assertFalse( future.isCompletedExceptionally() );
+    assertEquals( "SESSION_OK", future.get().getJsessionId() );
+  }
+
+  @Test
+  public void cancelCurrentAuthIncrementsGenerationToPreventStaleCleanup() {
+    BrowserAuthenticationService noopService = new BrowserAuthenticationService() {
+      @Override void openSystemBrowser( String url ) {
+        // no-op
+      }
+    };
+
+    noopService.authenticate( "http://server:8080/pentaho" );
+    noopService.cancelCurrentAuth();
+
+    // After cancel, a new authenticate should work without the old whenComplete interfering
+    CompletableFuture<BrowserAuthenticationService.SessionInfo> second =
+      noopService.authenticate( "http://server:8080/pentaho" );
+
+    assertFalse( second.isDone() );
+    assertTrue( noopService.isAuthInProgress() );
+    noopService.stopCallbackServer();
+  }
+
+  @Test
+  public void isUserInitiatedCancellationReturnsTrueForUserCancelledException() {
+    Throwable ex = new BrowserAuthenticationService.UserCancelledAuthException( "cancelled" );
+    assertTrue( BrowserAuthenticationService.isUserInitiatedCancellation( ex ) );
+  }
+
+  @Test
+  public void isUserInitiatedCancellationReturnsTrueWhenWrappedInCompletionException() {
+    Throwable cause = new BrowserAuthenticationService.UserCancelledAuthException( "cancelled" );
+    Throwable wrapped = new CompletionException( cause );
+    assertTrue( BrowserAuthenticationService.isUserInitiatedCancellation( wrapped ) );
+  }
+
+  @Test
+  public void isUserInitiatedCancellationReturnsFalseForOtherExceptions() {
+    assertFalse( BrowserAuthenticationService.isUserInitiatedCancellation( new RuntimeException( "other" ) ) );
+  }
+
+  @Test
+  public void isUserInitiatedCancellationReturnsFalseForNull() {
+    assertFalse( BrowserAuthenticationService.isUserInitiatedCancellation( null ) );
+  }
+
+  @Test
+  public void isUserInitiatedCancellationReturnsTrueWhenDeeplyNestedInCompletionExceptions() {
+    Throwable root = new BrowserAuthenticationService.UserCancelledAuthException( "deep" );
+    Throwable mid = new CompletionException( root );
+    Throwable outer = new CompletionException( mid );
+    assertTrue( BrowserAuthenticationService.isUserInitiatedCancellation( outer ) );
+  }
+
+  @Test
+  public void isUserInitiatedCancellationReturnsTrueWhenWrappedInGenericException() {
+    Throwable cause = new BrowserAuthenticationService.UserCancelledAuthException( "wrapped" );
+    Throwable wrapper = new RuntimeException( "runtime", cause );
+    assertTrue( BrowserAuthenticationService.isUserInitiatedCancellation( wrapper ) );
+  }
+
+  @Test
+  public void isUserInitiatedCancellationReturnsFalseForCompletionExceptionWithoutUserCancelled() {
+    Throwable inner = new IOException( "network error" );
+    Throwable wrapped = new CompletionException( inner );
+    assertFalse( BrowserAuthenticationService.isUserInitiatedCancellation( wrapped ) );
+  }
+
+  @Test
+  public void isUserInitiatedCancellationReturnsFalseForExceptionWithNullCause() {
+    Throwable ex = new RuntimeException( "no cause" );
+    assertFalse( BrowserAuthenticationService.isUserInitiatedCancellation( ex ) );
+  }
+
+  @Test
+  public void isUserInitiatedCancellationReturnsFalseForCompletionExceptionWithNullCause() {
+    Throwable ex = new CompletionException( null );
+    assertFalse( BrowserAuthenticationService.isUserInitiatedCancellation( ex ) );
+  }
+
+  @Test
+  public void userCancelledAuthExceptionPreservesMessage() {
+    BrowserAuthenticationService.UserCancelledAuthException ex =
+      new BrowserAuthenticationService.UserCancelledAuthException( "Login cancelled by user to start a new login." );
+    assertEquals( "Login cancelled by user to start a new login.", ex.getMessage() );
+  }
+
+  @Test
+  public void userCancelledAuthExceptionIsAnException() {
+    BrowserAuthenticationService.UserCancelledAuthException ex =
+      new BrowserAuthenticationService.UserCancelledAuthException( "test" );
+    assertTrue( ex instanceof Exception );
+  }
+
+  @Test
+  public void userCancelledAuthExceptionAllowsNullMessage() {
+    BrowserAuthenticationService.UserCancelledAuthException ex =
+      new BrowserAuthenticationService.UserCancelledAuthException( null );
+    assertNull( ex.getMessage() );
+  }
+
+  @Test
   public void callbackPortIsPositive() {
     assertTrue( BrowserAuthenticationService.CALLBACK_PORT > 0 );
   }
@@ -427,11 +756,6 @@ public class BrowserAuthenticationServiceTest {
   }
 
   @Test
-  public void resolveCallbackHostUsesIpFromServerUrl() {
-    assertEquals( "192.168.1.50", service.resolveCallbackHost( "http://192.168.1.50:8080/pentaho" ) );
-  }
-
-  @Test
   public void resolveCallbackHostFallsBackToLocalhostForNullUrl() {
     assertEquals( "localhost", service.resolveCallbackHost( null ) );
   }
@@ -455,12 +779,6 @@ public class BrowserAuthenticationServiceTest {
     };
     assertEquals( "localhost", testService.resolveCallbackHost( "http://anything" ) );
   }
-
-  @Test
-  public void resolveCallbackHostUsesHostnameFromServerUrl() {
-    assertEquals( "myserver.example.com", service.resolveCallbackHost( "http://myserver.example.com:8080/pentaho" ) );
-  }
-
 
   @Test
   public void escapeHtmlEncodesAmpersand() {
@@ -510,6 +828,226 @@ public class BrowserAuthenticationServiceTest {
     } catch ( IOException e ) {
       assertTrue( e.getMessage().contains( "Port" ) );
     }
+  }
+
+  // ===== startCallbackServerWithRetry =====
+
+  @Test
+  public void startCallbackServerWithRetrySucceedsOnFirstAttempt() throws IOException {
+    final int[] attempts = { 0 };
+    BrowserAuthenticationService testService = new BrowserAuthenticationService() {
+      @Override void startCallbackServer() throws IOException {
+        attempts[0]++;
+      }
+    };
+
+    testService.startCallbackServerWithRetry();
+
+    assertEquals( 1, attempts[0] );
+  }
+
+  @Test
+  public void startCallbackServerWithRetryRetriesOnBindException() throws IOException {
+    final int[] attempts = { 0 };
+    BrowserAuthenticationService testService = new BrowserAuthenticationService() {
+      @Override void startCallbackServer() throws IOException {
+        attempts[0]++;
+        if ( attempts[0] < 3 ) {
+          throw new IOException( "address already in use", new BindException( "Address already in use" ) );
+        }
+      }
+    };
+
+    testService.startCallbackServerWithRetry();
+
+    assertEquals( 3, attempts[0] );
+  }
+
+  @Test
+  public void startCallbackServerWithRetrySucceedsOnSecondAttempt() throws IOException {
+    final int[] attempts = { 0 };
+    BrowserAuthenticationService testService = new BrowserAuthenticationService() {
+      @Override void startCallbackServer() throws IOException {
+        attempts[0]++;
+        if ( attempts[0] == 1 ) {
+          throw new IOException( "address already in use", new BindException( "Address already in use" ) );
+        }
+      }
+    };
+
+    testService.startCallbackServerWithRetry();
+
+    assertEquals( 2, attempts[0] );
+  }
+
+  @Test
+  public void startCallbackServerWithRetryThrowsImmediatelyForNonBindException() {
+    final int[] attempts = { 0 };
+    BrowserAuthenticationService testService = new BrowserAuthenticationService() {
+      @Override void startCallbackServer() throws IOException {
+        attempts[0]++;
+        throw new IOException( "permission denied" );
+      }
+    };
+
+    try {
+      testService.startCallbackServerWithRetry();
+      fail( "Expected IOException" );
+    } catch ( IOException e ) {
+      assertEquals( "permission denied", e.getMessage() );
+      assertEquals( 1, attempts[0] );
+    }
+  }
+
+  @Test
+  public void startCallbackServerWithRetryThrowsAfterMaxRetries() {
+    final int[] attempts = { 0 };
+    BrowserAuthenticationService testService = new BrowserAuthenticationService() {
+      @Override void startCallbackServer() throws IOException {
+        attempts[0]++;
+        throw new IOException( "address already in use", new BindException( "Address already in use" ) );
+      }
+    };
+
+    try {
+      testService.startCallbackServerWithRetry();
+      fail( "Expected IOException" );
+    } catch ( IOException e ) {
+      assertTrue( e.getMessage().contains( "address already in use" ) );
+      assertEquals( 5, attempts[0] );
+    }
+  }
+
+  @Test
+  public void startCallbackServerWithRetryThrowsOnLastAttemptWithBindException() {
+    BrowserAuthenticationService testService = new BrowserAuthenticationService() {
+      @Override void startCallbackServer() throws IOException {
+        throw new IOException( "Address already in use", new BindException( "Address already in use" ) );
+      }
+    };
+
+    try {
+      testService.startCallbackServerWithRetry();
+      fail( "Expected IOException" );
+    } catch ( IOException e ) {
+      assertTrue( e.getCause() instanceof BindException );
+    }
+  }
+
+  @Test
+  public void startCallbackServerWithRetryThrowsIOExceptionOnInterruptDuringSleep() {
+    final int[] attempts = { 0 };
+    BrowserAuthenticationService testService = new BrowserAuthenticationService() {
+      @Override void startCallbackServer() throws IOException {
+        attempts[0]++;
+        throw new IOException( "address already in use", new BindException( "Address already in use" ) );
+      }
+    };
+
+    Thread.currentThread().interrupt();
+
+    try {
+      testService.startCallbackServerWithRetry();
+      fail( "Expected IOException" );
+    } catch ( IOException e ) {
+      assertTrue( e.getMessage().contains( "Interrupted" ) );
+      assertTrue( e.getCause() instanceof InterruptedException );
+    } finally {
+      // Clear interrupted status
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void startCallbackServerWithRetryRestoresInterruptFlagOnInterrupt() {
+    final int[] attempts = { 0 };
+    BrowserAuthenticationService testService = new BrowserAuthenticationService() {
+      @Override void startCallbackServer() throws IOException {
+        attempts[0]++;
+        throw new IOException( "address already in use", new BindException( "Address already in use" ) );
+      }
+    };
+
+    Thread.currentThread().interrupt();
+
+    try {
+      testService.startCallbackServerWithRetry();
+      fail( "Expected IOException" );
+    } catch ( IOException e ) {
+      assertTrue( Thread.currentThread().isInterrupted() );
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void startCallbackServerWithRetryOnlyRetriesOnFirstAttemptBeforeInterrupt() {
+    final int[] attempts = { 0 };
+    BrowserAuthenticationService testService = new BrowserAuthenticationService() {
+      @Override void startCallbackServer() throws IOException {
+        attempts[0]++;
+        throw new IOException( "address already in use", new BindException( "Address already in use" ) );
+      }
+    };
+
+    Thread.currentThread().interrupt();
+
+    try {
+      testService.startCallbackServerWithRetry();
+      fail( "Expected IOException" );
+    } catch ( IOException e ) {
+      assertEquals( 1, attempts[0] );
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  // ===== isAddressAlreadyInUse =====
+
+  @Test
+  public void isAddressAlreadyInUseReturnsTrueForBindException() {
+    assertTrue( service.isAddressAlreadyInUse( new BindException( "Address already in use" ) ) );
+  }
+
+  @Test
+  public void isAddressAlreadyInUseReturnsTrueForNestedBindException() {
+    IOException wrapper = new IOException( "Failed to start", new BindException( "Address already in use" ) );
+    assertTrue( service.isAddressAlreadyInUse( wrapper ) );
+  }
+
+  @Test
+  public void isAddressAlreadyInUseReturnsTrueForMessageContainingAddressAlreadyInUse() {
+    IOException ex = new IOException( "Could not bind: Address already in use" );
+    assertTrue( service.isAddressAlreadyInUse( ex ) );
+  }
+
+  @Test
+  public void isAddressAlreadyInUseReturnsTrueForMessageCaseInsensitive() {
+    IOException ex = new IOException( "ADDRESS ALREADY IN USE" );
+    assertTrue( service.isAddressAlreadyInUse( ex ) );
+  }
+
+  @Test
+  public void isAddressAlreadyInUseReturnsFalseForUnrelatedIOException() {
+    assertFalse( service.isAddressAlreadyInUse( new IOException( "permission denied" ) ) );
+  }
+
+  @Test
+  public void isAddressAlreadyInUseReturnsFalseForNull() {
+    assertFalse( service.isAddressAlreadyInUse( null ) );
+  }
+
+  @Test
+  public void isAddressAlreadyInUseReturnsFalseForExceptionWithNullMessage() {
+    assertFalse( service.isAddressAlreadyInUse( new IOException( (String) null ) ) );
+  }
+
+  @Test
+  public void isAddressAlreadyInUseReturnsTrueForDeeplyNestedBindException() {
+    BindException bind = new BindException( "Address already in use" );
+    IOException mid = new IOException( "mid", bind );
+    RuntimeException outer = new RuntimeException( "outer", mid );
+    assertTrue( service.isAddressAlreadyInUse( outer ) );
   }
 
   @Test
@@ -881,6 +1419,33 @@ public class BrowserAuthenticationServiceTest {
 
     assertTrue( future.isCompletedExceptionally() );
     testService.stopCallbackServer();
+  }
+
+  @Test
+  public void getInstanceReturnsNonNull() {
+    BrowserAuthenticationService instance = BrowserAuthenticationService.getInstance();
+    assertNotNull( instance );
+  }
+
+  @Test
+  public void getInstanceReturnsSameInstanceOnMultipleCalls() {
+    BrowserAuthenticationService first = BrowserAuthenticationService.getInstance();
+    BrowserAuthenticationService second = BrowserAuthenticationService.getInstance();
+    assertSame( first, second );
+  }
+
+  @Test
+  public void getInstanceReturnsSameInstanceAcrossThreads() throws Exception {
+    CompletableFuture<BrowserAuthenticationService> future1 = CompletableFuture.supplyAsync(
+      BrowserAuthenticationService::getInstance );
+    CompletableFuture<BrowserAuthenticationService> future2 = CompletableFuture.supplyAsync(
+      BrowserAuthenticationService::getInstance );
+
+    BrowserAuthenticationService instance1 = future1.get();
+    BrowserAuthenticationService instance2 = future2.get();
+
+    assertNotNull( instance1 );
+    assertSame( instance1, instance2 );
   }
 }
 


### PR DESCRIPTION
[BACKLOG-500157]- Fix :Cancel existing auth flow and release callback port before initiating new browser login to prevent "Address already in use" BindException