### PR TITLE
[FUSE-562] Integrate CMS with pentaho-server's connection repository.

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/BaseDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/BaseDatabaseMeta.java
@@ -261,6 +261,7 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterfaceEx
 
   private static final String FIELDNAME_PROTECTOR = "_";
 
+  private String connectionId;
   private String name;
   private String displayName;
   private int accessType; // Database.TYPE_ODBC / NATIVE / OCI
@@ -363,6 +364,22 @@ public abstract class BaseDatabaseMeta implements Cloneable, DatabaseInterfaceEx
   @Override
   public void setChanged( boolean changed ) {
     this.changed = changed;
+  }
+
+  /**
+   * @return Returns the connection Id from the connection management service.
+   */
+  @Override
+  public String getConnectionId() {
+    return connectionId;
+  }
+
+  /**
+   * @param connectionId
+   *      The connection Id from the connection management service to set.
+   */
+  public void setConnectionId( String connectionId ) {
+    this.connectionId = connectionId;
   }
 
   /**

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
@@ -80,6 +80,17 @@ public interface DatabaseInterface extends Cloneable {
   void setChanged( boolean changed );
 
   /**
+   * @return Returns the connection Id from the connection management service.
+   */
+  String getConnectionId();
+
+  /**
+   * @param connectionId
+   *      The connection Id from the connection management service to set.
+   */
+  void setConnectionId( String connectionId );
+
+  /**
    * @return Returns the connection Name.
    */
   String getName();

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
@@ -610,6 +610,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     this.setServername( databaseMeta.getServername() );
     this.setDataTablespace( databaseMeta.getDataTablespace() );
     this.setIndexTablespace( databaseMeta.getIndexTablespace() );
+    this.setConnectionId( databaseMeta.getConnectionId() );
 
     this.databaseInterface = (DatabaseInterface) databaseMeta.databaseInterface.clone();
 
