### PR TITLE
[PPP-6393]-CVE-2026-35554 | pdia-master has a security violation in gav://org.apache.kafka:kafka-clients:3.9.1

### DIFF
--- a/plugins/kafka/core/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaDialogHelper.java
+++ b/plugins/kafka/core/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaDialogHelper.java
@@ -36,6 +36,8 @@ import org.pentaho.di.ui.core.widget.TextVar;
 import org.pentaho.hadoop.shim.api.cluster.NamedClusterService;
 import org.pentaho.metastore.locator.api.MetastoreLocator;
 
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,11 +45,45 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 import static org.pentaho.big.data.kettle.plugins.kafka.KafkaConsumerInputMeta.ConnectionType.CLUSTER;
 import static org.pentaho.big.data.kettle.plugins.kafka.KafkaConsumerInputMeta.ConnectionType.DIRECT;
 
 public class KafkaDialogHelper {
+
+  /**
+   * An {@link Executor} that submits tasks to {@link ForkJoinPool#commonPool()} while
+   * ensuring each task runs with the kafka-clients classloader as the thread context
+   * classloader.
+   *
+   * <p>Kafka 4.x's {@code ConsumerConfig} and {@code ProducerConfig} static initializers
+   * call {@code ConfigDef.parseType()} → {@code Utils.loadClass()} using the <em>thread
+   * context classloader</em> to validate CLASS-type config defaults (e.g.
+   * {@code DefaultJwtRetriever}).  {@link ForkJoinPool#commonPool()} worker threads inherit
+   * the <em>system</em> classloader, not the PDI plugin classloader, so those lookups fail
+   * with a {@link NoClassDefFoundError} and leave the Kafka config classes permanently
+   * broken ({@link ExceptionInInitializerError}).
+   *
+   * <p>By routing all async Kafka work through this executor every submitted task is
+   * guaranteed to run with the correct classloader, regardless of which pool thread is used.
+   */
+  private static final Executor KAFKA_CLASSLOADER_EXECUTOR;
+
+  static {
+    ClassLoader kafkaClassLoader = KafkaConsumer.class.getClassLoader();
+    KAFKA_CLASSLOADER_EXECUTOR = task -> ForkJoinPool.commonPool().execute( () -> {
+      Thread current = Thread.currentThread();
+      ClassLoader original = current.getContextClassLoader();
+      current.setContextClassLoader( kafkaClassLoader );
+      try {
+        task.run();
+      } finally {
+        current.setContextClassLoader( original );
+      }
+    } );
+  }
   protected ComboVar wTopic;
   protected ComboVar wClusterName;
   protected Button wbCluster;
@@ -94,7 +130,7 @@ public class KafkaDialogHelper {
     }
 
     CompletableFuture
-      .supplyAsync( () -> listTopics( clusterName, isCluster, directBootstrapServers, config ) )
+      .supplyAsync( () -> listTopics( clusterName, isCluster, directBootstrapServers, config ), KAFKA_CLASSLOADER_EXECUTOR )
       .thenAccept( topicMap -> Display.getDefault().syncExec( () -> populateTopics( topicMap, current ) ) );
   }
 
