### PR TITLE
fix[PDI-20901]: Fix Internal.Entry.Current.Directory resolution in child transformations

### DIFF
--- a/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
+++ b/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
@@ -159,8 +159,7 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
       final String[] idContainer = new String[ 1 ]; //unigue portion of cache key passed though argument
       switch ( specificationMethod ) {
         case FILENAME:
-          VariableSpace filenameResolutionSpace = space != null ? space : tmpSpace;
-          String realFilename = filenameResolutionSpace.environmentSubstitute( filename );
+          String realFilename = resolveFilenameForLoad( space, tmpSpace, filename );
           // Once the child filename is fully resolved, rebase the temp variable space to that file.
           // This ensures the loaded meta gets its own directory variables instead of the parent job's.
           tmpSpace = r.resolveCurrentDirectory( bowl, tmpSpace, null, realFilename );
@@ -346,6 +345,21 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
       idContainer[ 0 ] = realFilename;  //only pass back the id used in the cache, if a cache entry should be created
     }
     return theMeta;
+  }
+
+  String resolveFilenameForLoad( VariableSpace space, VariableSpace tmpSpace, String filename ) {
+    VariableSpace primarySpace = space != null ? space : tmpSpace;
+    String realFilename = primarySpace.environmentSubstitute( filename );
+
+    if ( hasUnresolvedFilenamePlaceholders( realFilename ) && space != null && tmpSpace != null && space != tmpSpace ) {
+      realFilename = tmpSpace.environmentSubstitute( filename );
+    }
+
+    return realFilename;
+  }
+
+  boolean hasUnresolvedFilenamePlaceholders( String filename ) {
+    return filename != null && ( filename.contains( "${" ) || filename.contains( "%%" ) );
   }
 
   private T getMetaFromRepository( Bowl bowl, Repository rep, CurrentDirectoryResolver r, String metaPath, VariableSpace tmpSpace )

