### PR TITLE
test[BACKLOG-43728]: repair engine job entry integration tests

### DIFF
--- a/engine/src/it/java/org/pentaho/di/job/entries/job/JobEntryJobIT.java
+++ b/engine/src/it/java/org/pentaho/di/job/entries/job/JobEntryJobIT.java
@@ -19,6 +19,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.Props;
@@ -37,7 +38,6 @@ import org.pentaho.di.www.SlaveServerJobStatus;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -88,6 +88,7 @@ public class JobEntryJobIT extends JobEntryJob {
 
     when( parentJob.getLogLevel() ).thenReturn( LogLevel.BASIC );
     when( parentJobMeta.getRepositoryDirectory() ).thenReturn( null );
+    when( parentJobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
     when( jobMeta.getRepositoryDirectory() ).thenReturn( mock( RepositoryDirectoryInterface.class ) );
     when( jobMeta.getName() ).thenReturn( JOB_META_NAME );
     when( parentJob.getJobMeta() ).thenReturn( parentJobMeta );
@@ -122,8 +123,20 @@ public class JobEntryJobIT extends JobEntryJob {
     job.setParentJobMeta( parentJobMeta );
 
     job.execute( new Result(), 0 );
-    String result = Files.lines( FILE ).collect( Collectors.joining( "" ) );
-    assertTrue( result.contains( LOG ) );
+    assertTrue( "Remote log output was not written before the timeout", awaitLogFileContents( LOG ).contains( LOG ) );
+  }
+
+  private static String awaitLogFileContents( String expectedContent ) throws Exception {
+    long deadline = System.currentTimeMillis() + 10_000;
+    String contents = "";
+    while ( System.currentTimeMillis() < deadline ) {
+      contents = Files.readString( FILE );
+      if ( contents.contains( expectedContent ) ) {
+        return contents;
+      }
+      Thread.sleep( 100 );
+    }
+    return contents;
   }
 
   @BeforeClass

--- a/engine/src/it/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFileIT.java
+++ b/engine/src/it/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFileIT.java
@@ -23,6 +23,7 @@ import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobMeta;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -60,9 +61,11 @@ public class JobEntryZipFileIT {
     try {
       Result result = new Result();
       JobEntryZipFile entry = new JobEntryZipFile();
+      JobMeta jobMeta = new JobMeta();
+      Job parentJob = new Job( null, jobMeta );
+      entry.setParentJobMeta( jobMeta );
       assertTrue(
-              entry.processRowFile(new Job(), result, zipPath, null, null, tempFile.getAbsolutePath(), null, false));
-      boolean isTrue = true;
+        entry.processRowFile( parentJob, result, zipPath, null, null, tempFile.getAbsolutePath(), null, false ) );
 
       FileObject zip = KettleVFS.getInstance( DefaultBowl.getInstance() ).getFileObject(zipPath);
       assertTrue("Zip archive should be created", zip.exists());


### PR DESCRIPTION
## Summary
- initialize the JobMeta context required by the ZIP entry integration test
- provide a VFS bowl and wait for the asynchronous remote log write in the job entry integration test

## Validation
- `mvn --batch-mode -pl engine -DrunITs compile resources:testResources@test-integration_add-resources build-helper:add-test-source@test-integration_add-source compiler:testCompile@test-integration_compile failsafe:integration-test@test-integration_execute failsafe:verify@test-integration_report -Dit.test=JobEntryZipFileIT,JobEntryJobIT`
- Failsafe: 3 tests, 0 failures, 0 errors