### PR TITLE
PPP-6577: bump jsch to 0.2.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <!-- Third-party dependencies -->
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <encoder.version>1.2</encoder.version>
-    <jsch.version>0.2.9</jsch.version>
+    <jsch.version>0.2.26</jsch.version>
     <jface.version>3.31.0</jface.version>
     <commands.version>3.12.100</commands.version>
     <common.version>3.18.0</common.version>


### PR DESCRIPTION
Automated vulnerability remediation.

- Ticket: PPP-6577
- Library: jsch
- Target version: 0.2.26
- CVE(s): CVE-2023-48795

Branch was built successfully in Docker (maven:3.9-eclipse-temurin-21) with JDK 21 before this PR was raised.