--- a/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
+++ b/engine/src/main/java/org/pentaho/di/base/MetaFileLoaderImpl.java
@@ -159,7 +159,11 @@ public class MetaFileLoaderImpl<T> implements IMetaFileLoader<T> {
       final String[] idContainer = new String[ 1 ]; //unigue portion of cache key passed though argument
       switch ( specificationMethod ) {
         case FILENAME:
-          String realFilename = tmpSpace.environmentSubstitute( filename );
+          VariableSpace filenameResolutionSpace = space != null ? space : tmpSpace;
+          String realFilename = filenameResolutionSpace.environmentSubstitute( filename );
+          // Once the child filename is fully resolved, rebase the temp variable space to that file.
+          // This ensures the loaded meta gets its own directory variables instead of the parent job's.
+          tmpSpace = r.resolveCurrentDirectory( bowl, tmpSpace, null, realFilename );
           try {
             theMeta = attemptLoadMeta( bowl, realFilename, rep, metaStore, tmpSpace, null, idContainer );
           } catch ( KettleException e ) {

--- a/engine/src/main/java/org/pentaho/di/core/util/CurrentDirectoryResolver.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/CurrentDirectoryResolver.java
@@ -90,7 +90,16 @@ public class CurrentDirectoryResolver {
       tmpSpace.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, directory.toString() );
     } else if ( filename != null ) {
       try {
-        FileObject fileObject = KettleVFS.getInstance( bowl ).getFileObject( filename, tmpSpace );
+        String resolvedFilename = tmpSpace.environmentSubstitute( filename );
+
+        // If the filename still contains unresolved variables after substitution, skip the file existence check.
+        // The remaining variables will be resolved in the proper child execution context later.
+        // Attempting to resolve them here using the current context would set wrong directory paths.
+        if ( resolvedFilename == null || resolvedFilename.contains( "${" ) || resolvedFilename.contains( "%%" ) ) {
+          return tmpSpace;
+        }
+
+        FileObject fileObject = KettleVFS.getInstance( bowl ).getFileObject( resolvedFilename, tmpSpace );
 
         if ( !fileObject.exists() ) {
           // don't set variables if the file doesn't exist
@@ -183,11 +192,13 @@ public class CurrentDirectoryResolver {
       realParent = (JobMeta) parentVariables;
       filename = realParent.getFilename();
     }
-    // If directory is null or root directory, fall back to using filename
-    // For vfs, though connected to repository, we have no directory info - fall back to filename
+    // If directory is null or root directory, fall back to using filename.
+    // For vfs, though connected to repository, we have no directory info - fall back to filename.
+    // Preserve an already provided child filename (FILENAME spec path) so Internal.Entry.Current.Directory
+    // resolves to the child directory instead of being forced to the parent job's location.
     if ( directory == null || "/".equals( directory.toString() ) ) {
       directory = null;
-      if ( job != null && job.getJobMeta() != null ) {
+      if ( filename == null && job != null && job.getJobMeta() != null ) {
         filename = job.getJobMeta().getFilename();
       }
     }

--- a/engine/src/main/java/org/pentaho/di/core/util/CurrentDirectoryResolver.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/CurrentDirectoryResolver.java
@@ -172,10 +172,30 @@ public class CurrentDirectoryResolver {
     } else if ( job != null && repository == null
         && specificationMethod.equals( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME ) ) {
       filename = job.getFilename();
-    } else if ( job != null && job.getJobMeta() != null && repository != null
-        && specificationMethod.equals( ObjectLocationSpecificationMethod.FILENAME ) ) {
-      // we're using FILENAME but we are connected to a repository
-      directory = job.getJobMeta().getRepositoryDirectory();
+    } else if ( repository != null && specificationMethod.equals( ObjectLocationSpecificationMethod.FILENAME )
+        && filename != null ) {
+      String resolvedFilename = parentVariables.environmentSubstitute( filename );
+      if ( resolvedFilename != null && !resolvedFilename.contains( "${" ) && !resolvedFilename.contains( "%%" )
+          && resolvedFilename.startsWith( "/" ) && !resolvedFilename.contains( "://" ) ) {
+        boolean repositoryLookupRequired = true;
+        try {
+          repositoryLookupRequired = !KettleVFS.getInstance( bowl ).fileExists( resolvedFilename, parentVariables );
+        } catch ( Exception e ) {
+          repositoryLookupRequired = true;
+        }
+
+        if ( repositoryLookupRequired ) {
+          int lastSeparator = resolvedFilename.lastIndexOf( '/' );
+          if ( lastSeparator > 0 ) {
+            String childDirectoryPath = resolvedFilename.substring( 0, lastSeparator );
+            try {
+              directory = repository.findDirectory( childDirectoryPath );
+            } catch ( Exception e ) {
+              // Fall through to filename-based resolution below.
+            }
+          }
+        }
+      }
     } else if ( job != null && filename == null ) {
       filename = job.getFilename();
     } else if ( repository != null && JobMeta.class.isAssignableFrom( parentVariables.getClass() ) ) {

--- a/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/StepWithMappingMeta.java
@@ -308,7 +308,9 @@ public abstract class StepWithMappingMeta extends BaseSerializingMeta implements
     }
     String[] variableNames = toSpace.listVariables();
     for ( String variable : variableNames ) {
-      if ( fromSpace.getVariable( variable ) == null ) {
+      // Internal variables are execution-context specific and must be resolved on the child object,
+      // not inherited from the parent variable space.
+      if ( fromSpace.getVariable( variable ) == null && !isInternalVariable( variable, "" ) ) {
         fromSpace.setVariable( variable, toSpace.getVariable( variable ) );
       }
     }

--- a/engine/src/test/java/org/pentaho/di/base/MetaFileLoaderImplTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/MetaFileLoaderImplTest.java
@@ -19,6 +19,7 @@ import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.job.JobEntryJob;
@@ -362,23 +363,12 @@ public class MetaFileLoaderImplTest {
 
   @Test
   public void getMetaForEntry_WhenFilenameSpec_ThenRebasesToChildFileDirectory() throws Exception {
-    // Verifies that when loading a child transformation via FILENAME specification,
-    // Internal.Entry.Current.Directory on the loaded meta is set to the child file's directory,
-    // not the parent job's directory.
-    //
-    // The fix in MetaFileLoaderImpl.getMetaForEntry() FILENAME case re-bases tmpSpace:
-    //   tmpSpace = r.resolveCurrentDirectory( bowl, tmpSpace, null, realFilename );
-    // then reseedInternalDirectoryVars() propagates the re-based value onto the loaded meta.
-    // Removing that line would cause this assertion to fail.
-
     setupJobEntryTrans();
     specificationMethod = ObjectLocationSpecificationMethod.FILENAME;
 
     MetaFileLoaderImpl metaFileLoader = new MetaFileLoaderImpl<TransMeta>( jobEntryBase, specificationMethod );
     TransMeta transMeta = (TransMeta) metaFileLoader.getMetaForEntry( DefaultBowl.getInstance(), repository, store, space );
 
-    // The expected directory is the parent folder of the test resource file, in URI form
-    // (matching what KettleVFS FileName.getParent().getURI() returns)
     String expectedDir = Paths.get( getClass().getResource( TRANS_FILE ).toURI() ).getParent().toUri().toString();
     if ( expectedDir.endsWith( "/" ) ) {
       expectedDir = expectedDir.substring( 0, expectedDir.length() - 1 );
@@ -430,6 +420,37 @@ public class MetaFileLoaderImplTest {
     }
 
     assertEquals( expectedDir, transMeta.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
+  }
+
+  @Test
+  public void resolveFilenameForLoad_WhenPrimarySpaceLeavesInternalPlaceholderUnresolved_ThenFallsBackToTmpSpace() {
+    MetaFileLoaderImpl<TransMeta> metaFileLoader = new MetaFileLoaderImpl<>( mock( JobEntryTrans.class ),
+      ObjectLocationSpecificationMethod.FILENAME );
+
+    JobMeta primarySpace = new JobMeta();
+    Variables tmpSpace = new Variables();
+    tmpSpace.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "/home/user/project" );
+
+    String filename = "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/child.ktr";
+
+    assertEquals( "/home/user/project/child.ktr", metaFileLoader.resolveFilenameForLoad( primarySpace, tmpSpace,
+      filename ) );
+  }
+
+  @Test
+  public void resolveFilenameForLoad_WhenPrimarySpaceResolvesFilename_ThenDoesNotFallBackToTmpSpace() {
+    MetaFileLoaderImpl<TransMeta> metaFileLoader = new MetaFileLoaderImpl<>( mock( JobEntryTrans.class ),
+      ObjectLocationSpecificationMethod.FILENAME );
+
+    Variables primarySpace = new Variables();
+    Variables tmpSpace = new Variables();
+    primarySpace.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "/home/user/project" );
+    tmpSpace.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "/different/path" );
+
+    String filename = "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/child.ktr";
+
+    assertEquals( "/home/user/project/child.ktr", metaFileLoader.resolveFilenameForLoad( primarySpace, tmpSpace,
+      filename ) );
   }
 
   @Test

--- a/engine/src/test/java/org/pentaho/di/base/MetaFileLoaderImplTest.java
+++ b/engine/src/test/java/org/pentaho/di/base/MetaFileLoaderImplTest.java
@@ -34,6 +34,7 @@ import org.pentaho.di.trans.steps.transexecutor.TransExecutorMeta;
 import org.pentaho.metastore.api.IMetaStore;
 
 import java.io.File;
+import java.nio.file.Paths;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,6 +42,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -356,6 +358,78 @@ public class MetaFileLoaderImplTest {
 
   private String getKey() {
     return specificationMethod + ":" + keyPath;
+  }
+
+  @Test
+  public void getMetaForEntry_WhenFilenameSpec_ThenRebasesToChildFileDirectory() throws Exception {
+    // Verifies that when loading a child transformation via FILENAME specification,
+    // Internal.Entry.Current.Directory on the loaded meta is set to the child file's directory,
+    // not the parent job's directory.
+    //
+    // The fix in MetaFileLoaderImpl.getMetaForEntry() FILENAME case re-bases tmpSpace:
+    //   tmpSpace = r.resolveCurrentDirectory( bowl, tmpSpace, null, realFilename );
+    // then reseedInternalDirectoryVars() propagates the re-based value onto the loaded meta.
+    // Removing that line would cause this assertion to fail.
+
+    setupJobEntryTrans();
+    specificationMethod = ObjectLocationSpecificationMethod.FILENAME;
+
+    MetaFileLoaderImpl metaFileLoader = new MetaFileLoaderImpl<TransMeta>( jobEntryBase, specificationMethod );
+    TransMeta transMeta = (TransMeta) metaFileLoader.getMetaForEntry( DefaultBowl.getInstance(), repository, store, space );
+
+    // The expected directory is the parent folder of the test resource file, in URI form
+    // (matching what KettleVFS FileName.getParent().getURI() returns)
+    String expectedDir = Paths.get( getClass().getResource( TRANS_FILE ).toURI() ).getParent().toUri().toString();
+    if ( expectedDir.endsWith( "/" ) ) {
+      expectedDir = expectedDir.substring( 0, expectedDir.length() - 1 );
+    }
+
+    assertEquals( expectedDir, transMeta.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
+  }
+
+  @Test
+  public void getMetaForEntry_WhenFilenameSpecUsesParentDirectoryVariable_ThenDoesNotDoubleSubstitute()
+    throws Exception {
+    JobEntryTrans jobEntryTrans = new JobEntryTrans();
+    jobEntryBase = jobEntryTrans;
+
+    JobMeta parentJobMeta = spy( new JobMeta() );
+    LogChannelInterface logger = mock( LogChannelInterface.class );
+    metaFileCache = new MetaFileCacheImpl( logger );
+    parentJobMeta.setMetaFileCache( metaFileCache );
+    jobEntryTrans.setParentJobMeta( parentJobMeta );
+
+    Job job = new Job();
+    space = job;
+    jobEntryTrans.setParentJob( job );
+
+    String engineRoot = Paths.get( "" ).toAbsolutePath().toUri().toString();
+    if ( engineRoot.endsWith( "/" ) ) {
+      engineRoot = engineRoot.substring( 0, engineRoot.length() - 1 );
+    }
+    job.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, engineRoot );
+    job.setVariable( Const.INTERNAL_VARIABLE_JOB_FILENAME_DIRECTORY, engineRoot );
+    job.setVariable( Const.INTERNAL_VARIABLE_TRANSFORMATION_FILENAME_DIRECTORY, engineRoot );
+
+    String relativeFilename = "src/test/resources/org/pentaho/di/base/" + TRANS_FILE;
+    String variableizedFilename = "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}/" + relativeFilename;
+    jobEntryTrans.setFileName( variableizedFilename );
+    jobEntryTrans.setTransname( TRANS_FILE );
+    jobEntryTrans.setTransObjectId( null );
+    specificationMethod = ObjectLocationSpecificationMethod.FILENAME;
+
+    MetaFileLoaderImpl<TransMeta> metaFileLoader = new MetaFileLoaderImpl<>( jobEntryBase, specificationMethod );
+    TransMeta transMeta = metaFileLoader.getMetaForEntry( DefaultBowl.getInstance(), null, store, space );
+
+    assertNotNull( transMeta );
+    validateMetaName( TRANS_FILE, transMeta );
+
+    String expectedDir = Paths.get( relativeFilename ).toAbsolutePath().getParent().toUri().toString();
+    if ( expectedDir.endsWith( "/" ) ) {
+      expectedDir = expectedDir.substring( 0, expectedDir.length() - 1 );
+    }
+
+    assertEquals( expectedDir, transMeta.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
   }
 
   @Test

--- a/engine/src/test/java/org/pentaho/di/core/util/CurrentDirectoryResolverTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/util/CurrentDirectoryResolverTest.java
@@ -301,7 +301,7 @@ public class CurrentDirectoryResolverTest {
   }
 
   @Test
-  public void resolveCurrentDirectory_WhenJobWithFilenameSpecification_ThenUsesRepositoryDirectory() {
+  public void resolveCurrentDirectory_WhenJobWithFilenameSpecificationAndRepository_ThenPreservesChildFilename() throws Exception {
     Job job = mock( Job.class );
     JobMeta jobMeta = mock( JobMeta.class );
     RepositoryDirectoryInterface repoDir = mock( RepositoryDirectoryInterface.class );
@@ -309,17 +309,86 @@ public class CurrentDirectoryResolverTest {
     when( job.getJobMeta() ).thenReturn( jobMeta );
     when( jobMeta.getRepositoryDirectory() ).thenReturn( repoDir );
     when( repoDir.toString() ).thenReturn( "/repo/job" );
+    when( jobMeta.getFilename() ).thenReturn( "file:///parent/dir/job.kjb" );
 
-    VariableSpace result = resolver.resolveCurrentDirectory(
+    String childFilename = "file:///parent/dir/subfolder/child.ktr";
+    when( parentVariables.environmentSubstitute( childFilename ) ).thenReturn( childFilename );
+
+    CurrentDirectoryResolver spyResolver = spy( resolver );
+
+    spyResolver.resolveCurrentDirectory(
       bowl,
       ObjectLocationSpecificationMethod.FILENAME,
       parentVariables,
       repository,
       job,
-      "/some/file.kjb"
+      childFilename
     );
 
-    assertNotNull( result );
+    verify( spyResolver ).resolveCurrentDirectory( bowl, parentVariables, null, childFilename );
+    verify( spyResolver, never() ).resolveCurrentDirectory( bowl, parentVariables, repoDir, childFilename );
+    verify( spyResolver, never() ).resolveCurrentDirectory( bowl, parentVariables, null, "file:///parent/dir/job.kjb" );
+    verify( repository, never() ).findDirectory( anyString() );
+  }
+
+  @Test
+  public void resolveCurrentDirectory_WhenJobWithFilenameSpecificationAndRepositoryChildPath_ThenUsesChildRepositoryDirectory() throws Exception {
+    Job job = mock( Job.class );
+    RepositoryDirectoryInterface childRepoDir = mock( RepositoryDirectoryInterface.class );
+
+    Variables variables = new Variables();
+    variables.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "/public/InheritVariable" );
+
+    String childFilename = "${Internal.Entry.Current.Directory}/SubFolder/child.ktr";
+    String resolvedChildFilename = "/public/InheritVariable/SubFolder/child.ktr";
+    IKettleVFS kettleVFS = mock( IKettleVFS.class );
+
+    when( repository.findDirectory( "/public/InheritVariable/SubFolder" ) ).thenReturn( childRepoDir );
+
+    CurrentDirectoryResolver spyResolver = spy( resolver );
+
+    try ( MockedStatic<KettleVFS> mockedVFS = mockStatic( KettleVFS.class ) ) {
+      mockedVFS.when( () -> KettleVFS.getInstance( bowl ) ).thenReturn( kettleVFS );
+      when( kettleVFS.fileExists( resolvedChildFilename, variables ) ).thenReturn( false );
+
+      spyResolver.resolveCurrentDirectory(
+        bowl,
+        ObjectLocationSpecificationMethod.FILENAME,
+        variables,
+        repository,
+        job,
+        childFilename
+      );
+    }
+
+    verify( spyResolver ).resolveCurrentDirectory( bowl, variables, childRepoDir, childFilename );
+  }
+
+  @Test
+  public void resolveCurrentDirectory_WhenJobWithAbsoluteFilenameThatExistsAsVfsFile_ThenSkipsRepositoryLookup() throws Exception {
+    Job job = mock( Job.class );
+    String childFilename = "/tmp/child.ktr";
+    when( parentVariables.environmentSubstitute( childFilename ) ).thenReturn( childFilename );
+    IKettleVFS kettleVFS = mock( IKettleVFS.class );
+
+    CurrentDirectoryResolver spyResolver = spy( resolver );
+
+    try ( MockedStatic<KettleVFS> mockedVFS = mockStatic( KettleVFS.class ) ) {
+      mockedVFS.when( () -> KettleVFS.getInstance( bowl ) ).thenReturn( kettleVFS );
+      when( kettleVFS.fileExists( childFilename, parentVariables ) ).thenReturn( true );
+
+      spyResolver.resolveCurrentDirectory(
+        bowl,
+        ObjectLocationSpecificationMethod.FILENAME,
+        parentVariables,
+        repository,
+        job,
+        childFilename
+      );
+    }
+
+    verify( repository, never() ).findDirectory( anyString() );
+    verify( spyResolver ).resolveCurrentDirectory( bowl, parentVariables, null, childFilename );
   }
 
   @Test

--- a/engine/src/test/java/org/pentaho/di/core/util/CurrentDirectoryResolverTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/util/CurrentDirectoryResolverTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.MockitoRule;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.vfs.IKettleVFS;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.job.Job;
@@ -36,8 +37,17 @@ import org.pentaho.di.trans.step.StepMeta;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import org.mockito.MockedStatic;
+import org.pentaho.di.core.vfs.KettleVFS;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class CurrentDirectoryResolverTest {
@@ -479,6 +489,101 @@ public class CurrentDirectoryResolverTest {
 
     assertNotNull( result );
     assertEquals( "test_value", result.getVariable( "TEST_VAR" ) );
+  }
+
+  /**
+   * Regression test for PDI-20828 / PR-10484 follow-up:
+   *
+   * When a job entry invokes a sub-transformation by FILENAME (no repository), the cleanup block in
+   * resolveCurrentDirectory(Job) must NOT overwrite the provided child filename with the parent
+   * job's filename.  Before the fix, this overwrote always, causing MetaFileLoaderImpl to seed the
+   * wrong Internal.Entry.Current.Directory (parent's directory instead of the child's directory)
+   * onto the loaded TransMeta.
+   */
+  @Test
+  public void resolveCurrentDirectory_WhenFilenameSpecAndNoRepository_ThenPreservesChildFilenameNotParentJobFilename() {
+    Job job = mock( Job.class );
+    JobMeta jobMeta = mock( JobMeta.class );
+
+    // Parent job lives in a different directory than the child transformation
+    when( job.getJobMeta() ).thenReturn( jobMeta );
+    when( jobMeta.getFilename() ).thenReturn( "file:///parent/dir/job.kjb" );
+
+    String childFilename = "file:///parent/dir/subfolder/child.ktr";
+
+    CurrentDirectoryResolver spyResolver = spy( resolver );
+
+    spyResolver.resolveCurrentDirectory(
+      bowl,
+      ObjectLocationSpecificationMethod.FILENAME,
+      parentVariables,
+      null,       // no repository
+      job,
+      childFilename
+    );
+
+    // The 4-arg inner method must be called with the child's filename so that VFS can extract the
+    // child's directory.  It must NOT be called with the parent job's filename.
+    verify( spyResolver ).resolveCurrentDirectory( bowl, parentVariables, null, childFilename );
+    verify( spyResolver, never() ).resolveCurrentDirectory( bowl, parentVariables, null, "file:///parent/dir/job.kjb" );
+  }
+
+  @Test
+  public void resolveCurrentDirectory_WhenFilenameHasUnresolvedVariables_ThenSkipsFileExistenceCheck() {
+    // Verifies that when a filename contains ${...} expressions (unresolved variables),
+    // KettleVFS.getInstance() is never invoked. The fix returns tmpSpace early before
+    // any VFS call, preventing premature directory resolution using the parent's context.
+
+    String filenameWithUnresolvedVar = "/parent/dir/${Internal.Entry.Current.Directory}/child.ktr";
+    Variables variables = new Variables();
+
+    try ( MockedStatic<KettleVFS> mockedVFS = mockStatic( KettleVFS.class ) ) {
+      VariableSpace result = resolver.resolveCurrentDirectory( bowl, variables, null, filenameWithUnresolvedVar );
+
+      assertNotNull( result );
+      // The core assertion: KettleVFS must never be touched when the filename has unresolved variables
+      mockedVFS.verify( () -> KettleVFS.getInstance( bowl ), never() );
+    }
+  }
+
+  @Test
+  public void resolveCurrentDirectory_WhenFilenameHasUnresolvedWindowsVariables_ThenSkipsFileExistenceCheck() {
+    String filenameWithUnresolvedVar = "/parent/dir/%%Internal.Entry.Current.Directory%%/child.ktr";
+    Variables variables = new Variables();
+
+    try ( MockedStatic<KettleVFS> mockedVFS = mockStatic( KettleVFS.class ) ) {
+      VariableSpace result = resolver.resolveCurrentDirectory( bowl, variables, null, filenameWithUnresolvedVar );
+
+      assertNotNull( result );
+      mockedVFS.verify( () -> KettleVFS.getInstance( bowl ), never() );
+    }
+  }
+
+  @Test
+  public void resolveCurrentDirectory_WhenFilenameVariablesResolve_ThenUsesResolvedFilename() throws Exception {
+    String filenameWithVariable = "${BASE_DIR}/child.ktr";
+    String resolvedFilename = "/home/user/project/child.ktr";
+    Variables variables = new Variables();
+    variables.setVariable( "BASE_DIR", "/home/user/project" );
+
+    IKettleVFS kettleVFS = mock( IKettleVFS.class );
+
+    when( fileObject.exists() ).thenReturn( true );
+    when( fileObject.getName() ).thenReturn( fileName );
+    when( fileName.getBaseName() ).thenReturn( "child.ktr" );
+    when( fileName.getParent() ).thenReturn( parentFileName );
+    when( parentFileName.getURI() ).thenReturn( "file:///home/user/project" );
+
+    try ( MockedStatic<KettleVFS> mockedVFS = mockStatic( KettleVFS.class ) ) {
+      mockedVFS.when( () -> KettleVFS.getInstance( bowl ) ).thenReturn( kettleVFS );
+      when( kettleVFS.getFileObject( eq( resolvedFilename ), any( VariableSpace.class ) ) ).thenReturn( fileObject );
+
+      VariableSpace result = resolver.resolveCurrentDirectory( bowl, variables, null, filenameWithVariable );
+
+      assertNotNull( result );
+      assertEquals( "file:///home/user/project", result.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
+      verify( kettleVFS ).getFileObject( eq( resolvedFilename ), any( VariableSpace.class ) );
+    }
   }
 }
 

--- a/engine/src/test/java/org/pentaho/di/job/entries/job/JobEntryJobTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/job/JobEntryJobTest.java
@@ -147,9 +147,10 @@ public class JobEntryJobTest {
             {
               doCallRealMethod().when( mock ).normalizeSlashes( anyString() );
               doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ),
-                any( ObjectLocationSpecificationMethod.class ),
-                any( VariableSpace.class ), nullable( Repository.class ), nullable( Job.class ),
-                nullable( String.class ) );
+                any( ObjectLocationSpecificationMethod.class ), any( VariableSpace.class ),
+                nullable( Repository.class ), nullable( Job.class ), nullable( String.class ) );
+              doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ), any( VariableSpace.class ),
+                nullable( RepositoryDirectoryInterface.class ), nullable( String.class ) );
             } ) ) {
       JobEntryJob jej = getJej();
       jej.setSpecificationMethod( ObjectLocationSpecificationMethod.REPOSITORY_BY_REFERENCE );
@@ -187,8 +188,10 @@ public class JobEntryJobTest {
             {
               doCallRealMethod().when( mock ).normalizeSlashes( anyString() );
               doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ),
-                any( ObjectLocationSpecificationMethod.class ),
-                any( VariableSpace.class ), nullable( Repository.class ), nullable( Job.class ), anyString() );
+                any( ObjectLocationSpecificationMethod.class ), any( VariableSpace.class ),
+                nullable( Repository.class ), nullable( Job.class ), nullable( String.class ) );
+              doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ), any( VariableSpace.class ),
+                nullable( RepositoryDirectoryInterface.class ), nullable( String.class ) );
             } ) ) {
       JobEntryJob jej = getJej();
       jej.setSpecificationMethod( ObjectLocationSpecificationMethod.REPOSITORY_BY_NAME );
@@ -226,8 +229,10 @@ public class JobEntryJobTest {
             {
               doCallRealMethod().when( mock ).normalizeSlashes( anyString() );
               doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ),
-                any( ObjectLocationSpecificationMethod.class ),
-                any( VariableSpace.class ), nullable( Repository.class ), nullable( Job.class ), anyString() );
+                any( ObjectLocationSpecificationMethod.class ), any( VariableSpace.class ),
+                nullable( Repository.class ), nullable( Job.class ), nullable( String.class ) );
+              doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ), any( VariableSpace.class ),
+                nullable( RepositoryDirectoryInterface.class ), nullable( String.class ) );
             } ) ) {
       JobEntryJob jej = getJej();
       jej.setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
@@ -343,8 +348,10 @@ public class JobEntryJobTest {
             {
               doCallRealMethod().when( mock ).normalizeSlashes( anyString() );
               doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ),
-                any( ObjectLocationSpecificationMethod.class ),
-                any( VariableSpace.class ), nullable( Repository.class ), nullable( Job.class ), anyString() );
+                any( ObjectLocationSpecificationMethod.class ), any( VariableSpace.class ),
+                nullable( Repository.class ), nullable( Job.class ), nullable( String.class ) );
+              doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ), any( VariableSpace.class ),
+                nullable( RepositoryDirectoryInterface.class ), nullable( String.class ) );
             } ) ) {
       JobEntryJob jej = getJej();
       jej.setSpecificationMethod( ObjectLocationSpecificationMethod.FILENAME );
@@ -436,8 +443,10 @@ public class JobEntryJobTest {
             {
               doCallRealMethod().when( mock ).normalizeSlashes( anyString() );
               doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ),
-                any( ObjectLocationSpecificationMethod.class ),
-                any( VariableSpace.class ), nullable( Repository.class ), nullable( Job.class ), anyString() );
+                any( ObjectLocationSpecificationMethod.class ), any( VariableSpace.class ),
+                nullable( Repository.class ), nullable( Job.class ), nullable( String.class ) );
+              doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ), any( VariableSpace.class ),
+                nullable( RepositoryDirectoryInterface.class ), nullable( String.class ) );
             } ) ) {
       JobEntryJob jej = getJej();
       jej.setFileName( JOB_ENTRY_FILE_PATH );
@@ -564,8 +573,10 @@ public class JobEntryJobTest {
             {
               doCallRealMethod().when( mock ).normalizeSlashes( anyString() );
               doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ),
-                any( ObjectLocationSpecificationMethod.class ),
-                any( VariableSpace.class ), nullable( Repository.class ), nullable( Job.class ), anyString() );
+                any( ObjectLocationSpecificationMethod.class ), any( VariableSpace.class ),
+                nullable( Repository.class ), nullable( Job.class ), nullable( String.class ) );
+              doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ), any( VariableSpace.class ),
+                nullable( RepositoryDirectoryInterface.class ), nullable( String.class ) );
             } ) ) {
 
       doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
@@ -608,9 +619,10 @@ public class JobEntryJobTest {
             {
               doCallRealMethod().when( mock ).normalizeSlashes( anyString() );
               doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ),
-                any( ObjectLocationSpecificationMethod.class ),
-                any( VariableSpace.class ), nullable( Repository.class ), nullable( Job.class ),
-                nullable( String.class ) );
+                any( ObjectLocationSpecificationMethod.class ), any( VariableSpace.class ),
+                nullable( Repository.class ), nullable( Job.class ), nullable( String.class ) );
+              doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ), any( VariableSpace.class ),
+                nullable( RepositoryDirectoryInterface.class ), nullable( String.class ) );
             } ) ) {
       doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
       doReturn( "rep_name" ).when( myrepo )
@@ -784,8 +796,10 @@ public class JobEntryJobTest {
             {
               doCallRealMethod().when( mock ).normalizeSlashes( anyString() );
               doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ),
-                any( ObjectLocationSpecificationMethod.class ),
-                any( VariableSpace.class ), nullable( Repository.class ), nullable( Job.class ), anyString() );
+                any( ObjectLocationSpecificationMethod.class ), any( VariableSpace.class ),
+                nullable( Repository.class ), nullable( Job.class ), nullable( String.class ) );
+              doReturn( space ).when( mock ).resolveCurrentDirectory( any( Bowl.class ), any( VariableSpace.class ),
+                nullable( RepositoryDirectoryInterface.class ), nullable( String.class ) );
             } ) ) {
       doReturn( null ).when( myrepo ).getJobEntryAttributeString( any( ObjectId.class ), anyString() );
       doReturn( JOB_ENTRY_FILE_PATH ).when( myrepo ).getJobEntryAttributeString( JOB_ENTRY_JOB_OBJECT_ID, "file_name" );
@@ -891,4 +905,5 @@ public class JobEntryJobTest {
     when( jej.getParentJobMeta().getBowl() ).thenReturn( DefaultBowl.getInstance() );
     return jej;
   }
+
 }

