### PR TITLE
fix[SP-7428]: add missing aws-java-sdk-iam dependency

### DIFF
--- a/plugins/s3-vfs/assemblies/pom.xml
+++ b/plugins/s3-vfs/assemblies/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>pentaho-s3-vfs</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-iam</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/plugins/s3-vfs/assemblies/src/main/assembly/descriptors/s3-vfs.xml
+++ b/plugins/s3-vfs/assemblies/src/main/assembly/descriptors/s3-vfs.xml
@@ -22,6 +22,7 @@
             <includes>
                 <include>com.amazonaws:aws-java-sdk-core</include>
                 <include>com.amazonaws:aws-java-sdk-s3</include>
+                <include>com.amazonaws:aws-java-sdk-iam</include>
             </includes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7428 - Backport of PDI-20270 - (11.0 Suite) pentaho-s3-vfs-plugin missing important libraries needed to interact with AWS IAM Roles](https://pentaho-eng.atlassian.net/browse/SP-7428)
- **Base Case:** [PDI-20270 - Backport of PDI-20270 - (11.0 Suite) pentaho-s3-vfs-plugin missing important libraries needed to interact with AWS IAM Roles](https://pentaho-eng.atlassian.net/browse/PDI-20270)
- **Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10538

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-kettle/pull/10538
- Commit: d02dbce3b8c2204721aeb931eef463df375af084

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
