### PR TITLE
fix[SP-7418]: SSH timeout=0 now correctly means infinite, not treated as 30000ms

### DIFF
--- a/engine/src/main/java/org/pentaho/di/core/ssh/mina/MinaSshConnection.java
+++ b/engine/src/main/java/org/pentaho/di/core/ssh/mina/MinaSshConnection.java
@@ -239,18 +239,28 @@ public class MinaSshConnection implements SshConnection {
   }
 
   private void waitForConnection( ConnectFuture cf ) throws SshConnectionException {
-    long extendedTimeout = config.getConnectTimeoutMillis() > 0 ? config.getConnectTimeoutMillis() : 60000; // Default 60 seconds
+    // PDI-20898: In MINA SSHD 2.x await(0L) behaves like a non-blocking poll and can return
+    // immediately without waiting for connection completion. Use no-argument await() for
+    // non-positive timeouts; it waits
+    // until the connection is established with no deadline imposed.
+    long connectTimeout = config.getConnectTimeoutMillis();
     boolean connected;
 
     try {
-      connected = cf.await( extendedTimeout );
+      if ( connectTimeout > 0 ) {
+        connected = cf.await( connectTimeout );
+      } else {
+        connected = cf.await();
+      }
     } catch ( IOException e ) {
       throw new SshConnectionException( "SSH connection failed during await", e );
     }
 
-
     if ( !connected ) {
-      throw new SshTimeoutException( "SSH connection timed out after " + extendedTimeout + "ms" );
+      if ( connectTimeout > 0 ) {
+        throw new SshTimeoutException( "SSH connection timed out after " + connectTimeout + "ms" );
+      }
+      throw new SshTimeoutException( "SSH connection failed while waiting with no configured timeout" );
     }
 
     if ( !cf.isConnected() ) {
@@ -354,7 +364,9 @@ public class MinaSshConnection implements SshConnection {
 
   private boolean performPublicKeyAuth() throws IOException {
     AuthFuture authFuture = session.auth();
-    boolean success = authFuture.verify( config.getConnectTimeoutMillis() ).isSuccess();
+    long timeout = config.getConnectTimeoutMillis();
+    // PDI-20898: verify(0L) throws TimeoutException immediately; use no-arg verify() for infinite wait.
+    boolean success = ( timeout > 0 ? authFuture.verify( timeout ) : authFuture.verify() ).isSuccess();
 
     if ( success ) {
       log( DEBUG, "SSH public key authentication successful" );
@@ -383,7 +395,9 @@ public class MinaSshConnection implements SshConnection {
       log( DEBUG, "Added password identity for SSH authentication" );
 
       AuthFuture authFuture = session.auth();
-      boolean success = authFuture.verify( config.getConnectTimeoutMillis() ).isSuccess();
+      long timeout = config.getConnectTimeoutMillis();
+      // PDI-20898: verify(0L) throws TimeoutException immediately; use no-arg verify() for infinite wait.
+      boolean success = ( timeout > 0 ? authFuture.verify( timeout ) : authFuture.verify() ).isSuccess();
 
       if ( success ) {
         log( DEBUG, "SSH password authentication successful" );
@@ -419,7 +433,12 @@ public class MinaSshConnection implements SshConnection {
       try ( var ch = session.createExecChannel( command ) ) {
         ch.setOut( stdout );
         ch.setErr( stderr );
-        ch.open().verify( timeoutMs );
+        // PDI-20898: verify(0L) throws TimeoutException immediately; use no-arg verify() for infinite wait.
+        if ( timeoutMs > 0 ) {
+          ch.open().verify( timeoutMs );
+        } else {
+          ch.open().verify();
+        }
 
         // Wait for the command to complete and exit status to be available
         Set<ClientChannelEvent> events = ch.waitFor(

--- a/engine/src/main/java/org/pentaho/di/trans/steps/ssh/SSHData.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/ssh/SSHData.java
@@ -122,13 +122,16 @@ public class SSHData extends BaseStepData {
     SshConnection connection = null;
 
     try {
-      // Build basic SSH configuration
+      // PDI-20898: non-positive timeout means infinite (0), positive values are seconds converted to milliseconds.
+      long timeoutMillis = params.getTimeOut() <= 0 ? 0L : params.getTimeOut() * 1000L;
+
+      // Build SSH configuration with the same timeout semantics for connect and command execution.
       SshConfig config = SshConfig.create()
           .host( params.getServer() )
           .port( params.getPort() )
           .username( params.getUsername() )
-          .commandTimeoutMillis( params.getTimeOut() > 0 ? params.getTimeOut() * 1000 : 30000 )// Default 30 seconds
-          .connectTimeoutMillis( params.getTimeOut() > 0 ? params.getTimeOut() * 1000 : 30000 ); // Default 30 seconds
+          .commandTimeoutMillis( timeoutMillis )
+          .connectTimeoutMillis( timeoutMillis );
 
       // Set the log channel for debugging SSH connection issues
       if ( logChannel != null ) {

--- a/engine/src/main/java/org/pentaho/di/trans/steps/ssh/SshConnectionParameters.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/ssh/SshConnectionParameters.java
@@ -128,7 +128,7 @@ public class SshConnectionParameters {
     private boolean useKey = false;
     private String keyFilename;
     private String passPhrase;
-    private int timeOut = 30000; // Default 30 seconds
+    private int timeOut = 0; // Default: 0 = infinite (non-positive values mean no timeout)
     private VariableSpace space;
     private String proxyhost;
     private int proxyport;

--- a/engine/src/test/java/org/pentaho/di/core/ssh/mina/MinaSshConnectionEdgeCasesTest.java
+++ b/engine/src/test/java/org/pentaho/di/core/ssh/mina/MinaSshConnectionEdgeCasesTest.java
@@ -13,9 +13,15 @@
 package org.pentaho.di.core.ssh.mina;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 
+import org.apache.sshd.client.future.ConnectFuture;
 import org.junit.Test;
 import org.pentaho.di.core.ssh.SshConfig;
 import org.pentaho.di.core.ssh.exceptions.SshConnectionException;
@@ -216,5 +222,80 @@ public class MinaSshConnectionEdgeCasesTest {
       // Should throw exception when trying to open SFTP without connecting first
       connection.openSftp();
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // PDI-20898: timeout=0 (and negative) must mean "infinite" throughout the
+  // MINA connection layer.  In MINA SSHD 2.x, await(0L) returns immediately
+  // and await(negative) throws; the no-arg await() is the correct infinite-wait
+  // call and must be used whenever connectTimeoutMillis is non-positive.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testWaitForConnectionWithZeroTimeoutWaitsIndefinitely() throws Exception {
+    // connectTimeoutMillis=0 means "no timeout". In MINA SSHD 2.x, await(0L) returns
+    // immediately (non-blocking poll), so we must call the no-arg await() instead.
+    SshConfig config = SshConfig.create()
+      .host( "example.com" )
+      .username( "user" )
+      .password( "pass" )
+      .connectTimeoutMillis( 0L );
+
+    ConnectFuture mockFuture = mock( ConnectFuture.class );
+    when( mockFuture.await() ).thenReturn( true );
+    when( mockFuture.isConnected() ).thenReturn( true );
+
+    invokeWaitForConnection( new MinaSshConnection( config ), mockFuture );
+
+    verify( mockFuture ).await();
+    verify( mockFuture, never() ).await( 0L );
+  }
+
+  @Test
+  public void testWaitForConnectionWithNegativeTimeoutWaitsIndefinitely() throws Exception {
+    // Negative timeout is also treated as "no timeout". In MINA SSHD 2.x, await(negative)
+    // throws an IllegalArgumentException, so we must call the no-arg await() instead.
+    SshConfig config = SshConfig.create()
+      .host( "example.com" )
+      .username( "user" )
+      .password( "pass" )
+      .connectTimeoutMillis( -1L );
+
+    ConnectFuture mockFuture = mock( ConnectFuture.class );
+    when( mockFuture.await() ).thenReturn( true );
+    when( mockFuture.isConnected() ).thenReturn( true );
+
+    invokeWaitForConnection( new MinaSshConnection( config ), mockFuture );
+
+    verify( mockFuture ).await();
+    verify( mockFuture, never() ).await( -1L );
+  }
+
+  @Test
+  public void testWaitForConnectionWithPositiveTimeoutPassesItDirectlyToMina() throws Exception {
+    // Positive timeout is forwarded unchanged to MINA.
+    long customTimeout = 15_000L;
+    SshConfig config = SshConfig.create()
+      .host( "example.com" )
+      .username( "user" )
+      .password( "pass" )
+      .connectTimeoutMillis( customTimeout );
+
+    ConnectFuture mockFuture = mock( ConnectFuture.class );
+    when( mockFuture.await( customTimeout ) ).thenReturn( true );
+    when( mockFuture.isConnected() ).thenReturn( true );
+
+    invokeWaitForConnection( new MinaSshConnection( config ), mockFuture );
+
+    verify( mockFuture ).await( customTimeout );
+    verify( mockFuture, never() ).await( 0L );
+  }
+
+  /** Reflectively calls the private {@code waitForConnection} method. */
+  private static void invokeWaitForConnection( MinaSshConnection conn, ConnectFuture future )
+      throws Exception {
+    Method m = MinaSshConnection.class.getDeclaredMethod( "waitForConnection", ConnectFuture.class );
+    m.setAccessible( true );
+    m.invoke( conn, future );
   }
 }

--- a/engine/src/test/java/org/pentaho/di/trans/steps/ssh/SSHDataTest.java
+++ b/engine/src/test/java/org/pentaho/di/trans/steps/ssh/SSHDataTest.java
@@ -242,7 +242,30 @@ public class SSHDataTest {
     verify( mockFactory ).open( configCaptor.capture() );
 
     SshConfig config = configCaptor.getValue();
-    assertEquals( "Should use default timeout of 30 seconds", 30000L, config.getConnectTimeoutMillis() );
+    assertEquals( "PDI-20898: timeout=0 should be infinite (0ms), not default 30000ms", 0L, config.getConnectTimeoutMillis() );
+    assertEquals( "PDI-20898: both timeouts should be synchronized", 0L, config.getCommandTimeoutMillis() );
+  }
+
+  @Test
+  public void testPasswordAuthentication_NegativeTimeout_ShouldBeInfinite() throws Exception {
+    // PDI-20898: Regression test for negative timeout (treated as infinite)
+    SshConnectionParameters params = SshConnectionParameters.builder()
+        .bowl( DefaultBowl.getInstance() )
+        .server( server )
+        .port( port )
+        .username( username )
+        .password( password )
+        .useKey( false )
+        .timeOut( -1 )
+        .build();
+    SSHData.openSshConnection( params );
+
+    ArgumentCaptor<SshConfig> configCaptor = ArgumentCaptor.forClass( SshConfig.class );
+    verify( mockFactory ).open( configCaptor.capture() );
+
+    SshConfig config = configCaptor.getValue();
+    assertEquals( "PDI-20898: negative timeout should map to 0 (infinite)", 0L, config.getConnectTimeoutMillis() );
+    assertEquals( "PDI-20898: both timeouts should be synchronized", 0L, config.getCommandTimeoutMillis() );
   }
 
   @Test

--- a/plugins/ftp-delete/impl/src/test/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDeleteSSHMigrationTest.java
+++ b/plugins/ftp-delete/impl/src/test/java/org/pentaho/di/job/entries/ftpdelete/JobEntryFTPDeleteSSHMigrationTest.java
@@ -12,6 +12,7 @@
 
 package org.pentaho.di.job.entries.ftpdelete;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,6 +28,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -284,6 +286,29 @@ public class JobEntryFTPDeleteSSHMigrationTest {
 
       // Verify configuration was applied
       verify( sshConnectionFactory ).open( any( SshConfig.class ) );
+    }
+  }
+
+  @Test
+  public void testTimeoutZeroMeansInfiniteForSSHProtocol() throws Exception {
+    // PDI-20898: timeout=0 must not translate to a finite timeout.
+    jobEntry.setTimeout( "0" );
+
+    try ( MockedStatic<SshConnectionFactory> mockedFactory = mockStatic( SshConnectionFactory.class ) ) {
+      mockedFactory.when( SshConnectionFactory::defaultFactory ).thenReturn( sshConnectionFactory );
+      when( sshConnectionFactory.open( any( SshConfig.class ) ) ).thenReturn( sshConnection );
+      when( sshConnection.openSftp() ).thenReturn( sftpSession );
+      when( sftpSession.list( anyString() ) ).thenReturn( Arrays.asList() );
+
+      Result result = new Result();
+      jobEntry.execute( result, 0 );
+
+      ArgumentCaptor<SshConfig> configCaptor = ArgumentCaptor.forClass( SshConfig.class );
+      verify( sshConnectionFactory ).open( configCaptor.capture() );
+
+      SshConfig config = configCaptor.getValue();
+      assertEquals( "timeout=0 should keep connect timeout infinite", 0L, config.getConnectTimeoutMillis() );
+      assertEquals( "timeout=0 should keep command timeout infinite", 0L, config.getCommandTimeoutMillis() );
     }
   }
 

--- a/plugins/ftp-delete/ui/src/main/java/org/pentaho/di/ui/job/entries/ftpdelete/JobEntryFTPDeleteDialog.java
+++ b/plugins/ftp-delete/ui/src/main/java/org/pentaho/di/ui/job/entries/ftpdelete/JobEntryFTPDeleteDialog.java
@@ -1320,14 +1320,15 @@ public class JobEntryFTPDeleteDialog extends JobEntryDialog implements JobEntryD
       if ( conn == null ) { // Create a connection instance
         SshConfig config = SshConfig.create()
           .host( jobMeta.environmentSubstitute( wServerName.getText() ) )
-          .port( Const.toInt( jobMeta.environmentSubstitute( wPort.getText() ), 22 ) );
+          .port( Const.toInt( jobMeta.environmentSubstitute( wPort.getText() ), 22 ) )
+          .connectTimeoutMillis( 60000 );
 
         /* We want to connect through a HTTP proxy */
         if ( wuseProxy.getSelection() ) {
           /* Now connect */
           // if the proxy requires basic authentication:
           if ( !Utils.isEmpty( wProxyUsername.getText() ) ) {
-            config.proxy( jobMeta.environmentSubstitute( wProxyHost.getText() ), 
+            config.proxy( jobMeta.environmentSubstitute( wProxyHost.getText() ),
                          Const.toInt( wProxyPort.getText(), 22 ) )
               .proxyAuth( jobMeta.environmentSubstitute( wProxyUsername.getText() ),
                          Utils.resolvePassword( jobMeta, wProxyPassword.getText() ) );


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7418 - Backport of PDI-20894 - (11.0 Suite) FTP delete fails when using SSH protocol with timeout set to 0.](https://pentaho-eng.atlassian.net/browse/SP-7418)
- **Base Case:** [PDI-20894 - Backport of PDI-20894 - (11.0 Suite) FTP delete fails when using SSH protocol with timeout set to 0.](https://pentaho-eng.atlassian.net/browse/PDI-20894)
- **Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10575

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-kettle/pull/10575
- Commit: c5f5ebe182a7147683b3782e892113d1a7d1cd4e

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
