### PR TITLE
test(engine): use the bound loopback address [BACKLOG-43728]

### DIFF
--- a/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/http/HTTPIT.java
@@ -150,7 +150,9 @@ public class HTTPIT {
   }
 
   private String getHttpLocalhostUrl() {
-    return "http://" + host + ":" + httpServer.getAddress().getPort() + "/";
+    String boundHost = httpServer.getAddress().getAddress().getHostAddress();
+    return "http://" + ( boundHost.contains( ":" ) ? "[" + boundHost + "]" : boundHost )
+      + ":" + httpServer.getAddress().getPort() + "/";
   }
 
 

--- a/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
+++ b/engine/src/it/java/org/pentaho/di/trans/steps/httppost/HTTPPOSTIT.java
@@ -165,7 +165,9 @@ public class HTTPPOSTIT {
   }
 
   private String getHttpLocalhostUrl() {
-    return "http://" + host + ":" + httpServer.getAddress().getPort() + "/";
+    String boundHost = httpServer.getAddress().getAddress().getHostAddress();
+    return "http://" + ( boundHost.contains( ":" ) ? "[" + boundHost + "]" : boundHost )
+      + ":" + httpServer.getAddress().getPort() + "/";
   }
 
   @Test


### PR DESCRIPTION
## Summary
Corrects the HTTP integration tests so requests target the address actually bound by their loopback server.

`InetAddress.getLoopbackAddress()` may select IPv4 or IPv6 while `localhost` resolves independently. The test URL now derives its host from `httpServer.getAddress()` and brackets IPv6 literals correctly.

## Validation
```text
mvn --batch-mode -pl engine -DrunITs compiler:compile build-helper:add-test-source@test-integration_add-source resources:copy-resources@test-integration_add-resources compiler:testCompile@test-integration_compile -Dit.test=HTTPIT,HTTPPOSTIT failsafe:integration-test failsafe:verify
```
Failsafe XML: 9 tests, 0 failures, 0 errors, 0 skipped.

Base: `pentaho/master` at `4bf5ec0630a471c1a5fcb70a2618f7cdfbf37be1`.