### PR TITLE
[PDI-20945] Consolidate contentType and contentEncoding headers for X…

### DIFF
--- a/engine/src/main/java/org/pentaho/di/www/AddExportServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/AddExportServlet.java
@@ -183,8 +183,7 @@ public class AddExportServlet extends BaseHttpServlet implements CartePluginInte
     boolean isJob = TYPE_JOB.equalsIgnoreCase( request.getParameter( PARAMETER_TYPE ) );
     String load = request.getParameter( PARAMETER_LOAD ); // the resource to load
 
-    response.setContentType( "text/xml" );
-    out.print( XMLHandler.getXMLHeader() );
+    contentTypeAndHeader( true, response, out, null );
 
     response.setStatus( HttpServletResponse.SC_OK );
 

--- a/engine/src/main/java/org/pentaho/di/www/AddJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/AddJobServlet.java
@@ -19,7 +19,6 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.logging.LoggingObjectType;
 import org.pentaho.di.core.logging.SimpleLoggingObject;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobAdapter;
 import org.pentaho.di.job.JobConfiguration;
@@ -153,7 +152,7 @@ public class AddJobServlet extends BaseHttpServlet implements CartePluginInterfa
       logDebug( "Addition of job requested" );
     }
 
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     PrintWriter out = response.getWriter();
     BufferedReader in = request.getReader(); // read from the client
