### PR TITLE
build[SP-7461]: Move dependency management of httpcore5 to maven parent pom

### DIFF
--- a/plugins/repo-vfs/repo-vfs-core/pom.xml
+++ b/plugins/repo-vfs/repo-vfs-core/pom.xml
@@ -98,7 +98,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
-      <version>5.3.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7461 - Backport of PPP-6754 - (11.0 Suite) CVE-2026-54399 | pdia-master has a security violation in gav://org.apache.httpcomponents.core5:httpcore5:5.3.4](https://pentaho-eng.atlassian.net/browse/SP-7461)
- **Base Case:** [PPP-6754 - Backport of PPP-6754 - (11.0 Suite) CVE-2026-54399 | pdia-master has a security violation in gav://org.apache.httpcomponents.core5:httpcore5:5.3.4](https://pentaho-eng.atlassian.net/browse/PPP-6754)
- **Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10610

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-kettle/pull/10610
- Commit: 01e7a3dfad525c8764f65e913ec6031d6f7af3d0

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