--- a/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/StepWithMappingMetaTest.java
@@ -428,4 +428,28 @@ public class StepWithMappingMetaTest {
     Assert.assertEquals( variableChildOnly, ChildVariables.getVariable( variableChildOnly ) );
 
   }
+
+  @Test
+  public void addMissingVariables_WhenInternalVariable_ThenDoesNotCopyFromParent() {
+    // addMissingVariables(fromSpace, toSpace) copies variables present in toSpace but missing
+    // in fromSpace. The fix guards against copying internal variables, which are
+    // execution-context-specific and must not be inherited from the parent.
+    //
+    // Scenario: child (fromSpace) is empty; parent (toSpace) has both a custom var and
+    // Internal.Entry.Current.Directory. After the call, the child should receive the custom
+    // var but NOT the internal variable.
+
+    VariableSpace childSpace = new Variables(); // fromSpace – starts empty
+    VariableSpace parentSpace = new Variables(); // toSpace – source of variables
+    parentSpace.setVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY, "/parent/dir" );
+    parentSpace.setVariable( "customVar", "parentValue" );
+
+    StepWithMappingMeta.addMissingVariables( childSpace, parentSpace );
+
+    // Non-internal variable that was missing on child should be copied from parent
+    Assert.assertEquals( "parentValue", childSpace.getVariable( "customVar" ) );
+
+    // Internal variable must NOT be copied to child, even though it was missing there
+    Assert.assertNull( childSpace.getVariable( Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY ) );
+  }
 }


### PR DESCRIPTION
Original PRs: https://github.com/pentaho/pentaho-kettle/pull/10563, https://github.com/pentaho/pentaho-kettle/pull/10568
Original commits: https://github.com/pentaho/pentaho-kettle/pull/10563/changes/415ff051ab47d4c66c80d7b7480fb8df8f4785a3, https://github.com/pentaho/pentaho-kettle/pull/10563/changes/d56f378f504520060739ba678cd9a6dd5ac69462, https://github.com/pentaho/pentaho-kettle/pull/10563/changes/d6539775c7d0a0b1ce36fb0a39397fe3df262a19, https://github.com/pentaho/pentaho-kettle/pull/10568/changes/0d06f1ce3592cf5ffca226d67f436a1865b541db