### PR TITLE
CVE-2023-48795: inherit centralized jsch.version (0.2.26) from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,9 @@
     <!-- Third-party dependencies -->
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <encoder.version>1.2</encoder.version>
-    <!-- jsch.version is inherited from pentaho-parent-pom (centralized for CVE-2023-48795) -->
+    <!-- jsch.version is inherited via the parent POM chain (direct parent
+         pentaho-ce-jar-parent-pom -> ... -> org.pentaho:pentaho-parent-pom, which
+         defines it); centralized for CVE-2023-48795. Requires maven-parent-poms PR #902. -->
     <jface.version>3.31.0</jface.version>
     <commands.version>3.12.100</commands.version>
     <common.version>3.18.0</common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,6 @@
     <!-- Third-party dependencies -->
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <encoder.version>1.2</encoder.version>
-    <!-- jsch.version is inherited via the parent POM chain (direct parent
-         pentaho-ce-jar-parent-pom -> ... -> org.pentaho:pentaho-parent-pom, which
-         defines it); centralized for CVE-2023-48795. Requires maven-parent-poms PR #902. -->
     <jface.version>3.31.0</jface.version>
     <commands.version>3.12.100</commands.version>
     <common.version>3.18.0</common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <!-- Third-party dependencies -->
     <org.eclipse.swt.version>4.6</org.eclipse.swt.version>
     <encoder.version>1.2</encoder.version>
-    <jsch.version>0.2.9</jsch.version>
+    <!-- jsch.version is inherited from pentaho-parent-pom (centralized for CVE-2023-48795) -->
     <jface.version>3.31.0</jface.version>
     <commands.version>3.12.100</commands.version>
     <common.version>3.18.0</common.version>


### PR DESCRIPTION
## CVE fix: CVE-2023-48795 (Terrapin) in com.github.mwiede:jsch

Tracking: https://hv-eng.atlassian.net/browse/PPP-6577
Advisory: CVE-2023-48795 -- Medium (CVSS 5.9), SSH prefix-truncation (Terrapin)
Change: remove the local `jsch.version` override so `com.github.mwiede:jsch` resolves to the centralized `0.2.26` pin (fixed >= 0.2.15).

### ⚠ Blocked by pentaho/maven-parent-poms#902
This removes `<jsch.version>0.2.9</jsch.version>` from `pom.xml` and inherits the property added in maven-parent-poms#902. **Do not merge until #902 is merged and its `11.1.0.0-SNAPSHOT` parent is deployed**, or CI here cannot resolve `${jsch.version}`.

### Fix point / paths
Root `pom.xml` `<jsch.version>` property (drove `com.github.mwiede:jsch` via `<dependencyManagement>`; consumed by `core`, `plugins/json/core`, `plugins/google-analytics/core`). Impact paths in pdia-master: `data-integration/lib/jsch-*.jar` (pdi-ce/ee), `pentaho-server .../WEB-INF/lib`, `aggregation-designer/lib`.

### Dependency tree (before -> after)
`com.github.mwiede:jsch:jar:0.2.9` (present) -> `com.github.mwiede:jsch:jar:0.2.26:compile` (0.2.9 absent on every path).

### Tests
No code change needed (drop-in fork, same `com.jcraft.jsch` package). Existing SFTP suite exercising the jsch API is green on the 0.2.9 baseline and again on 0.2.26: SFTPClientTest (12), MinaSftpSessionTest (24), SftpFileTest (10), SftpFileObjectWithWindowsSupportTest (4), KettleSftpFileSystemConfigBuilderTest (2) = 52 tests, 0 failures.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.
