### PR TITLE
build[PPP-6754]: Move dependency management of httpcore5 to maven parent pom

### DIFF
--- a/plugins/repo-vfs/repo-vfs-ws/pom.xml
+++ b/plugins/repo-vfs/repo-vfs-ws/pom.xml
@@ -98,7 +98,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
-      <version>5.3.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What

Removes the hard-coded `httpcore5` version override (`5.3.4`) in `plugins/repo-vfs/repo-vfs-ws` so the test-scoped dependency inherits the managed version from `maven-parent-poms` (BOM / single source of truth).

### Why

Part of **CVE-2026-54399** remediation (Jira: **PPP-6754**). The literal version pinned the module to the vulnerable `5.3.4`. Inheriting from the parent picks up the fixed `5.4.3` and keeps future bumps centralized.

### Changes

- `plugins/repo-vfs/repo-vfs-ws/pom.xml`: dropped `<version>5.3.4</version>` from the `httpcore5` test-scope dependency (scope preserved).

### Validation

- `mvn -B -nsu -pl plugins/repo-vfs/repo-vfs-ws dependency:tree -Dincludes=org.apache.httpcomponents.core5:httpcore5` → `httpcore5:jar:5.4.3:test`, BUILD SUCCESS.

### Notes

- Depends on the companion `maven-parent-poms` PPP-6754 PR that bumps `httpcore5.version` to `5.4.3`.
- The adjacent `httpclient5` (5.5) declaration is out of scope and left unchanged.
