### PR TITLE
Fix typos in core comments

### DIFF
--- a/core/src/main/java/org/pentaho/di/core/DBCacheEntry.java
+++ b/core/src/main/java/org/pentaho/di/core/DBCacheEntry.java
@@ -106,7 +106,7 @@ public class DBCacheEntry {
    *
    * @param dos
    *          The DataOutputStream to write this entry to.
-   * @return True if all went well, false if an error occured!
+   * @return True if all went well, false if an error occurred!
    */
   public boolean write( DataOutputStream dos ) {
     try {

--- a/core/src/main/java/org/pentaho/di/core/vfs/configuration/KettleGenericFileSystemConfigBuilder.java
+++ b/core/src/main/java/org/pentaho/di/core/vfs/configuration/KettleGenericFileSystemConfigBuilder.java
@@ -74,7 +74,7 @@ public class KettleGenericFileSystemConfigBuilder extends FileSystemConfigBuilde
   }
 
   /**
-   * Extract the scheme from a Kettle VFS configuration paramter (vfs.scheme.parameter)
+   * Extract the scheme from a Kettle VFS configuration parameter (vfs.scheme.parameter)
    *
    * @param fullParameterName
    *          A VFS configuration parameter in the form of 'vfs.scheme.parameter'

--- a/core/src/main/java/org/pentaho/di/core/xml/XMLHandler.java
+++ b/core/src/main/java/org/pentaho/di/core/xml/XMLHandler.java
@@ -566,7 +566,7 @@ public class XMLHandler {
    * Load a file into an XML document
    *
    * @param fileObject The fileObject to load into a document
-   * @return the Document if all went well, null if an error occured!
+   * @return the Document if all went well, null if an error occurred!
    */
   public static Document loadXMLFile( FileObject fileObject ) throws KettleXMLException {
     return loadXMLFile( fileObject, null, false, false );
@@ -579,7 +579,7 @@ public class XMLHandler {
    * @param systemID       Provide a base for resolving relative URIs.
    * @param ignoreEntities Ignores external entities and returns an empty dummy.
    * @param namespaceAware support XML namespaces.
-   * @return the Document if all went well, null if an error occured!
+   * @return the Document if all went well, null if an error occurred!
    */
   public static Document loadXMLFile( FileObject fileObject, String systemID, boolean ignoreEntities,
                                       boolean namespaceAware ) throws KettleXMLException {
@@ -636,7 +636,7 @@ public class XMLHandler {
    * @param systemID       Provide a base for resolving relative URIs.
    * @param ignoreEntities Ignores external entities and returns an empty dummy.
    * @param namespaceAware support XML namespaces.
-   * @return the Document if all went well, null if an error occured!
+   * @return the Document if all went well, null if an error occurred!
    */
   public static Document loadXMLFile( InputStream inputStream, String systemID, boolean ignoreEntities,
                                       boolean namespaceAware ) throws KettleXMLException {
@@ -700,7 +700,7 @@ public class XMLHandler {
    * Load a file into an XML document
    *
    * @param resource The resource to load into a document
-   * @return the Document if all went well, null if an error occured!
+   * @return the Document if all went well, null if an error occurred!
    */
   public static Document loadXMLFile( URL resource ) throws KettleXMLException {
     DocumentBuilderFactory dbf;

--- a/core/src/main/java/org/pentaho/di/repository/RepositoryDirectory.java
+++ b/core/src/main/java/org/pentaho/di/repository/RepositoryDirectory.java
@@ -430,7 +430,7 @@ public class RepositoryDirectory implements RepositoryDirectoryInterface {
    *
    * @param repdirnode
    *          The node in which the Repository directory information resides.
-   * @return True if all went well, false if an error occured.
+   * @return True if all went well, false if an error occurred.
    */
   public boolean loadXML( Node repdirnode ) {
     try {


### PR DESCRIPTION
Fix common misspellings in comments, Javadoc and log/error messages:
- `occured` -> `occurred`
- `paramter` -> `parameter`

No functional changes.