### PR TITLE
fix: Backport of PDI-20926 Saving a Repository File Overwrites Existing Files Without Confirmation [SP-7532] (#10646)

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/Spoon.java
@@ -4891,22 +4891,20 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
 
   private boolean canRepoSaveOrOverwrite( EngineMetaInterface meta, String fileType, RepositoryObject repositoryObject ) throws KettleException {
     if ( rep.exists( repositoryObject.getName(), repositoryObject.getRepositoryDirectory(), StringUtils.equals( FileDialogOperation.TRANSFORMATION, fileType ) ? RepositoryObjectType.TRANSFORMATION : RepositoryObjectType.JOB ) ) {
-      MessageBox mb = new MessageBox( shell, SWT.NO | SWT.YES | SWT.ICON_WARNING );
-      // "This file already exists.  Do you want to overwrite it?"
-      mb.setMessage( BaseMessages.getString( PKG, SPOON_DIALOG_PROMPT_OVERWRITE_FILE + meta.getFileType()
-              + MESSAGE, Const.createName( repositoryObject.getName() ) ) );
-      // "This file already exists!"
-      mb.setText( BaseMessages.getString( PKG, SPOON_DIALOG_PROMPT_OVERWRITE_FILE_TITLE ) );
-      if ( mb.open() == SWT.YES ) {
-        // user wants to overwrite the file
-        return true;
-      } else {
-        // user does wants to overwrite the file
-        return false;
-      }
+      return confirmRepositoryOverwrite( meta, repositoryObject );
     }
     // the file does not exist
     return true;
+  }
+
+  boolean confirmRepositoryOverwrite( EngineMetaInterface meta, RepositoryObject repositoryObject ) {
+    MessageBox mb = new MessageBox( shell, SWT.NO | SWT.YES | SWT.ICON_WARNING );
+    // "This file already exists.  Do you want to overwrite it?"
+    mb.setMessage( BaseMessages.getString( PKG, SPOON_DIALOG_PROMPT_OVERWRITE_FILE + meta.getFileType()
+      + MESSAGE, Const.createName( repositoryObject.getName() ) ) );
+    // "This file already exists!"
+    mb.setText( BaseMessages.getString( PKG, SPOON_DIALOG_PROMPT_OVERWRITE_FILE_TITLE ) );
+    return mb.open() == SWT.YES;
   }
 
   public void addFileListener( FileListener listener ) {
@@ -5542,41 +5540,7 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       }
 
       if ( ask_name ) {
-        try {
-          String fileType = meta.getFileType().equals( LastUsedFile.FILE_TYPE_TRANSFORMATION )
-            ? FileDialogOperation.TRANSFORMATION : FileDialogOperation.JOB;
-          FileDialogOperation fileDialogOperation = getFileDialogOperation( FileDialogOperation.SAVE,
-            FileDialogOperation.ORIGIN_SPOON );
-          fileDialogOperation.setFileType( fileType );
-          fileDialogOperation.setFilter( deriveFileFilterFromFileType( fileType ) );
-          setFileOperatioPathForRepositoryFile( fileDialogOperation, meta );
-          //Set the filename so it can be used as the default filename in the save dialog
-          String fileName = ( meta.getFilename() == null || meta.getFilename().length() == 0 )
-                  ? meta.getName() : meta.getFilename();
-          fileDialogOperation.setFilename( fileName );
-          fileDialogOperation.setProviderFilter( evaluateFileBrowserProviderFilter() );
-          ExtensionPointHandler.callExtensionPoint( getLog(), KettleExtensionPoint.SpoonOpenSaveNew.id,
-            fileDialogOperation );
-          if ( fileDialogOperation.getRepositoryObject() != null ) {
-            RepositoryObject repositoryObject = (RepositoryObject) fileDialogOperation.getRepositoryObject();
-            final RepositoryDirectoryInterface oldDir = meta.getRepositoryDirectory();
-            final String oldName = meta.getName();
-            meta.setRepositoryDirectory( repositoryObject.getRepositoryDirectory() );
-            meta.setName( repositoryObject.getName() );
-            final boolean saved = saveToRepositoryConfirmed( meta );
-            // rename the tab only if the meta object was successfully saved
-            if ( saved ) {
-              delegates.tabs.renameTabs();
-            } else {
-              // if the object wasn't successfully saved, set the name and directory back to their original values
-              meta.setRepositoryDirectory( oldDir );
-              meta.setName( oldName );
-            }
-            return saved;
-          }
-        } catch ( KettleException ke ) {
-          //Ignore
-        }
+        return saveToRepositoryWithNewName( meta );
       } else {
         return saveToRepositoryConfirmed( meta );
       }
@@ -5590,6 +5554,54 @@ public class Spoon extends ApplicationWindow implements AddUndoPositionInterface
       mb.open();
     }
     return false;
