### PR TITLE
Fix typos in ui dialog messages

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobLoadProgressDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobLoadProgressDialog.java
@@ -114,10 +114,10 @@ public class JobLoadProgressDialog {
       if ( krle != null ) {
         throw krle;
       }
-      new ErrorDialog( shell, "Error loading job", "An error occured loading the job!", e );
+      new ErrorDialog( shell, "Error loading job", "An error occurred loading the job!", e );
       jobInfo = null;
     } catch ( InterruptedException e ) {
-      new ErrorDialog( shell, "Error loading job", "An error occured loading the job!", e );
+      new ErrorDialog( shell, "Error loading job", "An error occurred loading the job!", e );
       jobInfo = null;
     }
 

--- a/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobSaveProgressDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobSaveProgressDialog.java
@@ -66,6 +66,7 @@ public class JobSaveProgressDialog {
       pmd.run( true, true, op );
     } catch ( InvocationTargetException | InterruptedException e ) {
       new ErrorDialog( shell, "Error saving job", "An error occurred saving the job!", e );
+      Thread.currentThread().interrupt();
       retval = false;
     }
 

--- a/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobSaveProgressDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobSaveProgressDialog.java
@@ -65,10 +65,10 @@ public class JobSaveProgressDialog {
       ProgressMonitorDialog pmd = new ProgressMonitorDialog( shell );
       pmd.run( true, true, op );
     } catch ( InvocationTargetException e ) {
-      new ErrorDialog( shell, "Error saving job", "An error occured saving the job!", e );
+      new ErrorDialog( shell, "Error saving job", "An error occurred saving the job!", e );
       retval = false;
     } catch ( InterruptedException e ) {
-      new ErrorDialog( shell, "Error saving job", "An error occured saving the job!", e );
+      new ErrorDialog( shell, "Error saving job", "An error occurred saving the job!", e );
       retval = false;
     }
 

--- a/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobSaveProgressDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/dialog/JobSaveProgressDialog.java
@@ -64,10 +64,7 @@ public class JobSaveProgressDialog {
     try {
       ProgressMonitorDialog pmd = new ProgressMonitorDialog( shell );
       pmd.run( true, true, op );
-    } catch ( InvocationTargetException e ) {
-      new ErrorDialog( shell, "Error saving job", "An error occurred saving the job!", e );
-      retval = false;
-    } catch ( InterruptedException e ) {
+    } catch ( InvocationTargetException | InterruptedException e ) {
       new ErrorDialog( shell, "Error saving job", "An error occurred saving the job!", e );
       retval = false;
     }


### PR DESCRIPTION
Fix common misspellings in comments, Javadoc and log/error messages:
- `occured` -> `occurred`
- `paramter` -> `parameter`

No functional changes.