### PR TITLE
fix(kettle): repair PDI integration tests [BACKLOG-43728]

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/service/PluginServiceLoader.java
+++ b/core/src/main/java/org/pentaho/di/core/service/PluginServiceLoader.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -97,8 +98,9 @@ public class PluginServiceLoader {
       }
     }
     // add any providers created dynamically (not part of plugin registry initialization)
-    if ( dynamicallyAddedServices.containsKey( apiInterface.getName() ) ) {
-      unsortedServices.addAll( dynamicallyAddedServices.get( apiInterface.getName() ) );
+    Collection<ProviderServicePriority<?>> dynamicallyAdded = dynamicallyAddedServices.get( apiInterface.getName() );
+    if ( dynamicallyAdded != null ) {
+      unsortedServices.addAll( dynamicallyAdded );
     }
 
     // sort by priority, extract the service, and cast to the interface type
@@ -111,7 +113,7 @@ public class PluginServiceLoader {
     Collection<ProviderServicePriority<?>> providersAndServices;
     if ( dynamicallyAddedServices.containsKey( apiInterface.getName() ) ) {
       providersAndServices = dynamicallyAddedServices.get( apiInterface.getName() );
-      providersAndServices.removeIf( e -> e.getProvider().equals( provider ) );
+      providersAndServices.removeIf( e -> Objects.equals( e.getProvider(), provider ) );
     } else {
       providersAndServices = new ArrayList<>();
     }
@@ -121,7 +123,7 @@ public class PluginServiceLoader {
 
   public static void unregisterService( Object provider, Class<?> apiInterface ) {
     dynamicallyAddedServices.computeIfPresent( apiInterface.getName(), ( key, providersAndServices ) -> {
-      providersAndServices.removeIf( service -> service.getProvider().equals( provider ) );
+      providersAndServices.removeIf( service -> Objects.equals( service.getProvider(), provider ) );
       return providersAndServices.isEmpty() ? null : providersAndServices;
     } );
   }

--- a/core/src/main/java/org/pentaho/di/core/service/PluginServiceLoader.java
+++ b/core/src/main/java/org/pentaho/di/core/service/PluginServiceLoader.java
@@ -119,6 +119,13 @@ public class PluginServiceLoader {
     dynamicallyAddedServices.put( apiInterface.getName(), providersAndServices );
   }
 
+  public static void unregisterService( Object provider, Class<?> apiInterface ) {
+    dynamicallyAddedServices.computeIfPresent( apiInterface.getName(), ( key, providersAndServices ) -> {
+      providersAndServices.removeIf( service -> service.getProvider().equals( provider ) );
+      return providersAndServices.isEmpty() ? null : providersAndServices;
+    } );
+  }
+
   private static class WrappingClassLoaderChangingInvocationHandler implements InvocationHandler {
 
     private final Object o;

--- a/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
+++ b/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
@@ -22,17 +22,23 @@ public class PluginServiceLoaderTest {
   @Test
   public void unregisterServiceRemovesOnlyTheProviderRegistration() throws Exception {
     Object provider = new Object();
+    Object otherProvider = new Object();
     TestService service = new TestService() { };
+    TestService otherService = new TestService() { };
 
     PluginServiceLoader.registerService( provider, TestService.class, service, 0 );
+    PluginServiceLoader.registerService( otherProvider, TestService.class, otherService, 0 );
     try {
       assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+      assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( otherService ) );
 
       PluginServiceLoader.unregisterService( provider, TestService.class );
 
       assertFalse( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+      assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( otherService ) );
     } finally {
       PluginServiceLoader.unregisterService( provider, TestService.class );
+      PluginServiceLoader.unregisterService( otherProvider, TestService.class );
     }
   }
 

--- a/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
+++ b/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
@@ -36,6 +36,22 @@ public class PluginServiceLoaderTest {
     }
   }
 
+  @Test
+  public void unregisterServiceSupportsANullProvider() throws Exception {
+    TestService service = new TestService() { };
+
+    PluginServiceLoader.registerService( null, TestService.class, service, 0 );
+    try {
+      assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+
+      PluginServiceLoader.unregisterService( null, TestService.class );
+
+      assertFalse( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+    } finally {
+      PluginServiceLoader.unregisterService( null, TestService.class );
+    }
+  }
+
   private interface TestService {
   }
 }

--- a/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
+++ b/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
@@ -1,0 +1,41 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2031-09-03
+ ******************************************************************************/
+
+package org.pentaho.di.core.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PluginServiceLoaderTest {
+
+  @Test
+  public void unregisterServiceRemovesOnlyTheProviderRegistration() throws Exception {
+    Object provider = new Object();
+    TestService service = new TestService() { };
+
+    PluginServiceLoader.registerService( provider, TestService.class, service, 0 );
+    try {
+      assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+
+      PluginServiceLoader.unregisterService( provider, TestService.class );
+
+      assertFalse( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+    } finally {
+      PluginServiceLoader.unregisterService( provider, TestService.class );
+    }
+  }
+
+  private interface TestService {
+  }
+}

--- a/engine/src/it/java/org/pentaho/di/job/entries/job/JobEntryJobIT.java
+++ b/engine/src/it/java/org/pentaho/di/job/entries/job/JobEntryJobIT.java
@@ -18,6 +18,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.KettleClientEnvironment;
 import org.pentaho.di.core.ObjectLocationSpecificationMethod;
 import org.pentaho.di.core.Props;
@@ -36,7 +37,6 @@ import org.pentaho.di.www.SlaveServerJobStatus;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -87,6 +87,7 @@ public class JobEntryJobIT extends JobEntryJob {
 
     when( parentJob.getLogLevel() ).thenReturn( LogLevel.BASIC );
     when( parentJobMeta.getRepositoryDirectory() ).thenReturn( null );
+    when( parentJobMeta.getBowl() ).thenReturn( DefaultBowl.getInstance() );
     when( jobMeta.getRepositoryDirectory() ).thenReturn( mock( RepositoryDirectoryInterface.class ) );
     when( jobMeta.getName() ).thenReturn( JOB_META_NAME );
     when( parentJob.getJobMeta() ).thenReturn( parentJobMeta );
@@ -121,8 +122,20 @@ public class JobEntryJobIT extends JobEntryJob {
     job.setParentJobMeta( parentJobMeta );
 
     job.execute( new Result(), 0 );
-    String result = Files.lines( FILE ).collect( Collectors.joining( "" ) );
-    assertTrue( result.contains( LOG ) );
+    assertTrue( "Remote log output was not written before the timeout", awaitLogFileContents( LOG ).contains( LOG ) );
+  }
+
+  private static String awaitLogFileContents( String expectedContent ) throws Exception {
+    long deadline = System.currentTimeMillis() + 10_000;
+    String contents = "";
+    while ( System.currentTimeMillis() < deadline ) {
+      contents = Files.readString( FILE );
+      if ( contents.contains( expectedContent ) ) {
+        return contents;
+      }
+      Thread.sleep( 100 );
+    }
+    return contents;
   }
 
   @BeforeClass

--- a/engine/src/it/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFileIT.java
+++ b/engine/src/it/java/org/pentaho/di/job/entries/zipfile/JobEntryZipFileIT.java
@@ -22,6 +22,7 @@ import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.job.Job;
+import org.pentaho.di.job.JobMeta;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -59,9 +60,11 @@ public class JobEntryZipFileIT {
     try {
       Result result = new Result();
       JobEntryZipFile entry = new JobEntryZipFile();
+      JobMeta jobMeta = new JobMeta();
+      Job parentJob = new Job( null, jobMeta );
+      entry.setParentJobMeta( jobMeta );
       assertTrue(
-              entry.processRowFile(new Job(), result, zipPath, null, null, tempFile.getAbsolutePath(), null, false));
-      boolean isTrue = true;
+        entry.processRowFile( parentJob, result, zipPath, null, null, tempFile.getAbsolutePath(), null, false ) );
 
       FileObject zip = KettleVFS.getInstance( DefaultBowl.getInstance() ).getFileObject(zipPath);
       assertTrue("Zip archive should be created", zip.exists());

--- a/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
@@ -149,7 +149,9 @@ public class HTTPIT {
   }
 
   private String getHttpLocalhostUrl() {
-    return "http://" + host + ":" + httpServer.getAddress().getPort() + "/";
+    String boundHost = httpServer.getAddress().getAddress().getHostAddress();
+    return "http://" + ( boundHost.contains( ":" ) ? "[" + boundHost + "]" : boundHost )
+      + ":" + httpServer.getAddress().getPort() + "/";
   }
 
 

--- a/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
@@ -44,6 +44,7 @@ import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -120,8 +121,6 @@ public class HTTPIT {
 
 
   public static final String host = "localhost";
-  public static final int port = 9998;
-  public static final String HTTP_LOCALHOST_9998 = "http://localhost:9998/";
 
   @InjectMocks
   private StepMockHelper<HTTPMeta, HTTPData> stepMockHelper;
@@ -143,8 +142,14 @@ public class HTTPIT {
 
   @After
   public void tearDown() throws Exception {
-    httpServer.stop( 5 );
+    if ( httpServer != null ) {
+      httpServer.stop( 5 );
+    }
 
+  }
+
+  private String getHttpLocalhostUrl() {
+    return "http://" + host + ":" + httpServer.getAddress().getPort() + "/";
   }
 
 
@@ -162,7 +167,7 @@ public class HTTPIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     http.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getHeaderField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getResultCodeFieldName() ).thenReturn( "ResultCodeFieldName" );
@@ -190,7 +195,7 @@ public class HTTPIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     http.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getHeaderField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getResultCodeFieldName() ).thenReturn( "ResultCodeFieldName" );
@@ -219,7 +224,7 @@ public class HTTPIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     http.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getHeaderField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getEncoding() ).thenReturn( "UTF8" );
@@ -242,7 +247,7 @@ public class HTTPIT {
   }
 
   private void startHttpServer( HttpHandler httpHandler ) throws IOException {
-    httpServer = HttpServer.create( new InetSocketAddress( HTTPIT.host, HTTPIT.port ), 10 );
+    httpServer = HttpServer.create( new InetSocketAddress( InetAddress.getLoopbackAddress(), 0 ), 10 );
     httpServer.createContext( "/", httpHandler );
     httpServer.start();
   }

--- a/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
@@ -47,6 +47,7 @@ import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URLDecoder;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -133,8 +134,6 @@ public class HTTPPOSTIT {
   }
 
   public static final String host = "localhost";
-  public static final int port = 9998;
-  public static final String HTTP_LOCALHOST_9998 = "http://localhost:9998/";
 
   @InjectMocks
   private StepMockHelper<HTTPPOSTMeta, HTTPPOSTData> stepMockHelper;
@@ -158,8 +157,14 @@ public class HTTPPOSTIT {
 
   @After
   public void tearDown() throws Exception {
-    httpServer.stop( 5 );
+    if ( httpServer != null ) {
+      httpServer.stop( 5 );
+    }
 
+  }
+
+  private String getHttpLocalhostUrl() {
+    return "http://" + host + ":" + httpServer.getAddress().getPort() + "/";
   }
 
   @Test
@@ -176,7 +181,7 @@ public class HTTPPOSTIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     HTTPPOST.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getQueryField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getResultCodeFieldName() ).thenReturn( "ResultCodeFieldName" );
@@ -204,7 +209,7 @@ public class HTTPPOSTIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     HTTPPOST.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getQueryField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getResultCodeFieldName() ).thenReturn( "ResultCodeFieldName" );
@@ -231,7 +236,7 @@ public class HTTPPOSTIT {
     RowMetaInterface inputRowMeta = mock( RowMetaInterface.class );
     HTTPPOST.setInputRowMeta( inputRowMeta );
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getQueryField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getEncoding() ).thenReturn( "UTF-8" );
@@ -281,7 +286,7 @@ public class HTTPPOSTIT {
     httpPost.row = new Object[] { testString };
     when( inputRowMeta.clone() ).thenReturn( inputRowMeta );
     when( inputRowMeta.getString( httpPost.row, 0 ) ).thenReturn( testString );
-    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( HTTP_LOCALHOST_9998 );
+    when( stepMockHelper.processRowsStepMetaInterface.getUrl() ).thenReturn( getHttpLocalhostUrl() );
     when( stepMockHelper.processRowsStepMetaInterface.getQueryField() ).thenReturn( new String[] {} );
     when( stepMockHelper.processRowsStepMetaInterface.getArgumentField() )
       .thenReturn( new String[] { "testBodyField" } );
@@ -297,7 +302,7 @@ public class HTTPPOSTIT {
 
 
   private void startHttpServer( HttpHandler httpHandler ) throws IOException {
-    httpServer = HttpServer.create( new InetSocketAddress( HTTPPOSTIT.host, HTTPPOSTIT.port ), 10 );
+    httpServer = HttpServer.create( new InetSocketAddress( InetAddress.getLoopbackAddress(), 0 ), 10 );
     httpServer.createContext( "/", httpHandler );
     httpServer.start();
   }

--- a/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
@@ -164,7 +164,9 @@ public class HTTPPOSTIT {
   }
 
   private String getHttpLocalhostUrl() {
-    return "http://" + host + ":" + httpServer.getAddress().getPort() + "/";
+    String boundHost = httpServer.getAddress().getAddress().getHostAddress();
+    return "http://" + ( boundHost.contains( ":" ) ? "[" + boundHost + "]" : boundHost )
+      + ":" + httpServer.getAddress().getPort() + "/";
   }
 
   @Test

--- a/plugins/pur/core/.gitignore
+++ b/plugins/pur/core/.gitignore
@@ -1,0 +1,1 @@
+derby.log

--- a/plugins/pur/core/pom.xml
+++ b/plugins/pur/core/pom.xml
@@ -35,6 +35,7 @@
     <se-jcr.version>0.9</se-jcr.version>
     <jcr.version>2.0</jcr.version>
     <derby.version>10.17.1.0</derby.version>
+    <javax.transaction-api.version>1.2</javax.transaction-api.version>
     <commons-database.version>11.0.0.0-SNAPSHOT</commons-database.version>
 
     <!-- Wadl2Java Settings -->
@@ -397,6 +398,18 @@
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
       <version>${derby.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>javax.transaction-api</artifactId>
+      <version>${javax.transaction-api.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.di.plugins</groupId>
+      <artifactId>pentaho-metastore-locator-core</artifactId>
+      <version>${pdi.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/plugins/pur/core/src/it/java/org/pentaho/di/repository/pur/PurRepositoryIT.java
+++ b/plugins/pur/core/src/it/java/org/pentaho/di/repository/pur/PurRepositoryIT.java
@@ -46,6 +46,7 @@ import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.bowl.DefaultBowl;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.NotePadMeta;
+import org.pentaho.di.core.Props;
 import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -55,6 +56,7 @@ import org.pentaho.di.core.logging.KettleLoggingEventListener;
 import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.plugins.JobEntryPluginType;
 import org.pentaho.di.core.plugins.StepPluginType;
+import org.pentaho.di.core.service.PluginServiceLoader;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.imp.ImportRules;
 import org.pentaho.di.imp.rule.ImportRuleInterface;
@@ -74,6 +76,10 @@ import org.pentaho.di.shared.SharedObjectInterface;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.tableinput.TableInputMeta;
+import org.pentaho.metastore.locator.api.MetastoreLocator;
+import org.pentaho.metastore.locator.api.MetastoreProvider;
+import org.pentaho.metastore.locator.api.impl.MetastoreLocatorImpl;
+import org.pentaho.metastore.locator.impl.repository.RepositoryMetastoreProvider;
 import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.api.IMetaStoreAttribute;
 import org.pentaho.metastore.api.IMetaStoreElement;
@@ -235,6 +241,14 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
     super.setUp();
 
     KettleEnvironment.init();
+    if ( !Props.isInitialized() ) {
+      Props.init( Props.TYPE_PROPERTIES_EMPTY );
+    }
+
+    PluginServiceLoader.registerService( PurRepositoryIT.class, MetastoreLocator.class,
+      new MetastoreLocatorImpl(), 0 );
+    PluginServiceLoader.registerService( PurRepositoryIT.class, MetastoreProvider.class,
+      new RepositoryMetastoreProvider( () -> repository ), 0 );
 
     // programmatically register plugins, annotation based plugins do not get loaded unless
     // they are in kettle's plugins folder.

--- a/plugins/pur/core/src/it/java/org/pentaho/di/repository/pur/PurRepositoryIT.java
+++ b/plugins/pur/core/src/it/java/org/pentaho/di/repository/pur/PurRepositoryIT.java
@@ -200,7 +200,12 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
 
   @AfterClass
   public static void tearDownClass() throws Exception {
-    PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_INHERITABLETHREADLOCAL );
+    try {
+      PluginServiceLoader.unregisterService( PurRepositoryIT.class, MetastoreLocator.class );
+      PluginServiceLoader.unregisterService( PurRepositoryIT.class, MetastoreProvider.class );
+    } finally {
+      PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_INHERITABLETHREADLOCAL );
+    }
   }
 
   @Before

--- a/plugins/pur/core/src/it/resources/jackrabbit-test-repo.xml
+++ b/plugins/pur/core/src/it/resources/jackrabbit-test-repo.xml
@@ -104,6 +104,7 @@ Jackrabbit configuration suitable for integration tests.
         class: FQN of class implementing the PersistenceManager interface
     -->
     <PersistenceManager class="org.apache.jackrabbit.core.persistence.pool.DerbyPersistenceManager">
+      <param name="driver" value="org.apache.derby.iapi.jdbc.AutoloadedDriver"/>
       <param name="url" value="jdbc:derby:${wsp.home}/db;create=true"/>
       <param name="schemaObjectPrefix" value="${wsp.name}_"/>
     </PersistenceManager>
@@ -142,6 +143,7 @@ Jackrabbit configuration suitable for integration tests.
         implementations.
     -->
     <PersistenceManager class="org.apache.jackrabbit.core.persistence.pool.DerbyPersistenceManager">
+      <param name="driver" value="org.apache.derby.iapi.jdbc.AutoloadedDriver"/>
       <param name="url" value="jdbc:derby:${rep.home}/version/db;create=true"/>
       <param name="schemaObjectPrefix" value="version_"/>
     </PersistenceManager>

--- a/plugins/pur/core/src/it/resources/repository-test-override.spring.xml
+++ b/plugins/pur/core/src/it/resources/repository-test-override.spring.xml
@@ -4,7 +4,7 @@
        xmlns:sec="http://www.springframework.org/schema/security"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-                           http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-5.8.xsd">
+                           http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-6.5.xsd">
 
   <!-- Bean definitions in this file override bean definitions in repository.spring.xml. -->
 

--- a/plugins/pur/core/src/it/resources/repository.spring.xml
+++ b/plugins/pur/core/src/it/resources/repository.spring.xml
@@ -6,7 +6,7 @@
        xmlns:sec="http://www.springframework.org/schema/security"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
                            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.3.xsd
-                           http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-5.8.xsd
+                           http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-6.5.xsd
                            http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd"
        default-lazy-init="true">
 

--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/RepositoryProxy.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/RepositoryProxy.java
@@ -453,28 +453,34 @@ public class RepositoryProxy extends AbstractRepository implements ILockService,
   private DatabaseMeta loadDatabaseMeta( String code, List<DatabaseMeta> databases ) throws KettleException {
     DataProperty codeProp = node.getProperty( code );
     if ( codeProp != null ) {
-      if ( DataNodeRef.REF_MISSING.equals( codeProp.getRef().getId() )
-          && System.getProperty( "kettle.allow_missing_refs" ) == null ) {
-        throw new KettleException( BaseMessages.getString( PKG, "RepositoryProxy.ERROR_0001_MISSING_REF" ) );
-      }
-      ObjectId databaseId = new StringObjectId( node.getProperty( code ).getRef().getId().toString() );
-      DatabaseMeta databaseMeta = DatabaseMeta.findDatabase( databases, databaseId );
-      if ( databaseMeta != null ) {
-        return databaseMeta;
-      } else {
-        // the referenced ObjectId is not in the current set of DBs. It may have been overridden by another.
-        // Try to find the original DB and load the overriding one by name.
-        DatabaseMeta orig = loadDatabaseMeta( databaseId, null );
-        if ( orig != null ) {
-          return DatabaseMeta.findDatabase( databases, orig.getName() );
-        }
-      }
+      return loadDatabaseMetaFromReference( codeProp, databases );
     } else {
       DataProperty nameProp = node.getProperty( code + PROP_CODE_NR_SEPARATOR + NAME_EXT );
       if ( nameProp != null ) {
         String dbName = nameProp.getString();
         return DatabaseMeta.findDatabase( databases, dbName );
       }
+    }
+    return null;
+  }
+
+  private DatabaseMeta loadDatabaseMetaFromReference( DataProperty codeProp, List<DatabaseMeta> databases )
+    throws KettleException {
+    if ( DataNodeRef.REF_MISSING.equals( codeProp.getRef().getId() )
+        && System.getProperty( "kettle.allow_missing_refs" ) == null ) {
+      throw new KettleException( BaseMessages.getString( PKG, "RepositoryProxy.ERROR_0001_MISSING_REF" ) );
+    }
+    ObjectId databaseId = new StringObjectId( codeProp.getRef().getId().toString() );
+    DatabaseMeta databaseMeta = DatabaseMeta.findDatabase( databases, databaseId );
+    if ( databaseMeta != null ) {
+      return databaseMeta;
+    }
+    // The referenced ObjectId is not in the current set of DBs. It may have been overridden by another.
+    // Try to find the original DB and load the overriding one by name.
+    DatabaseMeta orig = loadDatabaseMeta( databaseId, null );
+    if ( orig != null ) {
+      DatabaseMeta override = DatabaseMeta.findDatabase( databases, orig.getName() );
+      return override == null ? orig : override;
     }
     return null;
   }

--- a/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/RepositoryProxyTest.java
+++ b/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/RepositoryProxyTest.java
@@ -1,0 +1,81 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.di.repository.pur;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.pentaho.di.core.bowl.DefaultBowl;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.StringObjectId;
+import org.pentaho.platform.api.repository2.unified.data.node.DataNode;
+import org.pentaho.platform.api.repository2.unified.data.node.DataNodeRef;
+
+public class RepositoryProxyTest {
+
+  private static final String DATABASE_ATTRIBUTE = "database";
+  private static final String DATABASE_ID = "database-id";
+
+  @Test
+  public void returnsRepositoryDatabaseWhenNoLocalOverrideExists() throws Exception {
+    DatabaseMeta repositoryDatabase = mockDatabase( DATABASE_ID, "repositoryDatabase" );
+    Repository parentRepository = mockParentRepository( repositoryDatabase );
+
+    RepositoryProxy proxy = new RepositoryProxy( databaseAttributeNode(), parentRepository );
+
+    assertSame( repositoryDatabase,
+      proxy.loadDatabaseMetaFromStepAttribute( new StringObjectId( "step-id" ), DATABASE_ATTRIBUTE,
+        Collections.emptyList() ) );
+  }
+
+  @Test
+  public void prefersSameNameLocalDatabaseOverride() throws Exception {
+    DatabaseMeta repositoryDatabase = mockDatabase( DATABASE_ID, "sharedDatabase" );
+    DatabaseMeta localOverride = mockDatabase( "local-database-id", "sharedDatabase" );
+    Repository parentRepository = mockParentRepository( repositoryDatabase );
+
+    RepositoryProxy proxy = new RepositoryProxy( databaseAttributeNode(), parentRepository );
+
+    assertSame( localOverride,
+      proxy.loadDatabaseMetaFromStepAttribute( new StringObjectId( "step-id" ), DATABASE_ATTRIBUTE,
+        Collections.singletonList( localOverride ) ) );
+  }
+
+  private DataNode databaseAttributeNode() {
+    DataNode node = new DataNode( "custom" );
+    node.setProperty( DATABASE_ATTRIBUTE, new DataNodeRef( DATABASE_ID ) );
+    return node;
+  }
+
+  private DatabaseMeta mockDatabase( String objectId, String name ) {
+    DatabaseMeta database = mock( DatabaseMeta.class );
+    when( database.getObjectId() ).thenReturn( new StringObjectId( objectId ) );
+    when( database.getName() ).thenReturn( name );
+    return database;
+  }
+
+  private Repository mockParentRepository( DatabaseMeta database ) throws Exception {
+    Repository repository = mock( Repository.class );
+    when( repository.getBowl() ).thenReturn( DefaultBowl.getInstance() );
+    when( repository.loadDatabaseMeta( any( ObjectId.class ), isNull( String.class ) ) ).thenReturn( database );
+    return repository;
+  }
+}


### PR DESCRIPTION
## Summary
Backports pentaho/pentaho-kettle#10686, pentaho/pentaho-kettle#10688, and pentaho/pentaho-kettle#10689 to the 11.0 line. Additional pentaho/pentaho-kettle#10695 and https://github.com/pentaho/pentaho-kettle/pull/10696, due a detected error by copilot review.

The patch removes fixed-port HTTP test collisions, repairs job-entry fixture isolation, updates PUR Spring Security schemas and Derby configuration, initializes PUR metastore test services, and fixes `RepositoryProxy` so a referenced repository database is returned when no same-name local override exists.

## Follow-up review fixes
The HTTP ITs now build URLs from the actual bound loopback address, including IPv6-safe bracket handling, rather than resolving `localhost` separately. PUR test registrations are now explicitly unregistered in `@AfterClass`; `PluginServiceLoader` provides the owner-scoped inverse of its public registration API and has direct unit coverage.

## 11.0 adaptation
The #10688 POM conflict was resolved by retaining the 11.0 `commons-database.version` (`11.0.0.0-SNAPSHOT`) while adding the source-required `javax.transaction-api` and `pentaho-metastore-locator-core` dependencies with `test` scope. POM validation found no duplicate dependency coordinates.

## Validation
```text
mvn --batch-mode -pl engine -DrunITs compiler:compile build-helper:add-test-source@test-integration_add-source resources:copy-resources@test-integration_add-resources compiler:testCompile@test-integration_compile -Dit.test=HTTPIT,HTTPPOSTIT,JobEntryJobIT,JobEntryZipFileIT failsafe:integration-test failsafe:verify
```
Failsafe XML: 12 tests, 0 failures, 0 errors, 0 skipped.

```text
mvn --batch-mode -pl plugins/pur/core -DrunITs compiler:compile resources:testResources build-helper:add-test-source@test-integration_add-source resources:copy-resources@test-integration_add-resources compiler:testCompile@test-integration_compile -Dit.test=PurRepositoryIT failsafe:integration-test failsafe:verify
```
Failsafe XML: 74 tests, 0 failures, 0 errors, 28 skipped.

```text
mvn --batch-mode -pl plugins/pur/core -Dtest=RepositoryProxyTest test
```
Surefire XML: 2 tests, 0 failures, 0 errors, 0 skipped.

Follow-up review validation: HTTPIT + HTTPPOSTIT Failsafe XML: 9 tests, 0 failures, 0 errors, 0 skipped; `PluginServiceLoaderTest` Surefire XML: 2 tests, 0 failures, 0 errors, 0 skipped; `PurRepositoryIT` Failsafe XML: 74 tests, 0 failures, 0 errors, 28 skipped.

Backport base: `pentaho/11.0` at `da341c3b87770073c5d870d442a4ded334947f4f`.
Current head: `e1acb10bb88817c381c770dbba6ec4926d59ac15`.

Kettle #10693 is intentionally excluded; it is an independent production concurrency fix not required for these reproduced failures.