@@ -123,6 +159,7 @@ public class KafkaDialogHelper {
       localMeta.setConnectionType( isCluster ? CLUSTER : DIRECT );
       localMeta.setClusterName( clusterName );
       localMeta.setDirectBootstrapServers( directBootstrapServers );
+      localMeta.setConsumerGroup( "kettle-topic-listing-temp" );
       localMeta.setConfig( config );
       localMeta.setParentStepMeta( parentMeta );
       kafkaConsumer = kafkaFactory.consumer( localMeta, Function.identity() );

--- a/plugins/kafka/core/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaDialogHelperTest.java
+++ b/plugins/kafka/core/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaDialogHelperTest.java
@@ -1,0 +1,168 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.big.data.kettle.plugins.kafka;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith( MockitoJUnitRunner.class )
+public class KafkaDialogHelperTest {
+
+  private static Executor kafkaClassloaderExecutor() throws Exception {
+    Field field = KafkaDialogHelper.class.getDeclaredField( "KAFKA_CLASSLOADER_EXECUTOR" );
+    field.setAccessible( true );
+    return (Executor) field.get( null );
+  }
+
+  @Test
+  public void kafkaClassloaderExecutorIsInitialized() throws Exception {
+    assertNotNull( kafkaClassloaderExecutor() );
+  }
+
+  @Test
+  public void submittedTaskIsExecuted() throws Exception {
+    CountDownLatch latch = new CountDownLatch( 1 );
+    AtomicBoolean executed = new AtomicBoolean( false );
+
+    kafkaClassloaderExecutor().execute( () -> {
+      executed.set( true );
+      latch.countDown();
+    } );
+
+    assertTrue( latch.await( 5, TimeUnit.SECONDS ) );
+    assertTrue( executed.get() );
+  }
+
+  @Test
+  public void taskRunsWithKafkaClientsAsContextClassloader() throws Exception {
+    CountDownLatch latch = new CountDownLatch( 1 );
+    AtomicReference<ClassLoader> capturedClassLoader = new AtomicReference<>();
+
+    kafkaClassloaderExecutor().execute( () -> {
+      capturedClassLoader.set( Thread.currentThread().getContextClassLoader() );
+      latch.countDown();
+    } );
+
+    assertTrue( latch.await( 5, TimeUnit.SECONDS ) );
+    assertSame( KafkaConsumer.class.getClassLoader(), capturedClassLoader.get() );
+  }
+
+  @Test
+  public void taskRunsWithKafkaClientsClassloaderRegardlessOfCallingThreadClassloader() throws Exception {
+    CountDownLatch latch = new CountDownLatch( 1 );
+    AtomicReference<ClassLoader> capturedClassLoader = new AtomicReference<>();
+
+    Thread callingThread = Thread.currentThread();
+    ClassLoader originalCallerClassLoader = callingThread.getContextClassLoader();
+    ClassLoader customClassLoader = new ClassLoader( originalCallerClassLoader ) { };
+    callingThread.setContextClassLoader( customClassLoader );
+
+    try {
+      kafkaClassloaderExecutor().execute( () -> {
+        capturedClassLoader.set( Thread.currentThread().getContextClassLoader() );
+        latch.countDown();
+      } );
+
+      assertTrue( latch.await( 5, TimeUnit.SECONDS ) );
+      assertSame( KafkaConsumer.class.getClassLoader(), capturedClassLoader.get() );
+      assertNotSame( customClassLoader, capturedClassLoader.get() );
+    } finally {
+      callingThread.setContextClassLoader( originalCallerClassLoader );
+    }
+  }
+
+  @Test
+  public void subsequentTasksExecuteAfterPreviousTaskThrowsException() throws Exception {
+    CountDownLatch firstTaskLatch = new CountDownLatch( 1 );
+    CountDownLatch secondTaskLatch = new CountDownLatch( 1 );
+    AtomicBoolean secondTaskExecuted = new AtomicBoolean( false );
+
+    Executor executor = kafkaClassloaderExecutor();
+
+    executor.execute( () -> {
+      firstTaskLatch.countDown();
+      throw new RuntimeException( "intentional failure to verify finally-block classloader restore" );
+    } );
+
+    assertTrue( firstTaskLatch.await( 5, TimeUnit.SECONDS ) );
+
+    executor.execute( () -> {
+      secondTaskExecuted.set( true );
+      secondTaskLatch.countDown();
+    } );
+
+    assertTrue( secondTaskLatch.await( 5, TimeUnit.SECONDS ) );
+    assertTrue( secondTaskExecuted.get() );
+  }
+
+  @Test
+  public void taskAfterThrowingTaskStillRunsWithKafkaClientsClassloader() throws Exception {
+    CountDownLatch firstTaskLatch = new CountDownLatch( 1 );
+    CountDownLatch secondTaskLatch = new CountDownLatch( 1 );
+    AtomicReference<ClassLoader> classloaderAfterFailure = new AtomicReference<>();
+
+    Executor executor = kafkaClassloaderExecutor();
+
+    executor.execute( () -> {
+      firstTaskLatch.countDown();
+      throw new RuntimeException( "intentional failure" );
+    } );
+
+    assertTrue( firstTaskLatch.await( 5, TimeUnit.SECONDS ) );
+
+    executor.execute( () -> {
+      classloaderAfterFailure.set( Thread.currentThread().getContextClassLoader() );
+      secondTaskLatch.countDown();
+    } );
+
+    assertTrue( secondTaskLatch.await( 5, TimeUnit.SECONDS ) );
+    assertSame( KafkaConsumer.class.getClassLoader(), classloaderAfterFailure.get() );
+  }
+
+  @Test
+  public void multipleConcurrentTasksAllRunWithKafkaClientsClassloader() throws Exception {
+    int taskCount = 5;
+    CountDownLatch latch = new CountDownLatch( taskCount );
+    AtomicBoolean allHadCorrectClassloader = new AtomicBoolean( true );
+    ClassLoader expectedClassLoader = KafkaConsumer.class.getClassLoader();
+
+    Executor executor = kafkaClassloaderExecutor();
+
+    for ( int i = 0; i < taskCount; i++ ) {
+      executor.execute( () -> {
+        if ( Thread.currentThread().getContextClassLoader() != expectedClassLoader ) {
+          allHadCorrectClassloader.set( false );
+        }
+        latch.countDown();
+      } );
+    }
+
+    assertTrue( latch.await( 5, TimeUnit.SECONDS ) );
+    assertTrue( allHadCorrectClassloader.get() );
+  }
+}
+


### PR DESCRIPTION
Kafka 4.x introduced DefaultJwtRetriever as the default value for the sasl.oauthbearer.jwt.retriever.class config key. Kafka validates CLASS-type default values at class-load time inside ConsumerConfig's static initializer by calling Class.forName() using the thread's context classloader. The dialog's topic-listing call was dispatched via CompletableFuture.supplyAsync() without a custom executor, so it ran on a ForkJoinPool.commonPool() worker thread. Those threads carry the Karaf system classloader as their context classloader — which has no visibility into the kafka-clients . The class lookup fails, ConsumerConfig.<clinit> throws, and the JVM permanently poisons the class for the rest of the session (ExceptionInInitializerError).