### PR TITLE
fix[PDI-20426]: bind AutoDoc images without report scripts

### DIFF
--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/autodoc/KettleFileTableModel.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/autodoc/KettleFileTableModel.java
@@ -14,22 +14,6 @@
 
 package org.pentaho.di.trans.steps.autodoc;
 
-import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.Const;
-import org.pentaho.di.core.database.Database;
-import org.pentaho.di.core.database.DatabaseMeta;
-import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.logging.LogChannel;
-import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.core.logging.LoggingObjectInterface;
-import org.pentaho.di.core.logging.LogStatus;
-import org.pentaho.di.core.logging.LogTableInterface;
-import org.pentaho.di.core.RowMetaAndData;
-import org.pentaho.di.core.util.Utils;
-import org.pentaho.di.core.xml.XMLHandler;
-import org.pentaho.di.job.JobMeta;
-import org.pentaho.di.trans.TransMeta;
-
 import java.awt.image.BufferedImage;
 import java.util.Date;
 import java.util.Iterator;
@@ -39,13 +23,29 @@ import javax.swing.event.TableModelListener;
 import javax.swing.table.TableModel;
 
 import org.jfree.ui.Drawable;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.database.Database;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.logging.LogStatus;
+import org.pentaho.di.core.logging.LogTableInterface;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.util.Utils;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.trans.TransMeta;
 
 public class KettleFileTableModel implements TableModel {
 
   public enum Field {
     location( ReportSubjectLocation.class ), filename( String.class ), name( String.class ), description(
       String.class ), extended_description( String.class ), logging( String.class ), creation( String.class ),
-      modification( String.class ), last_exec_result( String.class ), image( Drawable.class );
+      modification( String.class ), last_exec_result( String.class ), image( BufferedImage.class ),
+      pdf_image( Drawable.class );
 
     private Class<?> clazz;
 
@@ -121,6 +121,8 @@ public class KettleFileTableModel implements TableModel {
           return getLastExecutionResult( bowl, log, parentObject, location );
         case image:
           return getImage( bowl, location );
+        case pdf_image:
+          return new TransJobDrawable( bowl, location, true );
         default:
           throw new RuntimeException( "Unhandled field type: " + field + " in function getValueAt()" );
       }

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/autodoc/KettleReportBuilder.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/autodoc/KettleReportBuilder.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
 import org.pentaho.reporting.engine.classic.core.AttributeNames;
 import org.pentaho.reporting.engine.classic.core.Element;
@@ -32,10 +31,9 @@ import org.pentaho.reporting.engine.classic.core.ReportFooter;
 import org.pentaho.reporting.engine.classic.core.ReportHeader;
 import org.pentaho.reporting.engine.classic.core.SimplePageDefinition;
 import org.pentaho.reporting.engine.classic.core.TableDataFactory;
-import org.pentaho.reporting.engine.classic.core.elementfactory.ContentElementFactory;
+import org.pentaho.reporting.engine.classic.core.elementfactory.ContentFieldElementFactory;
 import org.pentaho.reporting.engine.classic.core.elementfactory.LabelElementFactory;
 import org.pentaho.reporting.engine.classic.core.elementfactory.TextFieldElementFactory;
-import org.pentaho.reporting.engine.classic.core.modules.misc.beanshell.BSHExpression;
 import org.pentaho.reporting.engine.classic.core.modules.output.pageable.pdf.PdfReportUtil;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.csv.CSVReportUtil;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.html.HtmlReportUtil;
@@ -126,6 +124,9 @@ public class KettleReportBuilder {
     // Create a new report
     //
     report = new MasterReport();
+
+    String imageFieldName = options.getOutputType() == OutputType.PDF
+      ? KettleFileTableModel.Field.pdf_image.name() : KettleFileTableModel.Field.image.name();
 
     // Define where which transformation and step to read from, explain it to the reporting engine
     //
@@ -221,19 +222,9 @@ public class KettleReportBuilder {
     // Optionally include an image of the transformation...
     //
     if ( options.isIncludingImage() ) {
-      // for this to work the reporting engine must be able to see our classes, we do this by changing the thread
-      // classloader to be the plugin's classloader. see #render()
-      String bshCode =
-        "Object getValue() { "
-          + Const.CR + "  return new " + TransJobDrawable.class.getName() + "(dataRow, "
-          + ( options.getOutputType() == OutputType.PDF ? "true" : "false" ) + ");" + Const.CR + "}";
-      BSHExpression bshExpression = new BSHExpression();
-      bshExpression.setExpression( bshCode );
-      bshExpression.setName( "getImage" );
-      report.addExpression( bshExpression );
-
-      ContentElementFactory contentElementFactory = new ContentElementFactory();
+      ContentFieldElementFactory contentElementFactory = new ContentFieldElementFactory();
       contentElementFactory.setName( "image" );
+      contentElementFactory.setFieldname( imageFieldName );
       contentElementFactory.setAbsolutePosition( new Point( 0, pagePosition ) );
       contentElementFactory.setMinimumWidth( 750f );
       contentElementFactory.setMaximumWidth( 750f );
@@ -243,8 +234,6 @@ public class KettleReportBuilder {
       contentElementFactory.setDynamicHeight( true );
       Element imageElement = contentElementFactory.createElement();
 
-      imageElement
-        .setAttributeExpression( AttributeNames.Core.NAMESPACE, AttributeNames.Core.VALUE, bshExpression );
       imageElement.setAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.IMAGE_ENCODING_QUALITY, "9" );
       imageElement.setAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.IMAGE_ENCODING_TYPE, "PNG" );
 

--- a/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/autodoc/TransJobDrawable.java
+++ b/plugins/core/impl/src/main/java/org/pentaho/di/trans/steps/autodoc/TransJobDrawable.java
@@ -18,24 +18,22 @@ import java.awt.geom.Rectangle2D;
 
 import org.jfree.ui.Drawable;
 import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.reporting.engine.classic.core.DataRow;
 
 public class TransJobDrawable implements Drawable {
 
-  private DataRow dataRow;
+  private ReportSubjectLocation location;
   private boolean pixelateImages;
   private Bowl bowl;
 
-  public TransJobDrawable( Bowl bowl, DataRow dataRow, boolean pixelateImages ) {
+  public TransJobDrawable( Bowl bowl, ReportSubjectLocation location, boolean pixelateImages ) {
     this.bowl = bowl;
-    this.dataRow = dataRow;
+    this.location = location;
     this.pixelateImages = pixelateImages;
   }
 
   @Override
   public void draw( Graphics2D graphics2D, Rectangle2D rectangle2D ) {
     try {
-      ReportSubjectLocation location = (ReportSubjectLocation) dataRow.get( "location" );
       if ( location.isTransformation() ) {
         TransformationInformation ti = TransformationInformation.getInstance();
         ti.drawImage( bowl, graphics2D, rectangle2D, location, pixelateImages );
@@ -46,21 +44,6 @@ public class TransJobDrawable implements Drawable {
     } catch ( Exception e ) {
       throw new RuntimeException( "Unable to draw image onto report", e );
     }
-  }
-
-  /**
-   * @return the dataRow
-   */
-  public DataRow getDataRow() {
-    return dataRow;
-  }
-
-  /**
-   * @param dataRow
-   *          the dataRow to set
-   */
-  public void setDataRow( DataRow dataRow ) {
-    this.dataRow = dataRow;
   }
 
   /**

--- a/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/autodoc/KettleReportBuilderTest.java
+++ b/plugins/core/impl/src/test/java/org/pentaho/di/trans/steps/autodoc/KettleReportBuilderTest.java
@@ -12,20 +12,33 @@
 
 package org.pentaho.di.trans.steps.autodoc;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.jfree.ui.Drawable;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.repository.RepositoryObjectType;
+import org.pentaho.di.trans.steps.autodoc.KettleReportBuilder.OutputType;
+import org.pentaho.reporting.engine.classic.core.AttributeNames;
 import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.Element;
+import org.pentaho.reporting.engine.classic.core.GroupDataBody;
+import org.pentaho.reporting.engine.classic.core.ItemBand;
+import org.pentaho.reporting.engine.classic.core.RelationalGroup;
+import org.pentaho.reporting.engine.classic.core.Section;
+import org.pentaho.reporting.engine.classic.core.function.Expression;
 import org.pentaho.reporting.libraries.base.util.ObjectUtilities;
 import org.pentaho.reporting.libraries.fonts.LibFontBoot;
 import org.pentaho.reporting.libraries.resourceloader.LibLoaderBoot;
-
-import java.util.Collections;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class KettleReportBuilderTest {
 
@@ -42,14 +55,8 @@ public class KettleReportBuilderTest {
   }
 
   @Test
-  public void createReport() throws Exception {
-    LoggingObjectInterface log = mock( LoggingObjectInterface.class );
-
-    AutoDocOptionsInterface options = mock( AutoDocOptionsInterface.class );
-    when( options.isIncludingImage() ).thenReturn( Boolean.TRUE );
-
-    KettleReportBuilder builder = new KettleReportBuilder( DefaultBowl.getInstance(), log,
-      Collections.<ReportSubjectLocation>emptyList(), "", options );
+  public void createReportBindsImageFieldForNonPdfOutput() throws Exception {
+    KettleReportBuilder builder = createReportBuilder( OutputType.HTML );
     builder.createReport();
 
     assertNotNull( builder.getReport() );
@@ -58,7 +65,80 @@ public class KettleReportBuilderTest {
     assertNotNull( builder.getReport().getReportFooter() );
     assertNotNull( builder.getReport().getRootGroup() );
     assertNotNull( builder.getReport().getPageDefinition() );
-    assertTrue( builder.getReport().getExpressions().size() > 0 );
+    assertNoGetImageExpression( builder );
+
+    Element imageElement = findImageElement( builder );
+    assertNotNull( imageElement );
+    assertEquals( KettleFileTableModel.Field.image.name(),
+      imageElement.getAttribute( AttributeNames.Core.NAMESPACE, "field" ) );
+  }
+
+  @Test
+  public void createReportBindsPdfImageFieldForPdfOutput() throws Exception {
+    KettleReportBuilder builder = createReportBuilder( OutputType.PDF );
+    builder.createReport();
+
+    assertNoGetImageExpression( builder );
+
+    Element imageElement = findImageElement( builder );
+    assertNotNull( imageElement );
+    assertEquals( KettleFileTableModel.Field.pdf_image.name(),
+      imageElement.getAttribute( AttributeNames.Core.NAMESPACE, "field" ) );
+  }
+
+  @Test
+  public void pdfImageColumnUsesDrawableType() {
+    ReportSubjectLocation location =
+      new ReportSubjectLocation( "sample.ktr", null, null, RepositoryObjectType.TRANSFORMATION );
+    KettleFileTableModel model =
+      new KettleFileTableModel( DefaultBowl.getInstance(), mock( LoggingObjectInterface.class ),
+        Collections.singletonList( location ) );
+
+    assertEquals( Drawable.class, KettleFileTableModel.Field.pdf_image.getClazz() );
+    assertEquals( Drawable.class, model.getColumnClass( KettleFileTableModel.Field.pdf_image.ordinal() ) );
+    assertTrue( model.getValueAt( 0, KettleFileTableModel.Field.pdf_image.ordinal() ) instanceof Drawable );
+  }
+
+  private KettleReportBuilder createReportBuilder( OutputType outputType ) {
+    LoggingObjectInterface log = mock( LoggingObjectInterface.class );
+
+    AutoDocOptionsInterface options = mock( AutoDocOptionsInterface.class );
+    when( options.isIncludingImage() ).thenReturn( Boolean.TRUE );
+    when( options.getOutputType() ).thenReturn( outputType );
+
+    return new KettleReportBuilder( DefaultBowl.getInstance(), log,
+      Collections.<ReportSubjectLocation>emptyList(), "", options );
+  }
+
+  private Element findImageElement( KettleReportBuilder builder ) {
+    RelationalGroup group = (RelationalGroup) builder.getReport().getRootGroup();
+    GroupDataBody groupDataBody = group.findGroupDataBody();
+    ItemBand itemBand = groupDataBody.getItemBand();
+
+    return findElementByName( itemBand, "image" );
+  }
+
+  private void assertNoGetImageExpression( KettleReportBuilder builder ) {
+    for ( int i = 0; i < builder.getReport().getExpressions().size(); i++ ) {
+      Expression expression = builder.getReport().getExpressions().getExpression( i );
+      assertNotEquals( "Unexpected legacy getImage expression found", "getImage", expression.getName() );
+    }
+  }
+
+  private Element findElementByName( Section section, String name ) {
+    for ( int i = 0; i < section.getElementCount(); i++ ) {
+      Element element = section.getElement( i );
+      if ( name.equals( element.getName() ) ) {
+        return element;
+      }
+      if ( element instanceof Section ) {
+        Element childElement = findElementByName( (Section) element, name );
+        if ( childElement != null ) {
+          return childElement;
+        }
+      }
+    }
+    return null;
   }
 
 }


### PR DESCRIPTION
**Main fix:**

Before this change, `KettleReportBuilder` did not bind the report image directly to report data. Instead, it attached a report expression that rebuilt the diagram at render time. That meant HTML AutoDoc output depended on report script execution being available.

Once script execution stopped being available by default, the report still rendered and the HTML file was still produced, but the diagram field could no longer be resolved through that expression. That is why the failure was partial: the document was generated, but the embedded transformation/job image was missing.

This change removes that dependency. `KettleReportBuilder` now binds the image element to a normal data field exposed by `KettleFileTableModel`, instead of rebuilding the image through a report script. For non-PDF output, the report reads the image field directly from the table model.

In short:

- Old path: rebuild the image through a report expression at render time.
- New path: bind the report element to image data already provided by the report model.

That is safer because AutoDoc no longer depends on report expression execution for HTML output.

**Additional PDF fix:**

Removing the scripted image path fixed the HTML regression, but it also removed the old PDF-specific rendering path. PDF was then forced through the same pre-rendered image path as HTML, which changed previous behavior.

The follow-up change restores that separation cleanly:

- non-PDF outputs use the `image` field backed by `BufferedImage`
- PDF output uses the `pdf_image` field backed by `Drawable`

So the final behavior is:

- HTML works without report script execution
- PDF keeps its previous dedicated rendering behavior
- neither path depends on scripted report image generation

**Test changes:**

The removed assertion was checking for the presence of a report expression. That was valid only for the old implementation. After removing the scripted image path, keeping that assertion would have locked the test to the obsolete design instead of the intended behavior.

The updated tests now check the real contract:

- non-PDF output binds to the `image` field
- PDF output binds to the `pdf_image` field
- the report no longer relies on image expressions

That gives us regression coverage for the behavior we actually want to preserve.