### PR TITLE
fix(pur): restore dynamically registered services [BACKLOG-43728]

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/service/PluginServiceLoader.java
+++ b/core/src/main/java/org/pentaho/di/core/service/PluginServiceLoader.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -98,8 +99,9 @@ public class PluginServiceLoader {
       }
     }
     // add any providers created dynamically (not part of plugin registry initialization)
-    if ( dynamicallyAddedServices.containsKey( apiInterface.getName() ) ) {
-      unsortedServices.addAll( dynamicallyAddedServices.get( apiInterface.getName() ) );
+    Collection<ProviderServicePriority<?>> dynamicallyAdded = dynamicallyAddedServices.get( apiInterface.getName() );
+    if ( dynamicallyAdded != null ) {
+      unsortedServices.addAll( dynamicallyAdded );
     }
 
     // sort by priority, extract the service, and cast to the interface type
@@ -112,7 +114,7 @@ public class PluginServiceLoader {
     Collection<ProviderServicePriority<?>> providersAndServices;
     if ( dynamicallyAddedServices.containsKey( apiInterface.getName() ) ) {
       providersAndServices = dynamicallyAddedServices.get( apiInterface.getName() );
-      providersAndServices.removeIf( e -> e.getProvider().equals( provider ) );
+      providersAndServices.removeIf( e -> Objects.equals( e.getProvider(), provider ) );
     } else {
       providersAndServices = new ArrayList<>();
     }
@@ -122,7 +124,7 @@ public class PluginServiceLoader {
 
   public static void unregisterService( Object provider, Class<?> apiInterface ) {
     dynamicallyAddedServices.computeIfPresent( apiInterface.getName(), ( key, providersAndServices ) -> {
-      providersAndServices.removeIf( service -> service.getProvider().equals( provider ) );
+      providersAndServices.removeIf( service -> Objects.equals( service.getProvider(), provider ) );
       return providersAndServices.isEmpty() ? null : providersAndServices;
     } );
   }

--- a/core/src/main/java/org/pentaho/di/core/service/PluginServiceLoader.java
+++ b/core/src/main/java/org/pentaho/di/core/service/PluginServiceLoader.java
@@ -120,6 +120,13 @@ public class PluginServiceLoader {
     dynamicallyAddedServices.put( apiInterface.getName(), providersAndServices );
   }
 
+  public static void unregisterService( Object provider, Class<?> apiInterface ) {
+    dynamicallyAddedServices.computeIfPresent( apiInterface.getName(), ( key, providersAndServices ) -> {
+      providersAndServices.removeIf( service -> service.getProvider().equals( provider ) );
+      return providersAndServices.isEmpty() ? null : providersAndServices;
+    } );
+  }
+
   private static class WrappingClassLoaderChangingInvocationHandler implements InvocationHandler {
 
     private final Object o;

--- a/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
+++ b/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
@@ -22,17 +22,23 @@ public class PluginServiceLoaderTest {
   @Test
   public void unregisterServiceRemovesOnlyTheProviderRegistration() throws Exception {
     Object provider = new Object();
+    Object otherProvider = new Object();
     TestService service = new TestService() { };
+    TestService otherService = new TestService() { };
 
     PluginServiceLoader.registerService( provider, TestService.class, service, 0 );
+    PluginServiceLoader.registerService( otherProvider, TestService.class, otherService, 0 );
     try {
       assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+      assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( otherService ) );
 
       PluginServiceLoader.unregisterService( provider, TestService.class );
 
       assertFalse( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+      assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( otherService ) );
     } finally {
       PluginServiceLoader.unregisterService( provider, TestService.class );
+      PluginServiceLoader.unregisterService( otherProvider, TestService.class );
     }
   }
 

--- a/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
+++ b/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
@@ -36,6 +36,22 @@ public class PluginServiceLoaderTest {
     }
   }
 
+  @Test
+  public void unregisterServiceSupportsANullProvider() throws Exception {
+    TestService service = new TestService() { };
+
+    PluginServiceLoader.registerService( null, TestService.class, service, 0 );
+    try {
+      assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+
+      PluginServiceLoader.unregisterService( null, TestService.class );
+
+      assertFalse( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+    } finally {
+      PluginServiceLoader.unregisterService( null, TestService.class );
+    }
+  }
+
   private interface TestService {
   }
 }

--- a/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
+++ b/core/src/test/java/org/pentaho/di/core/service/PluginServiceLoaderTest.java
@@ -1,0 +1,41 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2031-09-03
+ ******************************************************************************/
+
+package org.pentaho.di.core.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PluginServiceLoaderTest {
+
+  @Test
+  public void unregisterServiceRemovesOnlyTheProviderRegistration() throws Exception {
+    Object provider = new Object();
+    TestService service = new TestService() { };
+
+    PluginServiceLoader.registerService( provider, TestService.class, service, 0 );
+    try {
+      assertTrue( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+
+      PluginServiceLoader.unregisterService( provider, TestService.class );
+
+      assertFalse( PluginServiceLoader.loadServices( TestService.class ).contains( service ) );
+    } finally {
+      PluginServiceLoader.unregisterService( provider, TestService.class );
+    }
+  }
+
+  private interface TestService {
+  }
+}

--- a/plugins/pur/core/src/it/java/org/pentaho/di/repository/pur/PurRepositoryIT.java
+++ b/plugins/pur/core/src/it/java/org/pentaho/di/repository/pur/PurRepositoryIT.java
@@ -201,7 +201,12 @@ public class PurRepositoryIT extends RepositoryTestBase implements ApplicationCo
 
   @AfterClass
   public static void tearDownClass() throws Exception {
-    PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_INHERITABLETHREADLOCAL );
+    try {
+      PluginServiceLoader.unregisterService( PurRepositoryIT.class, MetastoreLocator.class );
+      PluginServiceLoader.unregisterService( PurRepositoryIT.class, MetastoreProvider.class );
+    } finally {
+      PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_INHERITABLETHREADLOCAL );
+    }
   }
 
   @Before


### PR DESCRIPTION
## Summary
Restores the lifecycle boundary for dynamically registered PUR services.

`PurRepositoryIT` registered static `PluginServiceLoader` services but left them installed after the class completed. This adds the owner-scoped public `unregisterService` counterpart to `registerService`, verifies it directly, and unregisters the two PUR registrations in `@AfterClass` while preserving session strategy restoration.

## Validation
```text
mvn --batch-mode -pl core -Dtest=PluginServiceLoaderTest test
```
Surefire XML: 2 tests, 0 failures, 0 errors, 0 skipped.

```text
mvn --batch-mode -pl core install -DskipTests
mvn --batch-mode -pl plugins/pur/core -DrunITs compiler:compile resources:testResources build-helper:add-test-source@test-integration_add-source resources:copy-resources@test-integration_add-resources compiler:testCompile@test-integration_compile -Dit.test=PurRepositoryIT failsafe:integration-test failsafe:verify
```
Failsafe XML: 74 tests, 0 failures, 0 errors, 28 skipped.

```text
mvn --batch-mode -pl plugins/pur/core -Dtest=RepositoryProxyTest test
```
Surefire XML: 2 tests, 0 failures, 0 errors, 0 skipped.

Base: `pentaho/master` at `4bf5ec0630a471c1a5fcb70a2618f7cdfbf37be1`.