### PR TITLE
CVE fix: CVE-2021-28170 in org.glassfish:javax.el (inherit managed cron-utils 9.1.7)

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -802,7 +802,9 @@
     <dependency>
       <groupId>com.cronutils</groupId>
       <artifactId>cron-utils</artifactId>
-      <version>9.1.6</version>
+      <!-- Version managed centrally in org.pentaho:pentaho-parent-pom (cronutils.version).
+           9.1.7+ pulls the fixed org.glassfish:jakarta.el 3.0.4 in place of the vulnerable
+           org.glassfish:javax.el 3.0.0 (CVE-2021-28170). -->
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -802,9 +802,10 @@
     <dependency>
       <groupId>com.cronutils</groupId>
       <artifactId>cron-utils</artifactId>
-      <!-- Version managed centrally in org.pentaho:pentaho-parent-pom (cronutils.version).
-           9.1.7+ pulls the fixed org.glassfish:jakarta.el 3.0.4 in place of the vulnerable
-           org.glassfish:javax.el 3.0.0 (CVE-2021-28170). -->
+      <!-- cron-utils version is managed centrally via the parent POM chain: dependencyManagement
+           in the org root org.pentaho:pentaho-parent-pom (property cron-utils.version), inherited
+           here through pentaho-ce-jar-parent-pom. 9.1.7+ pulls the fixed org.glassfish:jakarta.el
+           3.0.4 in place of the vulnerable org.glassfish:javax.el 3.0.0 (CVE-2021-28170). -->
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
## CVE fix: CVE-2021-28170 in `org.glassfish:javax.el` (via `com.cronutils:cron-utils`)

Advisory: CVE-2021-28170 / GHSA-v6w3-2prq-h95f — **Medium** (CVSS 5.3)
Jira: PPP-6565, PPP-5971
Change: drop the leaf `com.cronutils:cron-utils` **9.1.6** override in `engine/pom.xml` so it inherits the version managed centrally in `org.pentaho:pentaho-parent-pom` (**9.1.7**).

### ⚠️ Blocked by
pentaho/maven-parent-poms#915 — must merge and publish `11.1.0.0-SNAPSHOT` first (this PR removes the `<version>`, relying on the managed 9.1.7).

### Why this fixes the CVE
`cron-utils:9.1.7` depends on the fixed **`org.glassfish:jakarta.el:3.0.4`** (a binary drop-in — retains the `javax.el.*` namespace) instead of the vulnerable `org.glassfish:javax.el:3.0.0`. In this repo `cron-utils` is used only for the `com.cronutils.utils.VisibleForTesting` annotation (present in 9.1.7).

### Dependency tree (before → after) in `engine`
```
before: com.cronutils:cron-utils:9.1.6 -> org.glassfish:javax.el:3.0.0
after:  com.cronutils:cron-utils:9.1.7 -> org.glassfish:jakarta.el:3.0.4   (javax.el:3.0.0 absent)
```

### Review
Fixed and reviewed locally via `codemedic-local-remediator` before push.
