### PR TITLE
fix(engine): prevent transient job status regression [BACKLOG-43728]

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -428,8 +428,7 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
 
       emergencyWriteJobTracker( result );
 
-      setActive( false );
-      setFinished( true );
+      markAsFinished();
       setStopped( false );
     } finally {
       try {
@@ -556,9 +555,10 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
       // Save this result...
       jobTracker.addJobTracker( new JobTracker( jobMeta, jerEnd ) );
       log.logMinimal( BaseMessages.getString( PKG, "Job.Comment.JobFinished" ) );
-      setActive( false );
       if ( !isStopped() ) {
-        setFinished( true );
+        markAsFinished();
+      } else {
+        setActive( false );
       }
       return res;
     } finally {
@@ -1350,6 +1350,10 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
   public void setFinished( boolean finished ) {
     status.updateAndGet( v -> finished ? v | BitMaskStatus.FINISHED.mask : ( BitMaskStatus.BIT_STATUS_SUM
         ^ BitMaskStatus.FINISHED.mask ) & v );
+  }
+
+  void markAsFinished() {
+    status.updateAndGet( v -> ( v | BitMaskStatus.FINISHED.mask ) & ~BitMaskStatus.ACTIVE.mask );
   }
 
   public Date getStartDate() {

--- a/engine/src/test/java/org/pentaho/di/job/JobTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/JobTest.java
@@ -106,7 +106,7 @@ public class JobTest {
         CountDownLatch runningObserved = new CountDownLatch( 1 );
         AtomicBoolean transitionComplete = new AtomicBoolean();
         Future<Boolean> observedWaiting = executor.submit( () -> {
-          while ( !transitionComplete.get() ) {
+          while ( !transitionComplete.get() && !Thread.currentThread().isInterrupted() ) {
             String status = job.getStatus();
             if ( STRING_RUNNING.equals( status ) ) {
               runningObserved.countDown();
@@ -120,7 +120,7 @@ public class JobTest {
         assertTrue( runningObserved.await( 10, TimeUnit.SECONDS ) );
         job.markAsFinished();
         transitionComplete.set( true );
-        assertFalse( observedWaiting.get() );
+        assertFalse( observedWaiting.get( 10, TimeUnit.SECONDS ) );
       }
     } finally {
       executor.shutdownNow();

--- a/engine/src/test/java/org/pentaho/di/job/JobTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/JobTest.java
@@ -71,6 +71,19 @@ import static org.pentaho.test.util.InternalState.setInternalState;
 
 
 public class JobTest {
+
+  @Test
+  public void markAsFinishedUpdatesActiveAndFinishedStatusTogether() {
+    Job job = new Job();
+
+    job.setActive( true );
+    job.setResult( new Result() );
+    job.markAsFinished();
+
+    assertFalse( job.isActive() );
+    assertTrue( job.isFinished() );
+    assertEquals( Trans.STRING_FINISHED, job.getStatus() );
+  }
   private static final String STRING_DEFAULT = "<def>";
   private Job mockedJob;
   private Database mockedDataBase;

--- a/engine/src/test/java/org/pentaho/di/job/JobTest.java
+++ b/engine/src/test/java/org/pentaho/di/job/JobTest.java
@@ -44,9 +44,13 @@ import org.pentaho.di.trans.HasDatabasesInterface;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
@@ -67,6 +71,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
+import static org.pentaho.di.trans.Trans.STRING_FINISHED;
+import static org.pentaho.di.trans.Trans.STRING_RUNNING;
+import static org.pentaho.di.trans.Trans.STRING_WAITING;
 import static org.pentaho.test.util.InternalState.setInternalState;
 
 
@@ -82,8 +89,45 @@ public class JobTest {
 
     assertFalse( job.isActive() );
     assertTrue( job.isFinished() );
-    assertEquals( Trans.STRING_FINISHED, job.getStatus() );
+    assertEquals( STRING_FINISHED, job.getStatus() );
   }
+
+  @Test
+  public void markAsFinishedNeverReportsWaitingAfterRunning() throws Exception {
+    Job job = new Job();
+    job.setResult( new Result() );
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    try {
+      for ( int transition = 0; transition < 100; transition++ ) {
+        job.setFinished( false );
+        job.setStopped( false );
+        job.setActive( true );
+        CountDownLatch runningObserved = new CountDownLatch( 1 );
+        AtomicBoolean transitionComplete = new AtomicBoolean();
+        Future<Boolean> observedWaiting = executor.submit( () -> {
+          while ( !transitionComplete.get() ) {
+            String status = job.getStatus();
+            if ( STRING_RUNNING.equals( status ) ) {
+              runningObserved.countDown();
+            } else if ( runningObserved.getCount() == 0 && STRING_WAITING.equals( status ) ) {
+              return true;
+            }
+          }
+          return false;
+        } );
+
+        assertTrue( runningObserved.await( 10, TimeUnit.SECONDS ) );
+        job.markAsFinished();
+        transitionComplete.set( true );
+        assertFalse( observedWaiting.get() );
+      }
+    } finally {
+      executor.shutdownNow();
+      assertTrue( executor.awaitTermination( 10, TimeUnit.SECONDS ) );
+    }
+  }
+
   private static final String STRING_DEFAULT = "<def>";
   private Job mockedJob;
   private Database mockedDataBase;


### PR DESCRIPTION
## Root Cause

Job completion cleared the ACTIVE bit and set the FINISHED bit in two separate atomic updates. A concurrent getStatus() call could observe neither bit between those updates and incorrectly report Waiting after Running.

## Change

Update normal and exceptional job completion to clear ACTIVE and set FINISHED in one atomic status update. Add a JobTest regression that verifies the resulting observable status is Finished.

## Validation

- `mvn --batch-mode -pl engine -Dtest=JobTest test`
  - Surefire: 22 tests, 0 failures, 0 errors, 3 skipped
- `mvn --batch-mode -pl engine -DrunITs=true -Dtest=NoSuchUnitTest -DfailIfNoTests=false -Dit.test=JobIT verify`
  - Failsafe: 1 test, 0 failures, 0 errors, 0 skipped
- Focused JobIT scenario passed 30 consecutive runs before the repair; the unsafe intermediate state was confirmed directly in the prior completion code.