### PR TITLE
fix[PPP-6483]: Remove Flexjson from pentaho-kettle

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -39,7 +39,6 @@
     <asm.version>3.2</asm.version>
     <blueprints-core.version>2.6.0</blueprints-core.version>
     <commons-configuration.version>1.9</commons-configuration.version>
-    <flexjson.version>2.1</flexjson.version>
     <mimepull.version>1.9.3</mimepull.version>
     <enunciate-jersey-rt.version>1.27</enunciate-jersey-rt.version>
     <enunciate-core-annotations.version>1.27</enunciate-core-annotations.version>
@@ -528,17 +527,6 @@
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
       <version>${commons-configuration.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.flexjson</groupId>
-      <artifactId>flexjson</artifactId>
-      <version>${flexjson.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
## Summary

- Dependency: flexjson
- Target version: removal
- Change type: dependency removal

## Validation

- Base branch: master
- Maven build: passed

## Notes

- Removed flexjson.version property and Flexjson dependency block from assemblies/lib/pom.xml
- No Java code changes required; Flexjson was only a transitive assembly dependency