### PR TITLE
fix(security): org.hsqldb:hsqldb -> 2.7.2 (org.hsqldb:hsqldb:2.3.2)

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -31,7 +31,7 @@
     <pentaho-hadoop-shims.version>11.1.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
 
     <!-- third party -->
-    <hsqldb.version>2.3.2</hsqldb.version>
+    <hsqldb.version>2.7.2</hsqldb.version>
     <jaybird.version>2.1.6</jaybird.version>
     <jt400.version>6.1</jt400.version>
     <LucidDbClient-minimal.version>0.9.4</LucidDbClient-minimal.version>


### PR DESCRIPTION
## Security Remediation Summary

- Vulnerability: org.hsqldb:hsqldb:2.3.2
- Repository: https://github.com/pentaho/pentaho-kettle.git
- Base branch: master
- Source branch: Vulnerability-Agent-6
- Dependency: org.hsqldb:hsqldb
- Target safe version: 2.7.2
- Affected occurrences found: 1
- Files changed: 1

## Root Cause
To analyze the Java Maven dependency vulnerability related to `org.hsqldb:hsqldb:2.3.2`, we need to break down the components of the issue and understand the potential root causes.

### 1. **Understanding the Vulnerability**
The artifact in question is `org.hsqldb:hsqldb` version `2.3.2`. HSQLDB (HyperSQL DataBase) is a relational database management system written in Java. Vulnerabilities in database libraries can lead to various security issues, including SQL injection, data leakage, or denial of service.

### 2. **Identifying the Findings**
The mention of "findings=1" indicates that there is at least one known vulnerability associated with this specific version of HSQLDB. To understand the nature of the vulnerability, you would typically look it up in a vulnerability database (like the National Vulnerability Database, CVE Details, or similar) to find details about the specific issue, its severity, and any recommended mitigations or patches.

### 3. **Dependency Tree Execution Failure**
The error message "dependency:tree execution failed: Error configuring command line" suggests that there was an issue when trying to execute the Maven command to generate the dependency tree. This could be due to several reasons:

- **Incorrect Command Syntax**: Ensure that the command used to generate the dependency tree is correct. The typical command is:
  ```bash
  mvn dependency:tree
  ```

- **Maven Configuration Issues**: There may be issues in the `pom.xml` file or in the Maven settings that prevent the command from executing properly. Check for:
  - Missing or incorrect repository configurations.
  - Conflicting dependencies or plugin versions.
  - Issues with the local Maven repository (e.g., corrupted files).

- **Network Issues**: If Maven is trying to resolve dependencies from remote repositories, ensure that there are no network issues preventing access to those repositories.

- **Maven Version**: Ensure that you are using a compatible version of Maven that supports the plugins and dependencies defined in your project.

### 4. **Root Cause Analysis**
To analyze the root cause of the vulnerability and the command failure, follow these steps:

1. **Check the Vulnerability**: Look up the specific vulnerability associated with `org.hsqldb:hsqldb:2.3.2`. Identify the nature of the vulnerability and whether it has been fixed in later versions.

2. **Update the Dependency**: If a newer, patched version of HSQLDB is available, consider updating the dependency in your `pom.xml` file. For example:
   ```xml
   <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <version>2.5.2</version> <!-- Example of a newer version -->
   </dependency>
   ```

3. **Run Dependency Tree Command**: After making changes, try running the dependency tree command again. If it fails, check the error logs for more specific messages that can guide troubleshooting.

4. **Review Maven Configuration**: Ensure that your Maven setup is correct. Check the `settings.xml` file for any misconfigurations.

5. **Consult Documentation**: If issues persist, consult the Maven documentation or community forums for guidance on the specific error encountered.

### Conclusion
The vulnerability in `org.hsqldb:hsqldb:2.3.2` should be addressed by updating to a secure version if available. The command execution failure needs to be diagnosed by checking command syntax, Maven configuration, and network connectivity. By following these steps, you can mitigate the vulnerability and resolve the command execution issue.

## Compatibility Risk
Upgrading the `org.hsqldb:hsqldb` dependency to version 2.7.2 in a Spring Boot 3.x and Java 21 project involves several considerations regarding compatibility risks. Here’s a structured assessment:

### 1. **Spring Boot Compatibility**
   - **Spring Boot 3.x**: Spring Boot 3.x is designed to work with Java 17 and above, including Java 21. HSQLDB 2.7.2 is compatible with Java 8 and above, so there should be no issues on this front.
   - **Spring Data JPA**: If you are using Spring Data JPA, ensure that the version you are using is compatible with HSQLDB 2.7.2. Generally, Spring Data JPA should work well with HSQLDB, but it's good to check the specific version compatibility.

### 2. **HSQLDB Changes**
   - **Version Changes**: Review the release notes for HSQLDB 2.7.2 to identify any breaking changes or deprecated features from the previous version you are using. HSQLDB has had various updates, and while many are backward-compatible, there may be specific changes that could affect your application.
   - **SQL Syntax and Features**: Ensure that any SQL syntax or features you are using in your application are still supported in 2.7.2. Check for any changes in behavior, especially if you are using advanced features or specific configurations.

### 3. **Java Compatibility**
   - **Java 21 Features**: Ensure that your codebase does not rely on deprecated or removed features in Java 21 that may affect the interaction with HSQLDB. While HSQLDB 2.7.2 should work with Java 21, it’s essential to test your application thoroughly.

### 4. **Testing**
   - **Unit and Integration Tests**: Run your existing unit and integration tests to identify any issues that arise from the upgrade. Pay special attention to tests that involve database interactions.
   - **Performance Testing**: If your application has performance-sensitive components, consider running performance tests to ensure that the upgrade does not introduce any regressions.

### 5. **Dependencies**
   - **Transitive Dependencies**: Check for any transitive dependencies that may be affected by the upgrade. Use tools like Maven's `dependency:tree` or Gradle's `dependencies` task to analyze your dependency graph.
   - **Other Database Libraries**: If you are using other libraries that interact with HSQLDB, ensure they are compatible with version 2.7.2.

### 6. **Configuration Changes**
   - **Configuration Files**: Review your configuration files (e.g., `application.properties` or `application.yml`) for any settings that may need to be updated or adjusted based on the new version.

### 7. **Documentation and Community Feedback**
   - **Documentation**: Review the official HSQLDB documentation for version 2.7.2 for any migration notes or important changes.
   - **Community Feedback**: Look for community discussions, issues, or reports regarding the upgrade to gather insights on potential pitfalls or common issues encountered by others.

### Conclusion
While upgrading to HSQLDB 2.7.2 in a Spring Boot 3.x and Java 21 environment is generally feasible, it is crucial to conduct thorough testing and review the release notes for any breaking changes. By following best practices for dependency management and testing, you can mitigate compatibility risks effectively.

## Validation

- Build success: false
- Test success: false

## Changed Files

- assemblies\lib\pom.xml: 2.3.2 -> 2.7.2 (Upgrade minimum safe version)

---
Generated by vulnerability remediation agent.