### PR TITLE
[BACKLOG-50243] - update tree when refreshing caches

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -5078,6 +5078,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     fileDialogOperation.setPath(userHomeDir);
     fileDialogOperation.setProvider(ProviderFilterType.LOCAL.toString());
   }
+
   public boolean saveAsNew( EngineMetaInterface meta, boolean export, String providerFilter
           , String fileFilterType, String command ) {
     FileDialogOperation fileDialogOperation =
@@ -5226,9 +5227,8 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     // does the file exist? If not, show an error dialog
     boolean fileExists = false;
     boolean loaded = false;
-    clearBowlCaches();
-
-    if ( rep != null && !importFile && !forceLocalFile ) {
+    boolean loadFromRepository = rep != null && !importFile && !forceLocalFile;
+    if ( loadFromRepository ) {
       // load from the repository
       try {
         Path filePath = Paths.get( filename );
@@ -5257,6 +5257,9 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
         // nothing to do, not loaded will be handled below
       }
     } else {
+      // Repository opens refresh as part of loadObjectFromRepository, so pre-refresh only local/VFS/import paths.
+      forceRefreshTree();
+
       FileObject file = null;
       try {
         file = KettleVFS.getInstance( executionBowl ).getFileObject( filename, variableSpace );
@@ -6395,7 +6398,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       }
     }
     // make sure we export the latest config
-    clearBowlCaches();
+    forceRefreshTree();
     RepositoryExportProgressDialog repd =
       new RepositoryExportProgressDialog( shell, rep, directoryToExport, filename, importRules );
     repd.open();
@@ -6474,8 +6477,8 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       }
     }
 
-    // make sure any config import decisions are based on the latest state. 
-    clearBowlCaches();
+    // make sure any config import decisions are based on the latest state.
+    forceRefreshTree();
 
     String[] filenames = dialog.getFileNames();
     if ( filenames.length > 0 ) {
@@ -6752,6 +6755,8 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
     }
 
     if ( listener != null ) {
+      // update config and left hand tree so exported contents are up-to-date
+      forceRefreshTree();
       String sync = BasePropertyHandler.getProperty( SYNC_TRANS );
       if ( Boolean.parseBoolean( sync ) ) {
         listener.syncMetaName( meta, Const.createName( filename ) );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/job/JobGraph.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/job/JobGraph.java
@@ -3491,7 +3491,7 @@ public class JobGraph extends AbstractGraph implements XulEventHandler, Redrawab
             }
 
             JobMeta runJobMeta;
-            spoon.clearBowlCaches();
+            spoon.forceRefreshTree();
 
             if ( spoon.rep != null ) {
               runJobMeta = spoon.rep.loadJob( jobMeta.getName(), jobMeta.getRepositoryDirectory(), null, null );

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGraph.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGraph.java
@@ -3843,8 +3843,8 @@ public class TransGraph extends AbstractGraph implements XulEventHandler, Redraw
           // memory
           // To be able to completely test this, we need to run it as we would normally do in pan
           //
-          // clear caches before loading the new meta
-          spoon.clearBowlCaches();
+          // Refresh config tree state before loading the new meta.
+          spoon.forceRefreshTree();
 
           trans = DefaultTransFactoryManager.getInstance().getTransFactory( executionConfiguration.getRunConfiguration() )
             .create( transMeta, spoon.rep, transMeta.getName(), transMeta.getRepositoryDirectory().getPath(),
@@ -3996,8 +3996,8 @@ public class TransGraph extends AbstractGraph implements XulEventHandler, Redraw
 
         // Create a new transformation to execution
         //
-        // clear caches before beginning execution
-        spoon.clearBowlCaches();
+        // Refresh config tree state before beginning execution.
+        spoon.forceRefreshTree();
         trans = new Trans( transMeta );
         trans.setSafeModeEnabled( executionConfiguration.isSafeModeEnabled() );
         trans.setPreview( true );


### PR DESCRIPTION
Several locations that were only updating the caches are now also updating the left hand tree so the view reflects the internal state.