@@ -668,6 +669,25 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
 
   public void setValues( DatabaseMeta info ) {
     databaseInterface = (DatabaseInterface) info.databaseInterface.clone();
+  }
+
+  /**
+   * Sets the Id of the database connection from the connection management service.
+   *
+   * @param connectionId
+   *          The Id of the database connection.
+   */
+  public void setConnectionId( String connectionId ) {
+    databaseInterface.setConnectionId( connectionId );
+  }
+
+  /**
+   * Returns the Id of the database connection from the connection management service.
+   *
+   * @return The Id of the database connection.
+   */
+  public String getConnectionId() {
+    return databaseInterface.getConnectionId();
   }
 
   /**
@@ -1048,6 +1068,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
     StringBuilder retval = new StringBuilder( 250 );
 
     retval.append( "  <" ).append( XML_TAG ).append( '>' ).append( Const.CR );
+    retval.append( "    " ).append( XMLHandler.addTagValue( "connection_id", getConnectionId() ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "name", getName() ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "server", getHostname() ) );
     retval.append( "    " ).append( XMLHandler.addTagValue( "type", getPluginId() ) );

--- a/core/src/test/java/org/pentaho/di/core/database/DatabaseMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/DatabaseMetaTest.java
@@ -451,4 +451,35 @@ public class DatabaseMetaTest {
     verify( databaseInterface ).getSQLListOfSchemas( databaseMeta );
   }
 
+  @Test
+  public void testSetDatabaseType() {
+    DatabaseMeta dbmeta = new DatabaseMeta( "test", "Oracle", "JDBC", "localhost", "stuff", "5432", "jerry", null );
+    assertEquals( "Oracle", dbmeta.getDatabaseInterface().getPluginName() );
+
+    dbmeta.setDatabaseType( "Redshift" );
+
+    assertEquals( "Redshift", dbmeta.getDatabaseInterface().getPluginName() );
+    assertEquals( "test", dbmeta.getName() );
+    assertEquals( DatabaseMeta.getAccessType( "JDBC" ), dbmeta.getAccessType() );
+    assertEquals( "stuff", dbmeta.getDatabaseName() );
+    assertEquals( "localhost", dbmeta.getHostname() );
+    assertEquals( "5432", dbmeta.getDatabasePortNumberString() );
+    assertEquals( "jerry", dbmeta.getUsername() );
+  }
+
+  @Test
+  public void testReplaceMeta() {
+    DatabaseMeta origMeta = new DatabaseMeta( "test1", "Oracle", "JDBC", "localhost1", "stuff1", "0000", "Marry", null );
+    DatabaseMeta dbmeta = new DatabaseMeta( "test", "Redshift", "JDBC", "localhost", "stuff", "5432", "Jerry", null );
+
+    origMeta.replaceMeta( dbmeta, true );
+
+    assertEquals( "Redshift", origMeta.getDatabaseInterface().getPluginName() );
+    assertEquals( "test", origMeta.getName() );
+    assertEquals( DatabaseMeta.getAccessType( "JDBC" ), origMeta.getAccessType() );
+    assertEquals( "stuff", origMeta.getDatabaseName() );
+    assertEquals( "localhost", origMeta.getHostname() );
+    assertEquals( "5432", origMeta.getDatabasePortNumberString() );
+    assertEquals( "Jerry", origMeta.getUsername() );
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
+++ b/engine/src/main/java/org/pentaho/di/repository/RepositoryImporter.java
@@ -386,41 +386,49 @@ public class RepositoryImporter implements IRepositoryImporter, CanLimitDirs {
    * Adapted from KettleDatabaseRepositoryDatabaseDelegate.saveDatabaseMeta
    */
   protected boolean equals( DatabaseMeta databaseMeta, DatabaseMeta databaseMeta2 ) {
-    if ( !equals( databaseMeta.getName(), databaseMeta2.getName() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getPluginId(), databaseMeta2.getPluginId() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getAccessType(), databaseMeta2.getAccessType() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getHostname(), databaseMeta2.getHostname() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getDatabaseName(), databaseMeta2.getDatabaseName() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getDatabasePortNumberString(), databaseMeta2.getDatabasePortNumberString() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getUsername(), databaseMeta2.getUsername() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getPassword(), databaseMeta2.getPassword() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getServername(), databaseMeta2.getServername() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getDataTablespace(), databaseMeta2.getDataTablespace() ) ) {
-      return false;
-    } else if ( !equals( databaseMeta.getIndexTablespace(), databaseMeta2.getIndexTablespace() ) ) {
+    if ( !areDbMetaFieldsEqual( databaseMeta, databaseMeta2) ) {
       return false;
     }
-    Map<Object, Object> databaseMeta2Attributes = new HashMap<Object, Object>( databaseMeta2.getAttributes() );
-    for ( Entry<Object, Object> databaseMetaEntry : new HashMap<Object, Object>( databaseMeta.getAttributes() )
+    Map<Object, Object> databaseMeta2Attributes = new HashMap<>( databaseMeta2.getAttributes() );
+    for ( Entry<Object, Object> databaseMetaEntry : new HashMap<>( databaseMeta.getAttributes() )
         .entrySet() ) {
       Object value = databaseMeta2Attributes.remove( databaseMetaEntry.getKey() );
       if ( !equals( value, databaseMetaEntry.getValue() ) ) {
         return false;
       }
     }
-    if ( databaseMeta2Attributes.size() > 0 ) {
-      return false;
-    }
-    return true;
+
+    return databaseMeta2Attributes.isEmpty();
+  }
+
+  private boolean areDbMetaFieldsEqual( DatabaseMeta databaseMeta, DatabaseMeta databaseMeta2) {
+      if ( !equals( databaseMeta.getName(), databaseMeta2.getName() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getPluginId(), databaseMeta2.getPluginId() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getAccessType(), databaseMeta2.getAccessType() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getHostname(), databaseMeta2.getHostname() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getDatabaseName(), databaseMeta2.getDatabaseName() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getDatabasePortNumberString(), databaseMeta2.getDatabasePortNumberString() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getUsername(), databaseMeta2.getUsername() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getPassword(), databaseMeta2.getPassword() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getServername(), databaseMeta2.getServername() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getDataTablespace(), databaseMeta2.getDataTablespace() ) ) {
+          return false;
+      } else if ( !equals( databaseMeta.getIndexTablespace(), databaseMeta2.getIndexTablespace() ) ) {
+          return false;
+      } else if (!equals( databaseMeta.getConnectionId(), databaseMeta2.getConnectionId() ) ) {
+          return false;
+      }
+
+      return true;
   }
 
   protected boolean equals( SlaveServer slaveServer, SlaveServer slaveServer2 ) {

--- a/engine/src/test/java/org/pentaho/di/repository/RepositoriesMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/repository/RepositoriesMetaTest.java
@@ -99,6 +99,7 @@ public class RepositoriesMetaTest {
     String repositoriesXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + Const.CR
       + "<repositories>" + Const.CR
       + "  <connection>" + Const.CR
+      + "    <connection_id/>" + Const.CR
       + "    <name>local postgres</name>" + Const.CR
       + "    <server>localhost</server>" + Const.CR
       + "    <type>POSTGRESQL</type>" + Const.CR

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/DatabaseDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/DatabaseDelegate.java
@@ -39,6 +39,7 @@ public class DatabaseDelegate extends AbstractDelegate implements ITransformer, 
 
   // ~ Static fields/initializers ======================================================================================
 
+  private static final String CONNECTION_ID = "CONNECTION_ID";
   private static final String PROP_INDEX_TBS = "INDEX_TBS";
   private static final String PROP_DATA_TBS = "DATA_TBS";
   private static final String PROP_SERVERNAME = "SERVERNAME";
@@ -94,6 +95,7 @@ public class DatabaseDelegate extends AbstractDelegate implements ITransformer, 
     rootNode.setProperty( PROP_SERVERNAME, databaseMeta.getServername() );
     rootNode.setProperty( PROP_DATA_TBS, databaseMeta.getDataTablespace() );
     rootNode.setProperty( PROP_INDEX_TBS, databaseMeta.getIndexTablespace() );
+    rootNode.setProperty( CONNECTION_ID, databaseMeta.getConnectionId() );
 
     rootNode.setProperty( PROP_CONNECT_SQL, setNull( databaseMeta.getConnectSQL() ) );
     rootNode.setProperty( PROP_INITIAL_POOL_SIZE, databaseMeta.getInitialPoolSize() );
@@ -159,6 +161,7 @@ public class DatabaseDelegate extends AbstractDelegate implements ITransformer, 
     databaseMeta.setServername( getString( rootNode, PROP_SERVERNAME ) );
     databaseMeta.setDataTablespace( getString( rootNode, PROP_DATA_TBS ) );
     databaseMeta.setIndexTablespace( getString( rootNode, PROP_INDEX_TBS ) );
+    databaseMeta.setConnectionId( getString( rootNode, CONNECTION_ID ) );
 
     databaseMeta.setConnectSQL( getString( rootNode, PROP_CONNECT_SQL ) );
     databaseMeta.setInitialPoolSize( getInt( rootNode, PROP_INITIAL_POOL_SIZE ) );

--- a/plugins/pur/core/src/test/java/org/pentaho/di/repository/RepositoryTestBase.java
+++ b/plugins/pur/core/src/test/java/org/pentaho/di/repository/RepositoryTestBase.java
@@ -201,6 +201,8 @@ public abstract class RepositoryTestBase extends RepositoryTestLazySupport {
 
   protected static final String EXP_DBMETA_INDEX_TABLESPACE = "indexTablespace";
 
+  protected static final String EXP_CONNECTION_ID = "connectionId";
+
   protected static final String EXP_SLAVE_NAME = "slave54545";
 
   protected static final String EXP_SLAVE_HOSTNAME = "slave98745";
@@ -1177,6 +1179,7 @@ public abstract class RepositoryTestBase extends RepositoryTestLazySupport {
     dbMeta.setServername( EXP_DBMETA_SERVERNAME );
     dbMeta.setDataTablespace( EXP_DBMETA_DATA_TABLESPACE );
     dbMeta.setIndexTablespace( EXP_DBMETA_INDEX_TABLESPACE );
+    dbMeta.setConnectionId( EXP_CONNECTION_ID );
     // Properties attrs = new Properties();
     // exposed mutable state; yikes
     dbMeta.getAttributes().put( EXP_DBMETA_ATTR1_KEY, EXP_DBMETA_ATTR1_VALUE );
@@ -1201,22 +1204,7 @@ public abstract class RepositoryTestBase extends RepositoryTestLazySupport {
     assertTrue( repository.exists( EXP_DBMETA_NAME, null, RepositoryObjectType.DATABASE ) );
 
     DatabaseMeta fetchedDatabase = repository.loadDatabaseMeta( dbMeta.getObjectId(), null );
-    assertEquals( EXP_DBMETA_NAME, fetchedDatabase.getName() );
-    assertEquals( EXP_DBMETA_HOSTNAME, fetchedDatabase.getHostname() );
-    assertEquals( EXP_DBMETA_TYPE, fetchedDatabase.getPluginId() );
-    assertEquals( EXP_DBMETA_ACCESS, fetchedDatabase.getAccessType() );
-    assertEquals( EXP_DBMETA_DBNAME, fetchedDatabase.getDatabaseName() );
-    assertEquals( EXP_DBMETA_PORT, fetchedDatabase.getDatabasePortNumberString() );
-    assertEquals( EXP_DBMETA_USERNAME, fetchedDatabase.getUsername() );
-    assertEquals( EXP_DBMETA_PASSWORD, fetchedDatabase.getPassword() );
-    assertEquals( EXP_DBMETA_SERVERNAME, fetchedDatabase.getServername() );
-    assertEquals( EXP_DBMETA_DATA_TABLESPACE, fetchedDatabase.getDataTablespace() );
-    assertEquals( EXP_DBMETA_INDEX_TABLESPACE, fetchedDatabase.getIndexTablespace() );
-
-    // 2 for the ones explicitly set and 1 for port (set behind the scenes) + 10 defaults
-    assertEquals( 2 + 1 + 10, fetchedDatabase.getAttributes().size() );
-    assertEquals( EXP_DBMETA_ATTR1_VALUE, fetchedDatabase.getAttributes().getProperty( EXP_DBMETA_ATTR1_KEY ) );
-    assertEquals( EXP_DBMETA_ATTR2_VALUE, fetchedDatabase.getAttributes().getProperty( EXP_DBMETA_ATTR2_KEY ) );
+    assertDbMetaCorrect( fetchedDatabase );
 
     dbMeta.setHostname( EXP_DBMETA_HOSTNAME_V2 );
     repository.save( dbMeta, VERSION_COMMENT_V2, null );
@@ -1250,6 +1238,26 @@ public abstract class RepositoryTestBase extends RepositoryTestLazySupport {
     assertEquals( 0, repository.getDatabaseNames( true ).length );
 
     assertEquals( 0, repository.readDatabases().size() );
+  }
+
+  private void assertDbMetaCorrect( DatabaseMeta meta) {
+    assertEquals( EXP_DBMETA_NAME, meta.getName() );
+    assertEquals( EXP_DBMETA_HOSTNAME, meta.getHostname() );
+    assertEquals( EXP_DBMETA_TYPE, meta.getPluginId() );
+    assertEquals( EXP_DBMETA_ACCESS, meta.getAccessType() );
+    assertEquals( EXP_DBMETA_DBNAME, meta.getDatabaseName() );
+    assertEquals( EXP_DBMETA_PORT, meta.getDatabasePortNumberString() );
+    assertEquals( EXP_DBMETA_USERNAME, meta.getUsername() );
+    assertEquals( EXP_DBMETA_PASSWORD, meta.getPassword() );
+    assertEquals( EXP_DBMETA_SERVERNAME, meta.getServername() );
+    assertEquals( EXP_DBMETA_DATA_TABLESPACE, meta.getDataTablespace() );
+    assertEquals( EXP_DBMETA_INDEX_TABLESPACE, meta.getIndexTablespace() );
+    assertEquals( EXP_CONNECTION_ID, meta.getConnectionId() );
+
+    // 2 for the ones explicitly set and 1 for port (set behind the scenes) + 10 defaults
+    assertEquals( 2 + 1 + 10, meta.getAttributes().size() );
+    assertEquals( EXP_DBMETA_ATTR1_VALUE, meta.getAttributes().getProperty( EXP_DBMETA_ATTR1_KEY ) );
+    assertEquals( EXP_DBMETA_ATTR2_VALUE, meta.getAttributes().getProperty( EXP_DBMETA_ATTR2_KEY ) );
   }
 
   protected boolean hasVersionWithComment( final RepositoryElementInterface element, final String comment )

--- a/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/DatabaseDelegateTest.java
+++ b/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/DatabaseDelegateTest.java
@@ -61,6 +61,7 @@ public class DatabaseDelegateTest {
     when( dbMeta.getServername() ).thenReturn( "as400.dot.com" );
     when( dbMeta.getDataTablespace() ).thenReturn( "tableSpace" );
     when( dbMeta.getIndexTablespace() ).thenReturn( "123" );
+    when( dbMeta.getConnectionId() ).thenReturn( "testConnectionId" );
 
     // Create an extra options that has an unsupported character like '/'
     Properties extraOptions = new Properties();


### PR DESCRIPTION
### [FUSE-562](https://hv-eng.atlassian.net/browse/FUSE-562)

In order to add support of the [connection-management-service](https://github.com/pentaho/connection-management-service)'s connections to the data-access service, we need to add a new field to the DatabaseMeta which will specify the connection Id from the connection-management-service. This Id will later be used to retrieve actual connection metadata and perform requested operations.

### What was changed?
Added new field to the DatabaseMeta and the DatabaseInterface classes, added calls to this field to some necessary methods.

[FUSE-562]: https://hv-eng.atlassian.net/browse/FUSE-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