### PR TITLE
fix[FUSE-562] Integrate CMS with pentaho-server's connection repository

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterface.java
@@ -82,13 +82,17 @@ public interface DatabaseInterface extends Cloneable {
   /**
    * @return Returns the connection Id from the connection management service.
    */
-  String getConnectionId();
+  default String getConnectionId() {
+    return null;
+  }
 
   /**
    * @param connectionId
    *      The connection Id from the connection management service to set.
    */
-  void setConnectionId( String connectionId );
+  default void setConnectionId( String connectionId ) {
+    // default implementation
+  }
 
   /**
    * @return Returns the connection Name.


### PR DESCRIPTION
Fix to the previous [PR](https://github.com/pentaho/pentaho-kettle/pull/10539). Now new methods in the DatabaseInterface are declared as default so depending implementations will not be affected by the update.