### PR TITLE
fix[PDESIGNER-756]: ensure unzip file step fails when flag is active and file already exists

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -926,8 +927,8 @@ public class JobEntryUnZip extends JobEntryBase implements Cloneable, JobEntryIn
       return true;
     }
 
-    Long entrySize = sourceFile.getContent().getSize();
-    Long destinationSize = destination.getContent().getSize();
+    long entrySize = sourceFile.getContent().getSize();
+    long destinationSize = destination.getContent().getSize();
 
     if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_DIFF_SIZE ) {
       if ( entrySize != destinationSize ) {

--- a/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
@@ -14,6 +14,7 @@
 
 package org.pentaho.di.job.entries.unzip;
 
+import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.job.entry.validator.AbstractFileValidator;
 import org.pentaho.di.job.entry.validator.AndValidator;
 import org.pentaho.di.job.entry.validator.JobEntryValidatorUtils;
@@ -893,9 +894,10 @@ public class JobEntryUnZip extends JobEntryBase implements Cloneable, JobEntryIn
     return retval;
   }
 
-  private boolean takeThisFile( FileObject sourceFile, String destinationFile ) throws FileSystemException {
+  private boolean takeThisFile( FileObject sourceFile, String destinationFile )
+    throws FileSystemException, KettleFileException {
     boolean retval = false;
-    File destination = new File( destinationFile );
+    FileObject destination = KettleVFS.getInstance( parentJobMeta.getBowl() ).getFileObject( destinationFile, this );
     if ( !destination.exists() ) {
       if ( log.isDebug() ) {
         logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.CanNotFindFile", destinationFile ) );
@@ -925,7 +927,7 @@ public class JobEntryUnZip extends JobEntryBase implements Cloneable, JobEntryIn
     }
 
     Long entrySize = sourceFile.getContent().getSize();
-    Long destinationSize = destination.length();
+    Long destinationSize = destination.getContent().getSize();
 
     if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_DIFF_SIZE ) {
       if ( entrySize != destinationSize ) {
@@ -1287,7 +1289,6 @@ public class JobEntryUnZip extends JobEntryBase implements Cloneable, JobEntryIn
     }
 
     retval += filename.substring( lastindexOfDot, lenstring );
-
     return retval;
 
   }

--- a/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
@@ -19,14 +19,12 @@ import org.pentaho.di.job.entry.validator.AbstractFileValidator;
 import org.pentaho.di.job.entry.validator.AndValidator;
 import org.pentaho.di.job.entry.validator.JobEntryValidatorUtils;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
@@ -10,10 +10,9 @@
  * Change Date: 2030-06-15
  ******************************************************************************/
 
-
-
 package org.pentaho.di.job.entries.unzip;
 
+import org.apache.commons.vfs2.FileContent;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.job.entry.validator.AbstractFileValidator;
 import org.pentaho.di.job.entry.validator.AndValidator;
@@ -893,11 +892,14 @@ public class JobEntryUnZip extends JobEntryBase implements Cloneable, JobEntryIn
     return retval;
   }
 
-  private boolean takeThisFile( FileObject sourceFile, String destinationFile )
+  protected boolean takeThisFile( FileObject sourceFile, String destinationFile )
     throws FileSystemException, KettleFileException {
     boolean retval = false;
-    try ( FileObject destination = KettleVFS.getInstance( parentJobMeta.getBowl() )
-      .getFileObject( destinationFile, this ) ) {
+    try (
+      FileObject destination = KettleVFS.getInstance( parentJobMeta.getBowl() ).getFileObject( destinationFile, this );
+      FileContent destinationContent = destination.getContent();
+      FileContent sourceContent = sourceFile.getContent()
+    ) {
       if ( !destination.exists() ) {
         if ( log.isDebug() ) {
           logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.CanNotFindFile", destinationFile ) );
@@ -926,8 +928,8 @@ public class JobEntryUnZip extends JobEntryBase implements Cloneable, JobEntryIn
         return true;
       }
 
-      long entrySize = sourceFile.getContent().getSize();
-      long destinationSize = destination.getContent().getSize();
+      long entrySize = sourceContent.getSize();
+      long destinationSize = destinationContent.getSize();
 
       if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_DIFF_SIZE ) {
         if ( entrySize != destinationSize ) {

--- a/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
+++ b/engine/src/main/java/org/pentaho/di/job/entries/unzip/JobEntryUnZip.java
@@ -896,141 +896,159 @@ public class JobEntryUnZip extends JobEntryBase implements Cloneable, JobEntryIn
   private boolean takeThisFile( FileObject sourceFile, String destinationFile )
     throws FileSystemException, KettleFileException {
     boolean retval = false;
-    FileObject destination = KettleVFS.getInstance( parentJobMeta.getBowl() ).getFileObject( destinationFile, this );
-    if ( !destination.exists() ) {
+    try ( FileObject destination = KettleVFS.getInstance( parentJobMeta.getBowl() )
+      .getFileObject( destinationFile, this ) ) {
+      if ( !destination.exists() ) {
+        if ( log.isDebug() ) {
+          logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.CanNotFindFile", destinationFile ) );
+        }
+        return true;
+      }
       if ( log.isDebug() ) {
-        logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.CanNotFindFile", destinationFile ) );
+        logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileExists", destinationFile ) );
       }
-      return true;
-    }
-    if ( log.isDebug() ) {
-      logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileExists", destinationFile ) );
-    }
-    if ( iffileexist == IF_FILE_EXISTS_SKIP ) {
-      if ( log.isDebug() ) {
-        logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileSkip", destinationFile ) );
+      if ( iffileexist == IF_FILE_EXISTS_SKIP ) {
+        if ( log.isDebug() ) {
+          logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileSkip", destinationFile ) );
+        }
+        return false;
       }
-      return false;
-    }
-    if ( iffileexist == IF_FILE_EXISTS_FAIL ) {
-      updateErrors();
-      logError( BaseMessages.getString( PKG, "JobUnZip.Log.FileError", destinationFile, "" + NrErrors ) );
-      return false;
-    }
+      if ( iffileexist == IF_FILE_EXISTS_FAIL ) {
+        updateErrors();
+        logError( BaseMessages.getString( PKG, "JobUnZip.Log.FileError", destinationFile, "" + NrErrors ) );
+        return false;
+      }
 
-    if ( iffileexist == IF_FILE_EXISTS_OVERWRITE ) {
-      if ( log.isDebug() ) {
-        logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileOverwrite", destinationFile ) );
+      if ( iffileexist == IF_FILE_EXISTS_OVERWRITE ) {
+        if ( log.isDebug() ) {
+          logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileOverwrite", destinationFile ) );
+        }
+        return true;
       }
-      return true;
-    }
 
-    long entrySize = sourceFile.getContent().getSize();
-    long destinationSize = destination.getContent().getSize();
+      long entrySize = sourceFile.getContent().getSize();
+      long destinationSize = destination.getContent().getSize();
 
-    if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_DIFF_SIZE ) {
-      if ( entrySize != destinationSize ) {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString(
-            PKG, "JobUnZip.Log.FileDiffSize.Diff", sourceFile.getName().getURI(), "" + entrySize,
-            destinationFile, "" + destinationSize ) );
+      if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_DIFF_SIZE ) {
+        if ( entrySize != destinationSize ) {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileDiffSize.Diff", sourceFile.getName().getURI(), "" + entrySize,
+              destinationFile, "" + destinationSize
+            ) );
+          }
+          return true;
+        } else {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileDiffSize.Same", sourceFile.getName().getURI(), "" + entrySize,
+              destinationFile, "" + destinationSize
+            ) );
+          }
+          return false;
         }
-        return true;
-      } else {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString(
-            PKG, "JobUnZip.Log.FileDiffSize.Same", sourceFile.getName().getURI(), "" + entrySize,
-            destinationFile, "" + destinationSize ) );
-        }
-        return false;
       }
-    }
-    if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_EQUAL_SIZE ) {
-      if ( entrySize == destinationSize ) {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString(
-            PKG, "JobUnZip.Log.FileEqualSize.Same", sourceFile.getName().getURI(), "" + entrySize,
-            destinationFile, "" + destinationSize ) );
+      if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_EQUAL_SIZE ) {
+        if ( entrySize == destinationSize ) {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileEqualSize.Same", sourceFile.getName().getURI(), "" + entrySize,
+              destinationFile, "" + destinationSize
+            ) );
+          }
+          return true;
+        } else {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileEqualSize.Diff", sourceFile.getName().getURI(), "" + entrySize,
+              destinationFile, "" + destinationSize
+            ) );
+          }
+          return false;
         }
