### PR TITLE
FUSE-636 Create a global DatabaseDelegate class to cover all database types.

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -2627,6 +2627,16 @@ public class Const {
   }
 
   /**
+   * Returns the URL of the connection-management-service connections endpoint.
+   *
+   * @return the connections endpoint URL, or {@code null} if not configured.
+   */
+  public static String getCmsConnectionsUrl() {
+    return NVL( System.getenv( "CMS_CONNECTIONS_URL" ),
+      System.getProperty( "CMS_CONNECTIONS_URL" ) );
+  }
+
+  /**
    * Returns the Keycloak client ID for the PDI service account.
    *
    * <p>Resolution order (first non-blank value wins):

--- a/core/src/main/java/org/pentaho/di/core/database/CmsConnectionProvider.java
+++ b/core/src/main/java/org/pentaho/di/core/database/CmsConnectionProvider.java
@@ -1,0 +1,145 @@
+package org.pentaho.di.core.database;
+
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.exception.SecretsManagementException;
+import org.pentaho.di.core.util.HttpClientManager;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.pentaho.di.core.Const;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Http client for the connections from the connections-management-service.
+ */
+public class CmsConnectionProvider {
+
+  private static final CmsConnectionProvider INSTANCE = new CmsConnectionProvider();
+
+  private CmsConnectionProvider() {
+    // Prevents instantiation.
+  }
+
+  /**
+   * Returns the singleton instance.
+   */
+  public static CmsConnectionProvider getInstance() {
+    return INSTANCE;
+  }
+
+  private static String stripTrailingSlash( String s ) {
+    return s.endsWith( "/" ) ? s.substring( 0, s.length() - 1 ) : s;
+  }
+
+  public DatabaseInterface fetchConnectionDetails( String connectionId ) {
+    verifyConfigured();
+
+    try ( var client = getHttpClient() ) {
+      var request = prepareRequest( connectionId );
+      var response = client.execute( request );
+      var connectionDetails = verifyResponse( response );
+
+      return parseConnectionResponse( connectionDetails );
+    } catch ( IOException ex ) {
+      throw new RuntimeException( "Failed to fetch connection details for connection Id " + connectionId, ex );
+    }
+  }
+
+  private void verifyConfigured() {
+    if ( Const.getCmsConnectionsUrl() == null ) {
+      throw new IllegalStateException(
+        "CMS connection provider is not configured. Please set CMS_CONNECTIONS_URL, CMS_CLIENT_ID, and "
+          + "CMS_CLIENT_SECRET." );
+    }
+  }
+
+  private HttpGet prepareRequest( String connectionId ) {
+    var requestUrl = stripTrailingSlash( Const.getCmsConnectionsUrl() ) + "/" + connectionId;
+    var request = new HttpGet( requestUrl );
+
+    request.addHeader( "Content-Type", "application/json" );
+
+    try {
+      var token = CmsTokenProvider.getInstance().getToken();
+
+      if ( StringUtils.isNotBlank( token ) ) {
+        request.addHeader( "Authorization", "Bearer " + token );
+      }
+    } catch ( KettleDatabaseException e ) {
+      throw new RuntimeException( e );
+    }
+
+    return request;
+  }
+
+  private JsonNode verifyResponse( HttpResponse response ) throws IOException {
+    var statusCode = response.getStatusLine().getStatusCode();
+
+    if ( statusCode != 200 ) {
+      throw new RuntimeException(
+        "Failed to fetch connection details from the connection management service. Status code: " + statusCode );
+    }
+
+    var content = new String( response.getEntity().getContent().readAllBytes() );
+    var mapper = new ObjectMapper();
+
+    return mapper.readTree( content );
+  }
+
+  private DatabaseInterface parseConnectionResponse( JsonNode connectionNode ) {
+    var databaseConnection = connectionNode.path( "databaseConnection" );
+    var detail = databaseConnection.path( "detail" );
+    var type = detail.path( "databaseType" ).path( "shortName" ).asText();
+    var secretsRef = databaseConnection.path( "credentials" ).path( "secretReference" ).asText();
+
+    try {
+      var db = DatabaseMeta.getDatabaseInterface( type );
+
+      db.setConnectionId( databaseConnection.path( "id" ).asText() );
+      db.setName( databaseConnection.path( "name" ).asText() );
+      db.setHostname( detail.path( "hostname" ).asText() );
+      db.setDatabaseName( detail.path( "databaseName" ).asText() );
+      db.setDatabasePortNumberString( detail.path( "databasePort" ).asText() );
+
+      var credentials = fetchCredentials( secretsRef );
+      db.setUsername( credentials.get( "username" ) );
+      db.setPassword( credentials.get( "password" ) );
+
+      db.setDataTablespace( detail.path( "dataTablespace" ).asText() );
+      db.setIndexTablespace( detail.path( "indexTablespace" ).asText() );
+
+      return db;
+    } catch ( KettleDatabaseException e ) {
+      throw new RuntimeException( e );
+    }
+  }
+
+  private Map<String, String> fetchCredentials( String connectionId ) {
+    try {
+      var secrets = SecretsManagementClient.getInstance().getSecrets( connectionId );
+      var user = secrets.get( "username" );
+      var pass = secrets.get( "password" );
+
+      if ( user == null && pass == null ) {
+        throw new SecretsManagementException(
+          SecretsManagementException.Reason.INVALID_RESPONSE,
+          "Secret bundle for connection '" + connectionId + "' did not contain 'username' or 'password'" );
+      }
+
+      return secrets;
+    } catch ( SecretsManagementException ex ) {
+      throw new RuntimeException( ex );
+    }
+  }
+
+  private CloseableHttpClient getHttpClient() {
+    return HttpClientManager.getInstance()
+      .createBuilder()
+      .build();
+  }
+}

