### PR TITLE
build[PDI-20871]: Include jersey-apache-connector in data-integration/lib

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -606,6 +606,17 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.connectors</groupId>
+      <artifactId>jersey-apache-connector</artifactId>
+      <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
       <version>${jersey.version}</version>


### PR DESCRIPTION
## Summary

- Dependency: `org.glassfish.jersey.connectors:jersey-apache-connector`
- Target version: `${jersey.version}` (3.1.10)
- Change type: add missing runtime dependency to `data-integration/lib`

Adds `jersey-apache-connector` to the PDI client libraries assembly so the Apache
`ConnectorProvider` is available in `data-integration/lib`. Prior to the Jersey 3.1.x
upgrade (BACKLOG-41589), Pentaho 10.2 shipped `jersey-apache-client4-1.19.1.jar`, which
allowed an Apache HttpClient-backed Jersey client. In Pentaho 11 that jar was dropped and
never replaced, so Jersey falls back to `java.net.HttpURLConnection`, which does not
support HTTP PATCH.

With this jar present, a client can be built with the Apache connector:

```java
ClientConfig clientConfig = new ClientConfig();
clientConfig.connectorProvider( new ApacheConnectorProvider() );
data.client = ClientBuilder.newClient( clientConfig );
```

## Validation

- Base branch: `master`
- Maven build: verified the artifact resolves and is copied into the `lib` assembly output
  via `maven-dependency-plugin:copy-dependencies` (`includeScope=compile`). Full reactor
  build not run to completion locally due to an unrelated internal Artifactory
  checksum/infra issue on other pentaho SNAPSHOT artifacts.

## Notes

- Jira: PDI-20871
- Caused by: BACKLOG-41589 (Jersey upgrade in pentaho-kettle)
- Causes: BACKLOG-47896 (Salesforce Bulk plugin insert/update/delete failing in 11.0/11.1)
- Related: PDI-20862 (duplicate jars from `data-integration/lib`) — declared with full
  transitive exclusions to avoid pulling duplicate jars into `lib`.
