### PR TITLE
fix(job-zip-file): append to existing discards zip content [PDI-20734]

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
@@ -416,6 +416,10 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
                   + localrealZipfilename + BaseMessages.getString( PKG, "JobZipFiles.Zip_FileNameChange1.Label" ) );
               }
             } else if ( ifZipFileExists == 1 && Fileexists ) {
+              if ( !isLocalFile( realZipfilename ) ) {
+                logError( BaseMessages.getString( PKG, "JobZipFiles.Append_LocalFileOnly.Label", realZipfilename ) );
+                return false;
+              }
               fileZip = getFile( localrealZipfilename );
               tempFile = createTemporaryZipFile( fileZip );
               Files.move( fileZip.toPath(), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
@@ -669,6 +673,10 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     File parentDirectory = zipFile.getAbsoluteFile().getParentFile();
     String prefix = zipFile.getName().length() < 3 ? "zip" : zipFile.getName();
     return File.createTempFile( prefix, null, parentDirectory );
+  }
+
+  static boolean isLocalFile( String filename ) {
+    return filename != null && ( filename.startsWith( "file:" ) || !KettleVFS.hasSchemePattern( filename ) );
   }
 
   private void deleteTemporaryZipFile( File tempFile ) {

--- a/engine/src/main/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFile.java
@@ -25,6 +25,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.text.DecimalFormat;
 import java.text.ParsePosition;
 import java.util.HashSet;
@@ -250,7 +252,7 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     try {
       FileObject zipFileObject = KettleVFS.getInstance( parentJobMeta.getBowl() ).getFileObject( filename, this );
       parentfolder = zipFileObject.getParent();
-      if (parentfolder != null && !parentfolder.exists() ) {
+      if ( parentfolder != null && !parentfolder.exists() ) {
         if ( log.isDetailed() ) {
           logDetailed( BaseMessages.getString( PKG, "JobEntryZipFile.CanNotFindFolder", ""
             + parentfolder.getName() ) );
@@ -285,17 +287,14 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     File tempFile = null;
     File fileZip;
     boolean resultat = false;
-    boolean renameOk = false;
     boolean orginExist = false;
 
     // Check if target file/folder exists!
     FileObject originFile = null;
-    ZipInputStream zin = null;
     byte[] buffer;
     OutputStream dest = null;
     BufferedOutputStreamWithCloseDetection buff = null;
     ZipOutputStream out = null;
-    ZipEntry entry;
     String localSourceFilename = realSourceDirectoryOrFile;
 
     try {
@@ -417,12 +416,14 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
                   + localrealZipfilename + BaseMessages.getString( PKG, "JobZipFiles.Zip_FileNameChange1.Label" ) );
               }
             } else if ( ifZipFileExists == 1 && Fileexists ) {
-              // Append mode: delete existing and recreate with current source files
+              fileZip = getFile( localrealZipfilename );
+              tempFile = createTemporaryZipFile( fileZip );
+              Files.move( fileZip.toPath(), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
+
               if ( log.isDebug() ) {
                 logDebug( BaseMessages.getString( PKG, "JobZipFiles.Zip_FileAppend1.Label" )
                   + localrealZipfilename + BaseMessages.getString( PKG, "JobZipFiles.Zip_FileAppend2.Label" ) );
               }
-              fileObject.delete();
             }
 
             if ( log.isDetailed() ) {
@@ -437,11 +438,8 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
             buff = new BufferedOutputStreamWithCloseDetection( dest );
             out = new ZipOutputStream( buff );
 
-            HashSet<String> fileSet = new HashSet<String>();
-
-            // Set the method
+            // Configure compression before writing both existing and new entries.
             out.setMethod( ZipOutputStream.DEFLATED );
-            // Set the compression level
             if ( compressionRate == 0 ) {
               out.setLevel( Deflater.NO_COMPRESSION );
             } else if ( compressionRate == 1 ) {
@@ -453,6 +451,27 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
             if ( compressionRate == 3 ) {
               out.setLevel( Deflater.BEST_SPEED );
             }
+
+            HashSet<String> fileSet = new HashSet<String>();
+
+            if ( tempFile != null ) {
+              try ( ZipInputStream zipInput = new ZipInputStream( new FileInputStream( tempFile ) ) ) {
+                ZipEntry entry;
+                while ( ( entry = zipInput.getNextEntry() ) != null ) {
+                  String name = entry.getName();
+                  if ( !fileSet.contains( name ) ) {
+                    out.putNextEntry( new ZipEntry( name ) );
+                    int len;
+                    while ( ( len = zipInput.read( buffer ) ) > 0 ) {
+                      out.write( buffer, 0, len );
+                    }
+                    out.closeEntry();
+                    fileSet.add( name );
+                  }
+                }
+              }
+            }
+
             // Specify Zipped files (After that we will move,delete them...)
             FileObject[] zippedFiles = new FileObject[fileList.length];
             int fileNum = 0;
@@ -547,6 +566,8 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
             buff.close();
             dest.close();
 
+            deleteTemporaryZipFile( tempFile );
+
             if ( log.isBasic() ) {
               logBasic( BaseMessages.getString( PKG, "JobZipFiles.Log.TotalZippedFiles", "" + zippedFiles.length ) );
             }
@@ -626,9 +647,6 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
           if ( dest != null ) {
             dest.close();
           }
-          if ( zin != null ) {
-            zin.close();
-          }
 
         } catch ( IOException ex ) {
           logError( "Error closing zip file entry for file '" + originFile.toString() + "'", ex );
@@ -645,6 +663,22 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     }
     // return a verifier
     return resultat;
+  }
+
+  static File createTemporaryZipFile( File zipFile ) throws IOException {
+    File parentDirectory = zipFile.getAbsoluteFile().getParentFile();
+    String prefix = zipFile.getName().length() < 3 ? "zip" : zipFile.getName();
+    return File.createTempFile( prefix, null, parentDirectory );
+  }
+
+  private void deleteTemporaryZipFile( File tempFile ) {
+    if ( tempFile != null ) {
+      try {
+        Files.delete( tempFile.toPath() );
+      } catch ( IOException e ) {
+        logError( "Could not delete temporary ZIP file '" + tempFile + "'", e );
+      }
+    }
   }
 
   private int determineDepth( String depthString ) throws KettleException {
@@ -1157,7 +1191,7 @@ public class JobEntryZipFile extends JobEntryBase implements Cloneable, JobEntry
     return resultat;
   }
 
-   @Override
+  @Override
   public JobEntryHelperInterface getJobEntryHelperInterface() {
     return new JobEntryZipFileHelper( this );
   }

--- a/engine/src/main/resources/org/pentaho/di/job/entries/zipfile/messages/messages_en_US.properties
+++ b/engine/src/main/resources/org/pentaho/di/job/entries/zipfile/messages/messages_en_US.properties
@@ -35,6 +35,7 @@ JobZipFiles.Zip_FileNameChange1.Label=New Zip file to create [
 JobZipFiles.Zip_FileNameChange2.Label=]
 JobZipFiles.Zip_FileAppend1.Label=Append to the Zip file [
 JobZipFiles.Zip_FileAppend2.Label=]
+JobZipFiles.Append_LocalFileOnly.Label=Appending to an existing ZIP file is only supported for local file targets. Target: [{0}]
 JobZipFiles.Files_Found1.Label=Found 
 JobZipFiles.Files_Found2.Label= file(s) in the directory [
 JobZipFiles.Files_Found3.Label=]

--- a/engine/src/test/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFileAppendTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFileAppendTest.java
@@ -1,0 +1,144 @@
+/*
+ * ! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.zipfile;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobMeta;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipFile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JobEntryZipFileAppendTest {
+
+  @BeforeClass
+  public static void init() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  @Test
+  public void appendingPreservesExistingArchiveEntries() throws Exception {
+    File directory = Files.createTempDirectory( "JobEntryZipFileAppendTest" ).toFile();
+    File existingSource = writeFile( directory, "old.txt", "old content" );
+    File newSource = writeFile( directory, "new.txt", "new content" );
+    File archive = new File( directory, "archive.zip" );
+
+    try {
+      JobEntryZipFile entry = new JobEntryZipFile();
+      JobMeta jobMeta = new JobMeta();
+      Job parentJob = new Job( null, jobMeta );
+      entry.setParentJobMeta( jobMeta );
+
+      assertTrue( entry.processRowFile( parentJob, new Result(), archive.getAbsolutePath(), null, null,
+        existingSource.getAbsolutePath(), null, false ) );
+
+      entry.ifZipFileExists = 1;
+      assertTrue( entry.processRowFile( parentJob, new Result(), archive.getAbsolutePath(), null, null,
+        newSource.getAbsolutePath(), null, false ) );
+
+      Set<String> expectedEntryNames = new HashSet<>();
+      expectedEntryNames.add( existingSource.getName() );
+      expectedEntryNames.add( newSource.getName() );
+      assertEquals( expectedEntryNames, getZipEntryNames( archive ) );
+    } finally {
+      Files.deleteIfExists( archive.toPath() );
+      Files.deleteIfExists( existingSource.toPath() );
+      Files.deleteIfExists( newSource.toPath() );
+      Files.deleteIfExists( directory.toPath() );
+    }
+  }
+
+  @Test
+  public void createsAppendTemporaryFileBesideTargetArchive() throws IOException {
+    File directory = Files.createTempDirectory( "JobEntryZipFileTempTest" ).toFile();
+    File archive = new File( directory, "archive.zip" );
+    File temporaryArchive = JobEntryZipFile.createTemporaryZipFile( archive );
+
+    try {
+      assertEquals( archive.getAbsoluteFile().getParentFile(), temporaryArchive.getParentFile() );
+    } finally {
+      Files.deleteIfExists( temporaryArchive.toPath() );
+      Files.deleteIfExists( directory.toPath() );
+    }
+  }
+
+  @Test
+  public void appendingAppliesCompressionRateToExistingEntries() throws Exception {
+    File directory = Files.createTempDirectory( "JobEntryZipFileCompressionTest" ).toFile();
+    byte[] content = new byte[ 8192 ];
+    Arrays.fill( content, (byte) 'a' );
+    File existingSource = writeFile( directory, "old.txt", content );
+    File newSource = writeFile( directory, "new.txt", content );
+    File archive = new File( directory, "archive.zip" );
+
+    try {
+      JobEntryZipFile entry = new JobEntryZipFile();
+      JobMeta jobMeta = new JobMeta();
+      Job parentJob = new Job( null, jobMeta );
+      entry.setParentJobMeta( jobMeta );
+
+      assertTrue( entry.processRowFile( parentJob, new Result(), archive.getAbsolutePath(), null, null,
+        existingSource.getAbsolutePath(), null, false ) );
+
+      entry.ifZipFileExists = 1;
+      entry.compressionRate = 0;
+      assertTrue( entry.processRowFile( parentJob, new Result(), archive.getAbsolutePath(), null, null,
+        newSource.getAbsolutePath(), null, false ) );
+
+      try ( ZipFile zipFile = new ZipFile( archive ) ) {
+        assertTrue( zipFile.getEntry( existingSource.getName() ).getCompressedSize() > content.length / 2 );
+        assertTrue( zipFile.getEntry( newSource.getName() ).getCompressedSize() > content.length / 2 );
+      }
+    } finally {
+      Files.deleteIfExists( archive.toPath() );
+      Files.deleteIfExists( existingSource.toPath() );
+      Files.deleteIfExists( newSource.toPath() );
+      Files.deleteIfExists( directory.toPath() );
+    }
+  }
+  private File writeFile( File directory, String name, String content ) throws IOException {
+    return writeFile( directory, name, content.getBytes( StandardCharsets.UTF_8 ) );
+  }
+
+  private File writeFile( File directory, String name, byte[] content ) throws IOException {
+    File file = new File( directory, name );
+    Files.write( file.toPath(), content );
+    return file;
+  }
+
+  private Set<String> getZipEntryNames( File archive ) throws IOException {
+    Set<String> entryNames = new HashSet<>();
+    try ( ZipInputStream input = new ZipInputStream( Files.newInputStream( archive.toPath() ) ) ) {
+      ZipEntry entry;
+      while ( ( entry = input.getNextEntry() ) != null ) {
+        entryNames.add( entry.getName() );
+      }
+    }
+    return entryNames;
+  }
+}

--- a/engine/src/test/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFileAppendTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFileAppendTest.java
@@ -32,6 +32,7 @@ import java.util.zip.ZipInputStream;
 import java.util.zip.ZipFile;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class JobEntryZipFileAppendTest {
@@ -121,6 +122,15 @@ public class JobEntryZipFileAppendTest {
       Files.deleteIfExists( directory.toPath() );
     }
   }
+
+  @Test
+  public void appendOnlySupportsLocalTargets() {
+    assertTrue( JobEntryZipFile.isLocalFile( "/tmp/archive.zip" ) );
+    assertTrue( JobEntryZipFile.isLocalFile( "file:///tmp/archive.zip" ) );
+    assertFalse( JobEntryZipFile.isLocalFile( "s3://bucket/archive.zip" ) );
+    assertFalse( JobEntryZipFile.isLocalFile( "hdfs://namenode/archive.zip" ) );
+  }
+
   private File writeFile( File directory, String name, String content ) throws IOException {
     return writeFile( directory, name, content.getBytes( StandardCharsets.UTF_8 ) );
   }


### PR DESCRIPTION
The change in [pentaho-kettle#10424](https://github.com/pentaho/pentaho-kettle/pull/10424) removes the failure by deleting the existing ZIP and creating a new archive from the current input files. It does **not** append to the existing archive. The fix is invalid as it silently discards existing archive entries: **data is lost**!

This PR does not revert of PR #10424 because that PR also contains unrelated dynamic-filename and VFS hardening. Reverting the whole PR would remove those changes and then require reapplying selected hunks.

The repaired append path does the following:

1. Creates a temporary ZIP in the target ZIP's parent directory.
2. Moves the existing target ZIP into that sibling temporary file with `Files.move(..., REPLACE_EXISTING)`.
3. Creates a new ZIP at the original target path.
4. Copies all existing ZIP entries into the new archive.
5. Adds the current source files, excluding names already copied from the old archive.
6. Deletes the temporary archive only after the new archive is written.

Creating the temporary file beside the target avoids cross-volume moves to `java.io.tmpdir`.
Also, in case of any error, the temporary file is the only copy of the original archive.

`JobEntryZipFileAppendTest.appendingPreservesExistingArchiveEntries` is the automated test:

1. Write `old.txt`.
2. Run the Zip File job entry with an absent `archive.zip`; this creates an archive containing `old.txt`.
3. Write `new.txt`, set the entry's `ifZipFileExists` option to append, and run the same entry again.
4. Read `archive.zip` and assert that it contains both `old.txt` and `new.txt`.