+  }
+
+  private boolean saveToRepositoryWithNewName( EngineMetaInterface meta ) {
+    try {
+      String fileType = meta.getFileType().equals( LastUsedFile.FILE_TYPE_TRANSFORMATION )
+        ? FileDialogOperation.TRANSFORMATION : FileDialogOperation.JOB;
+      FileDialogOperation fileDialogOperation = getFileDialogOperation( FileDialogOperation.SAVE,
+        FileDialogOperation.ORIGIN_SPOON );
+      fileDialogOperation.setFileType( fileType );
+      fileDialogOperation.setFilter( deriveFileFilterFromFileType( fileType ) );
+      setFileOperatioPathForRepositoryFile( fileDialogOperation, meta );
+      //Set the filename so it can be used as the default filename in the save dialog
+      String fileName = ( meta.getFilename() == null || meta.getFilename().length() == 0 )
+        ? meta.getName() : meta.getFilename();
+      fileDialogOperation.setFilename( fileName );
+      fileDialogOperation.setProviderFilter( evaluateFileBrowserProviderFilter() );
+      ExtensionPointHandler.callExtensionPoint( getLog(), KettleExtensionPoint.SpoonOpenSaveNew.id,
+        fileDialogOperation );
+      if ( fileDialogOperation.getRepositoryObject() == null ) {
+        return false;
+      }
+
+      RepositoryObject repositoryObject = (RepositoryObject) fileDialogOperation.getRepositoryObject();
+      return saveRepositoryObjectWithNewName( meta, fileType, repositoryObject );
+    } catch ( KettleException ke ) {
+      //Ignore
+      return false;
+    }
+  }
+
+  private boolean saveRepositoryObjectWithNewName( EngineMetaInterface meta, String fileType,
+                                                    RepositoryObject repositoryObject ) throws KettleException {
+    if ( !canRepoSaveOrOverwrite( meta, fileType, repositoryObject ) ) {
+      return false;
+    }
+
+    final RepositoryDirectoryInterface oldDir = meta.getRepositoryDirectory();
+    final String oldName = meta.getName();
+    meta.setRepositoryDirectory( repositoryObject.getRepositoryDirectory() );
+    meta.setName( repositoryObject.getName() );
+    final boolean saved = saveToRepositoryConfirmed( meta );
+    if ( saved ) {
+      delegates.tabs.renameTabs();
+    } else {
+      meta.setRepositoryDirectory( oldDir );
+      meta.setName( oldName );
+    }
+    return saved;
   }
 
   public boolean saveToRepositoryCheckSecurity( EngineMetaInterface meta ) {

--- a/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/spoon/SpoonTest.java
@@ -683,16 +683,39 @@ public class SpoonTest {
   }
 
   @Test
-  public void saveToRepository() throws Exception {
-    JobMeta mockJobMeta = mock( JobMeta.class );
+  public void saveToRepositoryJobSuccessfulSaveChecksDuplicate() throws Exception {
+    assertSaveToRepositoryChecksDuplicate( mock( JobMeta.class ), LastUsedFile.FILE_TYPE_JOB, RepositoryObjectType.JOB,
+      true );
+  }
 
-    prepareSetSaveTests( spoon, log, mockSpoonPerspective, mockJobMeta, false, false, "NotMainSpoonPerspective", true,
-      true, "filename", null, true, false );
+  @Test
+  public void saveToRepositoryJobFailedSaveChecksDuplicate() throws Exception {
+    assertSaveToRepositoryChecksDuplicate( mock( JobMeta.class ), LastUsedFile.FILE_TYPE_JOB, RepositoryObjectType.JOB,
+      false );
+  }
+
+  @Test
+  public void saveToRepositoryTransformationChecksDuplicateType() throws Exception {
+    assertSaveToRepositoryChecksDuplicate( mock( TransMeta.class ), LastUsedFile.FILE_TYPE_TRANSFORMATION,
+      RepositoryObjectType.TRANSFORMATION, true );
+  }
+
+  @Test
+  public void saveToRepositoryTransformationFailedSaveChecksDuplicate() throws Exception {
+    assertSaveToRepositoryChecksDuplicate( mock( TransMeta.class ), LastUsedFile.FILE_TYPE_TRANSFORMATION,
+      RepositoryObjectType.TRANSFORMATION, false );
+  }
+
+  private void assertSaveToRepositoryChecksDuplicate( AbstractMeta metaData, String fileType,
+                                                      RepositoryObjectType objectType, boolean saveConfirmed )
+    throws Exception {
+    prepareSetSaveTests( spoon, log, mockSpoonPerspective, metaData, false, false, "NotMainSpoonPerspective", true,
+      true, fileType, null, true, false );
 
     RepositoryDirectoryInterface dirMock = mock( RepositoryDirectoryInterface.class );
     doReturn( "my/path" ).when( dirMock ).getPath();
-    doReturn( dirMock ).when( mockJobMeta ).getRepositoryDirectory();
-    doReturn( "trans" ).when( mockJobMeta ).getName();
+    doReturn( dirMock ).when( metaData ).getRepositoryDirectory();
+    doReturn( "trans" ).when( metaData ).getName();
 
     RepositoryDirectoryInterface newDirMock = mock( RepositoryDirectoryInterface.class );
     doReturn( "my/new/path" ).when( newDirMock ).getPath();
@@ -704,28 +727,101 @@ public class SpoonTest {
     doReturn( fileDlgOp ).when( spoon ).getFileDialogOperation( FileDialogOperation.SAVE,
       FileDialogOperation.ORIGIN_SPOON );
     doReturn( "newTrans" ).when( repositoryObject ).getName();
+
+    doCallRealMethod().when( spoon ).saveToRepository( metaData, true );
+
+    doReturn( saveConfirmed ).when( spoon ).saveToRepositoryConfirmed( metaData );
+    spoon.saveToRepository( metaData, true );
+
+    verify( spoon.rep, times( 1 ) ).exists( "newTrans", newDirMock, objectType );
+    verify( spoon, Mockito.description( "Expected repository save confirmation to be invoked once" ) )
+      .saveToRepositoryConfirmed( metaData );
+    verify( metaData, times( 1 ) ).setRepositoryDirectory( newDirMock );
+    verify( metaData, times( 1 ) ).setName( "newTrans" );
+    if ( saveConfirmed ) {
+      verify( spoon.delegates.tabs, times( 1 ) ).renameTabs();
+      verify( metaData, never() ).setRepositoryDirectory( dirMock );
+      verify( metaData, never() ).setName( "trans" );
+    } else {
+      verify( spoon.delegates.tabs, never() ).renameTabs();
+      verify( metaData, times( 1 ) ).setRepositoryDirectory( dirMock );
+      verify( metaData, times( 1 ) ).setName( "trans" );
+    }
+  }
+
+  @Test
+  public void saveToRepositoryDoesNotSaveWhenOverwriteDeclined() throws Exception {
+    JobMeta mockJobMeta = mock( JobMeta.class );
+    prepareSetSaveTests( spoon, log, mockSpoonPerspective, mockJobMeta, false, false, "NotMainSpoonPerspective", true,
+      true, LastUsedFile.FILE_TYPE_JOB, null, true, false );
+
+    RepositoryDirectoryInterface originalDir = mock( RepositoryDirectoryInterface.class );
+    doReturn( originalDir ).when( mockJobMeta ).getRepositoryDirectory();
+    doReturn( "original" ).when( mockJobMeta ).getName();
+
+    RepositoryDirectoryInterface targetDir = mock( RepositoryDirectoryInterface.class );
+    RepositoryObject repositoryObject = mock( RepositoryObject.class );
+    doReturn( targetDir ).when( repositoryObject ).getRepositoryDirectory();
+    doReturn( "existing" ).when( repositoryObject ).getName();
+
+    FileDialogOperation fileDlgOp = mock( FileDialogOperation.class );
+    doReturn( repositoryObject ).when( fileDlgOp ).getRepositoryObject();
+    doReturn( fileDlgOp ).when( spoon ).getFileDialogOperation( eq( FileDialogOperation.SAVE ),
+      eq( FileDialogOperation.ORIGIN_SPOON ) );
+    doReturn( true ).when( spoon.rep ).exists( "existing", targetDir, RepositoryObjectType.JOB );
+    doReturn( false ).when( spoon ).confirmRepositoryOverwrite( mockJobMeta, repositoryObject );
     doCallRealMethod().when( spoon ).saveToRepository( mockJobMeta, true );
 
-    // mock a successful save
-    doReturn( true ).when( spoon ).saveToRepositoryConfirmed( mockJobMeta );
-    spoon.saveToRepository( mockJobMeta, true );
-    // verify that the meta name and directory have been updated and renameTabs is called
-    verify( spoon.delegates.tabs, times( 1 ) ).renameTabs();
-    verify( mockJobMeta, times( 1 ) ).setRepositoryDirectory( newDirMock );
-    verify( mockJobMeta, never() ).setRepositoryDirectory( dirMock ); // verify that the dir is never set back
-    verify( mockJobMeta, times( 1 ) ).setName( "newTrans" );
-    verify( mockJobMeta, never()  ).setName( "trans" ); // verify that the name is never set back
+    assertFalse( spoon.saveToRepository( mockJobMeta, true ) );
 
-    // mock a failed save
-    doReturn( false ).when( spoon ).saveToRepositoryConfirmed( mockJobMeta );
-    spoon.saveToRepository( mockJobMeta, true );
-    // verify that the meta name and directory have not changed and renameTabs is not called (only once form the
-    // previous test)
-    verify( spoon.delegates.tabs, times( 1 ) ).renameTabs();
-    verify( mockJobMeta, times( 2 ) ).setRepositoryDirectory( newDirMock );
-    verify( mockJobMeta, times( 1 ) ).setRepositoryDirectory( dirMock ); // verify that the dir is set back
-    verify( mockJobMeta, times( 2 ) ).setName( "newTrans" );
-    verify( mockJobMeta, times( 1 ) ).setName( "trans" ); // verify that the name is set back
+    verify( spoon, Mockito.description( "Expected overwrite confirmation to be presented for an existing repository object" ) )
+      .confirmRepositoryOverwrite( mockJobMeta, repositoryObject );
+    verify( spoon, never() ).saveToRepositoryConfirmed( mockJobMeta );
+    verify( mockJobMeta, never() ).setRepositoryDirectory( targetDir );
+    verify( mockJobMeta, never() ).setName( "existing" );
+    verify( spoon.delegates.tabs, never() ).renameTabs();
+  }
+
+  @Test
+  public void saveToRepositoryReturnsFalseWhenNameDialogIsCancelled() throws Exception {
+    JobMeta mockJobMeta = mock( JobMeta.class );
+    prepareSetSaveTests( spoon, log, mockSpoonPerspective, mockJobMeta, false, false, "NotMainSpoonPerspective", true,
+      true, LastUsedFile.FILE_TYPE_JOB, null, true, false );
+
+    RepositoryDirectoryInterface currentDir = mock( RepositoryDirectoryInterface.class );
+    doReturn( currentDir ).when( mockJobMeta ).getRepositoryDirectory();
+    doReturn( "current/path" ).when( currentDir ).getPath();
+
+    FileDialogOperation fileDlgOp = mock( FileDialogOperation.class );
+    doReturn( fileDlgOp ).when( spoon ).getFileDialogOperation( eq( FileDialogOperation.SAVE ),
+      eq( FileDialogOperation.ORIGIN_SPOON ) );
+    doReturn( null ).when( fileDlgOp ).getRepositoryObject();
+    doCallRealMethod().when( spoon ).saveToRepository( mockJobMeta, true );
+
+    assertFalse( spoon.saveToRepository( mockJobMeta, true ) );
+
+    verify( spoon, never() ).saveToRepositoryConfirmed( mockJobMeta );
+    verify( spoon.rep, never() ).exists( anyString(), any( RepositoryDirectoryInterface.class ),
+      any( RepositoryObjectType.class ) );
+  }
+
+  @Test
+  public void saveToRepositoryWithoutNamePromptUsesDefaultDirectory() throws Exception {
+    JobMeta mockJobMeta = mock( JobMeta.class );
+    prepareSetSaveTests( spoon, log, mockSpoonPerspective, mockJobMeta, false, false, "NotMainSpoonPerspective", true,
+      true, LastUsedFile.FILE_TYPE_JOB, null, true, false );
+
+    RepositoryDirectoryInterface defaultDir = mock( RepositoryDirectoryInterface.class );
+    doReturn( null ).when( mockJobMeta ).getRepositoryDirectory();
+    doReturn( defaultDir ).when( spoon.rep ).getDefaultSaveDirectory( mockJobMeta );
+    doReturn( true ).when( spoon ).saveToRepositoryConfirmed( mockJobMeta );
+    doCallRealMethod().when( spoon ).saveToRepository( mockJobMeta, false );
+
+    assertTrue( spoon.saveToRepository( mockJobMeta, false ) );
+
+    verify( mockJobMeta ).setRepositoryDirectory( defaultDir );
+    verify( spoon ).saveToRepositoryConfirmed( mockJobMeta );
+    verify( spoon, never() ).getFileDialogOperation( anyString(), anyString() );
   }
 
   private static void prepareSetSaveTests( Spoon spoon, LogChannelInterface log, SpoonPerspective spoonPerspective,


### PR DESCRIPTION
cherry-pick of 13d42e6

original PR: https://github.com/pentaho/pentaho-kettle/pull/10646