### PR TITLE
fix:[BACKLOG-50640] Restore HSQLDB schema visibility for grant-only u…

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/database/HypersonicDatabaseMeta.java
+++ b/core/src/main/java/org/pentaho/di/core/database/HypersonicDatabaseMeta.java
@@ -56,6 +56,28 @@ public class HypersonicDatabaseMeta extends BaseDatabaseMeta implements Database
   }
 
   /**
+   * @return the SQL to retrieve the list of schemas.
+   *
+   *    Since HSQLDB 2.7.x, INFORMATION_SCHEMA.SCHEMATA (and therefore the plain JDBC
+   *    DatabaseMetaData#getSchemas() call) only returns schemas that the connecting user has direct
+   *    authorization over (schema ownership or DBA role membership). A user that was only granted SELECT
+   *    on individual tables within a schema - but was never granted any privilege on the schema itself -
+   *    will no longer see that schema, even though the tables inside it are fully visible. This is a
+   *    behavioral change compared to older HSQLDB versions (e.g. 2.3.2), where such a user could still
+   *    see the schema.
+   *
+   *    To keep schema visibility consistent regardless of the privileges the connecting user was
+   *    granted, we union the schemas visible through INFORMATION_SCHEMA.SCHEMATA (e.g. for DBA users)
+   *    with the schemas that can be derived from INFORMATION_SCHEMA.TABLES (visible to any user that has
+   *    at least one table-level grant in that schema).
+   */
+  @Override
+  public String getSQLListOfSchemas() {
+    return "SELECT SCHEMA_NAME AS name FROM INFORMATION_SCHEMA.SCHEMATA "
+      + "UNION SELECT DISTINCT TABLE_SCHEMA AS name FROM INFORMATION_SCHEMA.TABLES";
+  }
+
+  /**
    * @return true if the database supports bitmap indexes
    */
   @Override

--- a/core/src/test/java/org/pentaho/di/core/database/HypersonicDatabaseMetaTest.java
+++ b/core/src/test/java/org/pentaho/di/core/database/HypersonicDatabaseMetaTest.java
@@ -267,6 +267,18 @@ public class HypersonicDatabaseMetaTest {
   }
 
   @Test
+  public void testGetSQLListOfSchemas() throws Exception {
+    // HSQLDB 2.7.x restricts INFORMATION_SCHEMA.SCHEMATA (and therefore DatabaseMetaData#getSchemas())
+    // to schemas the connecting user has direct authorization over. Users that were only granted table-level
+    // privileges (and not schema-level/DBA privileges) would no longer see their own schema. Union in the
+    // schemas visible through INFORMATION_SCHEMA.TABLES to restore visibility for such users.
+    String sql = hypersonicDatabaseMeta.getSQLListOfSchemas();
+    String expectedSql = "SELECT SCHEMA_NAME AS name FROM INFORMATION_SCHEMA.SCHEMATA "
+      + "UNION SELECT DISTINCT TABLE_SCHEMA AS name FROM INFORMATION_SCHEMA.TABLES";
+    assertEquals( expectedSql, sql );
+  }
+
+  @Test
   public void testGetFieldDefinition() throws Exception {
     ValueMetaInterface vm = new ValueMetaString();
     String sql = hypersonicDatabaseMeta.getFieldDefinition( vm, null, null, false, false, false );


### PR DESCRIPTION
…sers

HSQLDB 2.7.4 tightened privilege checks on INFORMATION_SCHEMA.SCHEMATA (which backs DatabaseMetaData#getSchemas()), so it now only returns schemas the connecting user directly owns or has DBA-role membership over. Users granted only table-level SELECT privileges (e.g. the SampleData JNDI connection's pentaho_user) no longer see their schema in the Database Explorer, even though the tables inside are fully queryable. This was a regression introduced when hsqldb was upgraded from 2.3.2 to 2.7.4; sampledata.script content was verified not to be the cause.

Add a getSQLListOfSchemas() override to HypersonicDatabaseMeta, following the same extension point used by MSSQLServerDatabaseMeta, that unions schemas visible via INFORMATION_SCHEMA.SCHEMATA with schemas derivable from INFORMATION_SCHEMA.TABLES. This restores visibility for grant-only users without granting any new privileges to sample accounts or modifying the shipped sample scripts.