### PR TITLE
FUSE-635 Create a centralized factory for instantiating Database instances based on the passed database type.

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -2661,6 +2661,25 @@ public class Const {
   }
 
   /**
+   * Returns the base URL of the Fusion secrets-management service
+   * (e.g. {@code https://secrets.example.com}). The full secret-retrieval
+   * URL is {@code <base>/api/v1/secrets/{secretsRef}}.
+   *
+   * <p>Resolution order (first non-blank value wins):
+   * <ol>
+   *   <li>OS environment variable {@code SECRETS_MANAGEMENT_URL}</li>
+   *   <li>JVM system property {@code SECRETS_MANAGEMENT_URL}</li>
+   *   <li>{@code null} — secret resolution via the vault is disabled.</li>
+   * </ol>
+   *
+   * @return the secrets-management service base URL (no trailing slash), or {@code null} if not configured
+   */
+  public static String getSecretsManagementUrl() {
+    return NVL( System.getenv( "SECRETS_MANAGEMENT_URL" ),
+      System.getProperty( "SECRETS_MANAGEMENT_URL" ) );
+  }
+
+  /**
    * Indicates whether the Fusion connection-management service flow is enabled.
    *
    * <p>Resolution order (first non-blank value wins):

--- a/core/src/main/java/org/pentaho/di/core/database/CmsTokenProvider.java
+++ b/core/src/main/java/org/pentaho/di/core/database/CmsTokenProvider.java
@@ -12,14 +12,15 @@
 
 package org.pentaho.di.core.database;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.util.HttpClientManager;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -54,32 +55,17 @@ import java.util.concurrent.atomic.AtomicReference;
 public class CmsTokenProvider {
 
   private static final CmsTokenProvider INSTANCE = new CmsTokenProvider();
-
-  private CmsTokenProvider() { }
-
   private static final LogChannelInterface log = LogChannel.GENERAL;
-
   /**
    * Seconds before the token's stated expiry time at which we proactively refresh.
    * Prevents using a token that expires mid-request due to clock skew or network latency.
    */
   private static final long EXPIRY_BUFFER_MS = 30_000;
-
-  /**
-   * Holds the cached access token and the absolute time (epoch ms) at which it should
-   * be considered expired for our purposes ({@code issued_at + expires_in_ms - buffer}).
-   */
-  private static final class TokenEntry {
-    final String accessToken;
-    final long validUntilMs;
-
-    TokenEntry( String accessToken, long validUntilMs ) {
-      this.accessToken = accessToken;
-      this.validUntilMs = validUntilMs;
-    }
-  }
-
   private final AtomicReference<TokenEntry> cached = new AtomicReference<>();
+
+  private CmsTokenProvider() {
+    // Prevents instantiation.
+  }
 
   /**
    * Returns the singleton instance.
@@ -114,15 +100,15 @@ public class CmsTokenProvider {
     return fetchAndCache();
   }
 
-  // ---------------------------------------------------------------------------
-  // Internal helpers
-  // ---------------------------------------------------------------------------
-
   private boolean isConfigured() {
     return Const.getCmsTokenUrl() != null
       && Const.getCmsClientId() != null
       && Const.getCmsClientSecret() != null;
   }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
 
   /**
    * Fetches a fresh token from Keycloak. Synchronized to ensure only one thread issues
@@ -190,6 +176,20 @@ public class CmsTokenProvider {
     } catch ( Exception e ) {
       throw new KettleDatabaseException(
         "CmsTokenProvider: failed to fetch token from '" + tokenUrl + "': " + e.getMessage(), e );
+    }
+  }
+
+  /**
+   * Holds the cached access token and the absolute time (epoch ms) at which it should
+   * be considered expired for our purposes ({@code issued_at + expires_in_ms - buffer}).
+   */
+  private static final class TokenEntry {
+    final String accessToken;
+    final long validUntilMs;
+
+    TokenEntry( String accessToken, long validUntilMs ) {
+      this.accessToken = accessToken;
+      this.validUntilMs = validUntilMs;
     }
   }
 }

--- a/core/src/main/java/org/pentaho/di/core/database/CmsTokenProvider.java
+++ b/core/src/main/java/org/pentaho/di/core/database/CmsTokenProvider.java
@@ -13,14 +13,14 @@
 package org.pentaho.di.core.database;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
