### PR TITLE
Fix typos in engine comments

### DIFF
--- a/engine/src/main/java/org/pentaho/di/job/Job.java
+++ b/engine/src/main/java/org/pentaho/di/job/Job.java
@@ -977,14 +977,14 @@ public class Job extends Thread implements VariableSpace, NamedParams, HasLogCha
   }
 
   /**
-   * Set the number of occured errors to 0.
+   * Set the number of occurred errors to 0.
    */
   public void resetErrors() {
     errors.set( 0 );
   }
 
   /**
-   * Add a number of errors to the total number of erros that occured during execution.
+   * Add a number of errors to the total number of erros that occurred during execution.
    *
    * @param nrToAdd
    *          nr of errors to add.

--- a/engine/src/main/java/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryDirectoryDelegate.java
+++ b/engine/src/main/java/org/pentaho/di/repository/kdr/delegates/KettleDatabaseRepositoryDirectoryDelegate.java
@@ -97,7 +97,7 @@ public class KettleDatabaseRepositoryDirectoryDelegate extends KettleDatabaseRep
 
       return root;
     } catch ( Exception e ) {
-      throw new KettleException( "An error occured loading the directory tree from the repository", e );
+      throw new KettleException( "An error occurred loading the directory tree from the repository", e );
     }
   }
 

--- a/engine/src/main/java/org/pentaho/di/trans/step/StepErrorMeta.java
+++ b/engine/src/main/java/org/pentaho/di/trans/step/StepErrorMeta.java
@@ -56,7 +56,7 @@ public class StepErrorMeta extends ChangedFlag implements XMLInterface, Cloneabl
   private String errorDescriptionsValuename;
 
   /**
-   * the name of the field value to contain the fields for which the error(s) occured (null or empty means it's not
+   * the name of the field value to contain the fields for which the error(s) occurred (null or empty means it's not
    * needed)
    */
   private String errorFieldsValuename;
@@ -114,7 +114,7 @@ public class StepErrorMeta extends ChangedFlag implements XMLInterface, Cloneabl
    * @param errorDescriptionsValuename
    *          the name of the field value to contain the error description(s) (null or empty means it's not needed)
    * @param errorFieldsValuename
-   *          the name of the field value to contain the fields for which the error(s) occured (null or empty means it's
+   *          the name of the field value to contain the fields for which the error(s) occurred (null or empty means it's
    *          not needed)
    * @param errorCodesValuename
    *          the name of the field value to contain the error code(s) (null or empty means it's not needed)

--- a/engine/src/main/java/org/pentaho/di/trans/steps/webservices/wsdl/WsdlOpParameter.java
+++ b/engine/src/main/java/org/pentaho/di/trans/steps/webservices/wsdl/WsdlOpParameter.java
@@ -145,7 +145,7 @@ public final class WsdlOpParameter extends WsdlOpReturnType implements java.io.S
   }
 
   /**
-   * Is this paramter's name element form qualified?
+   * Is this parameter's name element form qualified?
    *
    * @return True if element form qualified.
    */


### PR DESCRIPTION
Fix common misspellings in comments, Javadoc and log/error messages:
- `occured` -> `occurred`
- `paramter` -> `parameter`

No functional changes.