### PR TITLE
fix[PDI-20901]: handle repository-backed case of child current-directory resolution

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/util/CurrentDirectoryResolver.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/CurrentDirectoryResolver.java
@@ -172,10 +172,30 @@ public class CurrentDirectoryResolver {
     } else if ( job != null && repository == null
         && specificationMethod.equals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME ) ) {
       filename = job.getFilename();
-    } else if ( job != null && job.getJobMeta() != null && repository != null
-        && specificationMethod.equals( ObjectLocationSpecificationMethod.FILENAME ) ) {
-      // we're using FILENAME but we are connected to a repository
-      directory = job.getJobMeta().getRepositoryDirectory();
+    } else if ( repository != null && specificationMethod.equals( ObjectLocationSpecificationMethod.FILENAME )
+        && filename != null ) {
+      String resolvedFilename = parentVariables.environmentSubstitute( filename );
+      if ( resolvedFilename != null && !resolvedFilename.contains( "${" ) && !resolvedFilename.contains( "%%" )
+          && resolvedFilename.startsWith( "/" ) && !resolvedFilename.contains( "://" ) ) {
+        boolean repositoryLookupRequired = true;
+        try {
+          repositoryLookupRequired = !KettleVFS.getInstance( bowl ).fileExists( resolvedFilename, parentVariables );
+        } catch ( Exception e ) {
+          repositoryLookupRequired = true;
+        }
+
+        if ( repositoryLookupRequired ) {
+          int lastSeparator = resolvedFilename.lastIndexOf( '/' );
+          if ( lastSeparator > 0 ) {
+            String childDirectoryPath = resolvedFilename.substring( 0, lastSeparator );
+            try {
+              directory = repository.findDirectory( childDirectoryPath );
+            } catch ( Exception e ) {
+              // Fall through to filename-based resolution below.
+            }
+          }
+        }
+      }
     } else if ( job != null && filename == null ) {
       filename = job.getFilename();
     } else if ( repository != null && JobMeta.class.isAssignableFrom( parentVariables.getClass() ) ) {

--- a/engine/src/test/java/org/pentaho/di/core/util/CurrentDirectoryResolverTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/util/CurrentDirectoryResolverTest.java
@@ -301,7 +301,7 @@ public class CurrentDirectoryResolverTest {
   }
 
   @Test
-  public void resolveCurrentDirectory_WhenJobWithFilenameSpecification_ThenUsesRepositoryDirectory() {
+  public void resolveCurrentDirectory_WhenJobWithFilenameSpecificationAndRepository_ThenPreservesChildFilename() throws Exception {
     Job job = mock( Job.class );
     JobMeta jobMeta = mock( JobMeta.class );
     RepositoryDirectoryInterface repoDir = mock( RepositoryDirectoryInterface.class );
@@ -309,17 +309,86 @@ public class CurrentDirectoryResolverTest {
     when( job.getJobMeta() ).thenReturn( jobMeta );
     when( jobMeta.getRepositoryDirectory() ).thenReturn( repoDir );
     when( repoDir.toString() ).thenReturn( "/repo/job" );
+    when( jobMeta.getFilename() ).thenReturn( "file:///parent/dir/job.kjb" );
 
-    VariableSpace result = resolver.resolveCurrentDirectory(
+    String childFilename = "file:///parent/dir/subfolder/child.ktr";
+    when( parentVariables.environmentSubstitute( childFilename ) ).thenReturn( childFilename );
+
+    CurrentDirectoryResolver spyResolver = spy( resolver );
+
+    spyResolver.resolveCurrentDirectory(
       bowl,
       ObjectLocationSpecificationMethod.FILENAME,
       parentVariables,
       repository,
       job,
-      "/some/file.kjb"
+      childFilename
     );
 
-    assertNotNull( result );
+    verify( spyResolver ).resolveCurrentDirectory( bowl, parentVariables, null, childFilename );
+    verify( spyResolver, never() ).resolveCurrentDirectory( bowl, parentVariables, repoDir, childFilename );
+    verify( spyResolver, never() ).resolveCurrentDirectory( bowl, parentVariables, null, "file:///parent/dir/job.kjb" );
+    verify( repository, never() ).findDirectory( anyString() );
+  }
+
+  @Test
+  public void resolveCurrentDirectory_WhenJobWithFilenameSpecificationAndRepositoryChildPath_ThenUsesChildRepositoryDirectory() throws Exception {
+    Job job = mock( Job.class );
+    RepositoryDirectoryInterface childRepoDir = mock( RepositoryDirectoryInterface.class );
+
+    Variables variables = new Variables();
+    variables.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "/public/InheritVariable" );
+
+    String childFilename = "${Internal.Entry.Current.Directory}/SubFolder/child.ktr";
+    String resolvedChildFilename = "/public/InheritVariable/SubFolder/child.ktr";
+    IKettleVFS kettleVFS = mock( IKettleVFS.class );
+
+    when( repository.findDirectory( "/public/InheritVariable/SubFolder" ) ).thenReturn( childRepoDir );
+
+    CurrentDirectoryResolver spyResolver = spy( resolver );
+
+    try ( MockedStatic<KettleVFS> mockedVFS = mockStatic( KettleVFS.class ) ) {
+      mockedVFS.when( () -> KettleVFS.getInstance( bowl ) ).thenReturn( kettleVFS );
+      when( kettleVFS.fileExists( resolvedChildFilename, variables ) ).thenReturn( false );
+
+      spyResolver.resolveCurrentDirectory(
+        bowl,
+        ObjectLocationSpecificationMethod.FILENAME,
+        variables,
+        repository,
+        job,
+        childFilename
+      );
+    }
+
+    verify( spyResolver ).resolveCurrentDirectory( bowl, variables, childRepoDir, childFilename );
+  }
+
+  @Test
+  public void resolveCurrentDirectory_WhenJobWithAbsoluteFilenameThatExistsAsVfsFile_ThenSkipsRepositoryLookup() throws Exception {
+    Job job = mock( Job.class );
+    String childFilename = "/tmp/child.ktr";
+    when( parentVariables.environmentSubstitute( childFilename ) ).thenReturn( childFilename );
+    IKettleVFS kettleVFS = mock( IKettleVFS.class );
+
+    CurrentDirectoryResolver spyResolver = spy( resolver );
+
+    try ( MockedStatic<KettleVFS> mockedVFS = mockStatic( KettleVFS.class ) ) {
+      mockedVFS.when( () -> KettleVFS.getInstance( bowl ) ).thenReturn( kettleVFS );
+      when( kettleVFS.fileExists( childFilename, parentVariables ) ).thenReturn( true );
+
+      spyResolver.resolveCurrentDirectory(
+        bowl,
+        ObjectLocationSpecificationMethod.FILENAME,
+        parentVariables,
+        repository,
+        job,
+        childFilename
+      );
+    }
+
+    verify( repository, never() ).findDirectory( anyString() );
+    verify( spyResolver ).resolveCurrentDirectory( bowl, parentVariables, null, childFilename );
   }
 
   @Test


### PR DESCRIPTION
This **if** was no longer correct because it mixed up two separate things:

- `specificationMethod == FILENAME` means the child is identified by its filename/path
- `repository != null` only means we are connected to a repository

Those are not equivalent.

The old logic effectively treated any repository-connected `FILENAME` load as if the parent job’s repository directory should take precedence over the child location. That made current-directory resolution depend on connection state instead of the actual child object being loaded.

The updated logic still keeps the repository connection available, but it no longer lets that connection override the child location. It first respects the resolved child path itself. If that path already resolves as a VFS/file location, it stays on the filename-based path. If it does not, and the child path is repository-backed, for example `/public/.../SubFolder`, the repository connection is then used to resolve the child repository directory from that child path.

So the repository connection is no longer used as a blanket substitute for the child location. It is only used as a fallback to resolve the child location when the child path itself points into the repository.