-        return true;
-      } else {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString(
-            PKG, "JobUnZip.Log.FileEqualSize.Diff", sourceFile.getName().getURI(), "" + entrySize,
-            destinationFile, "" + destinationSize ) );
-        }
-        return false;
       }
-    }
-    if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_ZIP_BIG ) {
-      if ( entrySize > destinationSize ) {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileBigSize.Big", sourceFile.getName().getURI(), ""
-            + entrySize, destinationFile, "" + destinationSize ) );
+      if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_ZIP_BIG ) {
+        if ( entrySize > destinationSize ) {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileBigSize.Big", sourceFile.getName().getURI(), ""
+                + entrySize, destinationFile, "" + destinationSize
+            ) );
+          }
+          return true;
+        } else {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileBigSize.Small", sourceFile.getName().getURI(), "" + entrySize,
+              destinationFile, "" + destinationSize
+            ) );
+          }
+          return false;
         }
-        return true;
-      } else {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString(
-            PKG, "JobUnZip.Log.FileBigSize.Small", sourceFile.getName().getURI(), "" + entrySize,
-            destinationFile, "" + destinationSize ) );
-        }
-        return false;
       }
-    }
-    if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_ZIP_BIG_EQUAL ) {
-      if ( entrySize >= destinationSize ) {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileBigEqualSize.Big", sourceFile
-            .getName().getURI(), "" + entrySize, destinationFile, "" + destinationSize ) );
+      if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_ZIP_BIG_EQUAL ) {
+        if ( entrySize >= destinationSize ) {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileBigEqualSize.Big", sourceFile
+                .getName().getURI(), "" + entrySize, destinationFile, "" + destinationSize
+            ) );
+          }
+          return true;
+        } else {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileBigEqualSize.Small", sourceFile
+                .getName().getURI(), "" + entrySize, destinationFile, "" + destinationSize
+            ) );
+          }
+          return false;
         }