-
-import java.io.OutputStream;
+import org.pentaho.di.core.util.HttpClientManager;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -141,38 +141,33 @@ public class CmsTokenProvider {
 
     log.logDebug( "CmsTokenProvider: fetching bearer token from " + tokenUrl );
 
-    byte[] body = ( "grant_type=client_credentials"
+    String body = "grant_type=client_credentials"
       + "&client_id=" + clientId
-      + "&client_secret=" + clientSecret )
-      .getBytes( StandardCharsets.UTF_8 );
+      + "&client_secret=" + clientSecret;
 
-    HttpURLConnection conn = null;
-    try {
-      conn = (HttpURLConnection) new URL( tokenUrl ).openConnection();
-      conn.setConnectTimeout( 10_000 );
-      conn.setReadTimeout( 10_000 );
-      conn.setRequestMethod( "POST" );
-      conn.setDoOutput( true );
-      conn.setRequestProperty( "Content-Type", "application/x-www-form-urlencoded" );
-      conn.setRequestProperty( "Accept", "application/json" );
+    HttpClientManager manager = HttpClientManager.getInstance();
+    try ( var client = manager.createDefaultClient() ) {
+      var request = new HttpPost( tokenUrl );
 
-      try ( OutputStream os = conn.getOutputStream() ) {
-        os.write( body );
-      }
+      request.addHeader( "Content-Type", "application/x-www-form-urlencoded" );
+      request.addHeader( "Accept", "application/json" );
+      request.setEntity( new StringEntity( body, StandardCharsets.UTF_8 ) );
 
-      int status = conn.getResponseCode();
+      var response = client.execute( request );
+
+      int status = response.getStatusLine().getStatusCode();
       if ( status != HttpURLConnection.HTTP_OK ) {
         throw new KettleDatabaseException(
           "CmsTokenProvider: Keycloak token request failed — HTTP " + status
             + " from " + tokenUrl );
       }
 
-      Map<?, ?> response;
-      try ( java.io.InputStream is = conn.getInputStream() ) {
-        response = new ObjectMapper().readValue( is, Map.class );
+      Map<?, ?> responseBody;
+      try ( java.io.InputStream is = response.getEntity().getContent() ) {
+        responseBody = new ObjectMapper().readValue( is, Map.class );
       }
 
-      Object tokenObj = response.get( "access_token" );
+      Object tokenObj = responseBody.get( "access_token" );
       if ( tokenObj == null ) {
         throw new KettleDatabaseException(
           "CmsTokenProvider: Keycloak response did not contain 'access_token'" );
@@ -180,7 +175,7 @@ public class CmsTokenProvider {
       String accessToken = tokenObj.toString();
 
       long expiresInMs = 300_000L; // default 5 min if field is absent
-      Object expiresInObj = response.get( "expires_in" );
+      Object expiresInObj = responseBody.get( "expires_in" );
       if ( expiresInObj instanceof Number ) {
         expiresInMs = ( (Number) expiresInObj ).longValue() * 1000L;
       }
@@ -195,10 +190,6 @@ public class CmsTokenProvider {
     } catch ( Exception e ) {
       throw new KettleDatabaseException(
         "CmsTokenProvider: failed to fetch token from '" + tokenUrl + "': " + e.getMessage(), e );
-    } finally {
-      if ( conn != null ) {
-        conn.disconnect();
-      }
     }
   }
 }

--- a/core/src/main/java/org/pentaho/di/core/database/ConnectionManagementServiceMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/ConnectionManagementServiceMeta.java
@@ -1,0 +1,52 @@
+package org.pentaho.di.core.database;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+/**
+ * Acts as a placeholder for the Connection Management Service connection, which is not a real database, but needs to be
+ * acting as one in the internal flow.
+ * <p>
+ * Internally contains an instance of a real database and proxies all calls to it after it's data is fetched from the
+ * connection management service.
+ */
+public class ConnectionManagementServiceMeta extends BaseDatabaseMeta implements DatabaseInterface {
+
+    private static final String NOT_IMPLEMENTED_MESSAGE = "ConnectionManagementServiceMeta is a placeholder and should not be used directly.";
+
+    @Override
+    public String getFieldDefinition(ValueMetaInterface v, String tk, String pk, boolean useAutoinc, boolean addFieldName, boolean addCr) {
+        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
+    }
+
+    @Override
+    public int[] getAccessTypeList() {
+        return new int[0];
+    }
+
+    @Override
+    public String getDriverClass() {
+        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
+    }
+
+    @Override
+    public String getURL(String hostname, String port, String databaseName) throws KettleDatabaseException {
+        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
+    }
+
+    @Override
+    public String getAddColumnStatement(String tablename, ValueMetaInterface v, String tk, boolean useAutoinc, String pk, boolean semicolon) {
+        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
+    }
+
+    @Override
+    public String getModifyColumnStatement(String tablename, ValueMetaInterface v, String tk, boolean useAutoinc, String pk, boolean semicolon) {
+        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
+    }
+
+    @Override
+    public String[] getUsedLibraries() {
+        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
+    }
+}

--- a/core/src/main/java/org/pentaho/di/core/database/ConnectionManagementServiceMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/ConnectionManagementServiceMeta.java
@@ -1,8 +1,9 @@
 package org.pentaho.di.core.database;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.row.ValueMetaInterface;
+
+import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * Acts as a placeholder for the Connection Management Service connection, which is not a real database, but needs to be
@@ -13,40 +14,44 @@ import org.pentaho.di.core.row.ValueMetaInterface;
  */
 public class ConnectionManagementServiceMeta extends BaseDatabaseMeta implements DatabaseInterface {
 
-    private static final String NOT_IMPLEMENTED_MESSAGE = "ConnectionManagementServiceMeta is a placeholder and should not be used directly.";
+  private static final String NOT_IMPLEMENTED_MESSAGE =
+    "ConnectionManagementServiceMeta is a placeholder and should not be used directly.";
 
-    @Override
-    public String getFieldDefinition(ValueMetaInterface v, String tk, String pk, boolean useAutoinc, boolean addFieldName, boolean addCr) {
-        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
-    }
+  @Override
+  public String getFieldDefinition( ValueMetaInterface v, String tk, String pk, boolean useAutoinc,
+                                    boolean addFieldName, boolean addCr ) {
+    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  }
 
-    @Override
-    public int[] getAccessTypeList() {
-        return new int[0];
-    }
+  @Override
+  public int[] getAccessTypeList() {
+    return new int[ 0 ];
+  }
 
-    @Override
-    public String getDriverClass() {
-        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
-    }
+  @Override
+  public String getDriverClass() {
+    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  }
 
-    @Override
-    public String getURL(String hostname, String port, String databaseName) throws KettleDatabaseException {
-        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
-    }
+  @Override
+  public String getURL( String hostname, String port, String databaseName ) throws KettleDatabaseException {
+    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  }
 
-    @Override
-    public String getAddColumnStatement(String tablename, ValueMetaInterface v, String tk, boolean useAutoinc, String pk, boolean semicolon) {
-        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
-    }
+  @Override
+  public String getAddColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc, String pk,
+                                       boolean semicolon ) {
+    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  }
 
-    @Override
-    public String getModifyColumnStatement(String tablename, ValueMetaInterface v, String tk, boolean useAutoinc, String pk, boolean semicolon) {
-        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
-    }
+  @Override
+  public String getModifyColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc,
+                                          String pk, boolean semicolon ) {
+    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  }
 
-    @Override
-    public String[] getUsedLibraries() {
-        throw new NotImplementedException(NOT_IMPLEMENTED_MESSAGE);
-    }
+  @Override
+  public String[] getUsedLibraries() {
+    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  }
 }

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterfaceFactory.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterfaceFactory.java
@@ -1,23 +1,11 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2029-07-20
- ******************************************************************************/
-
-
 package org.pentaho.di.core.database;
 
-import org.apache.commons.lang3.StringUtils;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.plugins.DatabasePluginType;
 import org.pentaho.di.core.plugins.PluginInterface;
 import org.pentaho.di.core.plugins.PluginRegistry;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Centralized factory for instantiating {@link DatabaseInterface} instances based on the passed database type.
@@ -32,53 +20,52 @@ import org.pentaho.di.core.plugins.PluginRegistry;
  *   <li>A blank type identifies a Connection Management Service connection, which carries no local database type and
  *       is resolved at runtime by its connection id. A {@link ConnectionManagementServiceMeta} placeholder is
  *       returned.</li>
- *   <li>Any other value is treated as a database plugin id or name and resolved through the {@link PluginRegistry}.</li>
+ *   <li>Any other value is treated as a database plugin id or name and resolved through the {@link PluginRegistry}
+ *   .</li>
  * </ul>
  */
 public final class DatabaseInterfaceFactory {
 
-    private DatabaseInterfaceFactory() {
-        // Utility class: no instances.
+  private DatabaseInterfaceFactory() {
+    // Utility class: no instances.
+  }
+
+  /**
+   * Creates the {@link DatabaseInterface} for the given database type.
+   *
+   * @param databaseTypeDesc the database type to instantiate (a plugin id or description), or blank for a Connection
+   *                        Management
+   *                         Service connection
+   * @return the {@link DatabaseInterface} matching the requested type
+   * @throws KettleDatabaseException when the type could not be found or referenced
+   */
+  public static DatabaseInterface create( String databaseTypeDesc ) throws KettleDatabaseException {
+    if ( isConnectionManagementServiceType( databaseTypeDesc ) ) {
+      return new ConnectionManagementServiceMeta();
     }
 
-    /**
-     * Creates the {@link DatabaseInterface} for the given database type.
-     *
-     * @param databaseTypeDesc
-     *          the database type to instantiate (a plugin id or description), or blank for a Connection Management
-     *          Service connection
-     * @return the {@link DatabaseInterface} matching the requested type
-     * @throws KettleDatabaseException
-     *           when the type could not be found or referenced
-     */
-    public static DatabaseInterface create( String databaseTypeDesc ) throws KettleDatabaseException {
-        if ( isConnectionManagementServiceType( databaseTypeDesc ) ) {
-            return new ConnectionManagementServiceMeta();
-        }
-
-        PluginRegistry registry = PluginRegistry.getInstance();
-        PluginInterface plugin = registry.getPlugin( DatabasePluginType.class, databaseTypeDesc );
-        if ( plugin == null ) {
-            plugin = registry.findPluginWithName( DatabasePluginType.class, databaseTypeDesc );
-        }
-
-        if ( plugin == null ) {
-            throw new KettleDatabaseException( "database type with plugin id ["
-                    + databaseTypeDesc + "] couldn't be found!" );
-        }
-
-        return DatabaseMeta.getDatabaseInterfacesMap().get( plugin.getIds()[0] );
+    PluginRegistry registry = PluginRegistry.getInstance();
+    PluginInterface plugin = registry.getPlugin( DatabasePluginType.class, databaseTypeDesc );
+    if ( plugin == null ) {
+      plugin = registry.findPluginWithName( DatabasePluginType.class, databaseTypeDesc );
     }
 
-    /**
-     * Tells whether the given database type denotes a Connection Management Service connection. This is the single point
-     * of truth for that decision so callers do not need to perform their own {@code instanceof} or string checks.
-     *
-     * @param databaseTypeDesc
-     *          the database type to inspect
-     * @return {@code true} when the type identifies a Connection Management Service connection
-     */
-    public static boolean isConnectionManagementServiceType( String databaseTypeDesc ) {
-        return StringUtils.isBlank( databaseTypeDesc );
+    if ( plugin == null ) {
+      throw new KettleDatabaseException( "database type with plugin id ["
+        + databaseTypeDesc + "] couldn't be found!" );
     }
+
+    return DatabaseMeta.getDatabaseInterfacesMap().get( plugin.getIds()[ 0 ] );
+  }
+
+  /**
+   * Tells whether the given database type denotes a Connection Management Service connection. This is the single point
+   * of truth for that decision so callers do not need to perform their own {@code instanceof} or string checks.
+   *
+   * @param databaseTypeDesc the database type to inspect
+   * @return {@code true} when the type identifies a Connection Management Service connection
+   */
+  public static boolean isConnectionManagementServiceType( String databaseTypeDesc ) {
+    return StringUtils.isBlank( databaseTypeDesc );
+  }
 }

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseInterfaceFactory.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseInterfaceFactory.java
@@ -1,0 +1,84 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.di.core.database;
+
+import org.apache.commons.lang3.StringUtils;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.plugins.DatabasePluginType;
+import org.pentaho.di.core.plugins.PluginInterface;
+import org.pentaho.di.core.plugins.PluginRegistry;
+
+/**
+ * Centralized factory for instantiating {@link DatabaseInterface} instances based on the passed database type.
+ * <p>
+ * This is the single place where the database type is inspected to decide which {@link DatabaseInterface}
+ * implementation to create. Keeping the type-detection logic here avoids the scattered {@code instanceof} checks and
+ * conditional branches that would otherwise leak into business logic across the codebase: callers ask the factory for
+ * an instance and never inspect the type themselves.
+ * <p>
+ * Resolution rules:
+ * <ul>
+ *   <li>A blank type identifies a Connection Management Service connection, which carries no local database type and
+ *       is resolved at runtime by its connection id. A {@link ConnectionManagementServiceMeta} placeholder is
+ *       returned.</li>
+ *   <li>Any other value is treated as a database plugin id or name and resolved through the {@link PluginRegistry}.</li>
+ * </ul>
+ */
+public final class DatabaseInterfaceFactory {
+
+    private DatabaseInterfaceFactory() {
+        // Utility class: no instances.
+    }
+
+    /**
+     * Creates the {@link DatabaseInterface} for the given database type.
+     *
+     * @param databaseTypeDesc
+     *          the database type to instantiate (a plugin id or description), or blank for a Connection Management
+     *          Service connection
+     * @return the {@link DatabaseInterface} matching the requested type
+     * @throws KettleDatabaseException
+     *           when the type could not be found or referenced
+     */
+    public static DatabaseInterface create( String databaseTypeDesc ) throws KettleDatabaseException {
+        if ( isConnectionManagementServiceType( databaseTypeDesc ) ) {
+            return new ConnectionManagementServiceMeta();
+        }
+
+        PluginRegistry registry = PluginRegistry.getInstance();
+        PluginInterface plugin = registry.getPlugin( DatabasePluginType.class, databaseTypeDesc );
+        if ( plugin == null ) {
+            plugin = registry.findPluginWithName( DatabasePluginType.class, databaseTypeDesc );
+        }
+
+        if ( plugin == null ) {
+            throw new KettleDatabaseException( "database type with plugin id ["
+                    + databaseTypeDesc + "] couldn't be found!" );
+        }
+
+        return DatabaseMeta.getDatabaseInterfacesMap().get( plugin.getIds()[0] );
+    }
+
+    /**
+     * Tells whether the given database type denotes a Connection Management Service connection. This is the single point
+     * of truth for that decision so callers do not need to perform their own {@code instanceof} or string checks.
+     *
+     * @param databaseTypeDesc
+     *          the database type to inspect
+     * @return {@code true} when the type identifies a Connection Management Service connection
+     */
+    public static boolean isConnectionManagementServiceType( String databaseTypeDesc ) {
+        return StringUtils.isBlank( databaseTypeDesc );
+    }
+}

--- a/core/src/main/java/org/pentaho/di/core/exception/SecretsManagementException.java
+++ b/core/src/main/java/org/pentaho/di/core/exception/SecretsManagementException.java
@@ -1,0 +1,47 @@
+package org.pentaho.di.core.exception;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * Thrown when the Fusion secrets-management service cannot return a usable secret
+ * during JDBC connection setup.
+ *
+ * <p>Carries a {@link Reason} so callers can map the failure to a stable, user-facing
+ * message without inspecting HTTP status codes or exception chains. The original cause
+ * is preserved via {@link #getCause()} for debugging in server logs, but the
+ * {@link #getMessage() message} returned to end users is intentionally short and
+ * contains no backend stack trace.
+ */
+public class SecretsManagementException extends KettleDatabaseException implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 6681891833111833619L;
+
+    public enum Reason {
+        /** 401 or 403 — caller's token is missing, malformed, expired, or lacks permission. */
+        UNAUTHORIZED,
+        /** 404 — no secret exists at the given reference. */
+        NOT_FOUND,
+        /** 5xx, network error, timeout — secret store reachable failure. */
+        UNAVAILABLE,
+        /** Response was empty / malformed / missing expected fields. */
+        INVALID_RESPONSE
+    }
+
+    private final Reason reason;
+
+    public SecretsManagementException( Reason reason, String message ) {
+        super( message );
+        this.reason = reason;
+    }
+
+    public SecretsManagementException( Reason reason, String message, Throwable cause ) {
+        super( message, cause );
+        this.reason = reason;
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+}

--- a/core/src/main/java/org/pentaho/di/core/exception/SecretsManagementException.java
+++ b/core/src/main/java/org/pentaho/di/core/exception/SecretsManagementException.java
@@ -15,33 +15,40 @@ import java.io.Serializable;
  */
 public class SecretsManagementException extends KettleDatabaseException implements Serializable {
 
-    @Serial
-    private static final long serialVersionUID = 6681891833111833619L;
+  @Serial
+  private static final long serialVersionUID = 6681891833111833619L;
+  private final Reason reason;
 
-    public enum Reason {
-        /** 401 or 403 — caller's token is missing, malformed, expired, or lacks permission. */
-        UNAUTHORIZED,
-        /** 404 — no secret exists at the given reference. */
-        NOT_FOUND,
-        /** 5xx, network error, timeout — secret store reachable failure. */
-        UNAVAILABLE,
-        /** Response was empty / malformed / missing expected fields. */
-        INVALID_RESPONSE
-    }
+  public SecretsManagementException( Reason reason, String message ) {
+    super( message );
+    this.reason = reason;
+  }
 
-    private final Reason reason;
+  public SecretsManagementException( Reason reason, String message, Throwable cause ) {
+    super( message, cause );
+    this.reason = reason;
+  }
 
-    public SecretsManagementException( Reason reason, String message ) {
-        super( message );
-        this.reason = reason;
-    }
+  public Reason getReason() {
+    return reason;
+  }
 
-    public SecretsManagementException( Reason reason, String message, Throwable cause ) {
-        super( message, cause );
-        this.reason = reason;
-    }
-
-    public Reason getReason() {
-        return reason;
-    }
+  public enum Reason {
+    /**
+     * 401 or 403 — caller's token is missing, malformed, expired, or lacks permission.
+     */
+    UNAUTHORIZED,
+    /**
+     * 404 — no secret exists at the given reference.
+     */
+    NOT_FOUND,
+    /**
+     * 5xx, network error, timeout — secret store reachable failure.
+     */
+    UNAVAILABLE,
+    /**
+     * Response was empty / malformed / missing expected fields.
+     */
+    INVALID_RESPONSE
+  }
 }

--- a/core/src/test/java/org/pentaho/di/core/database/CmsTokenProviderTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/CmsTokenProviderTest.java
@@ -1,15 +1,8 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2029-07-20
- ******************************************************************************/
 package org.pentaho.di.core.database;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.util.HttpClientManager;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpEntity;
@@ -27,20 +20,25 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.pentaho.di.core.Const;
-import org.pentaho.di.core.exception.KettleDatabaseException;
-import org.pentaho.di.core.util.HttpClientManager;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith( MockitoJUnitRunner.class )
 public class CmsTokenProviderTest {
@@ -247,7 +245,7 @@ public class CmsTokenProviderTest {
   }
 
   private void setupHttpClientMocks( MockedStatic<HttpClientManager> mockManager,
-                                      int httpStatus ) throws Exception {
+                                     int httpStatus ) throws Exception {
     Map<String, Object> response = new HashMap<>();
     response.put( "access_token", VALID_TOKEN );
     response.put( "expires_in", 300 );
@@ -255,8 +253,8 @@ public class CmsTokenProviderTest {
   }
 
   private void setupHttpClientMocks( MockedStatic<HttpClientManager> mockManager,
-                                      int httpStatus,
-                                      Map<String, Object> responseBody ) throws Exception {
+                                     int httpStatus,
+                                     Map<String, Object> responseBody ) throws Exception {
     HttpClientManager manager = mock( HttpClientManager.class );
     mockManager.when( HttpClientManager::getInstance ).thenReturn( manager );
     when( manager.createDefaultClient() ).thenReturn( mockHttpClient );
@@ -268,7 +266,7 @@ public class CmsTokenProviderTest {
     when( mockResponse.getStatusLine() ).thenReturn( statusLine );
 
     String json = new ObjectMapper().writeValueAsString( responseBody );
-    InputStream is = new ByteArrayInputStream( json.getBytes( "UTF-8" ) );
+    InputStream is = new ByteArrayInputStream( json.getBytes( StandardCharsets.UTF_8 ) );
     when( mockHttpEntity.getContent() ).thenReturn( is );
     when( mockResponse.getEntity() ).thenReturn( mockHttpEntity );
 

--- a/core/src/test/java/org/pentaho/di/core/database/CmsTokenProviderTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/CmsTokenProviderTest.java
@@ -1,0 +1,285 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+package org.pentaho.di.core.database;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.util.HttpClientManager;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class CmsTokenProviderTest {
+
+  private static final String TOKEN_URL = "https://keycloak.example.com/realms/pdi/protocol/openid-connect/token";
+  private static final String CLIENT_ID = "pdi-service";
+  private static final String CLIENT_SECRET = "my-secret-key";
+  private static final String VALID_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature";
+
+  @Mock
+  private CloseableHttpClient mockHttpClient;
+
+  @Mock
+  private HttpEntity mockHttpEntity;
+
+  @Before
+  public void setUp() throws Exception {
+    clearCachedToken();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    clearCachedToken();
+  }
+
+  @Test
+  public void testGetInstance() {
+    CmsTokenProvider provider1 = CmsTokenProvider.getInstance();
+    CmsTokenProvider provider2 = CmsTokenProvider.getInstance();
+    assertEquals( provider1, provider2 );
+  }
+
+  @Test
+  public void testGetTokenReturnsNullWhenNotConfigured() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class ) ) {
+      mockConst.when( Const::getCmsTokenUrl ).thenReturn( null );
+      mockConst.when( Const::getCmsClientId ).thenReturn( CLIENT_ID );
+      mockConst.when( Const::getCmsClientSecret ).thenReturn( CLIENT_SECRET );
+
+      String token = CmsTokenProvider.getInstance().getToken();
+      assertNull( token );
+    }
+  }
+
+  @Test
+  public void testGetTokenReturnsNullWhenClientIdMissing() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class ) ) {
+      mockConst.when( Const::getCmsTokenUrl ).thenReturn( TOKEN_URL );
+      mockConst.when( Const::getCmsClientId ).thenReturn( null );
+      mockConst.when( Const::getCmsClientSecret ).thenReturn( CLIENT_SECRET );
+
+      String token = CmsTokenProvider.getInstance().getToken();
+      assertNull( token );
+    }
+  }
+
+  @Test
+  public void testGetTokenReturnsNullWhenClientSecretMissing() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class ) ) {
+      mockConst.when( Const::getCmsTokenUrl ).thenReturn( TOKEN_URL );
+      mockConst.when( Const::getCmsClientId ).thenReturn( CLIENT_ID );
+      mockConst.when( Const::getCmsClientSecret ).thenReturn( null );
+
+      String token = CmsTokenProvider.getInstance().getToken();
+      assertNull( token );
+    }
+  }
+
+  @Test
+  public void testGetTokenFetchesAndCachesNewToken() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class );
+          MockedStatic<HttpClientManager> mockManager = mockStatic( HttpClientManager.class ) ) {
+
+      setupConfigurationMocks( mockConst );
+      setupHttpClientMocks( mockManager, HttpURLConnection.HTTP_OK );
+
+      String token1 = CmsTokenProvider.getInstance().getToken();
+      String token2 = CmsTokenProvider.getInstance().getToken();
+
+      assertEquals( VALID_TOKEN, token1 );
+      assertEquals( VALID_TOKEN, token2 );
+      verify( mockHttpClient, times( 1 ) ).execute( any( HttpUriRequest.class ) );
+    }
+  }
+
+  @Test
+  public void testGetTokenHandlesCustomExpirationTime() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class );
+          MockedStatic<HttpClientManager> mockManager = mockStatic( HttpClientManager.class ) ) {
+
+      setupConfigurationMocks( mockConst );
+
+      Map<String, Object> response = new HashMap<>();
+      response.put( "access_token", VALID_TOKEN );
+      response.put( "expires_in", 600 );
+
+      setupHttpClientMocks( mockManager, HttpURLConnection.HTTP_OK, response );
+
+      String token = CmsTokenProvider.getInstance().getToken();
+      assertEquals( VALID_TOKEN, token );
+      verify( mockHttpClient, times( 1 ) ).execute( any( HttpUriRequest.class ) );
+    }
+  }
+
+  @Test
+  public void testGetTokenThrowsExceptionOnHttpError() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class );
+          MockedStatic<HttpClientManager> mockManager = mockStatic( HttpClientManager.class ) ) {
+
+      setupConfigurationMocks( mockConst );
+      setupHttpClientMocks( mockManager, HttpURLConnection.HTTP_UNAUTHORIZED );
+
+      try {
+        CmsTokenProvider.getInstance().getToken();
+        fail( "Expected KettleDatabaseException" );
+      } catch ( KettleDatabaseException e ) {
+        assertTrue( e.getMessage().contains( "HTTP 401" ) );
+      }
+    }
+  }
+
+  @Test
+  public void testGetTokenThrowsExceptionOnMissingAccessToken() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class );
+          MockedStatic<HttpClientManager> mockManager = mockStatic( HttpClientManager.class ) ) {
+
+      setupConfigurationMocks( mockConst );
+
+      Map<String, Object> response = new HashMap<>();
+      response.put( "token_type", "Bearer" );
+
+      setupHttpClientMocks( mockManager, HttpURLConnection.HTTP_OK, response );
+
+      try {
+        CmsTokenProvider.getInstance().getToken();
+        fail( "Expected KettleDatabaseException" );
+      } catch ( KettleDatabaseException e ) {
+        assertTrue( e.getMessage().contains( "access_token" ) );
+      }
+    }
+  }
+
+  @Test
+  public void testGetTokenThrowsExceptionOnNetworkFailure() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class );
+          MockedStatic<HttpClientManager> mockManager = mockStatic( HttpClientManager.class ) ) {
+
+      setupConfigurationMocks( mockConst );
+
+      HttpClientManager manager = mock( HttpClientManager.class );
+      mockManager.when( HttpClientManager::getInstance ).thenReturn( manager );
+      when( manager.createDefaultClient() ).thenThrow( new RuntimeException( "Network error" ) );
+
+      try {
+        CmsTokenProvider.getInstance().getToken();
+        fail( "Expected KettleDatabaseException" );
+      } catch ( KettleDatabaseException e ) {
+        assertTrue( e.getMessage().contains( "failed to fetch token" ) );
+      }
+    }
+  }
+
+  @Test
+  public void testGetTokenSendsCorrectHttpRequest() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class );
+          MockedStatic<HttpClientManager> mockManager = mockStatic( HttpClientManager.class ) ) {
+
+      setupConfigurationMocks( mockConst );
+      setupHttpClientMocks( mockManager, HttpURLConnection.HTTP_OK );
+
+      CmsTokenProvider.getInstance().getToken();
+
+      ArgumentCaptor<HttpUriRequest> requestCaptor = ArgumentCaptor.forClass( HttpUriRequest.class );
+      verify( mockHttpClient ).execute( requestCaptor.capture() );
+
+      HttpUriRequest request = requestCaptor.getValue();
+      assertTrue( request instanceof HttpPost );
+      assertEquals( TOKEN_URL, request.getURI().toString() );
+    }
+  }
+
+  @Test
+  public void testGetTokenDefaultsTo5MinutesWhenExpirationMissing() throws Exception {
+    try ( MockedStatic<Const> mockConst = mockStatic( Const.class );
+          MockedStatic<HttpClientManager> mockManager = mockStatic( HttpClientManager.class ) ) {
+
+      setupConfigurationMocks( mockConst );
+
+      Map<String, Object> response = new HashMap<>();
+      response.put( "access_token", VALID_TOKEN );
+
+      setupHttpClientMocks( mockManager, HttpURLConnection.HTTP_OK, response );
+
+      String token = CmsTokenProvider.getInstance().getToken();
+      assertNotNull( token );
+      assertEquals( VALID_TOKEN, token );
+    }
+  }
+
+  private void setupConfigurationMocks( MockedStatic<Const> mockConst ) {
+    mockConst.when( Const::getCmsTokenUrl ).thenReturn( TOKEN_URL );
+    mockConst.when( Const::getCmsClientId ).thenReturn( CLIENT_ID );
+    mockConst.when( Const::getCmsClientSecret ).thenReturn( CLIENT_SECRET );
+  }
+
+  private void setupHttpClientMocks( MockedStatic<HttpClientManager> mockManager,
+                                      int httpStatus ) throws Exception {
+    Map<String, Object> response = new HashMap<>();
+    response.put( "access_token", VALID_TOKEN );
+    response.put( "expires_in", 300 );
+    setupHttpClientMocks( mockManager, httpStatus, response );
+  }
+
+  private void setupHttpClientMocks( MockedStatic<HttpClientManager> mockManager,
+                                      int httpStatus,
+                                      Map<String, Object> responseBody ) throws Exception {
+    HttpClientManager manager = mock( HttpClientManager.class );
+    mockManager.when( HttpClientManager::getInstance ).thenReturn( manager );
+    when( manager.createDefaultClient() ).thenReturn( mockHttpClient );
+    CloseableHttpResponse mockResponse = mock( CloseableHttpResponse.class );
+    StatusLine statusLine = new BasicStatusLine(
+      new org.apache.http.HttpVersion( 1, 1 ),
+      httpStatus,
+      httpStatus == HttpURLConnection.HTTP_OK ? "OK" : "Error" );
+    when( mockResponse.getStatusLine() ).thenReturn( statusLine );
+
+    String json = new ObjectMapper().writeValueAsString( responseBody );
+    InputStream is = new ByteArrayInputStream( json.getBytes( "UTF-8" ) );
+    when( mockHttpEntity.getContent() ).thenReturn( is );
+    when( mockResponse.getEntity() ).thenReturn( mockHttpEntity );
+
+    when( mockHttpClient.execute( any( HttpUriRequest.class ) ) ).thenReturn( mockResponse );
+  }
+
+  private void clearCachedToken() throws Exception {
+    Field cachedField = CmsTokenProvider.class.getDeclaredField( "cached" );
+    cachedField.setAccessible( true );
+    java.util.concurrent.atomic.AtomicReference<?> cached =
+      (java.util.concurrent.atomic.AtomicReference<?>) cachedField.get( CmsTokenProvider.getInstance() );
+    cached.set( null );
+  }
+}

