### PR TITLE
build[SP-7535]: Include jersey-apache-connector in data-integration/lib

### DIFF
--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -546,6 +546,17 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.connectors</groupId>
+      <artifactId>jersey-apache-connector</artifactId>
+      <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
       <version>${jersey.version}</version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7535 - Backport of PDI-20871 - (11.0 Suite) Upgrade to Jersey Client 3.1.x Missing Dependency for ApacheConnectionProvider in data-integration/lib](https://pentaho-eng.atlassian.net/browse/SP-7535)
- **Base Case:** [PDI-20871 - Backport of PDI-20871 - (11.0 Suite) Upgrade to Jersey Client 3.1.x Missing Dependency for ApacheConnectionProvider in data-integration/lib](https://pentaho-eng.atlassian.net/browse/PDI-20871)
- **Original Master PR:** https://github.com/pentaho/pentaho-kettle/pull/10618

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-kettle/pull/10618
- Commit: 54f3c0dc876985e026e694eb81328c533c52b916

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