-        return true;
-      } else {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileBigEqualSize.Small", sourceFile
-            .getName().getURI(), "" + entrySize, destinationFile, "" + destinationSize ) );
-        }
-        return false;
       }
-    }
-    if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_ZIP_SMALL ) {
-      if ( entrySize < destinationSize ) {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString(
-            PKG, "JobUnZip.Log.FileSmallSize.Small", sourceFile.getName().getURI(), "" + entrySize,
-            destinationFile, "" + destinationSize ) );
+      if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_ZIP_SMALL ) {
+        if ( entrySize < destinationSize ) {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileSmallSize.Small", sourceFile.getName().getURI(), "" + entrySize,
+              destinationFile, "" + destinationSize
+            ) );
+          }
+          return true;
+        } else {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileSmallSize.Big", sourceFile.getName().getURI(), "" + entrySize,
+              destinationFile, "" + destinationSize
+            ) );
+          }
+          return false;
         }
-        return true;
-      } else {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString(
-            PKG, "JobUnZip.Log.FileSmallSize.Big", sourceFile.getName().getURI(), "" + entrySize,
-            destinationFile, "" + destinationSize ) );
-        }
-        return false;
       }
-    }
-    if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_ZIP_SMALL_EQUAL ) {
-      if ( entrySize <= destinationSize ) {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileSmallEqualSize.Small", sourceFile
-            .getName().getURI(), "" + entrySize, destinationFile, "" + destinationSize ) );
+      if ( iffileexist == IF_FILE_EXISTS_OVERWRITE_ZIP_SMALL_EQUAL ) {
+        if ( entrySize <= destinationSize ) {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileSmallEqualSize.Small", sourceFile
+                .getName().getURI(), "" + entrySize, destinationFile, "" + destinationSize
+            ) );
+          }
+          return true;
+        } else {
+          if ( log.isDebug() ) {
+            logDebug( BaseMessages.getString(
+              PKG, "JobUnZip.Log.FileSmallEqualSize.Big", sourceFile
+                .getName().getURI(), "" + entrySize, destinationFile, "" + destinationSize
+            ) );
+          }
+          return false;
         }
