### PR TITLE
fix[SP-7425]: add PENTAHO_SCHEDULER_HIDE_INTERNAL_VARIABLES to kettle_properties

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/Const.java
+++ b/core/src/main/java/org/pentaho/di/core/Const.java
@@ -1732,7 +1732,7 @@ public class Const {
   public static final String STRING_ONLY_USED_DB_TO_XML = "STRING_ONLY_USED_DB_TO_XML";
 
   /**
-   Value to Configure if we want to disable/grayed out internal variables, and remove from the new/edit schedule.
+   Value to Configure if we want to disable/gray out internal variables, and remove them from the new/edit schedule dialog.
    */
   public static final String HIDE_INTERNAL_VARIABLES = "PENTAHO_SCHEDULER_HIDE_INTERNAL_VARIABLES";
   public static final String HIDE_INTERNAL_VARIABLES_DEFAULT = "Y";

--- a/engine/src/main/resources/kettle-variables.xml
+++ b/engine/src/main/resources/kettle-variables.xml
@@ -707,4 +707,11 @@
     <default-value>N</default-value>
   </kettle-variable>
 
+  <kettle-variable>
+    <description>Set this variable to Y to disable/gray out internal variables and remove them from the new/edit schedule dialog.
+      Set it to N to show internal variables in the new/edit schedule dialog.</description>
+    <variable>PENTAHO_SCHEDULER_HIDE_INTERNAL_VARIABLES</variable>
+    <default-value>Y</default-value>
+  </kettle-variable>
+
 </kettle-variables>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7425 - Backport of PDI-20350 - (10.2 Suite) PENTAHO_SCHEDULER_HIDE_INTERNAL_VARIABLES usage is not documented](https://pentaho-eng.atlassian.net/browse/SP-7425)
- **Base Case:** [PDI-20350 - Backport of PDI-20350 - (10.2 Suite) PENTAHO_SCHEDULER_HIDE_INTERNAL_VARIABLES usage is not documented](https://pentaho-eng.atlassian.net/browse/PDI-20350)
- **Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10540

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-kettle/pull/10540
- Commit: a554816fa481bea01c36c595ef9af939f77cff1d

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
