### PR TITLE
test[BACKLOG-43728]: stabilize flaky HTTP integration tests

### DIFF
--- a/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
@@ -45,6 +45,7 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -247,7 +248,7 @@ public class HTTPIT {
   }
 
   private void startHttpServer( HttpHandler httpHandler ) throws IOException {
-    httpServer = HttpServer.create( new InetSocketAddress( HTTPIT.host, 0 ), 10 );
+    httpServer = HttpServer.create( new InetSocketAddress( InetAddress.getLoopbackAddress(), 0 ), 10 );
     httpServer.createContext( "/", httpHandler );
     httpServer.start();
   }

--- a/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
@@ -121,8 +121,6 @@ public class HTTPIT {
 
 
   public static final String host = "localhost";
-  public static final int port = 9998;
-  public static final String HTTP_LOCALHOST_9998 = "http://localhost:9998/";
 
   @InjectMocks
   private StepMockHelper<HTTPMeta, HTTPData> stepMockHelper;
@@ -144,8 +142,14 @@ public class HTTPIT {
 
   @After
   public void tearDown() throws Exception {
-    httpServer.stop( 5 );
+    if ( httpServer != null ) {
+      httpServer.stop( 5 );
+    }
 
+  }
+
+  private String getHttpLocalhostUrl() {
+    return "http://" + host + ":" + httpServer.getAddress().getPort() + "/";
   }
 
 
@@ -163,7 +167,7 @@ public class HTTPIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     http.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getHeaderField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getResultCodeFieldName() ).thenReturn( "ResultCodeFieldName" );
@@ -191,7 +195,7 @@ public class HTTPIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     http.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getHeaderField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getResultCodeFieldName() ).thenReturn( "ResultCodeFieldName" );
@@ -220,7 +224,7 @@ public class HTTPIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     http.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getHeaderField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getEncoding() ).thenReturn( "UTF8" );
@@ -243,7 +247,7 @@ public class HTTPIT {
   }
 
   private void startHttpServer( HttpHandler httpHandler ) throws IOException {
-    httpServer = HttpServer.create( new InetSocketAddress( HTTPIT.host, HTTPIT.port ), 10 );
+    httpServer = HttpServer.create( new InetSocketAddress( HTTPIT.host, 0 ), 10 );
     httpServer.createContext( "/", httpHandler );
     httpServer.start();
   }

--- a/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
@@ -48,6 +48,7 @@ import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URLDecoder;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -302,7 +303,7 @@ public class HTTPPOSTIT {
 
 
   private void startHttpServer( HttpHandler httpHandler ) throws IOException {
-    httpServer = HttpServer.create( new InetSocketAddress( HTTPPOSTIT.host, 0 ), 10 );
+    httpServer = HttpServer.create( new InetSocketAddress( InetAddress.getLoopbackAddress(), 0 ), 10 );
     httpServer.createContext( "/", httpHandler );
     httpServer.start();
   }

--- a/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
@@ -134,8 +134,6 @@ public class HTTPPOSTIT {
   }
 
   public static final String host = "localhost";
-  public static final int port = 9998;
-  public static final String HTTP_LOCALHOST_9998 = "http://localhost:9998/";
 
   @InjectMocks
   private StepMockHelper<HTTPPOSTMeta, HTTPPOSTData> stepMockHelper;
@@ -159,8 +157,14 @@ public class HTTPPOSTIT {
 
   @After
   public void tearDown() throws Exception {
-    httpServer.stop( 5 );
+    if ( httpServer != null ) {
+      httpServer.stop( 5 );
+    }
 
+  }
+
+  private String getHttpLocalhostUrl() {
+    return "http://" + host + ":" + httpServer.getAddress().getPort() + "/";
   }
 
   @Test
@@ -177,7 +181,7 @@ public class HTTPPOSTIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     HTTPPOST.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getQueryField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getResultCodeFieldName() ).thenReturn( "ResultCodeFieldName" );
@@ -205,7 +209,7 @@ public class HTTPPOSTIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     HTTPPOST.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getQueryField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getResultCodeFieldName() ).thenReturn( "ResultCodeFieldName" );
@@ -232,7 +236,7 @@ public class HTTPPOSTIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     HTTPPOST.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getQueryField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getEncoding() ).thenReturn( "UTF-8" );
@@ -282,7 +286,7 @@ public class HTTPPOSTIT {
     httpPost.row = new Object[] { testString };
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
     when( inputRowMeta.getString( httpPost.row, 0 ) ).thenReturn( testString );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getQueryField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() )
       .thenReturn( new String[] { "testBodyField" } );
@@ -298,7 +302,7 @@ public class HTTPPOSTIT {
 
 
   private void startHttpServer( HttpHandler httpHandler ) throws IOException {
-    httpServer = HttpServer.create( new InetSocketAddress( HTTPPOSTIT.host, HTTPPOSTIT.port ), 10 );
+    httpServer = HttpServer.create( new InetSocketAddress( HTTPPOSTIT.host, 0 ), 10 );
     httpServer.createContext( "/", httpHandler );
     httpServer.start();
   }


### PR DESCRIPTION
## Summary
This PR stabilizes flaky HTTP integration tests by removing fixed localhost port assumptions.

## Root Cause
The failing tests used a hardcoded HTTP server port (`9998`). Under suite execution, this intermittently caused `NoHttpResponseException: localhost:9998 failed to respond`, leading to non-deterministic failures in `HTTPPOSTIT` and potential collisions with sibling tests.

## Changes
- Updated `HTTPPOSTIT` to bind test HTTP server on an ephemeral port (`0`)
- Updated `HTTPIT` to bind test HTTP server on an ephemeral port (`0`)
- Added helper methods in both tests to build the URL from `httpServer.getAddress().getPort()`
- Made `tearDown()` null-safe in both tests

## Validation
Executed repeatedly on JDK 21:
- `mvn -B -e verify -DrunITs -Dit.test=HTTPPOSTIT` (3 runs)
- `mvn -B -e verify -DrunITs -Dit.test=HTTPIT,HTTPPOSTIT` (3 runs)

All runs passed with zero failures/errors for these classes.

## Scope
Test-only changes. No production code modified.
