### PR TITLE
fix(security): org.hsqldb:hsqldb -> 2.7.2 (org.hsqldb:hsqldb:2.3.2)

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -31,7 +31,7 @@
     <pentaho-hadoop-shims.version>11.1.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
 
     <!-- third party -->
-    <hsqldb.version>2.3.2</hsqldb.version>
+    <hsqldb.version>2.7.2</hsqldb.version>
     <jaybird.version>2.1.6</jaybird.version>
     <jt400.version>6.1</jt400.version>
     <LucidDbClient-minimal.version>0.9.4</LucidDbClient-minimal.version>


### PR DESCRIPTION
## Security Remediation Summary

- Vulnerability: org.hsqldb:hsqldb:2.3.2
- Repository: https://github.com/pentaho/pentaho-kettle.git
- Base branch: master
- Source branch: Vulnerability-Agent-7
- Dependency: org.hsqldb:hsqldb
- Target safe version: 2.7.2
- Affected occurrences found: 1
- Files changed: 1

## Root Cause
To analyze the Java Maven dependency vulnerability related to `org.hsqldb:hsqldb:2.3.2`, we need to break down the components of the issue and understand the root cause of the vulnerability, as well as the error message you provided.

### 1. Understanding the Vulnerability

**Artifact**: `org.hsqldb:hsqldb`  
**Version**: `2.3.2`  
**Findings**: 1 (indicating that there is at least one known vulnerability associated with this version)

#### Common Vulnerabilities in HSQLDB
HSQLDB (HyperSQL Database) is a relational database management system written in Java. Vulnerabilities in database systems can include:

- SQL injection vulnerabilities
- Denial of Service (DoS) attacks
- Insecure default configurations
- Data exposure due to improper access controls

To find the specific vulnerability associated with version `2.3.2`, you would typically check resources like the National Vulnerability Database (NVD), GitHub security advisories, or other vulnerability databases.

### 2. Analyzing the Error Message

**Error Message**: `dependency:tree execution failed: Error configuring command line`

This error indicates that there was a problem executing the `mvn dependency:tree` command, which is used to display the project's dependency tree. The error could stem from several issues:

- **Incorrect Maven Configuration**: There might be a problem in your `pom.xml` file, such as a syntax error or an invalid dependency declaration.
- **Maven Version**: Ensure that you are using a compatible version of Maven. Sometimes, older versions may not support certain features or configurations.
- **Network Issues**: If Maven cannot access the remote repository to resolve dependencies, it may fail. Check your internet connection and repository settings.
- **Plugin Issues**: The `dependency:tree` command relies on the Maven Dependency Plugin. Ensure that this plugin is correctly configured and up to date.

### 3. Steps to Resolve the Issue

1. **Check the POM File**: Review your `pom.xml` for any syntax errors or misconfigurations. Ensure that the dependency for HSQLDB is correctly specified.

   ```xml
   <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <version>2.3.2</version>
   </dependency>
   ```

2. **Update Dependencies**: If possible, consider updating to a newer version of HSQLDB that addresses the vulnerability. Check the [HSQLDB release notes](http://hsqldb.org/) for newer versions.

3. **Run Maven with Debugging**: Use the `-X` flag to run Maven in debug mode, which may provide more insight into what is causing the failure.

   ```bash
   mvn dependency:tree -X
   ```

4. **Check Maven Version**: Ensure you are using a supported version of Maven. You can check your Maven version with:

   ```bash
   mvn -v
   ```

5. **Check Network Configuration**: Ensure that your network settings allow Maven to access the necessary repositories. If you are behind a proxy, configure Maven to use the proxy settings in the `settings.xml` file.

6. **Consult Documentation**: If the issue persists, consult the Maven Dependency Plugin documentation for any specific configurations or known issues.

### Conclusion

The vulnerability in `org.hsqldb:hsqldb:2.3.2` should be addressed by either updating to a secure version or applying mitigations as necessary. The error with the `dependency:tree` command likely stems from configuration issues, network problems, or plugin-related issues. Following the steps outlined above should help you diagnose and resolve the problem.

## Compatibility Risk
Upgrading the HSQLDB library (org.hsqldb:hsqldb) to version 2.7.2 in a Spring Boot 3.x and Java 21 environment involves several considerations regarding compatibility risks. Here are the key factors to assess:

### 1. **Spring Boot Compatibility**
   - **Spring Boot 3.x**: Ensure that the version of HSQLDB you are upgrading to is compatible with Spring Boot 3.x. Spring Boot 3.x typically supports newer versions of libraries, but you should check the Spring Boot documentation or release notes for any specific compatibility notes regarding HSQLDB.
   - **Dependency Management**: Spring Boot uses a dependency management mechanism that may include specific versions of libraries. Check if Spring Boot 3.x has a recommended version of HSQLDB and whether 2.7.2 is included or compatible.

### 2. **Java Version Compatibility**
   - **Java 21**: HSQLDB 2.7.2 should be compatible with Java 21, but you should verify that there are no deprecated features or breaking changes in the Java language or libraries that could affect HSQLDB's functionality.

### 3. **Breaking Changes in HSQLDB**
   - Review the release notes and changelog for HSQLDB from your current version to 2.7.2. Look for any breaking changes, deprecated features, or changes in behavior that could affect your application.
   - Pay attention to changes in SQL syntax, data types, or any new features that might require code changes in your application.

### 4. **Testing**
   - **Unit and Integration Tests**: Ensure that you have a comprehensive suite of tests that cover the functionality relying on HSQLDB. Run these tests after the upgrade to identify any issues.
   - **Database Migration**: If your application uses specific database features or configurations, test the migration process to ensure that existing data and schema are compatible with the new version.

### 5. **Performance Considerations**
   - Check if there are any performance improvements or regressions in HSQLDB 2.7.2 compared to your current version. Performance testing may be necessary to ensure that the upgrade does not negatively impact your application.

### 6. **Community and Support**
   - Look for community feedback or issues reported regarding HSQLDB 2.7.2. This can provide insights into potential problems others have faced during the upgrade.

### 7. **Documentation and Migration Guides**
   - Review the official HSQLDB documentation for any migration guides or notes that may assist in the upgrade process.

### Conclusion
To summarize, while upgrading to HSQLDB 2.7.2 in a Spring Boot 3.x and Java 21 environment is likely to be compatible, it is essential to conduct thorough testing and review the release notes for both Spring Boot and HSQLDB. By following best practices for dependency upgrades, you can mitigate compatibility risks effectively.

## Validation

- Build success: false
- Test success: false

## Changed Files

- assemblies\lib\pom.xml: 2.3.2 -> 2.7.2 (Upgrade minimum safe version)

---
Generated by vulnerability remediation agent.