--- a/core/src/main/java/org/pentaho/di/core/database/CmsTokenProvider.java
+++ b/core/src/main/java/org/pentaho/di/core/database/CmsTokenProvider.java
@@ -12,17 +12,21 @@
 
 package org.pentaho.di.core.database;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.core.util.HttpClientManager;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -55,17 +59,32 @@ import java.util.concurrent.atomic.AtomicReference;
 public class CmsTokenProvider {
 
   private static final CmsTokenProvider INSTANCE = new CmsTokenProvider();
+
+  private CmsTokenProvider() { }
+
   private static final LogChannelInterface log = LogChannel.GENERAL;
+
   /**
    * Seconds before the token's stated expiry time at which we proactively refresh.
    * Prevents using a token that expires mid-request due to clock skew or network latency.
    */
   private static final long EXPIRY_BUFFER_MS = 30_000;
-  private final AtomicReference<TokenEntry> cached = new AtomicReference<>();
 
-  private CmsTokenProvider() {
-    // Prevents instantiation.
+  /**
+   * Holds the cached access token and the absolute time (epoch ms) at which it should
+   * be considered expired for our purposes ({@code issued_at + expires_in_ms - buffer}).
+   */
+  private static final class TokenEntry {
+    final String accessToken;
+    final long validUntilMs;
+
+    TokenEntry( String accessToken, long validUntilMs ) {
+      this.accessToken = accessToken;
+      this.validUntilMs = validUntilMs;
+    }
   }
+
+  private final AtomicReference<TokenEntry> cached = new AtomicReference<>();
 
   /**
    * Returns the singleton instance.
@@ -100,15 +119,15 @@ public class CmsTokenProvider {
     return fetchAndCache();
   }
 
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
   private boolean isConfigured() {
     return Const.getCmsTokenUrl() != null
       && Const.getCmsClientId() != null
       && Const.getCmsClientSecret() != null;
   }
-
-  // ---------------------------------------------------------------------------
-  // Internal helpers
-  // ---------------------------------------------------------------------------
 
   /**
    * Fetches a fresh token from Keycloak. Synchronized to ensure only one thread issues
@@ -127,33 +146,38 @@ public class CmsTokenProvider {
 
     log.logDebug( "CmsTokenProvider: fetching bearer token from " + tokenUrl );
 
-    String body = "grant_type=client_credentials"
+    byte[] body = ( "grant_type=client_credentials"
       + "&client_id=" + clientId
-      + "&client_secret=" + clientSecret;
+      + "&client_secret=" + clientSecret )
+      .getBytes( StandardCharsets.UTF_8 );
 
-    HttpClientManager manager = HttpClientManager.getInstance();
-    try ( var client = manager.createDefaultClient() ) {
-      var request = new HttpPost( tokenUrl );
+    HttpURLConnection conn = null;
+    try {
+      conn = createInsecureConnection( tokenUrl );
+      conn.setConnectTimeout( 10_000 );
+      conn.setReadTimeout( 10_000 );
+      conn.setRequestMethod( "POST" );
+      conn.setDoOutput( true );
+      conn.setRequestProperty( "Content-Type", "application/x-www-form-urlencoded" );
+      conn.setRequestProperty( "Accept", "application/json" );
 
-      request.addHeader( "Content-Type", "application/x-www-form-urlencoded" );
-      request.addHeader( "Accept", "application/json" );
-      request.setEntity( new StringEntity( body, StandardCharsets.UTF_8 ) );
+      try ( OutputStream os = conn.getOutputStream() ) {
+        os.write( body );
+      }
 
-      var response = client.execute( request );
-
-      int status = response.getStatusLine().getStatusCode();
+      int status = conn.getResponseCode();
       if ( status != HttpURLConnection.HTTP_OK ) {
         throw new KettleDatabaseException(
           "CmsTokenProvider: Keycloak token request failed — HTTP " + status
             + " from " + tokenUrl );
       }
 
-      Map<?, ?> responseBody;
-      try ( java.io.InputStream is = response.getEntity().getContent() ) {
-        responseBody = new ObjectMapper().readValue( is, Map.class );
+      Map<?, ?> response;
+      try ( java.io.InputStream is = conn.getInputStream() ) {
+        response = new ObjectMapper().readValue( is, Map.class );
       }
 
-      Object tokenObj = responseBody.get( "access_token" );
+      Object tokenObj = response.get( "access_token" );
       if ( tokenObj == null ) {
         throw new KettleDatabaseException(
           "CmsTokenProvider: Keycloak response did not contain 'access_token'" );
@@ -161,7 +185,7 @@ public class CmsTokenProvider {
       String accessToken = tokenObj.toString();
 
       long expiresInMs = 300_000L; // default 5 min if field is absent
-      Object expiresInObj = responseBody.get( "expires_in" );
+      Object expiresInObj = response.get( "expires_in" );
       if ( expiresInObj instanceof Number ) {
         expiresInMs = ( (Number) expiresInObj ).longValue() * 1000L;
       }
@@ -176,20 +200,46 @@ public class CmsTokenProvider {
     } catch ( Exception e ) {
       throw new KettleDatabaseException(
         "CmsTokenProvider: failed to fetch token from '" + tokenUrl + "': " + e.getMessage(), e );
+    } finally {
+      if ( conn != null ) {
+        conn.disconnect();
+      }
     }
   }
 
-  /**
-   * Holds the cached access token and the absolute time (epoch ms) at which it should
-   * be considered expired for our purposes ({@code issued_at + expires_in_ms - buffer}).
-   */
-  private static final class TokenEntry {
-    final String accessToken;
-    final long validUntilMs;
+  public static HttpsURLConnection createInsecureConnection(String urlString) {
+    try {
+      java.net.URL url = new java.net.URL(urlString);
+      HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
 
-    TokenEntry( String accessToken, long validUntilMs ) {
-      this.accessToken = accessToken;
-      this.validUntilMs = validUntilMs;
+      // Create and set custom trust manager
+      TrustManager[] trustAllCerts = new TrustManager[]{
+        new X509TrustManager() {
+          @Override
+          public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+          }
+
+          @Override
+          public void checkClientTrusted(X509Certificate[] certs, String authType) {
+          }
+
+          @Override
+          public void checkServerTrusted(X509Certificate[] certs, String authType) {
+          }
+        }
+      };
+
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+
+      connection.setSSLSocketFactory(sslContext.getSocketFactory());
+      connection.setHostnameVerifier((hostname, session) -> true);
+
+      return connection;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create insecure HTTPS connection", e);
     }
   }
+
 }

--- a/core/src/main/java/org/pentaho/di/core/database/ConnectionManagementServiceMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/ConnectionManagementServiceMeta.java
@@ -1,9 +1,17 @@
 package org.pentaho.di.core.database;
 
 import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.exception.KettleValueException;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.variables.VariableSpace;
 
-import org.apache.commons.lang3.NotImplementedException;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Acts as a placeholder for the Connection Management Service connection, which is not a real database, but needs to be
@@ -14,44 +22,857 @@ import org.apache.commons.lang3.NotImplementedException;
  */
 public class ConnectionManagementServiceMeta extends BaseDatabaseMeta implements DatabaseInterface {
 
-  private static final String NOT_IMPLEMENTED_MESSAGE =
-    "ConnectionManagementServiceMeta is a placeholder and should not be used directly.";
+  private DatabaseInterface delegate;
 
-  @Override
-  public String getFieldDefinition( ValueMetaInterface v, String tk, String pk, boolean useAutoinc,
-                                    boolean addFieldName, boolean addCr ) {
-    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  public boolean isDataLoaded() {
+    return delegate != null;
   }
 
-  @Override
-  public int[] getAccessTypeList() {
-    return new int[ 0 ];
+  public DatabaseInterface getDelegateDatabaseInterface() {
+    return delegate;
   }
 
-  @Override
-  public String getDriverClass() {
-    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  public void setDelegateDatabaseInterface( DatabaseInterface delegate ) {
+    this.delegate = delegate;
   }
 
-  @Override
-  public String getURL( String hostname, String port, String databaseName ) throws KettleDatabaseException {
-    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  @Override public String getPluginId() {
+    return delegate == null ? null : delegate.getPluginId();
+  }
+
+  @Override public void setPluginId( String pluginId ) {
+    if ( delegate != null ) {
+      delegate.setPluginId( pluginId );
+    }
+  }
+
+  @Override public String getPluginName() {
+    return delegate == null ? null : delegate.getPluginName();
+  }
+
+  @Override public void setPluginName( String pluginName ) {
+    if ( delegate != null ) {
+      delegate.setPluginName( pluginName );
+    }
+  }
+
+  @Override public int getAccessType() {
+    return delegate == null ? 0 : delegate.getAccessType();
+  }
+
+  @Override public void setAccessType( int accessType ) {
+    if ( delegate != null ) {
+      delegate.setAccessType( accessType );
+    }
+  }
+
+  @Override public boolean isChanged() {
+    return delegate != null && delegate.isChanged();
+  }
+
+  @Override public void setChanged( boolean changed ) {
+    if ( delegate != null ) {
+      delegate.setChanged( changed );
+    }
+  }
+
+  @Override public String getDatabaseName() {
+    return delegate == null ? null : delegate.getDatabaseName();
+  }
+
+  @Override public void setDatabaseName( String databaseName ) {
+    if ( delegate != null ) {
+      delegate.setDatabaseName( databaseName );
+    }
+  }
+
+  @Override public String getDatabasePortNumberString() {
+    return delegate == null ? null : delegate.getDatabasePortNumberString();
+  }
+
+  @Override public void setDatabasePortNumberString( String databasePortNumberString ) {
+    if ( delegate != null ) {
+      delegate.setDatabasePortNumberString( databasePortNumberString );
+    }
+  }
+
+  @Override public String getHostname() {
+    return delegate == null ? null : delegate.getHostname();
+  }
+
+  @Override public void setHostname( String hostname ) {
+    if ( delegate != null ) {
+      delegate.setHostname( hostname );
+    }
+  }
+
+  @Override public String getUsername() {
+    return delegate == null ? null : delegate.getUsername();
+  }
+
+  @Override public void setUsername( String username ) {
+    if ( delegate != null ) {
+      delegate.setUsername( username );
+    }
+  }
+
+  @Override public String getPassword() {
+    return delegate == null ? null : delegate.getPassword();
+  }
+
+  @Override public void setPassword( String password ) {
+    if ( delegate != null ) {
+      delegate.setPassword( password );
+    }
+  }
+
+  @Override public String getServername() {
+    return delegate == null ? null : delegate.getServername();
+  }
+
+  @Override public void setServername( String servername ) {
+    if ( delegate != null ) {
+      delegate.setServername( servername );
+    }
+  }
+
+  @Override public String getDataTablespace() {
+    return delegate == null ? null : delegate.getDataTablespace();
+  }
+
+  @Override public void setDataTablespace( String dataTablespace ) {
+    if ( delegate != null ) {
+      delegate.setDataTablespace( dataTablespace );
+    }
+  }
+
+  @Override public String getIndexTablespace() {
+    return delegate == null ? null : delegate.getIndexTablespace();
+  }
+
+  @Override public void setIndexTablespace( String indexTablespace ) {
+    if ( delegate != null ) {
+      delegate.setIndexTablespace( indexTablespace );
+    }
+  }
+
+  @Override public Properties getAttributes() {
+    return delegate == null ? super.getAttributes() : delegate.getAttributes();
+  }
+
+  @Override public void setAttributes( Properties attributes ) {
+    if ( delegate != null ) {
+      delegate.setAttributes( attributes );
+    } else {
+      super.setAttributes( attributes );
+    }
+  }
+
+  @Override public void addAttribute( String attributeId, String value ) {
+    if ( delegate != null ) {
+      delegate.addAttribute( attributeId, value );
+    }
+  }
+
+  @Override public String getAttribute( String attributeId, String defaultValue ) {
+    return delegate == null ? null : delegate.getAttribute( attributeId, defaultValue );
+  }
+
+  @Override public boolean supportsSetCharacterStream() {
+    return delegate != null && delegate.supportsSetCharacterStream();
+  }
+
+  @Override public boolean supportsAutoInc() {
+    return delegate != null && delegate.supportsAutoInc();
+  }
+
+  @Override public String getFieldDefinition( ValueMetaInterface v, String tk, String pk, boolean useAutoinc,
+                                              boolean addFieldName, boolean addCr ) {
+    return delegate == null ? null : delegate.getFieldDefinition( v, tk, pk, useAutoinc, addFieldName, addCr );
+  }
+
+  @Override public int[] getAccessTypeList() {
+    return delegate == null ? new int[ 0 ] : delegate.getAccessTypeList();
+  }
+
+  @Override public int getDefaultDatabasePort() {
+    return delegate == null ? 0 : delegate.getDefaultDatabasePort();
+  }
+
+  @Override public Map<String, String> getDefaultOptions() {
+    return delegate == null ? null : delegate.getDefaultOptions();
+  }
+
+  @Override public String getLimitClause( int nrRows ) {
+    return delegate == null ? null : delegate.getLimitClause( nrRows );
+  }
+
+  @Override public String getSQLQueryFields( String tableName ) {
+    return delegate == null ? null : delegate.getSQLQueryFields( tableName );
+  }
+
+  @Override public int getNotFoundTK( boolean useAutoinc ) {
+    return delegate == null ? 0 : delegate.getNotFoundTK( useAutoinc );
+  }
+
+  @Override public String getDriverClass() {
+    return delegate == null ? null : delegate.getDriverClass();
+  }
+
+  @Override public String getURL( String hostname, String port, String databaseName ) throws KettleDatabaseException {
+    return delegate == null ? null : delegate.getURL( hostname, port, databaseName );
+  }
+
+  @Override public boolean supportsSequences() {
+    return delegate != null && delegate.supportsSequences();
+  }
+
+  @Override public String getSQLNextSequenceValue( String sequenceName ) {
+    return delegate == null ? null : delegate.getSQLNextSequenceValue( sequenceName );
+  }
+
+  @Override public String getSQLCurrentSequenceValue( String sequenceName ) {
+    return delegate == null ? null : delegate.getSQLCurrentSequenceValue( sequenceName );
+  }
+
+  @Override public String getSQLSequenceExists( String sequenceName ) {
+    return delegate == null ? null : delegate.getSQLSequenceExists( sequenceName );
+  }
+
+  @Override public boolean isFetchSizeSupported() {
+    return delegate != null && delegate.isFetchSizeSupported();
+  }
+
+  @Override public boolean supportsTransactions() {
+    return delegate != null && delegate.supportsTransactions();
+  }
+
+  @Override public boolean supportsBitmapIndex() {
+    return delegate != null && delegate.supportsBitmapIndex();
+  }
+
+  @Override public boolean supportsIndexes() {
+    return delegate != null && delegate.supportsIndexes();
+  }
+
+  @Override public boolean supportsSetLong() {
+    return delegate != null && delegate.supportsSetLong();
+  }
+
+  @Override public boolean supportsSchemas() {
+    return delegate != null && delegate.supportsSchemas();
+  }
+
+  @Override public boolean supportsCatalogs() {
+    return delegate != null && delegate.supportsCatalogs();
+  }
+
+  @Override public boolean supportsEmptyTransactions() {
+    return delegate != null && delegate.supportsEmptyTransactions();
+  }
+
+  @Override public boolean needsPlaceHolder() {
+    return delegate != null && delegate.needsPlaceHolder();
+  }
+
+  @Override public String getFunctionSum() {
+    return delegate == null ? null : delegate.getFunctionSum();
+  }
+
+  @Override public String getFunctionAverage() {
+    return delegate == null ? null : delegate.getFunctionAverage();
+  }
+
+  @Override public String getFunctionMinimum() {
+    return delegate == null ? null : delegate.getFunctionMinimum();
+  }
+
+  @Override public String getFunctionMaximum() {
+    return delegate == null ? null : delegate.getFunctionMaximum();
+  }
+
+  @Override public String getFunctionCount() {
+    return delegate == null ? null : delegate.getFunctionCount();
+  }
+
+  @Override public String getSchemaTableCombination( String schemaName, String tablePart ) {
+    return delegate == null ? null : delegate.getSchemaTableCombination( schemaName, tablePart );
+  }
+
+  @Override public int getMaxTextFieldLength() {
+    return delegate == null ? 0 : delegate.getMaxTextFieldLength();
+  }
+
+  @Override public int getMaxVARCHARLength() {
+    return delegate == null ? 0 : delegate.getMaxVARCHARLength();
   }
 
   @Override
   public String getAddColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc, String pk,
                                        boolean semicolon ) {
-    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+    return delegate == null ? null : delegate.getAddColumnStatement( tablename, v, tk, useAutoinc, pk, semicolon );
+  }
+
+  @Override public String getDropColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc,
+                                                  String pk, boolean semicolon ) {
+    return delegate == null ? null : delegate.getDropColumnStatement( tablename, v, tk, useAutoinc, pk, semicolon );
   }
 
   @Override
   public String getModifyColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc,
                                           String pk, boolean semicolon ) {
-    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+    return delegate == null ? null : delegate.getModifyColumnStatement( tablename, v, tk, useAutoinc, pk, semicolon );
+  }
+
+  @Override public String[] getReservedWords() {
+    return delegate == null ? new String[ 0 ] : delegate.getReservedWords();
+  }
+
+  @Override public boolean quoteReservedWords() {
+    return delegate != null && delegate.quoteReservedWords();
+  }
+
+  @Override public String getStartQuote() {
+    return delegate == null ? null : delegate.getStartQuote();
+  }
+
+  @Override public String getEndQuote() {
+    return delegate == null ? null : delegate.getEndQuote();
+  }
+
+  @Override public boolean supportsRepository() {
+    return delegate != null && delegate.supportsRepository();
+  }
+
+  @Override public String[] getTableTypes() {
+    return delegate == null ? null : delegate.getTableTypes();
+  }
+
+  @Override public String[] getViewTypes() {
+    return delegate == null ? null : delegate.getViewTypes();
+  }
+
+  @Override public String[] getSynonymTypes() {
+    return delegate == null ? null : delegate.getSynonymTypes();
+  }
+
+  @Override public boolean useSchemaNameForTableList() {
+    return delegate != null && delegate.useSchemaNameForTableList();
+  }
+
+  @Override public boolean supportsViews() {
+    return delegate != null && delegate.supportsViews();
+  }
+
+  @Override public boolean supportsSynonyms() {
+    return delegate != null && delegate.supportsSynonyms();
+  }
+
+  @Override public String getSQLListOfProcedures() {
+    return delegate == null ? null : delegate.getSQLListOfProcedures();
+  }
+
+  @Override public String getTruncateTableStatement( String tableName ) {
+    return delegate == null ? null : delegate.getTruncateTableStatement( tableName );
+  }
+
+  @Override public boolean supportsFloatRoundingOnUpdate() {
+    return delegate != null && delegate.supportsFloatRoundingOnUpdate();
+  }
+
+  @Override public String getSQLLockTables( String[] tableNames ) {
+    return delegate == null ? null : delegate.getSQLLockTables( tableNames );
+  }
+
+  @Override public String getSQLUnlockTables( String[] tableNames ) {
+    return delegate == null ? null : delegate.getSQLUnlockTables( tableNames );
+  }
+
+  @Override public boolean supportsTimeStampToDateConversion() {
+    return delegate != null && delegate.supportsTimeStampToDateConversion();
+  }
+
+  @Override public boolean supportsBatchUpdates() {
+    return delegate != null && delegate.supportsBatchUpdates();
+  }
+
+  @Override public boolean supportsBooleanDataType() {
+    return delegate != null && delegate.supportsBooleanDataType();
+  }
+
+  @Override public void setSupportsBooleanDataType( boolean b ) {
+    if ( delegate != null ) {
+      delegate.setSupportsBooleanDataType( b );
+    }
+  }
+
+  @Override public boolean preserveReservedCase() {
+    return delegate != null && delegate.preserveReservedCase();
+  }
+
+  @Override public void setPreserveReservedCase( boolean b ) {
+    if ( delegate != null ) {
+      delegate.setPreserveReservedCase( b );
+    }
+  }
+
+  @Override public boolean isDefaultingToUppercase() {
+    return delegate != null && delegate.isDefaultingToUppercase();
+  }
+
+  @Override public Map<String, String> getExtraOptions() {
+    return delegate == null ? super.getExtraOptions() : delegate.getExtraOptions();
+  }
+
+  @Override public void addExtraOption( String databaseTypeCode, String option, String value ) {
+    if ( delegate != null ) {
+      delegate.addExtraOption( databaseTypeCode, option, value );
+    } else {
+      super.addExtraOption( databaseTypeCode, option, value );
+    }
+  }
+
+  @Override public String getExtraOptionSeparator() {
+    return delegate == null ? null : delegate.getExtraOptionSeparator();
+  }
+
+  @Override public String getExtraOptionValueSeparator() {
+    return delegate == null ? null : delegate.getExtraOptionValueSeparator();
+  }
+
+  @Override public String getExtraOptionIndicator() {
+    return delegate == null ? null : delegate.getExtraOptionIndicator();
+  }
+
+  @Override public boolean supportsOptionsInURL() {
+    return delegate != null && delegate.supportsOptionsInURL();
+  }
+
+  @Override public String getExtraOptionsHelpText() {
+    return delegate == null ? null : delegate.getExtraOptionsHelpText();
+  }
+
+  @Override public boolean supportsGetBlob() {
+    return delegate != null && delegate.supportsGetBlob();
+  }
+
+  @Override public String getConnectSQL() {
+    return delegate == null ? null : delegate.getConnectSQL();
+  }
+
+  @Override public void setConnectSQL( String sql ) {
+    if ( delegate != null ) {
+      delegate.setConnectSQL( sql );
+    }
+  }
+
+  @Override public boolean supportsSetMaxRows() {
+    return delegate != null && delegate.supportsSetMaxRows();
+  }
+
+  @Override public boolean isUsingConnectionPool() {
+    return delegate != null && delegate.isUsingConnectionPool();
+  }
+
+  @Override public void setUsingConnectionPool( boolean usePool ) {
+    if ( delegate != null ) {
+      delegate.setUsingConnectionPool( usePool );
+    }
+  }
+
+  @Override public int getMaximumPoolSize() {
+    return delegate == null ? 0 : delegate.getMaximumPoolSize();
+  }
+
+  @Override public void setMaximumPoolSize( int maximumPoolSize ) {
+    if ( delegate != null ) {
+      delegate.setMaximumPoolSize( maximumPoolSize );
+    }
+  }
+
+  @Override public String getMaximumPoolSizeString() {
+    return delegate == null ? "0" : delegate.getMaximumPoolSizeString();
+  }
+
+  @Override public void setMaximumPoolSizeString( String maximumPoolSize ) {
+    if ( delegate != null ) {
+      delegate.setMaximumPoolSizeString( maximumPoolSize );
+    }
+  }
+
+  @Override public int getInitialPoolSize() {
+    return delegate == null ? 0 : delegate.getInitialPoolSize();
+  }
+
+  @Override public void setInitialPoolSize( int initalPoolSize ) {
+    if ( delegate != null ) {
+      delegate.setInitialPoolSize( initalPoolSize );
+    }
+  }
+
+  @Override public String getInitialPoolSizeString() {
+    return delegate == null ? "0" : delegate.getInitialPoolSizeString();
+  }
+
+  @Override public void setInitialPoolSizeString( String initialPoolSize ) {
+    if ( delegate != null ) {
+      delegate.setInitialPoolSizeString( initialPoolSize );
+    }
+  }
+
+  @Override public boolean isPartitioned() {
+    return delegate != null && delegate.isPartitioned();
+  }
+
+  @Override public void setPartitioned( boolean partitioned ) {
+    if ( delegate != null ) {
+      delegate.setPartitioned( partitioned );
+    }
+  }
+
+  @Override public PartitionDatabaseMeta[] getPartitioningInformation() {
+    return delegate == null ? null : delegate.getPartitioningInformation();
+  }
+
+  @Override public void setPartitioningInformation( PartitionDatabaseMeta[] partitionInfo ) {
+    if ( delegate != null ) {
+      delegate.setPartitioningInformation( partitionInfo );
+    }
+  }
+
+  @Override public String[] getUsedLibraries() {
+    return delegate == null ? new String[ 0 ] : delegate.getUsedLibraries();
+  }
+
+  @Override public Properties getConnectionPoolingProperties() {
+    return delegate == null ? null : delegate.getConnectionPoolingProperties();
+  }
+
+  @Override public void setConnectionPoolingProperties( Properties properties ) {
+    if ( delegate != null ) {
+      delegate.setConnectionPoolingProperties( properties );
+    }
+  }
+
+  @Override public String getSQLTableExists( String tablename ) {
+    return delegate == null ? null : delegate.getSQLTableExists( tablename );
+  }
+
+  @Override public String getSQLColumnExists( String column, String tablename ) {
+    return delegate == null ? null : delegate.getSQLColumnExists( column, tablename );
+  }
+
+  @Override public boolean needsToLockAllTables() {
+    return delegate != null && delegate.needsToLockAllTables();
+  }
+
+  @Override public boolean isStreamingResults() {
+    return delegate != null && delegate.isStreamingResults();
+  }
+
+  @Override public void setStreamingResults( boolean useStreaming ) {
+    if ( delegate != null ) {
+      delegate.setStreamingResults( useStreaming );
+    }
+  }
+
+  @Override public boolean isQuoteAllFields() {
+    return delegate != null && delegate.isQuoteAllFields();
+  }
+
+  @Override public void setQuoteAllFields( boolean quoteAllFields ) {
+    if ( delegate != null ) {
+      delegate.setQuoteAllFields( quoteAllFields );
+    }
+  }
+
+  @Override public boolean isForcingIdentifiersToLowerCase() {
+    return delegate != null && delegate.isForcingIdentifiersToLowerCase();
+  }
+
+  @Override public void setForcingIdentifiersToLowerCase( boolean forceLowerCase ) {
+    if ( delegate != null ) {
+      delegate.setForcingIdentifiersToLowerCase( forceLowerCase );
+    }
+  }
+
+  @Override public boolean isForcingIdentifiersToUpperCase() {
+    return delegate != null && delegate.isForcingIdentifiersToUpperCase();
+  }
+
+  @Override public void setForcingIdentifiersToUpperCase( boolean forceUpperCase ) {
+    if ( delegate != null ) {
+      delegate.setForcingIdentifiersToUpperCase( forceUpperCase );
+    }
+  }
+
+  @Override public boolean isUsingDoubleDecimalAsSchemaTableSeparator() {
+    return delegate != null && delegate.isUsingDoubleDecimalAsSchemaTableSeparator();
+  }
+
+  @Override public void setUsingDoubleDecimalAsSchemaTableSeparator( boolean useDoubleDecimalSeparator ) {
+    if ( delegate != null ) {
+      delegate.setUsingDoubleDecimalAsSchemaTableSeparator( useDoubleDecimalSeparator );
+    }
+  }
+
+  @Override public boolean isRequiringTransactionsOnQueries() {
+    return delegate != null && delegate.isRequiringTransactionsOnQueries();
+  }
+
+  @Override public String getDatabaseFactoryName() {
+    return delegate == null ? null : delegate.getDatabaseFactoryName();
+  }
+
+  @Override public String getPreferredSchemaName() {
+    return delegate == null ? null : delegate.getPreferredSchemaName();
+  }
+
+  @Override public void setPreferredSchemaName( String preferredSchemaName ) {
+    if ( delegate != null ) {
+      delegate.setPreferredSchemaName( preferredSchemaName );
+    }
   }
 
   @Override
-  public String[] getUsedLibraries() {
-    throw new NotImplementedException( NOT_IMPLEMENTED_MESSAGE );
+  public boolean checkIndexExists( Database database, String schemaName, String tableName, String[] idxFields )
+    throws KettleDatabaseException {
+    return delegate != null && delegate.checkIndexExists( database, schemaName, tableName, idxFields );
+  }
+
+  @Override public boolean supportsSequenceNoMaxValueOption() {
+    return delegate != null && delegate.supportsSequenceNoMaxValueOption();
+  }
+
+  @Override public boolean requiresCreateTablePrimaryKeyAppend() {
+    return delegate != null && delegate.requiresCreateTablePrimaryKeyAppend();
+  }
+
+  @Override public boolean requiresCastToVariousForIsNull() {
+    return delegate != null && delegate.requiresCastToVariousForIsNull();
+  }
+
+  @Override public boolean isDisplaySizeTwiceThePrecision() {
+    return delegate != null && delegate.isDisplaySizeTwiceThePrecision();
+  }
+
+  @Override public boolean supportsPreparedStatementMetadataRetrieval() {
+    return delegate != null && delegate.supportsPreparedStatementMetadataRetrieval();
+  }
+
+  @Override public boolean isSystemTable( String tableName ) {
+    return delegate != null && delegate.isSystemTable( tableName );
+  }
+
+  @Override public boolean supportsNewLinesInSQL() {
+    return delegate != null && delegate.supportsNewLinesInSQL();
+  }
+
+  @Override public String getSQLListOfSchemas() {
+    return delegate == null ? null : delegate.getSQLListOfSchemas();
+  }
+
+  @Override public String getSQLListOfSchemas( DatabaseMeta dbMeta ) {
+    return delegate == null ? null : delegate.getSQLListOfSchemas( dbMeta );
+  }
+
+  @Override public int getMaxColumnsInIndex() {
+    return delegate == null ? 0 : delegate.getMaxColumnsInIndex();
+  }
+
+  @Override public boolean supportsErrorHandlingOnBatchUpdates() {
+    return delegate != null && delegate.supportsErrorHandlingOnBatchUpdates();
+  }
+
+  @Override
+  public String getSQLInsertAutoIncUnknownDimensionRow( String schemaTable, String keyField, String versionField ) {
+    return delegate == null ? null :
+      delegate.getSQLInsertAutoIncUnknownDimensionRow( schemaTable, keyField, versionField );
+  }
+
+  @Override public boolean isExplorable() {
+    return delegate != null && delegate.isExplorable();
+  }
+
+  @Override public String getXulOverlayFile() {
+    return delegate == null ? null : delegate.getXulOverlayFile();
+  }
+
+  @Override public String getSQLListOfSequences() {
+    return delegate == null ? null : delegate.getSQLListOfSequences();
+  }
+
+  @Override public String quoteSQLString( String string ) {
+    if ( delegate != null ) {
+      return delegate.quoteSQLString( string );
+    } else {
+      throw new IllegalStateException( "Delegate is null" );
+    }
+  }
+
+  @Override public String getSelectCountStatement( String tableName ) {
+    return delegate == null ? null : delegate.getSelectCountStatement( tableName );
+  }
+
+  @Override public String generateColumnAlias( int columnIndex, String suggestedName ) {
+    if ( delegate != null ) {
+      return delegate.generateColumnAlias( columnIndex, suggestedName );
+    } else {
+      throw new IllegalStateException( "Delegate is null" );
+    }
+  }
+
+  @Override public List<String> parseStatements( String sqlScript ) {
+    if ( delegate != null ) {
+      return delegate.parseStatements( sqlScript );
+    } else {
+      throw new IllegalStateException( "Delegate is null" );
+    }
+  }
+
+  @Override public List<SqlScriptStatement> getSqlScriptStatements( String sqlScript ) {
+    return delegate == null ? null : delegate.getSqlScriptStatements( sqlScript );
+  }
+
+  @Override public boolean isMySQLVariant() {
+    return delegate != null && delegate.isMySQLVariant();
+  }
+
+  @Override public boolean releaseSavepoint() {
+    return delegate != null && delegate.releaseSavepoint();
+  }
+
+  @Override
+  public Long getNextBatchId( DatabaseMeta dbm, Database ldb, String schemaName, String tableName, String fieldName )
+    throws KettleDatabaseException {
+    return delegate == null ? null : delegate.getNextBatchId( dbm, ldb, schemaName, tableName, fieldName );
+  }
+
+  @Override public String getDataTablespaceDDL( VariableSpace variables, DatabaseMeta databaseMeta ) {
+    return delegate == null ? null : delegate.getDataTablespaceDDL( variables, databaseMeta );
+  }
+
+  @Override public String getIndexTablespaceDDL( VariableSpace variables, DatabaseMeta databaseMeta ) {
+    return delegate == null ? null : delegate.getIndexTablespaceDDL( variables, databaseMeta );
+  }
+
+  @Override public Object getValueFromResultSet( ResultSet resultSet, ValueMetaInterface valueMeta, int index )
+    throws KettleDatabaseException {
+    return delegate == null ? null : delegate.getValueFromResultSet( resultSet, valueMeta, index );
+  }
+
+  @Override public boolean useSafePoints() {
+    return delegate != null && delegate.useSafePoints();
+  }
+
+  @Override public boolean supportsErrorHandling() {
+    return delegate != null && delegate.supportsErrorHandling();
+  }
+
+  @Override public String getSQLValue( ValueMetaInterface valueMeta, Object valueData, String dateFormat )
+    throws KettleValueException {
+    return delegate == null ? null : delegate.getSQLValue( valueMeta, valueData, dateFormat );
+  }
+
+  @Override public boolean supportsResultSetMetadataRetrievalOnly() {
+    return delegate != null && delegate.supportsResultSetMetadataRetrievalOnly();
+  }
+
+  @Override public boolean supportsTimestampDataType() {
+    return delegate != null && delegate.supportsTimestampDataType();
+  }
+
+  @Override public void setSupportsTimestampDataType( boolean b ) {
+    if ( delegate != null ) {
+      delegate.setSupportsTimestampDataType( b );
+    }
+  }
+
+  @Override public String getSafeFieldname( String fieldName ) {
+    return delegate == null ? null : delegate.getSafeFieldname( fieldName );
+  }
+
+  @Override public String getSequenceNoMaxValueOption() {
+    return delegate == null ? null : delegate.getSequenceNoMaxValueOption();
+  }
+
+  @Override public boolean supportsAutoGeneratedKeys() {
+    return delegate != null && delegate.supportsAutoGeneratedKeys();
+  }
+
+  @Override public ValueMetaInterface customizeValueFromSQLType( ValueMetaInterface v, ResultSetMetaData rm, int index )
+    throws SQLException {
+    if ( delegate != null ) {
+      return delegate.customizeValueFromSQLType( v, rm, index );
+    } else {
+      throw new IllegalStateException( "Delegate is null" );
+    }
+  }
+
+  @Override public String getCreateTableStatement() {
+    return delegate == null ? null : delegate.getCreateTableStatement();
+  }
+
+  @Override @Deprecated public void addDefaultOptions() {
+    if ( delegate != null ) {
+      delegate.addDefaultOptions();
+    }
+  }
+
+  @Override public SqlScriptParser createSqlScriptParser() {
+    if ( delegate != null ) {
+      return delegate.createSqlScriptParser();
+    } else {
+      throw new IllegalStateException( "Delegate is null" );
+    }
+  }
+
+  @Override public boolean supportsStandardTableOutput() {
+    return delegate != null && delegate.supportsStandardTableOutput();
+  }
+
+  @Override public String getUnsupportedTableOutputMessage() {
+    return delegate == null ? null : delegate.getUnsupportedTableOutputMessage();
+  }
+
+  @Override public String getLegacyColumnName( DatabaseMetaData dbMetaData, ResultSetMetaData rsMetaData, int index )
+    throws KettleDatabaseException {
+    return delegate == null ? null : delegate.getLegacyColumnName( dbMetaData, rsMetaData, index );
+  }
+
+  @Override public void putOptionalOptions( Map<String, String> extraOptions ) {
+    if ( delegate != null ) {
+      delegate.putOptionalOptions( extraOptions );
+    }
+  }
+
+  @Override public ResultSet getSchemas( DatabaseMetaData databaseMetaData, DatabaseMeta dbMeta ) throws SQLException {
+    return delegate == null ? null : delegate.getSchemas( databaseMetaData, dbMeta );
+  }
+
+  @Override public ResultSet getTables( DatabaseMetaData databaseMetaData, DatabaseMeta dbMeta, String schemaPattern,
+                                        String tableNamePattern, String[] tableTypes ) throws SQLException {
+    return delegate == null ? null :
+      delegate.getTables( databaseMetaData, dbMeta, schemaPattern, tableNamePattern, tableTypes );
+  }
+
+  @Override public String getNamedCluster() {
+    return delegate == null ? null : delegate.getNamedCluster();
+  }
+
+  @Override public void setNamedCluster( String namedCluster ) {
+    if ( delegate != null ) {
+      delegate.setNamedCluster( namedCluster );
+    }
+  }
+
+  @Override public List<String> getNamedClusterList() {
+    return delegate == null ? null : delegate.getNamedClusterList();
+  }
+
+  @Override public void setConnectionSpecificInfoFromAttributes( Map<String, String> attributes ) {
+    if ( delegate != null ) {
+      delegate.setConnectionSpecificInfoFromAttributes( attributes );
+    }
   }
 }

--- a/core/src/main/java/org/pentaho/di/core/database/Database.java
+++ b/core/src/main/java/org/pentaho/di/core/database/Database.java
@@ -688,6 +688,13 @@ public class Database implements VariableSpace, LoggingObjectInterface, Closeabl
           Encr.decryptPasswordOptionallyEncrypted( partition.getPassword() ) };
       }
     }
+
+    if ( databaseMeta.isConnectionManagementServiceConnection() ) {
+      return new String[] {
+        environmentSubstitute( databaseMeta.getUsername() ),
+        environmentSubstitute( databaseMeta.getPassword() ) };
+    }
+
     return new String[] {
       environmentSubstitute( databaseMeta.getUsername() ),
       Encr.decryptPasswordOptionallyEncrypted( environmentSubstitute( databaseMeta.getPassword() ) ) };

--- a/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/DatabaseMeta.java
@@ -519,6 +519,11 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
    * @return the system dependend database interface for this database metadata definition
    */
   public DatabaseInterface getDatabaseInterface() {
+    // if database interface is a proxy one, and it has loaded the actual one - return it
+    if ( databaseInterface instanceof ConnectionManagementServiceMeta cmsMeta && cmsMeta.isDataLoaded() ) {
+      return cmsMeta.getDelegateDatabaseInterface();
+    }
+
     return databaseInterface;
   }
 
@@ -561,19 +566,8 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
    * @throws KettleDatabaseException
    *           when the type could not be found or referenced.
    */
-  private static final DatabaseInterface findDatabaseInterface( String databaseTypeDesc ) throws KettleDatabaseException {
-    PluginRegistry registry = PluginRegistry.getInstance();
-    PluginInterface plugin = registry.getPlugin( DatabasePluginType.class, databaseTypeDesc );
-    if ( plugin == null ) {
-      plugin = registry.findPluginWithName( DatabasePluginType.class, databaseTypeDesc );
-    }
-
-    if ( plugin == null ) {
-      throw new KettleDatabaseException( "database type with plugin id ["
-        + databaseTypeDesc + "] couldn't be found!" );
-    }
-
-    return getDatabaseInterfacesMap().get( plugin.getIds()[0] );
+  private static DatabaseInterface findDatabaseInterface( String databaseTypeDesc ) throws KettleDatabaseException {
+    return DatabaseInterfaceFactory.create( databaseTypeDesc );
   }
 
   /**
@@ -604,9 +598,14 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
 
   public void replaceMeta( DatabaseMeta databaseMeta, boolean cloneUpdateFlag ) {
     this.setValues(
-      databaseMeta.getName(), databaseMeta.getPluginId(), databaseMeta.getAccessTypeDesc(), databaseMeta
-        .getHostname(), databaseMeta.getDatabaseName(), databaseMeta.getDatabasePortNumberString(),
-      databaseMeta.getUsername(), databaseMeta.getPassword() );
+      databaseMeta.getName(),
+      databaseMeta.getPluginId(),
+      databaseMeta.getAccessTypeDesc(),
+      databaseMeta.getHostname(),
+      databaseMeta.getDatabaseName(),
+      databaseMeta.getDatabasePortNumberString(),
+      databaseMeta.getUsername(),
+      databaseMeta.getPassword() );
     this.setServername( databaseMeta.getServername() );
     this.setDataTablespace( databaseMeta.getDataTablespace() );
     this.setIndexTablespace( databaseMeta.getIndexTablespace() );
@@ -653,6 +652,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
       throw new RuntimeException( "Database type [" + type + "] not found!", kde );
     }
 
+    setConnectionId( oldInterface.getConnectionId() );
     setName( oldInterface.getName() );
     setDisplayName( oldInterface.getDisplayName() );
     setAccessType( oldInterface.getAccessType() );
@@ -1008,6 +1008,7 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
       if ( name == null ) {
         name = "";
       }
+      setConnectionId( XMLHandler.getTagValue( con, "connection_id" ) );
       setName( name );
       setDisplayName( getName() );
       setHostname( XMLHandler.getTagValue( con, "server" ) );
@@ -1111,6 +1112,10 @@ public class DatabaseMeta extends SharedObjectBase implements Cloneable, XMLInte
 
     retval.append( "  </" + XML_TAG + ">" ).append( Const.CR );
     return retval.toString();
+  }
+
+  public boolean isConnectionManagementServiceConnection() {
+    return databaseInterface instanceof ConnectionManagementServiceMeta;
   }
 
   @Override

--- a/core/src/main/java/org/pentaho/di/core/database/SecretsManagementClient.java
+++ b/core/src/main/java/org/pentaho/di/core/database/SecretsManagementClient.java
@@ -1,0 +1,140 @@
+package org.pentaho.di.core.database;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.SecretsManagementException;
+import org.pentaho.di.core.util.HttpClientManager;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+class SecretsManagementClient {
+
+  private static final String SECRETS_PATH = "/api/v1/secrets";
+
+  private static final int CONNECT_TIMEOUT_MS = 5_000;
+  private static final int SOCKET_TIMEOUT_MS = 10_000;
+
+  private static final SecretsManagementClient INSTANCE =
+    new SecretsManagementClient( HttpClientManager.getInstance().createBuilder().ignoreSsl( true ).build() );
+
+
+  private final CloseableHttpClient httpClient;
+
+  /**
+   * Package-private constructor for tests; production code uses {@link #getInstance()}.
+   */
+  SecretsManagementClient( CloseableHttpClient httpClient ) {
+    this.httpClient = httpClient;
+  }
+
+  public static SecretsManagementClient getInstance() {
+    return INSTANCE;
+  }
+
+  private static String stripTrailingSlash( String s ) {
+    return s.endsWith( "/" ) ? s.substring( 0, s.length() - 1 ) : s;
+  }
+
+  /**
+   * Test-only helper to avoid pulling in StandardCharsets from callers.
+   */
+  static byte[] toBytes( String s ) {
+    return s.getBytes( StandardCharsets.UTF_8 );
+  }
+
+  public Map<String, String> getSecrets( String secretsRef ) throws SecretsManagementException {
+    if ( secretsRef == null || secretsRef.trim().isEmpty() ) {
+      throw new IllegalStateException( "secretsRef must be a non-blank reference" );
+    }
+    String baseUrl = Const.getSecretsManagementUrl();
+    if ( baseUrl == null || baseUrl.trim().isEmpty() ) {
+      throw new IllegalStateException(
+        "SECRETS_MANAGEMENT_URL is not configured — cannot resolve secret '" + secretsRef + "'" );
+    }
+
+    String url = stripTrailingSlash( baseUrl ) + SECRETS_PATH + "/" + secretsRef;
+    HttpGet request = new HttpGet( url );
+    request.setConfig( RequestConfig.custom()
+      .setConnectTimeout( CONNECT_TIMEOUT_MS )
+      .setSocketTimeout( SOCKET_TIMEOUT_MS )
+      .build() );
+    request.setHeader( "Accept", "application/json" );
+
+    String bearerToken;
+    try {
+      bearerToken = CmsTokenProvider.getInstance().getToken();
+    } catch ( Exception e ) {
+      // Token-endpoint failure: treat as unauthorized so the caller gets the standard message.
+      throw new SecretsManagementException( SecretsManagementException.Reason.UNAUTHORIZED,
+        "Secret unauthorized or expired", e );
+    }
+    if ( bearerToken != null ) {
+      request.setHeader( "Authorization", "Bearer " + bearerToken );
+    }
+
+    try ( CloseableHttpResponse response = httpClient.execute( request ) ) {
+      int status = response.getStatusLine().getStatusCode();
+      if ( status == 200 ) {
+        return parseBody( response.getEntity(), secretsRef );
+      }
+      throw mapStatus( status, secretsRef );
+    } catch ( SecretsManagementException e ) {
+      throw e;
+    } catch ( IOException e ) {
+      throw new SecretsManagementException( SecretsManagementException.Reason.UNAVAILABLE,
+        "Secret store unavailable", e );
+    }
+  }
+
+  private Map<String, String> parseBody( HttpEntity entity, String secretsRef ) throws SecretsManagementException {
+    if ( entity == null ) {
+      throw new SecretsManagementException( SecretsManagementException.Reason.INVALID_RESPONSE,
+        "Secret response was empty for '" + secretsRef + "'" );
+    }
+    try {
+      byte[] body = EntityUtils.toByteArray( entity );
+      if ( body.length == 0 ) {
+        throw new SecretsManagementException( SecretsManagementException.Reason.INVALID_RESPONSE,
+          "Secret response was empty for '" + secretsRef + "'" );
+      }
+      Map<String, String> parsed = new ObjectMapper().readValue( body,
+        new TypeReference<Map<String, String>>() {
+        } );
+      return parsed == null ? Collections.emptyMap() : parsed;
+    } catch ( SecretsManagementException e ) {
+      throw e;
+    } catch ( IOException e ) {
+      // Do not include the body in the message — it may contain plaintext secret material.
+      throw new SecretsManagementException( SecretsManagementException.Reason.INVALID_RESPONSE,
+        "Secret response could not be parsed for '" + secretsRef + "'", e );
+    }
+  }
+
+  private SecretsManagementException mapStatus( int status, String secretsRef ) {
+    return switch ( status ) {
+      case 401, 403 -> new SecretsManagementException( SecretsManagementException.Reason.UNAUTHORIZED,
+        "Secret unauthorized or expired" );
+      case 404 -> new SecretsManagementException( SecretsManagementException.Reason.NOT_FOUND,
+        "Secret not found: " + secretsRef );
+      default -> {
+        if ( status >= 500 ) {
+          yield new SecretsManagementException( SecretsManagementException.Reason.UNAVAILABLE,
+            "Secret store unavailable" );
+        }
+        yield new SecretsManagementException( SecretsManagementException.Reason.UNAVAILABLE,
+          "Secret store returned unexpected HTTP " + status );
+      }
+    };
+  }
+}
+

--- a/core/src/test/java/org/pentaho/di/core/database/DatabaseInterfaceFactoryTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/DatabaseInterfaceFactoryTest.java
@@ -57,12 +57,4 @@ public class DatabaseInterfaceFactoryTest {
       // expected
     }
   }