-        return true;
-      } else {
-        if ( log.isDebug() ) {
-          logDebug( BaseMessages.getString( PKG, "JobUnZip.Log.FileSmallEqualSize.Big", sourceFile
-            .getName().getURI(), "" + entrySize, destinationFile, "" + destinationSize ) );
-        }
-        return false;
       }
+      if ( iffileexist == IF_FILE_EXISTS_UNIQ ) {
+        // Create file with unique name
+        return true;
+      }
+      return retval;
     }
-    if ( iffileexist == IF_FILE_EXISTS_UNIQ ) {
-      // Create file with unique name
-      return true;
-    }
-
-    return retval;
   }
 
   public boolean evaluates() {

--- a/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
@@ -13,6 +13,7 @@
 package org.pentaho.di.job.entries.unzip;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -178,6 +179,37 @@ public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip
       Boolean result = (Boolean) takeThisFileMethod.invoke( jobEntryUnZip, sourceFile, "existing.txt" );
 
       assertFalse( "Should not take file when using FAIL policy (error is logged)", result );
+    }
+  }
+
+  @Test
+  public void testTakeThisFileFailsIfFileDoesNotYetExist() throws Exception {
+    try ( MockedStatic<KettleVFS> kettleVFSMockedStatic = Mockito.mockStatic( KettleVFS.class ) ) {
+      KettleVFSImpl vfsImpl = mock( KettleVFSImpl.class );
+      kettleVFSMockedStatic.when( () -> KettleVFS.getInstance( any( Bowl.class ) ) ).thenReturn( vfsImpl );
+      FileObject destinationFileObject = mock( FileObject.class );
+      when( destinationFileObject.exists() ).thenReturn( false );
+      when( vfsImpl.getFileObject( any( String.class ), any( VariableSpace.class ) ) ).thenReturn(
+        destinationFileObject );
+
+      JobEntryUnZip jobEntryUnZip = new JobEntryUnZip();
+      JobMeta mockJobMeta = mock( JobMeta.class );
+      when( mockJobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
+      jobEntryUnZip.setParentJobMeta( mockJobMeta );
+      jobEntryUnZip.setIfFileExists( JobEntryUnZip.IF_FILE_EXISTS_FAIL );
+      Method
+        takeThisFileMethod =
+        jobEntryUnZip.getClass().getDeclaredMethod( "takeThisFile", FileObject.class, String.class );
+      takeThisFileMethod.setAccessible( true );
+
+      FileObject sourceFile = mock( FileObject.class );
+      FileContent sourceContent = mock( FileContent.class );
+      when( sourceFile.getContent() ).thenReturn( sourceContent );
+      when( sourceContent.getSize() ).thenReturn( 1000L );
+
+      Boolean result = (Boolean) takeThisFileMethod.invoke( jobEntryUnZip, sourceFile, "existing.txt" );
+
+      assertTrue( "Should take file when the destination does not exist", result );
     }
   }
 }

--- a/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
@@ -152,7 +152,7 @@ public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip
   }
 
   @Test
