### PR TITLE
docs: describe S3-compatible endpoint options in s3-vfs

### DIFF
--- a/plugins/s3-vfs/README.md
+++ b/plugins/s3-vfs/README.md
@@ -1,6 +1,24 @@
 # Pentaho S3 VFS
 
 
+#### Connecting to an S3-compatible service
+
+The **S3 Connection Type** of an S3 connection selects how the client is built. `Amazon` uses the
+Amazon S3 endpoint of the selected region. `Minio/HCP` builds the client from an endpoint that you
+provide, so it also covers other services that implement the S3 API, such as Backblaze B2,
+Cloudflare R2, Hitachi Content Platform or MinIO. The fields of that connection type are:
+
+* **Region:** free text, as those services do not always use the AWS region names. When left empty,
+the default region of the AWS SDK is used.
+* **Access Key** / **Secret Key:** the credentials issued by the service.
+* **Endpoint:** the service endpoint, for example `https://s3.example-region.example.com`. It is
+passed to the client together with the region.
+* **Signature Version:** the AWS SDK signer type used to sign the requests.
+* **Trust Store** / **Key Store:** for endpoints presenting a certificate that the JVM does not
+trust by default, or requiring a client certificate.
+* **PathStyle Access:** addresses the bucket in the request path instead of in the host name, for
+services that do not support virtual host style addressing.
+
 #### Pre-requisites for building the project:
 * Maven, version 3+
 * Java JDK 1.8


### PR DESCRIPTION
The `s3-vfs` plugin already builds the S3 client from a user supplied endpoint when the `Minio/HCP` S3 connection type is selected (`S3CommonFileSystem.createClientFromEndpoint`), but nothing in the repository describes what the fields of that connection type do.

This adds a short section to `plugins/s3-vfs/README.md` listing those fields in the same order the connection dialog shows them (region, access key, secret key, endpoint, signature version, trust store, key store, path style access), with a placeholder endpoint as the example.

Documentation only, no code, dependency or build changes. I do not have a Jira case for this. Happy to open one for tracking, or to move the section elsewhere if the module README is not the right place.