-
-  @Test
-  public void isConnectionManagementServiceTypeDetectsBlank() {
-    assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( null ) );
-    assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( "" ) );
-    assertTrue( DatabaseInterfaceFactory.isConnectionManagementServiceType( "   " ) );
-    assertFalse( DatabaseInterfaceFactory.isConnectionManagementServiceType( "MYSQL" ) );
-  }
 }

--- a/engine/src/main/java/org/pentaho/di/core/util/ConnectionUtil.java
+++ b/engine/src/main/java/org/pentaho/di/core/util/ConnectionUtil.java
@@ -15,7 +15,12 @@ package org.pentaho.di.core.util;
 
 import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.connections.ConnectionManager;
+import org.pentaho.di.core.database.CmsConnectionProvider;
+import org.pentaho.di.core.database.DatabaseInterface;
+import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.metastore.MetaStoreConst;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.core.database.ConnectionManagementServiceMeta;
 
 /**
  * Utility for managing embedded named connections
@@ -35,4 +40,25 @@ public class ConnectionUtil {
     connectionManager.setMetastoreSupplier( MetaStoreConst.getDefaultMetastoreSupplier() );
   }
 
+  /**
+   * Find remote connection-management-service connections and initiate them.
+   *
+   * @param meta The meta containing named connections
+   */
+  public static void initConnectionManagementServiceConnections( TransMeta meta) {
+    meta.getSteps().forEach(step -> {
+      DatabaseMeta[] dbMetaList = step.getStepMetaInterface().getUsedDatabaseConnections();
+
+      if ( dbMetaList.length != 0 ) {
+        DatabaseMeta dbMeta = dbMetaList[0];
+        DatabaseInterface dbInterface = dbMeta.getDatabaseInterface();
+
+        if ( dbInterface instanceof ConnectionManagementServiceMeta cmsMeta ) {
+          var dbInfo = CmsConnectionProvider.getInstance()
+            .fetchConnectionDetails( cmsMeta.getConnectionId() );
+          cmsMeta.setDelegateDatabaseInterface( dbInfo );
+        }
+      }
+    });
+  }
 }