@@ -161,11 +160,9 @@ public class AddJobServlet extends BaseHttpServlet implements CartePluginInterfa
       logDetailed( "Encoding: " + request.getCharacterEncoding() );
     }
 
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      out.print( XMLHandler.getXMLHeader() );
-    } else {
-      response.setContentType( "text/html" );
+    contentTypeAndHeader( useXML, response, out, null );
+    
+    if ( !useXML ) {
       out.println( "<HTML>" );
       out.println( "<HEAD><TITLE>Add job</TITLE></HEAD>" );
       out.println( "<BODY>" );

--- a/engine/src/main/java/org/pentaho/di/www/AddTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/AddTransServlet.java
@@ -171,7 +171,7 @@ public class AddTransServlet extends BaseHttpServlet implements CartePluginInter
       logDebug( "Addition of transformation requested" );
     }
 
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     PrintWriter out = response.getWriter();
     BufferedReader in = request.getReader();
@@ -179,11 +179,8 @@ public class AddTransServlet extends BaseHttpServlet implements CartePluginInter
       logDetailed( "Encoding: " + request.getCharacterEncoding() );
     }
 
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      out.print( XMLHandler.getXMLHeader() );
-    } else {
-      response.setContentType( "text/html" );
+    contentTypeAndHeader( useXML, response, out, null );
+    if ( !useXML ) {
       out.println( "<HTML>" );
       out.println( "<HEAD><TITLE>Add transformation</TITLE></HEAD>" );
       out.println( "<BODY>" );

--- a/engine/src/main/java/org/pentaho/di/www/BaseHttpServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/BaseHttpServlet.java
@@ -15,20 +15,25 @@
 package org.pentaho.di.www;
 
 import java.io.IOException;
+import java.io.Writer;
 import java.util.Enumeration;
 import java.util.List;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.util.Utils;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.repository.Repository;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import org.pentaho.di.core.bowl.Bowl;
-import org.pentaho.di.core.bowl.DefaultBowl;
-import org.pentaho.di.core.logging.LogChannel;
-import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.core.variables.VariableSpace;
-import org.pentaho.di.repository.Repository;
+import jakarta.ws.rs.core.MediaType;
 
 
 public class BaseHttpServlet extends HttpServlet {
@@ -91,6 +96,42 @@ public class BaseHttpServlet extends HttpServlet {
     this.jettyMode = isJetty;
   }
 
+  protected boolean useXML( HttpServletRequest request ) {
+    //Consider honoring the "Accept" header values of "text/xml" or "application/xml" here as another potential way to trigger xml content
+    return "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+  }
+  
+
+  /**
+   * Sets contentType and encoding headers on the response. Also can optionally print the <?xml ...> declaration line.
+   * @param isXml A boolean indicating if the header should be written for xml or html
+   * @param response The HttpServlet Response to set the content type and character encoding
+   * @param outputWriter When a non-null value is passed and isXml is true, the <?xml> declaration is written to the Writer
+   * @param defaultEncoding A default encoding that should be used if no others are provided.
+   * @return  Returns the encoding that was used
+   * @throws IOException
+   */
+  protected String contentTypeAndHeader(boolean isXml, HttpServletResponse response, Writer outputWriter, String defaultEncoding  ) throws IOException {
+    if( isXml ) {
+      String xmlEncoding = Const.NVL( defaultEncoding, Const.XML_ENCODING );
+      response.setContentType( MediaType.APPLICATION_XML );
+      response.setCharacterEncoding( xmlEncoding );
+      if( outputWriter != null ) {
+        outputWriter.append( XMLHandler.getXMLHeader( xmlEncoding ) );
+      }
+      return xmlEncoding;
+    } else {
+      String encoding = System.getProperty( "KETTLE_DEFAULT_SERVLET_ENCODING", defaultEncoding );
+      if ( encoding != null && !Utils.isEmpty( encoding.trim() ) ) {
+        response.setCharacterEncoding( encoding );
+        response.setContentType( "text/html; charset=" + encoding );
+      } else {
+        response.setContentType( MediaType.TEXT_HTML );
+      }
+      return encoding;
+    }
+  }
+  
   protected void doPut( HttpServletRequest request, HttpServletResponse response ) throws ServletException,
     IOException {
     doGet( request, response );

--- a/engine/src/main/java/org/pentaho/di/www/BodyHttpServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/BodyHttpServlet.java
@@ -17,11 +17,11 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.PackageMessages;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,10 +34,6 @@ public abstract class BodyHttpServlet extends BaseHttpServlet implements CartePl
 
   public BodyHttpServlet() {
     messages = new PackageMessages( this.getClass() );
-  }
-
-  protected boolean useXML( HttpServletRequest request ) {
-    return "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
   }
 
   public void doGet( HttpServletRequest request, HttpServletResponse response ) throws IOException {
@@ -84,13 +80,13 @@ public abstract class BodyHttpServlet extends BaseHttpServlet implements CartePl
   }
 
   protected void beginHtml( HttpServletResponse response, PrintWriter out ) throws IOException {
-    response.setContentType( "text/html;charset=UTF-8" );
+    String encoding = contentTypeAndHeader( false, response, null, StandardCharsets.UTF_8.name() );
     out.println( "<HTML>" );
     out.println( "<HEAD>" );
     out.println( "<TITLE>" );
     out.println( Encode.forHtml( getTitle() ) );
     out.println( "</TITLE>" );
-    out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+    out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
     out.println( "</HEAD>" );
     out.println( "<BODY>" );
   }
@@ -102,9 +98,7 @@ public abstract class BodyHttpServlet extends BaseHttpServlet implements CartePl
   }
 
   protected void startXml( HttpServletResponse response, PrintWriter out ) throws IOException {
-    response.setContentType( "text/xml" );
-    response.setCharacterEncoding( Const.XML_ENCODING );
-    out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
+    contentTypeAndHeader( true, response, out, Const.XML_ENCODING );
   }
 
   abstract WebResult generateBody( HttpServletRequest request, HttpServletResponse response, boolean useXML )

--- a/engine/src/main/java/org/pentaho/di/www/CleanupTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/CleanupTransServlet.java
@@ -25,7 +25,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 
@@ -149,25 +148,21 @@ public class CleanupTransServlet extends BaseHttpServlet implements CartePluginI
 
     String transName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
     boolean onlySockets = "Y".equalsIgnoreCase( request.getParameter( "sockets" ) );
 
     response.setStatus( HttpServletResponse.SC_OK );
 
     PrintWriter out = response.getWriter();
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-      out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-    } else {
-      response.setContentType( "text/html;charset=UTF-8" );
+    String encoding = contentTypeAndHeader( useXML, response, out, Const.XML_ENCODING );
+    if ( !useXML ) {
       out.println( "<HTML>" );
       out.println( "<HEAD>" );
       out.println( "<TITLE>Transformation cleanup</TITLE>" );
       out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
         + convertContextPath( GetTransStatusServlet.CONTEXT_PATH ) + "?name="
         + URLEncoder.encode( transName, "UTF-8" ) + "\">" );
-      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
       out.println( "</HEAD>" );
       out.println( "<BODY>" );
     }

--- a/engine/src/main/java/org/pentaho/di/www/ExecuteJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/ExecuteJobServlet.java
@@ -195,7 +195,10 @@ public class ExecuteJobServlet extends BaseHttpServlet implements CartePluginInt
     String levelOption = request.getParameter( "level" );
 
     PrintWriter out = response.getWriter();
-
+    
+    //executeJob ALWAYS responds with XML
+    contentTypeAndHeader( true, response, out, null );
+    
     Repository repository;
     try {
       repository = openRepository( repOption, userOption, passOption );
@@ -224,12 +227,6 @@ public class ExecuteJobServlet extends BaseHttpServlet implements CartePluginInt
         PKG, "ExecuteJobServlet.Error.UnexpectedError", Const.CR + Const.getStackTracker( ke ) );
       out.println( new WebResult( WebResult.STRING_ERROR, message ) );
       return;
-    }
-
-    String encoding = System.getProperty( "KETTLE_DEFAULT_SERVLET_ENCODING", null );
-    if ( encoding != null && !Utils.isEmpty( encoding.trim() ) ) {
-      response.setCharacterEncoding( encoding );
-      response.setContentType( "text/html; charset=" + encoding );
     }
 
     JobMeta jobMeta;
@@ -307,7 +304,7 @@ public class ExecuteJobServlet extends BaseHttpServlet implements CartePluginInt
     try {
       runJob( job );
       WebResult webResult = new WebResult( WebResult.STRING_OK, "Job started", carteObjectId );
-      out.println( webResult.getXML() );
+      out.println( webResult );
       out.flush();
 
     } catch ( Exception executionException ) {

--- a/engine/src/main/java/org/pentaho/di/www/ExecuteTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/ExecuteTransServlet.java
@@ -236,13 +236,20 @@ public class ExecuteTransServlet extends BaseHttpServlet implements CartePluginI
 
     response.setStatus( HttpServletResponse.SC_OK );
 
-    String encoding = System.getProperty( "KETTLE_DEFAULT_SERVLET_ENCODING", null );
-    if ( encoding != null && !Utils.isEmpty( encoding.trim() ) ) {
-      response.setCharacterEncoding( encoding );
-      response.setContentType( "text/html; charset=" + encoding );
-    }
-
     PrintWriter out = response.getWriter();
+    
+    /* When running transformations with executeTrans, 
+     * the transformation may print output to the response.
+     * 
+     * This follows the previous pattern, which was to only add
+     * a text/html header if the KETTLE_DEFAULT_SERVLET_ENCODING
+     * system property is set.
+     */
+    if( Utils.isEmpty( contentTypeAndHeader( false, response, null, null ) ) ) {
+      //The contentTypeAndHeader method would have set this to text/html. 
+      //However, prior behavior just not set the header
+      response.setContentType( null );
+    }
 
     if ( transOption == null ) {
       response.setStatus( HttpServletResponse.SC_BAD_REQUEST );

--- a/engine/src/main/java/org/pentaho/di/www/GetJobImageServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/GetJobImageServlet.java
@@ -139,7 +139,7 @@ public class GetJobImageServlet extends BaseHttpServlet implements CartePluginIn
     String jobName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
 
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     // ID is optional...
     //
@@ -184,6 +184,7 @@ public class GetJobImageServlet extends BaseHttpServlet implements CartePluginIn
     PrintWriter out;
     try {
       out = response.getWriter();
+      contentTypeAndHeader( useXML, response, out, null );
       if ( useXML ) {
         out.println( new WebResult( WebResult.STRING_ERROR, message ) );
       } else {
@@ -226,6 +227,7 @@ public class GetJobImageServlet extends BaseHttpServlet implements CartePluginIn
     PrintWriter out;
     try {
       out = response.getWriter();
+      contentTypeAndHeader( useXML, response, out, null );
       if ( useXML ) {
         out.println( new WebResult( WebResult.STRING_ERROR, message ) );
       } else {

--- a/engine/src/main/java/org/pentaho/di/www/GetJobStatusServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/GetJobStatusServlet.java
@@ -19,6 +19,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,11 +38,10 @@ import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.www.cache.CarteStatusCache;
-import org.pentaho.di.www.exception.DuplicateKeyException;
 
 
 public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginInterface {
-  private static final String TEXT_XML = "text/xml";
+  
   private static final String HREF = "<a href=\"";
   private static Class<?> PKG = GetJobStatusServlet.class; // for i18n purposes, needed by Translator2!!
 
@@ -201,18 +201,13 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
     String root = request.getRequestURI() == null ? StatusServletUtils.PENTAHO_ROOT
       : request.getRequestURI().substring( 0, request.getRequestURI().indexOf( CONTEXT_PATH ) );
     String prefix = isJettyMode() ? StatusServletUtils.STATIC_PATH : root + StatusServletUtils.RESOURCES_PATH;
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
     int numberOfTailLines = Const.toInt( request.getParameter( "tail" ), 0 );
     int startLineNr = Const.toInt( request.getParameter( "from" ), 0 );
 
     response.setStatus( HttpServletResponse.SC_OK );
 
-    if ( useXML ) {
-      response.setContentType( TEXT_XML );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-    } else {
-      response.setContentType( "text/html;charset=UTF-8" );
-    }
+    String encoding = contentTypeAndHeader( useXML, response, null, StandardCharsets.UTF_8.name() ); 
 
     //Either jobName or id is required parameter
 
@@ -275,9 +270,6 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
               logText = logText.substring( StringUtils.lastOrdinalIndexOf(  logText, "\n", numberOfTailLines + 1 ) + 1 );
             }*/
 
-            response.setContentType( TEXT_XML );
-            response.setCharacterEncoding( Const.XML_ENCODING );
-
             SlaveServerJobStatus jobStatus = new SlaveServerJobStatus( jobName, id, job.getStatus() );
             jobStatus.setFirstLoggingLineNr( startLineNr );
             jobStatus.setLastLoggingLineNr( lastLineNr );
@@ -319,8 +311,6 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
         int lastLineNr = KettleLogStore.getLastBufferLineNr();
         int tableBorder = 0;
 
-        response.setContentType( "text/html" );
-
         out.println( "<HTML>" );
         out.println( "<HEAD>" );
         out
@@ -329,10 +319,10 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
         if ( EnvUtil.getSystemProperty( Const.KETTLE_CARTE_REFRESH_STATUS, "N" ).equalsIgnoreCase( "Y" ) ) {
           out.println( "<META http-equiv=\"Refresh\" content=\"10;url="
             + convertContextPath( GetJobStatusServlet.CONTEXT_PATH ) + "?name="
-            + URLEncoder.encode( Const.NVL( jobName, "" ), "UTF-8" ) + "&id=" + URLEncoder.encode( id, "UTF-8" )
+            + URLEncoder.encode( Const.NVL( jobName, "" ), encoding ) + "&id=" + URLEncoder.encode( id, encoding )
             + "\">" );
         }
-        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
         if ( isJettyMode() ) {
           out.println( "<link rel=\"stylesheet\" type=\"text/css\" href=\"/static/css/carte.css\" />" );
         } else {
@@ -451,23 +441,22 @@ public class GetJobStatusServlet extends BaseHttpServlet implements CartePluginI
     }
   }
 
-  private void printResponse( HttpServletResponse response, boolean useXML, PrintWriter out, String message ) {
-    if ( useXML ) {
-      response.setContentType( TEXT_XML );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-      out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
+  private void printResponse( HttpServletResponse response, boolean useXML, PrintWriter out, String message ) throws IOException {
+    
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
+    
+    if ( !useXML ) {
       out.println( new WebResult( WebResult.STRING_ERROR, message ) );
     } else {
       String h1End = "</H1>";
       String h1 = "<H1>";
       String hrefEnd = "</a><p>";
-      response.setContentType( "text/html;charset=UTF-8" );
       out.println( "<HTML>" );
       out.println( "<HEAD>" );
       out.println( "<TITLE>Start job</TITLE>" );
       out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
         + convertContextPath( GetStatusServlet.CONTEXT_PATH ) + "\">" );
-      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
       out.println( "</HEAD>" );
       out.println( "<BODY>" );
       out.println( h1 + Encode.forHtml( message ) + h1End );

--- a/engine/src/main/java/org/pentaho/di/www/GetPropertiesServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/GetPropertiesServlet.java
@@ -54,7 +54,6 @@ public class GetPropertiesServlet extends BodyHttpServlet {
 
   @Override
   protected void startXml( HttpServletResponse response, PrintWriter out ) throws IOException {
-    response.setContentType( "text/xml" );
-    response.setCharacterEncoding( Const.XML_ENCODING );
+    contentTypeAndHeader( true, response, null, Const.XML_ENCODING );
   }
 }

--- a/engine/src/main/java/org/pentaho/di/www/GetStatusServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/GetStatusServlet.java
@@ -15,7 +15,6 @@
 package org.pentaho.di.www;
 
 import org.owasp.encoder.Encode;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
@@ -30,6 +29,7 @@ import java.io.PrintWriter;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -190,23 +190,17 @@ public class GetStatusServlet extends BaseHttpServlet implements CartePluginInte
     String prefix = isJettyMode() ? StatusServletUtils.STATIC_PATH : root + StatusServletUtils.RESOURCES_PATH;
     prefix = encodeUriComponents( prefix );
     root = encodeUriComponents( root );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
     boolean useLightTheme = "Y".equalsIgnoreCase( request.getParameter( "useLightTheme" ) );
-
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-    } else {
-      response.setContentType( "text/html;charset=UTF-8" );
-    }
 
     PrintWriter out = response.getWriter();
 
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
+    
     List<CarteObjectEntry> transEntries = getTransformationMap().getTransformationObjects();
     List<CarteObjectEntry> jobEntries = getJobMap().getJobObjects();
 
     if ( useXML ) {
-      out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
       SlaveServerStatus serverStatus = new SlaveServerStatus();
       serverStatus.setStatusDescription( "Online" );
 
@@ -242,7 +236,7 @@ public class GetStatusServlet extends BaseHttpServlet implements CartePluginInte
       out.println( "<HTML>" );
       out.println( "<HEAD><TITLE>"
         + BaseMessages.getString( PKG, "GetStatusServlet.KettleSlaveServerStatus" ) + "</TITLE>" );
-      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
 
       int tableBorder = 1;
       if ( !useLightTheme ) {

--- a/engine/src/main/java/org/pentaho/di/www/GetTransStatusServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/GetTransStatusServlet.java
@@ -19,6 +19,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -207,19 +208,12 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
     String root = request.getRequestURI() == null ? StatusServletUtils.PENTAHO_ROOT
       : request.getRequestURI().substring( 0, request.getRequestURI().indexOf( CONTEXT_PATH ) );
     String prefix = isJettyMode() ? StatusServletUtils.STATIC_PATH : root + StatusServletUtils.RESOURCES_PATH;
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
     int startLineNr = Const.toInt( request.getParameter( "from" ), 0 );
 
     response.setStatus( HttpServletResponse.SC_OK );
 
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-    } else {
-      response.setCharacterEncoding( "UTF-8" );
-      response.setContentType( "text/html;charset=UTF-8" );
-
-    }
+    String encoding = contentTypeAndHeader( useXML, response, null, StandardCharsets.UTF_8.name() );
 
     // ID is optional...
     //
@@ -318,18 +312,16 @@ public class GetTransStatusServlet extends BaseHttpServlet implements CartePlugi
         int lastLineNr = KettleLogStore.getLastBufferLineNr();
         int tableBorder = 0;
 
-        response.setContentType( "text/html;charset=UTF-8" );
-
         out.println( "<HTML>" );
         out.println( "<HEAD>" );
         out.println( "<TITLE>"
           + BaseMessages.getString( PKG, "TransStatusServlet.KettleTransStatus" ) + "</TITLE>" );
         if ( EnvUtil.getSystemProperty( Const.KETTLE_CARTE_REFRESH_STATUS, "N" ).equalsIgnoreCase( "Y" ) ) {
           out.println( "<META http-equiv=\"Refresh\" content=\"10;url="
-            + convertContextPath( CONTEXT_PATH ) + "?name=" + URLEncoder.encode( transName, "UTF-8" ) + "&id="
-            + URLEncoder.encode( id, "UTF-8" ) + "\">" );
+            + convertContextPath( CONTEXT_PATH ) + "?name=" + URLEncoder.encode( transName, encoding ) + "&id="
+            + URLEncoder.encode( id, encoding ) + "\">" );
         }
-        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
 
         if ( isJettyMode() ) {
           out.println( "<link rel=\"stylesheet\" type=\"text/css\" href=\"/static/css/carte.css\" />" );

--- a/engine/src/main/java/org/pentaho/di/www/PauseTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/PauseTransServlet.java
@@ -17,6 +17,7 @@ package org.pentaho.di.www;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,7 +26,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 
@@ -140,28 +140,24 @@ public class PauseTransServlet extends BaseHttpServlet implements CartePluginInt
 
     String transName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     response.setStatus( HttpServletResponse.SC_OK );
 
-    response.setCharacterEncoding( "UTF-8" );
-
     PrintWriter out = response.getWriter();
+    
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
+    
     try {
-      if ( useXML ) {
-        response.setContentType( "text/xml" );
-        response.setCharacterEncoding( Const.XML_ENCODING );
-        out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-      } else {
-
-        response.setContentType( "text/html;charset=UTF-8" );
+      if ( !useXML ) {
+        
         out.println( "<HTML>" );
         out.println( "<HEAD>" );
         out.println( "<TITLE>" + BaseMessages.getString( PKG, "PauseTransServlet.PauseTrans" ) + "</TITLE>" );
         out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
           + convertContextPath( GetTransStatusServlet.CONTEXT_PATH ) + "?name="
-          + URLEncoder.encode( transName, "UTF-8" ) + "&id=" + URLEncoder.encode( id, "UTF-8" ) + "\">" );
-        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+          + URLEncoder.encode( transName, encoding ) + "&id=" + URLEncoder.encode( id, encoding ) + "\">" );
+        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
         out.println( "</HEAD>" );
         out.println( "<BODY>" );
       }

--- a/engine/src/main/java/org/pentaho/di/www/PrepareExecutionTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/PrepareExecutionTransServlet.java
@@ -17,6 +17,7 @@ package org.pentaho.di.www;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -146,18 +147,14 @@ public class PrepareExecutionTransServlet extends BaseHttpServlet implements Car
 
     String transName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     response.setStatus( HttpServletResponse.SC_OK );
 
     PrintWriter out = response.getWriter();
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-    } else {
-
-      response.setCharacterEncoding( "UTF-8" );
-      response.setContentType( "text/html;charset=UTF-8" );
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
+    
+    if ( !useXML ) {
 
       out.println( "<HTML>" );
       out.println( "<HEAD>" );
@@ -165,8 +162,8 @@ public class PrepareExecutionTransServlet extends BaseHttpServlet implements Car
         + BaseMessages.getString( PKG, "PrepareExecutionTransServlet.TransPrepareExecution" ) + "</TITLE>" );
       out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
         + convertContextPath( GetTransStatusServlet.CONTEXT_PATH ) + "?name="
-        + URLEncoder.encode( transName, "UTF-8" ) + "\">" );
-      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+        + URLEncoder.encode( transName, encoding) + "\">" );
+      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
       out.println( "</HEAD>" );
       out.println( "<BODY>" );
     }

--- a/engine/src/main/java/org/pentaho/di/www/RegisterSlaveServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RegisterSlaveServlet.java
@@ -122,8 +122,7 @@ if an error occurred. Response has <code>result</code> OK if there were no error
 
     // We always use XML to reply here...
     //
-    response.setContentType( "text/xml" );
-    out.print( XMLHandler.getXMLHeader() );
+    contentTypeAndHeader( true, response, out, Const.XML_ENCODING );
     response.setStatus( HttpServletResponse.SC_OK );
 
     try {

--- a/engine/src/main/java/org/pentaho/di/www/RemoveJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RemoveJobServlet.java
@@ -16,6 +16,7 @@ package org.pentaho.di.www;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,10 +24,8 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.owasp.encoder.Encode;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.logging.KettleLogStore;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.www.cache.CarteStatusCache;
@@ -145,18 +144,13 @@ public class RemoveJobServlet extends BaseHttpServlet implements CartePluginInte
 
     String jobName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     response.setStatus( HttpServletResponse.SC_OK );
 
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-    } else {
-      response.setContentType( "text/html;charset=UTF-8" );
-    }
-
     PrintWriter out = response.getWriter();
+    
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
 
     // ID is optional...
     //
@@ -186,17 +180,12 @@ public class RemoveJobServlet extends BaseHttpServlet implements CartePluginInte
       getJobMap().removeJob( entry );
 
       if ( useXML ) {
-        response.setContentType( "text/xml" );
-        response.setCharacterEncoding( Const.XML_ENCODING );
-        out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-        out.print( WebResult.OK.getXML() );
+        out.print( WebResult.OK );
       } else {
-        response.setContentType( "text/html;charset=UTF-8" );
-
         out.println( "<HTML>" );
         out.println( "<HEAD>" );
         out.println( "<TITLE>" + BaseMessages.getString( PKG, "RemoveJobServlet.JobRemoved" ) + "</TITLE>" );
-        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
         out.println( "</HEAD>" );
         out.println( "<BODY>" );
         out.println( "<H3>"

--- a/engine/src/main/java/org/pentaho/di/www/RemoveTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RemoveTransServlet.java
@@ -16,6 +16,7 @@ package org.pentaho.di.www;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,10 +24,8 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.owasp.encoder.Encode;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.logging.KettleLogStore;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.www.cache.CarteStatusCache;
@@ -145,20 +144,13 @@ public class RemoveTransServlet extends BaseHttpServlet implements CartePluginIn
 
     String transName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     response.setStatus( HttpServletResponse.SC_OK );
 
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-    } else {
-      response.setContentType( "text/html;charset=UTF-8" );
-    }
-
-    response.setCharacterEncoding( "UTF-8" );
-
     PrintWriter out = response.getWriter();
+    
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
 
     // ID is optional...
     //
@@ -188,17 +180,12 @@ public class RemoveTransServlet extends BaseHttpServlet implements CartePluginIn
       getTransformationMap().removeTransformation( entry );
 
       if ( useXML ) {
-        response.setContentType( "text/xml" );
-        response.setCharacterEncoding( Const.XML_ENCODING );
-        out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-        out.print( WebResult.OK.getXML() );
+        out.print( WebResult.OK );
       } else {
-        response.setContentType( "text/html;charset=UTF-8" );
-
         out.println( "<HTML>" );
         out.println( "<HEAD>" );
         out.println( "<TITLE>" + BaseMessages.getString( PKG, "RemoveTransServlet.TransRemoved" ) + "</TITLE>" );
-        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; " + encoding + "\">" );
         out.println( "</HEAD>" );
         out.println( "<BODY>" );
         out.println( "<H3>"

--- a/engine/src/main/java/org/pentaho/di/www/RunJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RunJobServlet.java
@@ -172,6 +172,10 @@ public class RunJobServlet extends BaseHttpServlet implements CartePluginInterfa
     response.setStatus( HttpServletResponse.SC_OK );
 
     PrintWriter out = response.getWriter();
+    
+    //runJob ALWAYS responds with XML
+    contentTypeAndHeader( true, response, out, null );
+    
     SlaveServerConfig serverConfig = transformationMap.getSlaveServerConfig();
     try {
       Repository slaveServerRepository = serverConfig.getRepository();
@@ -284,7 +288,7 @@ public class RunJobServlet extends BaseHttpServlet implements CartePluginInterfa
         runJob( job );
 
         WebResult webResult = new WebResult( WebResult.STRING_OK, "Job started", carteObjectId );
-        out.println( webResult.getXML() );
+        out.println( webResult );
         out.flush();
 
       } catch ( Exception executionException ) {

--- a/engine/src/main/java/org/pentaho/di/www/RunTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/RunTransServlet.java
@@ -156,12 +156,20 @@ public class RunTransServlet extends BaseHttpServlet implements CartePluginInter
 
     response.setStatus( HttpServletResponse.SC_OK );
 
-    String encoding = System.getProperty( "KETTLE_DEFAULT_SERVLET_ENCODING", null );
-    if ( encoding != null && !Utils.isEmpty( encoding.trim() ) ) {
-      response.setCharacterEncoding( encoding );
-      response.setContentType( "text/html; charset=" + encoding );
-    }
     PrintWriter out = response.getWriter();
+    
+    /* When running transformations with runTrans, 
+     * the transformation may print output to the response.
+     * 
+     * This follows the previous pattern, which was to only add
+     * a text/html header if the KETTLE_DEFAULT_SERVLET_ENCODING
+     * system property is set.
+     */
+    if( Utils.isEmpty( contentTypeAndHeader( false, response, null, null ) ) ) {
+      //The contentTypeAndHeader method would have set this to text/html. 
+      //However, prior behavior just not set the header
+      response.setContentType( null );
+    }
 
     try {
 

--- a/engine/src/main/java/org/pentaho/di/www/StartExecutionTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StartExecutionTransServlet.java
@@ -17,6 +17,7 @@ package org.pentaho.di.www;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,7 +27,6 @@ import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 
@@ -142,22 +142,20 @@ public class StartExecutionTransServlet extends BaseHttpServlet implements Carte
 
     String transName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     PrintWriter out = response.getWriter();
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-    } else {
-      response.setContentType( "text/html;charset=UTF-8" );
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
+    
+    if ( !useXML ) {
       out.println( "<HTML>" );
       out.println( "<HEAD>" );
       out.println( "<TITLE>"
         + BaseMessages.getString( PKG, "PrepareExecutionTransServlet.TransPrepareExecution" ) + "</TITLE>" );
       out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
         + convertContextPath( GetStatusServlet.CONTEXT_PATH ) + "?name="
-        + URLEncoder.encode( transName, "UTF-8" ) + "\">" );
-      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+        + URLEncoder.encode( transName, encoding ) + "\">" );
+      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
       out.println( "</HEAD>" );
       out.println( "<BODY>" );
     }

--- a/engine/src/main/java/org/pentaho/di/www/StartJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StartJobServlet.java
@@ -17,6 +17,7 @@ package org.pentaho.di.www;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import jakarta.servlet.ServletException;
@@ -29,7 +30,6 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.KettleLogStore;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobConfiguration;
@@ -161,13 +161,15 @@ public class StartJobServlet extends BaseHttpServlet implements CartePluginInter
     String jobName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
     String fetchJobConfigFromEntryStr = request.getParameter( "fetchJobConfigFromEntry" );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
     boolean fetchJobConfigFromEntry = "Y".equalsIgnoreCase( fetchJobConfigFromEntryStr );
 
     response.setStatus( HttpServletResponse.SC_OK );
 
     PrintWriter out = response.getWriter();
 
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
+    
     //Either jobName or id is required parameter
     String h1End = "</H1>";
     String h1 = "<H1>";
@@ -177,18 +179,14 @@ public class StartJobServlet extends BaseHttpServlet implements CartePluginInter
       response.setStatus( HttpServletResponse.SC_BAD_REQUEST );
       String message = BaseMessages.getString( PKG, "StartJobServlet.Log.JobNameOrIdIsMandatory" );
       if ( useXML ) {
-        response.setContentType( "text/xml" );
-        response.setCharacterEncoding( Const.XML_ENCODING );
-        out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
         out.println( new WebResult( WebResult.STRING_ERROR, message ) );
       } else {
-        response.setContentType( "text/html;charset=UTF-8" );
         out.println( "<HTML>" );
         out.println( "<HEAD>" );
         out.println( "<TITLE>Start job</TITLE>" );
         out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
           + convertContextPath( GetStatusServlet.CONTEXT_PATH ) + "\">" );
-        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
         out.println( "</HEAD>" );
         out.println( "<BODY>" );
         out.println( h1 + Encode.forHtml( message ) + h1End );
@@ -201,19 +199,14 @@ public class StartJobServlet extends BaseHttpServlet implements CartePluginInter
       return;
     }
 
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-      out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-    } else {
-      response.setContentType( "text/html;charset=UTF-8" );
+    if ( !useXML ) {
       out.println( "<HTML>" );
       out.println( "<HEAD>" );
       out.println( "<TITLE>Start job</TITLE>" );
       out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
-        + convertContextPath( GetStatusServlet.CONTEXT_PATH ) + "?name=" + URLEncoder.encode( jobName, "UTF-8" )
+        + convertContextPath( GetStatusServlet.CONTEXT_PATH ) + "?name=" + URLEncoder.encode( jobName, encoding )
         + "\">" );
-      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
       out.println( "</HEAD>" );
       out.println( "<BODY>" );
     }
@@ -287,7 +280,7 @@ public class StartJobServlet extends BaseHttpServlet implements CartePluginInter
 
         String message = BaseMessages.getString( PKG, "StartJobServlet.Log.JobStarted", jobName );
         if ( useXML ) {
-          out.println( new WebResult( WebResult.STRING_OK, message, id ).getXML() );
+          out.println( new WebResult( WebResult.STRING_OK, message, id ) );
         } else {
 
           out.println( h1 + Encode.forHtml( message ) + h1End );

--- a/engine/src/main/java/org/pentaho/di/www/StartTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StartTransServlet.java
@@ -17,6 +17,7 @@ package org.pentaho.di.www;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import jakarta.servlet.ServletException;
@@ -32,7 +33,6 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LoggingObjectType;
 import org.pentaho.di.core.logging.SimpleLoggingObject;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransConfiguration;
@@ -158,24 +158,22 @@ public class StartTransServlet extends BaseHttpServlet implements CartePluginInt
     if ( StringUtils.isEmpty( transName ) ) {
       transName = "";
     }
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     response.setStatus( HttpServletResponse.SC_OK );
 
     PrintWriter out = response.getWriter();
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-      out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-    } else {
-      response.setContentType( "text/html;charset=UTF-8" );
+    
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
+    
+    if ( !useXML ) {
       out.println( "<HTML>" );
       out.println( "<HEAD>" );
       out.println( "<TITLE>" + BaseMessages.getString( PKG, "StartTransServlet.Log.StartOfTrans" ) + "</TITLE>" );
       out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
         + convertContextPath( GetTransStatusServlet.CONTEXT_PATH ) + "?name="
         + URLEncoder.encode( transName, "UTF-8" ) + "\">" );
-      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+      out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
       out.println( "</HEAD>" );
       out.println( "<BODY>" );
     }
@@ -243,7 +241,7 @@ public class StartTransServlet extends BaseHttpServlet implements CartePluginInt
 
         String message = BaseMessages.getString( PKG, "StartTransServlet.Log.TransStarted", transName );
         if ( useXML ) {
-          out.println( new WebResult( WebResult.STRING_OK, message ).getXML() );
+          out.println( new WebResult( WebResult.STRING_OK, message ) );
         } else {
 
           out.println( "<H1>" + Encode.forHtml( message ) + "</H1>" );

--- a/engine/src/main/java/org/pentaho/di/www/StopCarteServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StopCarteServlet.java
@@ -16,6 +16,7 @@ package org.pentaho.di.www;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -60,14 +61,9 @@ public class StopCarteServlet extends BaseHttpServlet implements CartePluginInte
     }
 
     response.setStatus( HttpServletResponse.SC_OK );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
-    if ( useXML ) {
-      response.setContentType( "text/xml" );
-      response.setCharacterEncoding( Const.XML_ENCODING );
-    } else {
-      response.setContentType( "text/html" );
-    }
+    contentTypeAndHeader( useXML, response, null, StandardCharsets.UTF_8.name() );
 
     PrintStream out = new PrintStream( response.getOutputStream() );
     final Carte carte = CarteSingleton.getCarte();

--- a/engine/src/main/java/org/pentaho/di/www/StopJobServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StopJobServlet.java
@@ -17,6 +17,7 @@ package org.pentaho.di.www;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,7 +26,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.Job;
 
@@ -140,23 +140,21 @@ public class StopJobServlet extends BaseHttpServlet implements CartePluginInterf
 
     String jobName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     PrintWriter out = response.getWriter();
+    
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
+    
     try {
-      if ( useXML ) {
-        response.setContentType( "text/xml" );
-        response.setCharacterEncoding( Const.XML_ENCODING );
-        out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-      } else {
-        response.setContentType( "text/html;charset=UTF-8" );
+      if ( !useXML ) { 
         out.println( "<HTML>" );
         out.println( "<HEAD>" );
         out.println( "<TITLE>Stop job</TITLE>" );
         out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
           + convertContextPath( GetJobStatusServlet.CONTEXT_PATH ) + "?name="
-          + URLEncoder.encode( jobName, "UTF-8" ) + "\">" );
-        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+          + URLEncoder.encode( jobName, encoding ) + "\">" );
+        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
         out.println( "</HEAD>" );
         out.println( "<BODY>" );
       }
@@ -187,18 +185,18 @@ public class StopJobServlet extends BaseHttpServlet implements CartePluginInterf
 
         String message = BaseMessages.getString( PKG, "JobStatusServlet.Log.JobStopRequested", jobName );
         if ( useXML ) {
-          out.println( new WebResult( WebResult.STRING_OK, message ).getXML() );
+          out.println( new WebResult( WebResult.STRING_OK, message ) );
         } else {
           out.println( "<H1>" + Encode.forHtml( message ) + "</H1>" );
           out.println( "<a href=\""
             + convertContextPath( GetJobStatusServlet.CONTEXT_PATH ) + "?name="
-            + URLEncoder.encode( jobName, "UTF-8" ) + "&id=" + URLEncoder.encode( id, "UTF-8" ) + "\">"
+            + URLEncoder.encode( jobName, encoding ) + "&id=" + URLEncoder.encode( id, encoding ) + "\">"
             + BaseMessages.getString( PKG, "JobStatusServlet.BackToJobStatusPage" ) + "</a><p>" );
         }
       } else {
         String message = BaseMessages.getString( PKG, "StopJobServlet.Log.CoundNotFindJob", jobName );
         if ( useXML ) {
-          out.println( new WebResult( WebResult.STRING_ERROR, message ).getXML() );
+          out.println( new WebResult( WebResult.STRING_ERROR, message ) );
         } else {
           out.println( "<H1>" + Encode.forHtml( message ) + "</H1>" );
           out.println( "<a href=\""
@@ -209,7 +207,7 @@ public class StopJobServlet extends BaseHttpServlet implements CartePluginInterf
       }
     } catch ( Exception ex ) {
       if ( useXML ) {
-        out.println( new WebResult( WebResult.STRING_ERROR, Const.getStackTracker( ex ) ).getXML() );
+        out.println( new WebResult( WebResult.STRING_ERROR, Const.getStackTracker( ex ) ) );
       } else {
         out.println( "<p>" );
         out.println( "<pre>" );

--- a/engine/src/main/java/org/pentaho/di/www/StopTransServlet.java
+++ b/engine/src/main/java/org/pentaho/di/www/StopTransServlet.java
@@ -17,6 +17,7 @@ package org.pentaho.di.www;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,7 +26,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.owasp.encoder.Encode;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.util.Utils;
-import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 
@@ -146,23 +146,21 @@ public class StopTransServlet extends BaseHttpServlet implements CartePluginInte
     String transName = request.getParameter( "name" );
     String id = request.getParameter( "id" );
     boolean inputOnly = "Y".equalsIgnoreCase( request.getParameter( "inputOnly" ) );
-    boolean useXML = "Y".equalsIgnoreCase( request.getParameter( "xml" ) );
+    boolean useXML = useXML( request );
 
     PrintWriter out = response.getWriter();
+    
+    String encoding = contentTypeAndHeader( useXML, response, out, StandardCharsets.UTF_8.name() );
+    
     try {
-      if ( useXML ) {
-        response.setContentType( "text/xml" );
-        response.setCharacterEncoding( Const.XML_ENCODING );
-        out.print( XMLHandler.getXMLHeader( Const.XML_ENCODING ) );
-      } else {
-        response.setContentType( "text/html;charset=UTF-8" );
+      if ( !useXML ) {
         out.println( "<HTML>" );
         out.println( "<HEAD>" );
         out.println( "<TITLE>" + BaseMessages.getString( PKG, "StopTransServlet.StopTrans" ) + "</TITLE>" );
         out.println( "<META http-equiv=\"Refresh\" content=\"2;url="
           + convertContextPath( GetTransStatusServlet.CONTEXT_PATH ) + "?name="
-          + URLEncoder.encode( transName, "UTF-8" ) + "\">" );
-        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" );
+          + URLEncoder.encode( transName, encoding ) + "\">" );
+        out.println( "<META http-equiv=\"Content-Type\" content=\"text/html; charset=" + encoding + "\">" );
         out.println( "</HEAD>" );
         out.println( "<BODY>" );
       }
@@ -198,19 +196,19 @@ public class StopTransServlet extends BaseHttpServlet implements CartePluginInte
         String message = BaseMessages.getString( PKG, "StopTransServlet.TransSopRequested", transName );
 
         if ( useXML ) {
-          out.println( new WebResult( WebResult.STRING_OK, message, id ).getXML() );
+          out.println( new WebResult( WebResult.STRING_OK, message, id ) );
         } else {
           out.println( "<H1>" + Encode.forHtml( message ) + "</H1>" );
           out.println( "<a href=\""
             + convertContextPath( GetTransStatusServlet.CONTEXT_PATH ) + "?name="
-            + URLEncoder.encode( transName, "UTF-8" ) + "&id=" + URLEncoder.encode( id, "UTF-8" ) + "\">"
+            + URLEncoder.encode( transName, encoding ) + "&id=" + URLEncoder.encode( id, encoding ) + "\">"
             + BaseMessages.getString( PKG, "TransStatusServlet.BackToTransStatusPage" ) + "</a><p>" );
         }
       } else {
         String message = BaseMessages.getString( PKG, "StopTransServlet.CanNotFindTrans", transName );
 
         if ( useXML ) {
-          out.println( new WebResult( WebResult.STRING_ERROR, message, id ).getXML() );
+          out.println( new WebResult( WebResult.STRING_ERROR, message, id ) );
         } else {
           out.println( "<H1>" + Encode.forHtml( message ) + "</H1>" );
           out.println( "<a href=\""
@@ -221,7 +219,7 @@ public class StopTransServlet extends BaseHttpServlet implements CartePluginInte
       }
     } catch ( Exception ex ) {
       if ( useXML ) {
-        out.println( new WebResult( WebResult.STRING_ERROR, Const.getStackTracker( ex ) ).getXML() );
+        out.println( new WebResult( WebResult.STRING_ERROR, Const.getStackTracker( ex ) ) );
       } else {
         out.println( "<p>" );
         out.println( "<pre>" );


### PR DESCRIPTION
- Consolidated headers across all Carte servlets into BaseHttpServlet method
- All servlets should now honor KETTLE_DEFAULT_SERVLET_ENCODING
- All XML from Carte servlets should now return with application/xml content type header (we may need to add a flag to choose text/xml OR application/xml)
- HTML generated by Carte servlets should have a <meta> tag that matches the set encoding
