### PR TITLE
PPP-6577: upgrade com.github.mwiede:jsch to 0.2.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <!-- Third-party dependencies -->
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <encoder.version>1.2</encoder.version>
-    <jsch.version>0.2.9</jsch.version>
+      <jsch.version>0.2.26</jsch.version>
     <jface.version>3.31.0</jface.version>
     <commands.version>3.12.100</commands.version>
     <common.version>3.18.0</common.version>


### PR DESCRIPTION
## Summary
- addresses PPP-6577
- upgrades com.github.mwiede:jsch from 0.2.9 to 0.2.26

## Context
JFrog Xray ticket PPP-6577 flags CVE-2023-48795 against com.github.mwiede:jsch:0.2.9 in pdia-master artifacts.

## Validation
- updated shared jsch.version property in the affected build