### PR TITLE
build[PPP-7120]: Move dependency management of Netty to maven parent pom

### DIFF
--- a/plugins/streaming/impls/jms/pom.xml
+++ b/plugins/streaming/impls/jms/pom.xml
@@ -141,21 +141,18 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- pulling newer version of io-netty version 108 -->
+      <!-- Ensure Netty dependencies use the parent-managed version. -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
 
     <dependency>
@@ -171,12 +168,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Summary
Remove the local Netty version from the JMS streaming implementation so it inherits shared parent dependency management.

## Validation
- `mvn -B -nsu -Dmaven.test.skip=true validate`