-  public void testTakeThisFileFailsIfFileExists() throws Exception {
+  public void testTakeThisFileReturnsFalseIfFileExistsWithIfFileExistsFailFlag() throws Exception {
     try ( MockedStatic<KettleVFS> kettleVFSMockedStatic = Mockito.mockStatic( KettleVFS.class ) ) {
       KettleVFSImpl vfsImpl = mock( KettleVFSImpl.class );
       kettleVFSMockedStatic.when( () -> KettleVFS.getInstance( any( Bowl.class ) ) ).thenReturn( vfsImpl );
@@ -172,13 +172,46 @@ public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip
       takeThisFileMethod.setAccessible( true );
 
       FileObject sourceFile = mock( FileObject.class );
+
+      Boolean result = (Boolean) takeThisFileMethod.invoke( jobEntryUnZip, sourceFile, "existing.txt" );
+
+      assertFalse( "Should not take file when using IF_FILE_EXISTS_FAIL and file exists", result );
+    }
+  }
+
+  @Test
+  public void testTakeThisFileReturnsTrueWithIfFileExistsOverwriteEqualSizeWhenConditionIsMet() throws Exception {
+    try ( MockedStatic<KettleVFS> kettleVFSMockedStatic = Mockito.mockStatic( KettleVFS.class ) ) {
+      KettleVFSImpl vfsImpl = mock( KettleVFSImpl.class );
+      kettleVFSMockedStatic.when( () -> KettleVFS.getInstance( any( Bowl.class ) ) ).thenReturn( vfsImpl );
+      FileObject destinationFileObject = mock( FileObject.class );
+      FileContent destinationContent = mock( FileContent.class );
+      when( destinationFileObject.getContent() ).thenReturn( destinationContent );
+      when( destinationContent.getSize() ).thenReturn( 1000L );
+      when( destinationFileObject.exists() ).thenReturn( true );
+      when( vfsImpl.getFileObject( any( String.class ), any( VariableSpace.class ) ) ).thenReturn(
+        destinationFileObject );
+
+      JobEntryUnZip jobEntryUnZip = new JobEntryUnZip();
+      JobMeta mockJobMeta = mock( JobMeta.class );
+      when( mockJobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
+      jobEntryUnZip.setParentJobMeta( mockJobMeta );
+      jobEntryUnZip.setIfFileExists( JobEntryUnZip.IF_FILE_EXISTS_OVERWRITE_EQUAL_SIZE );
+      Method
+        takeThisFileMethod =
+        jobEntryUnZip.getClass().getDeclaredMethod( "takeThisFile", FileObject.class, String.class );
+      takeThisFileMethod.setAccessible( true );
+
+      FileObject sourceFile = mock( FileObject.class );
       FileContent sourceContent = mock( FileContent.class );
       when( sourceFile.getContent() ).thenReturn( sourceContent );
       when( sourceContent.getSize() ).thenReturn( 1000L );
 
       Boolean result = (Boolean) takeThisFileMethod.invoke( jobEntryUnZip, sourceFile, "existing.txt" );
 
-      assertFalse( "Should not take file when using FAIL policy (error is logged)", result );
+      assertTrue(
+        "Should take file when using IF_FILE_EXISTS_OVERWRITE_EQUAL_SIZE and equal sized file exists", result
+      );
     }
   }
 

--- a/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
@@ -216,7 +216,7 @@ public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip
   }
 
   @Test
-  public void testTakeThisFileFailsIfFileDoesNotYetExist() throws Exception {
+  public void testTakeThisFileReturnsTrueIfFileDoesNotYetExist() throws Exception {
     try ( MockedStatic<KettleVFS> kettleVFSMockedStatic = Mockito.mockStatic( KettleVFS.class ) ) {
       KettleVFSImpl vfsImpl = mock( KettleVFSImpl.class );
       kettleVFSMockedStatic.when( () -> KettleVFS.getInstance( any( Bowl.class ) ) ).thenReturn( vfsImpl );

--- a/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
@@ -166,14 +166,10 @@ public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip
       when( mockJobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
       jobEntryUnZip.setParentJobMeta( mockJobMeta );
       jobEntryUnZip.setIfFileExists( JobEntryUnZip.IF_FILE_EXISTS_FAIL );
-      Method
-        takeThisFileMethod =
-        jobEntryUnZip.getClass().getDeclaredMethod( "takeThisFile", FileObject.class, String.class );
-      takeThisFileMethod.setAccessible( true );
 
       FileObject sourceFile = mock( FileObject.class );
 
-      Boolean result = (Boolean) takeThisFileMethod.invoke( jobEntryUnZip, sourceFile, "existing.txt" );
+      boolean result = jobEntryUnZip.takeThisFile( sourceFile, "existing.txt" );
 
       assertFalse( "Should not take file when using IF_FILE_EXISTS_FAIL and file exists", result );
     }
@@ -197,17 +193,13 @@ public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip
       when( mockJobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
       jobEntryUnZip.setParentJobMeta( mockJobMeta );
       jobEntryUnZip.setIfFileExists( JobEntryUnZip.IF_FILE_EXISTS_OVERWRITE_EQUAL_SIZE );
-      Method
-        takeThisFileMethod =
-        jobEntryUnZip.getClass().getDeclaredMethod( "takeThisFile", FileObject.class, String.class );
-      takeThisFileMethod.setAccessible( true );
 
       FileObject sourceFile = mock( FileObject.class );
       FileContent sourceContent = mock( FileContent.class );
       when( sourceFile.getContent() ).thenReturn( sourceContent );
       when( sourceContent.getSize() ).thenReturn( 1000L );
 
-      Boolean result = (Boolean) takeThisFileMethod.invoke( jobEntryUnZip, sourceFile, "existing.txt" );
+      boolean result = jobEntryUnZip.takeThisFile( sourceFile, "existing.txt" );
 
       assertTrue(
         "Should take file when using IF_FILE_EXISTS_OVERWRITE_EQUAL_SIZE and equal sized file exists", result
@@ -230,17 +222,13 @@ public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip
       when( mockJobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
       jobEntryUnZip.setParentJobMeta( mockJobMeta );
       jobEntryUnZip.setIfFileExists( JobEntryUnZip.IF_FILE_EXISTS_FAIL );
-      Method
-        takeThisFileMethod =
-        jobEntryUnZip.getClass().getDeclaredMethod( "takeThisFile", FileObject.class, String.class );
-      takeThisFileMethod.setAccessible( true );
 
       FileObject sourceFile = mock( FileObject.class );
       FileContent sourceContent = mock( FileContent.class );
       when( sourceFile.getContent() ).thenReturn( sourceContent );
       when( sourceContent.getSize() ).thenReturn( 1000L );
 
-      Boolean result = (Boolean) takeThisFileMethod.invoke( jobEntryUnZip, sourceFile, "existing.txt" );
+      boolean result = jobEntryUnZip.takeThisFile( sourceFile, "existing.txt" );
 
       assertTrue( "Should take file when the destination does not exist", result );
     }

--- a/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/entries/unzip/JobEntryUnZipTest.java
@@ -10,9 +10,10 @@
  * Change Date: 2030-06-15
  ******************************************************************************/
 
-
 package org.pentaho.di.job.entries.unzip;
 
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,18 +23,25 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.vfs2.FileContent;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.core.vfs.KettleVFSImpl;
 import org.pentaho.di.job.entry.loadSave.JobEntryLoadSaveTestSupport;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
 
 public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip> {
-  @ClassRule public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
+  @ClassRule
+  public static RestorePDIEngineEnvironment env = new RestorePDIEngineEnvironment();
 
   @Override
   protected Class<JobEntryUnZip> getJobEntryClass() {
@@ -43,85 +51,90 @@ public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip
   @Override
   protected List<String> listCommonAttributes() {
     return Arrays.asList(
-        "zipfilename",
-        "wildcard",
-        "wildcardexclude",
-        "targetdirectory",
-        "movetodirectory",
-        "addfiletoresult",
-        "isfromprevious",
-        "adddate",
-        "addtime",
-        "addOriginalTimestamp",
-        "SpecifyFormat",
-        "date_time_format",
-        "rootzip",
-        "createfolder",
-        "nr_limit",
-        "wildcardSource",
-        "success_condition",
-        "create_move_to_directory",
-        "setOriginalModificationDate" );
+      "zipfilename",
+      "wildcard",
+      "wildcardexclude",
+      "targetdirectory",
+      "movetodirectory",
+      "addfiletoresult",
+      "isfromprevious",
+      "adddate",
+      "addtime",
+      "addOriginalTimestamp",
+      "SpecifyFormat",
+      "date_time_format",
+      "rootzip",
+      "createfolder",
+      "nr_limit",
+      "wildcardSource",
+      "success_condition",
+      "create_move_to_directory",
+      "setOriginalModificationDate"
+    );
   }
 
   @Override
   protected Map<String, String> createGettersMap() {
     return toMap(
-        "zipfilename", "getZipFilename",
-        "wildcard", "getWildcard",
-        "wildcardexclude", "getWildcardExclude",
-        "targetdirectory", "getSourceDirectory",
-        "movetodirectory", "getMoveToDirectory",
-        "addfiletoresult", "isAddFileToResult",
-        "isfromprevious", "getDatafromprevious",
-        "adddate", "isDateInFilename",
-        "addtime", "isTimeInFilename",
-        "addOriginalTimestamp", "isOriginalTimestamp",
-        "SpecifyFormat", "isSpecifyFormat",
-        "date_time_format", "getDateTimeFormat",
-        "rootzip", "isCreateRootFolder",
-        "createfolder",  "isCreateFolder",
-        "nr_limit", "getLimit",
-        "wildcardSource", "getWildcardSource",
-        "success_condition", "getSuccessCondition",
-        "create_move_to_directory", "isCreateMoveToDirectory",
-        "setOriginalModificationDate", "isOriginalModificationDate" );
+      "zipfilename", "getZipFilename",
+      "wildcard", "getWildcard",
+      "wildcardexclude", "getWildcardExclude",
+      "targetdirectory", "getSourceDirectory",
+      "movetodirectory", "getMoveToDirectory",
+      "addfiletoresult", "isAddFileToResult",
+      "isfromprevious", "getDatafromprevious",
+      "adddate", "isDateInFilename",
+      "addtime", "isTimeInFilename",
+      "addOriginalTimestamp", "isOriginalTimestamp",
+      "SpecifyFormat", "isSpecifyFormat",
+      "date_time_format", "getDateTimeFormat",
+      "rootzip", "isCreateRootFolder",
+      "createfolder", "isCreateFolder",
+      "nr_limit", "getLimit",
+      "wildcardSource", "getWildcardSource",
+      "success_condition", "getSuccessCondition",
+      "create_move_to_directory", "isCreateMoveToDirectory",
+      "setOriginalModificationDate", "isOriginalModificationDate"
+    );
   }
 
   @Override
   protected Map<String, String> createSettersMap() {
     return toMap(
-        "zipfilename", "setZipFilename",
-        "wildcard", "setWildcard",
-        "wildcardexclude", "setWildcardExclude",
-        "targetdirectory", "setSourceDirectory",
-        "movetodirectory", "setMoveToDirectory",
-        "addfiletoresult", "setAddFileToResult",
-        "isfromprevious", "setDatafromprevious",
-        "adddate", "setDateInFilename",
-        "addtime", "setTimeInFilename",
-        "addOriginalTimestamp", "setAddOriginalTimestamp",
-        "SpecifyFormat", "setSpecifyFormat",
-        "date_time_format", "setDateTimeFormat",
-        "rootzip", "setCreateRootFolder",
-        "createfolder",  "setCreateFolder",
-        "nr_limit", "setLimit",
-        "wildcardSource", "setWildcardSource",
-        "success_condition", "setSuccessCondition",
-        "create_move_to_directory", "setCreateMoveToDirectory",
-        "setOriginalModificationDate", "setOriginalModificationDate" );
+      "zipfilename", "setZipFilename",
+      "wildcard", "setWildcard",
+      "wildcardexclude", "setWildcardExclude",
+      "targetdirectory", "setSourceDirectory",
+      "movetodirectory", "setMoveToDirectory",
+      "addfiletoresult", "setAddFileToResult",
+      "isfromprevious", "setDatafromprevious",
+      "adddate", "setDateInFilename",
+      "addtime", "setTimeInFilename",
+      "addOriginalTimestamp", "setAddOriginalTimestamp",
+      "SpecifyFormat", "setSpecifyFormat",
+      "date_time_format", "setDateTimeFormat",
+      "rootzip", "setCreateRootFolder",
+      "createfolder", "setCreateFolder",
+      "nr_limit", "setLimit",
+      "wildcardSource", "setWildcardSource",
+      "success_condition", "setSuccessCondition",
+      "create_move_to_directory", "setCreateMoveToDirectory",
+      "setOriginalModificationDate", "setOriginalModificationDate"
+    );
   }
-
 
   @Test
   public void unzipPostProcessingTest() throws Exception {
 
     JobEntryUnZip jobEntryUnZip = new JobEntryUnZip();
     JobMeta mockJobMeta = mock( JobMeta.class );
-    when( mockJobMeta .getBowl() ).thenReturn( DefaultBowl.getInstance() );
+    when( mockJobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
     jobEntryUnZip.setParentJobMeta( mockJobMeta );
 
-    Method unzipPostprocessingMethod = jobEntryUnZip.getClass().getDeclaredMethod( "doUnzipPostProcessing", FileObject.class, FileObject.class, String.class );
+    Method
+      unzipPostprocessingMethod =
+      jobEntryUnZip.getClass()
+        .getDeclaredMethod( "doUnzipPostProcessing", FileObject.class, FileObject.class, String.class );
     unzipPostprocessingMethod.setAccessible( true );
     FileObject sourceFileObject = Mockito.mock( FileObject.class );
     Mockito.doReturn( Mockito.mock( FileName.class ) ).when( sourceFileObject ).getName();
@@ -137,4 +150,34 @@ public class JobEntryUnZipTest extends JobEntryLoadSaveTestSupport<JobEntryUnZip
     Mockito.verify( sourceFileObject, Mockito.times( 1 ) ).moveTo( Mockito.any() );
   }
 
+  @Test
+  public void testTakeThisFileFailsIfFileExists() throws Exception {
+    try ( MockedStatic<KettleVFS> kettleVFSMockedStatic = Mockito.mockStatic( KettleVFS.class ) ) {
+      KettleVFSImpl vfsImpl = mock( KettleVFSImpl.class );
+      kettleVFSMockedStatic.when( () -> KettleVFS.getInstance( any( Bowl.class ) ) ).thenReturn( vfsImpl );
+      FileObject destinationFileObject = mock( FileObject.class );
+      when( destinationFileObject.exists() ).thenReturn( true );
+      when( vfsImpl.getFileObject( any( String.class ), any( VariableSpace.class ) ) ).thenReturn(
+        destinationFileObject );
+
+      JobEntryUnZip jobEntryUnZip = new JobEntryUnZip();
+      JobMeta mockJobMeta = mock( JobMeta.class );
+      when( mockJobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
+      jobEntryUnZip.setParentJobMeta( mockJobMeta );
+      jobEntryUnZip.setIfFileExists( JobEntryUnZip.IF_FILE_EXISTS_FAIL );
+      Method
+        takeThisFileMethod =
+        jobEntryUnZip.getClass().getDeclaredMethod( "takeThisFile", FileObject.class, String.class );
+      takeThisFileMethod.setAccessible( true );
+
+      FileObject sourceFile = mock( FileObject.class );
+      FileContent sourceContent = mock( FileContent.class );
+      when( sourceFile.getContent() ).thenReturn( sourceContent );
+      when( sourceContent.getSize() ).thenReturn( 1000L );
+
+      Boolean result = (Boolean) takeThisFileMethod.invoke( jobEntryUnZip, sourceFile, "existing.txt" );
+
+      assertFalse( "Should not take file when using FAIL policy (error is logged)", result );
+    }
+  }
 }


### PR DESCRIPTION
Addresses [PDESIGNER-756](https://pentaho-eng.atlassian.net/browse/PDESIGNER-756)

Ensure that when `IF_FILE_EXISTS_FAIL` flag is selected for the Unzip File Step, the steps effectively fails when the destination file already exists (for both local and VFS connections).

[PDESIGNER-756]: https://pentaho-eng.atlassian.net/browse/PDESIGNER-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