--- a/engine/src/main/java/org/pentaho/di/trans/Trans.java
+++ b/engine/src/main/java/org/pentaho/di/trans/Trans.java
@@ -832,6 +832,8 @@ public class Trans implements VariableSpace, NamedParams, HasLogChannelInterface
     transMeta.activateParameters();
     ConnectionUtil.init( transMeta );
 
+    ConnectionUtil.initConnectionManagementServiceConnections( transMeta );
+
     if ( transMeta.getName() == null ) {
       if ( transMeta.getFilename() != null ) {
         log.logBasic( BaseMessages.getString( PKG, "Trans.Log.DispacthingStartedForFilename", transMeta

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/DatabaseDelegate.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/DatabaseDelegate.java
@@ -157,7 +157,13 @@ public class DatabaseDelegate extends AbstractDelegate implements ITransformer, 
     databaseMeta.setDBName( getString( rootNode, PROP_DATABASE_NAME ) );
     databaseMeta.setDBPort( getString( rootNode, PROP_PORT ) );
     databaseMeta.setUsername( getString( rootNode, PROP_USERNAME ) );
-    databaseMeta.setPassword( Encr.decryptPasswordOptionallyEncrypted( getString( rootNode, PROP_PASSWORD ) ) );
+
+    if ( databaseMeta.isConnectionManagementServiceConnection() ) {
+      databaseMeta.setPassword( getString( rootNode, PROP_PASSWORD ) );
+    } else {
+      databaseMeta.setPassword( Encr.decryptPasswordOptionallyEncrypted( getString( rootNode, PROP_PASSWORD ) ) );
+    }
+
     databaseMeta.setServername( getString( rootNode, PROP_SERVERNAME ) );
     databaseMeta.setDataTablespace( getString( rootNode, PROP_DATA_TBS ) );
     databaseMeta.setIndexTablespace( getString( rootNode, PROP_INDEX_TBS ) );
@@ -177,13 +183,15 @@ public class DatabaseDelegate extends AbstractDelegate implements ITransformer, 
     // Also, load all the properties we can find...
 
     DataNode attrNode = rootNode.getNode( NODE_ATTRIBUTES );
-    for ( DataProperty property : attrNode.getProperties() ) {
-      String code = property.getName();
-      String attribute = property.getString();
+    if (attrNode != null) {
+      for ( DataProperty property : attrNode.getProperties() ) {
+        String code = property.getName();
+        String attribute = property.getString();
 
-      // We need to unescape the code as it was escaped to handle characters that JCR does not handle
-      String unescapeCode = RepositoryFilenameUtils.unescape( code );
-      databaseMeta.getAttributes().put( unescapeCode, Const.NVL( attribute, "" ) );
+        // We need to unescape the code as it was escaped to handle characters that JCR does not handle
+        String unescapeCode = RepositoryFilenameUtils.unescape( code );
+        databaseMeta.getAttributes().put( unescapeCode, Const.NVL( attribute, "" ) );
+      }
     }
 
     // Also, load any pooling params


### PR DESCRIPTION
### [FUSE-636](https://hv-eng.atlassian.net/browse/FUSE-636)

New implementation of the DatabaseInterface - ConnectionManagementServiceMeta.

### What was changed?

ConnectionManagementServiceMeta serves as a proxy for the real DatabaseInterface and proxies calls to it after real connection has been fetched. Additional connection-management-service and secrets-service clients were added.
New ConnectionManagementServiceMeta has to use empty database type because of the data-access plugin not recognizing any new custom database types (like "CMS"). In order to properly integrate this new meta as plugin, it is needed to modify data-access plugin (see Jira comments for details).

[FUSE-636]: https://hv-eng.atlassian.net/browse/FUSE-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