### PR TITLE
fix[PPP-6483]: Remove stale flexjson version property from assemblies/lib

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -39,7 +39,6 @@
     <asm.version>3.2</asm.version>
     <blueprints-core.version>2.6.0</blueprints-core.version>
     <commons-configuration.version>1.9</commons-configuration.version>
-    <flexjson.version>2.1</flexjson.version>
     <mimepull.version>1.9.3</mimepull.version>
     <enunciate-jersey-rt.version>1.27</enunciate-jersey-rt.version>
     <enunciate-core-annotations.version>1.27</enunciate-core-annotations.version>
@@ -528,17 +527,6 @@
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
       <version>${commons-configuration.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.flexjson</groupId>
-      <artifactId>flexjson</artifactId>
-      <version>${flexjson.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
## Summary
Removes the orphaned `flexjson.version` property from `assemblies/lib/pom.xml`.

## Changes
- `assemblies/lib/pom.xml`: Remove `<flexjson.version>2.1</flexjson.version>` property

## Context
The property is no longer referenced by any active dependency declaration in this module. Cleanup as part of the full flexjson removal (PPP-6483).