### PR TITLE
fix(security): org.hsqldb:hsqldb -> 2.7.2 (org.hsqldb:hsqldb:2.3.2)

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -31,7 +31,7 @@
     <pentaho-hadoop-shims.version>11.1.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
 
     <!-- third party -->
-    <hsqldb.version>2.3.2</hsqldb.version>
+    <hsqldb.version>2.7.2</hsqldb.version>
     <jaybird.version>2.1.6</jaybird.version>
     <jt400.version>6.1</jt400.version>
     <LucidDbClient-minimal.version>0.9.4</LucidDbClient-minimal.version>


### PR DESCRIPTION
## Security Remediation Summary

- Vulnerability: org.hsqldb:hsqldb:2.3.2
- Repository: https://github.com/pentaho/pentaho-kettle.git
- Base branch: master
- Source branch: Vulnerability-Agent-4
- Dependency: org.hsqldb:hsqldb
- Target safe version: 2.7.2
- Affected occurrences found: 1
- Files changed: 1

## Root Cause
Analyzing a Java Maven dependency vulnerability involves understanding the context of the vulnerability, the specific artifact in question, and the potential root causes. In this case, the vulnerability is associated with the `org.hsqldb:hsqldb:2.3.2` artifact.

### Vulnerability Overview
- **Artifact**: `org.hsqldb:hsqldb`
- **Version**: `2.3.2`
- **Findings**: 1 (indicating that there is at least one known vulnerability associated with this version)

### Common Vulnerabilities in HSQLDB
HSQLDB (HyperSQL Database) is a relational database management system written in Java. Vulnerabilities in database systems can include:
- SQL injection vulnerabilities
- Denial of service (DoS) attacks
- Insecure default configurations
- Data exposure due to improper access controls

### Root Cause Analysis
1. **Versioning**: The version `2.3.2` is relatively old, and it is common for older versions of libraries to have known vulnerabilities that have been patched in later releases. The root cause of the vulnerability could be that the application is using an outdated version of HSQLDB.

2. **Dependency Management**: If the project does not have proper dependency management practices, it may inadvertently include outdated or vulnerable versions of libraries. This can happen if:
   - The project does not specify a version range for dependencies.
   - Transitive dependencies are not managed correctly, leading to the inclusion of vulnerable versions.

3. **Configuration Issues**: The error message `dependency:tree execution failed: Error configuring command line` suggests that there may be issues with the Maven configuration itself. This could be due to:
   - Incorrectly specified command-line arguments.
   - Issues in the `pom.xml` file that prevent Maven from resolving dependencies correctly.
   - Conflicts between different versions of dependencies.

### Steps to Mitigate the Vulnerability
1. **Upgrade the Dependency**: Check for the latest version of HSQLDB and upgrade to a version that has addressed the known vulnerabilities. As of my last knowledge update, the latest version was beyond `2.3.2`, so upgrading is likely to resolve the issue.

2. **Review Dependency Tree**: Use the command `mvn dependency:tree` to analyze the project's dependencies and identify any transitive dependencies that may also be vulnerable. Ensure that all dependencies are up to date.

3. **Use Dependency Management Tools**: Consider using tools like OWASP Dependency-Check or Snyk to automatically scan for vulnerabilities in dependencies and provide recommendations for upgrades.

4. **Fix Configuration Issues**: Review the Maven command and `pom.xml` file for any misconfigurations. Ensure that the command is correctly formatted and that the `pom.xml` is valid.

5. **Regular Audits**: Implement a regular audit process for dependencies to ensure that all libraries are up to date and free from known vulnerabilities.

### Conclusion
The vulnerability associated with `org.hsqldb:hsqldb:2.3.2` is likely due to the use of an outdated version of the library. Upgrading to a newer version, reviewing the dependency tree, and ensuring proper configuration will help mitigate the risk associated with this vulnerability. Regular audits and the use of automated tools can further enhance the security posture of the application.

## Compatibility Risk
Upgrading the `org.hsqldb:hsqldb` dependency to version 2.7.2 in a Spring Boot 3.x and Java 21 project involves several considerations regarding compatibility risks. Here are the key factors to assess:

### 1. **Spring Boot Compatibility**
   - **Spring Boot 3.x**: Ensure that the version of HSQLDB you are upgrading to is compatible with Spring Boot 3.x. Spring Boot 3.x typically supports newer versions of libraries, but you should check the Spring Boot documentation or release notes for any specific compatibility notes regarding HSQLDB.
   - **Spring Data JPA**: If you are using Spring Data JPA, verify that the version of HSQLDB works well with the JPA provider you are using (e.g., Hibernate).

### 2. **Java Version Compatibility**
   - **Java 21**: HSQLDB 2.7.2 should be compatible with Java 21, but it’s essential to check the release notes or documentation for any specific mentions of Java version compatibility. Ensure that there are no deprecated features or APIs that might affect your application.

### 3. **Breaking Changes**
   - Review the release notes for HSQLDB from your current version to 2.7.2. Look for any breaking changes, deprecated features, or removed functionalities that could impact your application.
   - Pay attention to changes in SQL syntax, data types, or behavior of existing functions that might affect your database interactions.

### 4. **Testing**
   - **Unit and Integration Tests**: Run your existing test suite to identify any issues that arise from the upgrade. Pay special attention to tests that involve database interactions.
   - **Migration Scripts**: If you have any database migration scripts, ensure they are still valid and compatible with the new version of HSQLDB.

### 5. **Performance Considerations**
   - Check if there are any performance improvements or regressions noted in the release notes. Sometimes, newer versions can introduce changes that affect performance.

### 6. **Community Feedback**
   - Look for community feedback or issues reported by other users who have upgraded to HSQLDB 2.7.2. This can provide insights into potential pitfalls or common issues encountered during the upgrade.

### 7. **Dependencies**
   - Ensure that other dependencies in your project do not have conflicts with HSQLDB 2.7.2. This includes checking for transitive dependencies that might be affected by the upgrade.

### Conclusion
To summarize, upgrading to HSQLDB 2.7.2 in a Spring Boot 3.x and Java 21 project is generally feasible, but it requires careful assessment of compatibility risks. The best approach is to review the release notes, run thorough tests, and monitor for any issues that arise during the upgrade process. If possible, consider performing the upgrade in a staging environment before deploying to production.

## Validation

- Build success: false
- Test success: false

## Changed Files

- assemblies\lib\pom.xml: 2.3.2 -> 2.7.2 (Upgrade minimum safe version)

---
Generated by vulnerability remediation agent.