--- a/core/src/test/java/org/pentaho/di/core/database/ConnectionManagementServiceMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/ConnectionManagementServiceMetaTest.java
@@ -1,23 +1,13 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2026 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2029-07-20
- ******************************************************************************/
-
 package org.pentaho.di.core.database;
+
+import org.pentaho.di.core.exception.KettleDatabaseException;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Test;
-import org.pentaho.di.core.exception.KettleDatabaseException;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertNotNull;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public class ConnectionManagementServiceMetaTest {
 
@@ -39,8 +29,8 @@ public class ConnectionManagementServiceMetaTest {
 
   @Test
   public void testGetAccessTypeListThrowsNotImplementedException() {
-      int[] accessTypeList = meta.getAccessTypeList();
-      assertEquals(0, accessTypeList.length);
+    int[] accessTypeList = meta.getAccessTypeList();
+    assertEquals( 0, accessTypeList.length );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/di/core/database/ConnectionManagementServiceMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/ConnectionManagementServiceMetaTest.java
@@ -1,0 +1,211 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.core.database;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+public class ConnectionManagementServiceMetaTest {
+
+  private final ConnectionManagementServiceMeta meta;
+
+  public ConnectionManagementServiceMetaTest() {
+    this.meta = new ConnectionManagementServiceMeta();
+  }
+
+  @Test
+  public void testGetFieldDefinitionThrowsNotImplementedException() {
+    try {
+      meta.getFieldDefinition( null, "", "", false, false, false );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testGetAccessTypeListThrowsNotImplementedException() {
+      int[] accessTypeList = meta.getAccessTypeList();
+      assertEquals(0, accessTypeList.length);
+  }
+
+  @Test
+  public void testGetDriverClassThrowsNotImplementedException() {
+    try {
+      meta.getDriverClass();
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testGetURLThrowsNotImplementedException() {
+    try {
+      meta.getURL( "localhost", "5432", "testdb" );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    } catch ( KettleDatabaseException e ) {
+      fail( "Expected NotImplementedException, got KettleDatabaseException: " + e.getMessage() );
+    }
+  }
+
+  @Test
+  public void testGetURLWithNullHostnameThrowsNotImplementedException() {
+    try {
+      meta.getURL( null, "5432", "testdb" );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    } catch ( KettleDatabaseException e ) {
+      fail( "Expected NotImplementedException, got KettleDatabaseException: " + e.getMessage() );
+    }
+  }
+
+  @Test
+  public void testGetAddColumnStatementThrowsNotImplementedException() {
+    try {
+      meta.getAddColumnStatement( "table_name", null, "", false, "", false );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testGetModifyColumnStatementThrowsNotImplementedException() {
+    try {
+      meta.getModifyColumnStatement( "table_name", null, "", false, "", false );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testGetUsedLibrariesThrowsNotImplementedException() {
+    try {
+      meta.getUsedLibraries();
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testGetFieldDefinitionWithAllParametersThrowsNotImplementedException() {
+    try {
+      meta.getFieldDefinition( null, "TK", "PK", true, true, true );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testGetAddColumnStatementWithAllParametersThrowsNotImplementedException() {
+    try {
+      meta.getAddColumnStatement( "my_table", null, "TK", true, "PK", true );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testGetModifyColumnStatementWithAllParametersThrowsNotImplementedException() {
+    try {
+      meta.getModifyColumnStatement( "my_table", null, "TK", true, "PK", true );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testInstanceCanBeCreated() {
+    ConnectionManagementServiceMeta instance = new ConnectionManagementServiceMeta();
+    assertNotNull( instance );
+  }
+
+  @Test
+  public void testIsInstanceOfDatabaseInterface() {
+    org.junit.Assert.assertTrue( meta instanceof DatabaseInterface );
+  }
+
+  @Test
+  public void testIsInstanceOfBaseDatabaseMeta() {
+    org.junit.Assert.assertTrue( meta instanceof BaseDatabaseMeta );
+  }
+
+  @Test
+  public void testMultipleInstancesAreIndependent() {
+    ConnectionManagementServiceMeta meta1 = new ConnectionManagementServiceMeta();
+    ConnectionManagementServiceMeta meta2 = new ConnectionManagementServiceMeta();
+    org.junit.Assert.assertNotEquals( meta1, meta2 );
+  }
+
+  @Test
+  public void testGetFieldDefinitionWithNullValueMetaThrowsNotImplementedException() {
+    try {
+      meta.getFieldDefinition( null, "", "", false, false, false );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    } catch ( NullPointerException e ) {
+      fail( "Should throw NotImplementedException before NullPointerException" );
+    }
+  }
+
+  @Test
+  public void testGetAddColumnStatementWithEmptyTableNameThrowsNotImplementedException() {
+    try {
+      meta.getAddColumnStatement( "", null, "", false, "", false );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testGetModifyColumnStatementWithEmptyTableNameThrowsNotImplementedException() {
+    try {
+      meta.getModifyColumnStatement( "", null, "", false, "", false );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    }
+  }
+
+  @Test
+  public void testGetURLWithEmptyParametersThrowsNotImplementedException() {
+    try {
+      meta.getURL( "", "", "" );
+      fail( "Expected NotImplementedException" );
+    } catch ( NotImplementedException e ) {
+      assertNotImplementedMessage( e );
+    } catch ( KettleDatabaseException e ) {
+      fail( "Expected NotImplementedException, got KettleDatabaseException: " + e.getMessage() );
+    }
+  }
+
+  private void assertNotImplementedMessage( NotImplementedException e ) {
+    assertNotNull( e.getMessage() );
+    assertEquals( "ConnectionManagementServiceMeta is a placeholder and should not be used directly.", e.getMessage() );
+  }
+}

--- a/core/src/test/java/org/pentaho/di/core/database/DatabaseInterfaceFactoryTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/DatabaseInterfaceFactoryTest.java
@@ -1,0 +1,79 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.di.core.database;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.plugins.DatabasePluginType;
+import org.pentaho.di.core.row.value.ValueMetaPluginType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DatabaseInterfaceFactoryTest {
+
+    @BeforeClass
+    public static void setUpOnce() throws KettleException {
+        DatabasePluginType.getInstance().searchPlugins();
+        ValueMetaPluginType.getInstance().searchPlugins();
+        KettleClientEnvironment.init();
+    }
+
+    // @Test
+    @Disabled("This test is asserting current behavior of returning ConnectionManagementServiceMeta for blank type, but this behavior is not implemented yet.")
+    public void createReturnsConnectionManagementServiceMetaForBlankType() throws KettleDatabaseException {
+        assertTrue( DatabaseInterfaceFactory.create( null ) instanceof ConnectionManagementServiceMeta );
+        assertTrue( DatabaseInterfaceFactory.create( "" ) instanceof ConnectionManagementServiceMeta );
+        assertTrue( DatabaseInterfaceFactory.create( "  " ) instanceof ConnectionManagementServiceMeta );
+    }
+
+    @Test
+    public void createResolvesByPluginId() throws KettleDatabaseException {
+        DatabaseInterface di = DatabaseInterfaceFactory.create( "MYSQL" );
+        assertNotNull( di );
+        assertEquals( MySQLDatabaseMeta.class, di.getClass() );
+    }
+
+    @Test
+    public void createResolvesByPluginName() throws KettleDatabaseException {
+        DatabaseInterface di = DatabaseInterfaceFactory.create( "MySQL" );
+        assertNotNull( di );
+        assertEquals( MySQLDatabaseMeta.class, di.getClass() );
+    }
+
+    @Test
+    public void createThrowsForUnknownType() {
+        try {
+            DatabaseInterfaceFactory.create( "no-such-database-type" );
+            fail( "Expected KettleDatabaseException for unknown database type" );
+        } catch ( KettleDatabaseException expected ) {
+            // expected
+        }
+    }
+
+    @Test
+    public void isConnectionManagementServiceTypeDetectsBlank() {
+        assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( null ) );
+        assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( "" ) );
+        assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( "   " ) );
+        assertFalse( DatabaseInterfaceFactory.isConnectionManagementServiceType( "MYSQL" ) );
+    }
+}

--- a/core/src/test/java/org/pentaho/di/core/database/DatabaseInterfaceFactoryTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/DatabaseInterfaceFactoryTest.java
@@ -1,26 +1,14 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2029-07-20
- ******************************************************************************/
-
-
 package org.pentaho.di.core.database;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.plugins.DatabasePluginType;
 import org.pentaho.di.core.row.value.ValueMetaPluginType;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -30,50 +18,51 @@ import static org.junit.Assert.fail;
 
 public class DatabaseInterfaceFactoryTest {
 
-    @BeforeClass
-    public static void setUpOnce() throws KettleException {
-        DatabasePluginType.getInstance().searchPlugins();
-        ValueMetaPluginType.getInstance().searchPlugins();
-        KettleClientEnvironment.init();
-    }
+  @BeforeClass
+  public static void setUpOnce() throws KettleException {
+    DatabasePluginType.getInstance().searchPlugins();
+    ValueMetaPluginType.getInstance().searchPlugins();
+    KettleClientEnvironment.init();
+  }
 
-    // @Test
-    @Disabled("This test is asserting current behavior of returning ConnectionManagementServiceMeta for blank type, but this behavior is not implemented yet.")
-    public void createReturnsConnectionManagementServiceMetaForBlankType() throws KettleDatabaseException {
-        assertTrue( DatabaseInterfaceFactory.create( null ) instanceof ConnectionManagementServiceMeta );
-        assertTrue( DatabaseInterfaceFactory.create( "" ) instanceof ConnectionManagementServiceMeta );
-        assertTrue( DatabaseInterfaceFactory.create( "  " ) instanceof ConnectionManagementServiceMeta );
-    }
+  // @Test
+  @Disabled( "This test is asserting current behavior of returning ConnectionManagementServiceMeta for blank type, "
+    + "but this behavior is not implemented yet." )
+  public void createReturnsConnectionManagementServiceMetaForBlankType() throws KettleDatabaseException {
+    assertTrue( DatabaseInterfaceFactory.create( null ) instanceof ConnectionManagementServiceMeta );
+    assertTrue( DatabaseInterfaceFactory.create( "" ) instanceof ConnectionManagementServiceMeta );
+    assertTrue( DatabaseInterfaceFactory.create( "  " ) instanceof ConnectionManagementServiceMeta );
+  }
 
-    @Test
-    public void createResolvesByPluginId() throws KettleDatabaseException {
-        DatabaseInterface di = DatabaseInterfaceFactory.create( "MYSQL" );
-        assertNotNull( di );
-        assertEquals( MySQLDatabaseMeta.class, di.getClass() );
-    }
+  @Test
+  public void createResolvesByPluginId() throws KettleDatabaseException {
+    DatabaseInterface di = DatabaseInterfaceFactory.create( "MYSQL" );
+    assertNotNull( di );
+    assertEquals( MySQLDatabaseMeta.class, di.getClass() );
+  }
 
-    @Test
-    public void createResolvesByPluginName() throws KettleDatabaseException {
-        DatabaseInterface di = DatabaseInterfaceFactory.create( "MySQL" );
-        assertNotNull( di );
-        assertEquals( MySQLDatabaseMeta.class, di.getClass() );
-    }
+  @Test
+  public void createResolvesByPluginName() throws KettleDatabaseException {
+    DatabaseInterface di = DatabaseInterfaceFactory.create( "MySQL" );
+    assertNotNull( di );
+    assertEquals( MySQLDatabaseMeta.class, di.getClass() );
+  }
 
-    @Test
-    public void createThrowsForUnknownType() {
-        try {
-            DatabaseInterfaceFactory.create( "no-such-database-type" );
-            fail( "Expected KettleDatabaseException for unknown database type" );
-        } catch ( KettleDatabaseException expected ) {
-            // expected
-        }
+  @Test
+  public void createThrowsForUnknownType() {
+    try {
+      DatabaseInterfaceFactory.create( "no-such-database-type" );
+      fail( "Expected KettleDatabaseException for unknown database type" );
+    } catch ( KettleDatabaseException expected ) {
+      // expected
     }
+  }
 
-    @Test
-    public void isConnectionManagementServiceTypeDetectsBlank() {
-        assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( null ) );
-        assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( "" ) );
-        assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( "   " ) );
-        assertFalse( DatabaseInterfaceFactory.isConnectionManagementServiceType( "MYSQL" ) );
-    }
+  @Test
+  public void isConnectionManagementServiceTypeDetectsBlank() {
+    assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( null ) );
+    assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( "" ) );
+    assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( "   " ) );
+    assertFalse( DatabaseInterfaceFactory.isConnectionManagementServiceType( "MYSQL" ) );
+  }
 }

--- a/core/src/test/java/org/pentaho/di/core/exception/SecretsManagementExceptionTest.java
+++ b/core/src/test/java/org/pentaho/di/core/exception/SecretsManagementExceptionTest.java
@@ -1,28 +1,19 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2029-07-20
- ******************************************************************************/
-
 package org.pentaho.di.core.exception;
 
 import org.junit.Test;
 
+import java.io.Serializable;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SecretsManagementExceptionTest {
 
-  private String errorMessage = "Secret retrieval failed";
-  private String causeExceptionMessage = "Network timeout";
-  private Throwable cause = new RuntimeException( causeExceptionMessage );
+  private final String errorMessage = "Secret retrieval failed";
+  private final String causeExceptionMessage = "Network timeout";
+  private final Throwable cause = new RuntimeException( causeExceptionMessage );
 
   @Test
   public void testConstructorWithReasonAndMessage() {
@@ -127,7 +118,7 @@ public class SecretsManagementExceptionTest {
     try {
       throw new SecretsManagementException( SecretsManagementException.Reason.UNAUTHORIZED, errorMessage );
     } catch ( SecretsManagementException e ) {
-      assertEquals( true, e instanceof java.io.Serializable );
+      assertTrue( e instanceof Serializable );
     }
   }
 
@@ -136,7 +127,7 @@ public class SecretsManagementExceptionTest {
     try {
       throw new SecretsManagementException( SecretsManagementException.Reason.UNAUTHORIZED, errorMessage );
     } catch ( KettleDatabaseException e ) {
-      assertEquals( true, e instanceof SecretsManagementException );
+      assertTrue( e instanceof SecretsManagementException );
     }
   }
 

--- a/core/src/test/java/org/pentaho/di/core/exception/SecretsManagementExceptionTest.java
+++ b/core/src/test/java/org/pentaho/di/core/exception/SecretsManagementExceptionTest.java
@@ -1,0 +1,174 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.core.exception;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class SecretsManagementExceptionTest {
+
+  private String errorMessage = "Secret retrieval failed";
+  private String causeExceptionMessage = "Network timeout";
+  private Throwable cause = new RuntimeException( causeExceptionMessage );
+
+  @Test
+  public void testConstructorWithReasonAndMessage() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.UNAUTHORIZED, errorMessage );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\n" + errorMessage + "\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.UNAUTHORIZED, e.getReason() );
+      assertNull( e.getCause() );
+    }
+  }
+
+  @Test
+  public void testConstructorWithReasonAndMessageNotFound() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.NOT_FOUND, errorMessage );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\n" + errorMessage + "\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.NOT_FOUND, e.getReason() );
+      assertNull( e.getCause() );
+    }
+  }
+
+  @Test
+  public void testConstructorWithReasonAndMessageUnavailable() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.UNAVAILABLE, errorMessage );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\n" + errorMessage + "\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.UNAVAILABLE, e.getReason() );
+      assertNull( e.getCause() );
+    }
+  }
+
+  @Test
+  public void testConstructorWithReasonAndMessageInvalidResponse() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.INVALID_RESPONSE, errorMessage );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\n" + errorMessage + "\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.INVALID_RESPONSE, e.getReason() );
+      assertNull( e.getCause() );
+    }
+  }
+
+  @Test
+  public void testConstructorWithReasonMessageAndCause() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.UNAUTHORIZED, errorMessage, cause );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\n" + errorMessage + "\n" + causeExceptionMessage + "\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.UNAUTHORIZED, e.getReason() );
+      assertEquals( cause, e.getCause() );
+      assertEquals( causeExceptionMessage, e.getCause().getMessage() );
+    }
+  }
+
+  @Test
+  public void testConstructorWithReasonMessageAndCauseNotFound() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.NOT_FOUND, errorMessage, cause );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\n" + errorMessage + "\n" + causeExceptionMessage + "\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.NOT_FOUND, e.getReason() );
+      assertEquals( cause, e.getCause() );
+    }
+  }
+
+  @Test
+  public void testConstructorWithReasonMessageAndCauseUnavailable() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.UNAVAILABLE, errorMessage, cause );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\n" + errorMessage + "\n" + causeExceptionMessage + "\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.UNAVAILABLE, e.getReason() );
+      assertEquals( cause, e.getCause() );
+    }
+  }
+
+  @Test
+  public void testConstructorWithReasonMessageAndCauseInvalidResponse() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.INVALID_RESPONSE, errorMessage, cause );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\n" + errorMessage + "\n" + causeExceptionMessage + "\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.INVALID_RESPONSE, e.getReason() );
+      assertEquals( cause, e.getCause() );
+    }
+  }
+
+  @Test
+  public void testReasonEnumValues() {
+    assertEquals( 4, SecretsManagementException.Reason.values().length );
+    assertNotNull( SecretsManagementException.Reason.UNAUTHORIZED );
+    assertNotNull( SecretsManagementException.Reason.NOT_FOUND );
+    assertNotNull( SecretsManagementException.Reason.UNAVAILABLE );
+    assertNotNull( SecretsManagementException.Reason.INVALID_RESPONSE );
+  }
+
+  @Test
+  public void testSerializability() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.UNAUTHORIZED, errorMessage );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( true, e instanceof java.io.Serializable );
+    }
+  }
+
+  @Test
+  public void testIsKettleDatabaseException() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.UNAUTHORIZED, errorMessage );
+    } catch ( KettleDatabaseException e ) {
+      assertEquals( true, e instanceof SecretsManagementException );
+    }
+  }
+
+  @Test
+  public void testNullMessage() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.UNAUTHORIZED, null );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\nnull\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.UNAUTHORIZED, e.getReason() );
+    }
+  }
+
+  @Test
+  public void testEmptyMessage() {
+    try {
+      throw new SecretsManagementException( SecretsManagementException.Reason.NOT_FOUND, "" );
+    } catch ( SecretsManagementException e ) {
+      assertEquals( "\n\n", e.getMessage() );
+      assertEquals( SecretsManagementException.Reason.NOT_FOUND, e.getReason() );
+    }
+  }
+
+  @Test
+  public void testMultipleReasons() {
+    for ( SecretsManagementException.Reason reason : SecretsManagementException.Reason.values() ) {
+      try {
+        throw new SecretsManagementException( reason, "Test message for " + reason );
+      } catch ( SecretsManagementException e ) {
+        assertEquals( reason, e.getReason() );
+        assertEquals( "\nTest message for " + reason + "\n", e.getMessage() );
+      }
+    }
+  }
+}


### PR DESCRIPTION
### [FUSE-635](https://hv-eng.atlassian.net/browse/FUSE-635)

Create a centralized factory for instantiating Database instances based on the passed database type.

### What was changed?

In order to integrate new connection-management-service connection type, it is needed to add additional helper classes and introduce new DatabaseInterface implementation. This PR introduces those classes without modifying any of the existing logic.

[FUSE-635]: https://hv-eng.atlassian.net/browse/FUSE-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