### PR TITLE
Fix typos in plugin modules

### DIFF
--- a/plugins/gp-bulk-loader/core/src/main/java/org/pentaho/di/trans/steps/gpbulkloader/GPBulkDataOutput.java
+++ b/plugins/gp-bulk-loader/core/src/main/java/org/pentaho/di/trans/steps/gpbulkloader/GPBulkDataOutput.java
@@ -83,7 +83,7 @@ public class GPBulkDataOutput {
         output = new PrintWriter( new BufferedWriter( new OutputStreamWriter( os, encoding ) ) );
       }
     } catch ( IOException e ) {
-      throw new KettleException( "IO exception occured: " + e.getMessage(), e );
+      throw new KettleException( "IO exception occurred: " + e.getMessage(), e );
     }
   }
 

--- a/plugins/oracle-bulk-loader/impl/src/main/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkDataOutput.java
+++ b/plugins/oracle-bulk-loader/impl/src/main/java/org/pentaho/di/trans/steps/orabulkloader/OraBulkDataOutput.java
@@ -88,7 +88,7 @@ public class OraBulkDataOutput {
         output = new BufferedWriter( new OutputStreamWriter( os, encoding ) );
       }
     } catch ( IOException e ) {
-      throw new KettleException( "IO exception occured: " + e.getMessage(), e );
+      throw new KettleException( "IO exception occurred: " + e.getMessage(), e );
     }
   }
 
@@ -233,7 +233,7 @@ public class OraBulkDataOutput {
     try {
       output.append( outbuf );
     } catch ( IOException e ) {
-      throw new KettleException( "IO exception occured: " + e.getMessage(), e );
+      throw new KettleException( "IO exception occurred: " + e.getMessage(), e );
     }
   }
 

--- a/plugins/pentaho-reporting/impl/src/main/java/org/pentaho/di/trans/steps/pentahoreporting/urlrepository/FileObjectContentLocation.java
+++ b/plugins/pentaho-reporting/impl/src/main/java/org/pentaho/di/trans/steps/pentahoreporting/urlrepository/FileObjectContentLocation.java
@@ -40,7 +40,7 @@ public class FileObjectContentLocation extends FileObjectContentEntity implement
    *
    * @param parent  the parent location.
    * @param backend the backend.
-   * @throws ContentIOException if an error occured or the file did not point to a directory.
+   * @throws ContentIOException if an error occurred or the file did not point to a directory.
    */
   public FileObjectContentLocation( final ContentLocation parent, final FileObject backend ) throws ContentIOException {
     super( parent, backend );
@@ -60,7 +60,7 @@ public class FileObjectContentLocation extends FileObjectContentEntity implement
    *
    * @param repository the repository for which a location should be created.
    * @param backend    the backend.
-   * @throws ContentIOException if an error occured or the file did not point to a directory.
+   * @throws ContentIOException if an error occurred or the file did not point to a directory.
    */
   public FileObjectContentLocation( final Repository repository, final FileObject backend ) throws ContentIOException {
     super( repository, backend );
@@ -80,7 +80,7 @@ public class FileObjectContentLocation extends FileObjectContentEntity implement
    * name (according to the repository rules).
    *
    * @return the content entities for this location.
-   * @throws ContentIOException if an repository error occured.
+   * @throws ContentIOException if an repository error occurred.
    */
   public ContentEntity[] listContents() throws ContentIOException {
     try {
@@ -110,7 +110,7 @@ public class FileObjectContentLocation extends FileObjectContentEntity implement
    *
    * @param name the name of the entity to be retrieved.
    * @return the content entity for this name, never null.
-   * @throws ContentIOException if an repository error occured.
+   * @throws ContentIOException if an repository error occurred.
    */
   public ContentEntity getEntry( final String name ) throws ContentIOException {
     try {

--- a/plugins/pur/core/src/main/java/com/pentaho/di/purge/PurgeUtilityHTMLLayout.java
+++ b/plugins/pur/core/src/main/java/com/pentaho/di/purge/PurgeUtilityHTMLLayout.java
@@ -111,7 +111,7 @@ public class PurgeUtilityHTMLLayout implements StringLayout, IPurgeUtilityLayout
       try {
         time = df.format( date );
       } catch ( Exception ex ) {
-        StatusLogger.getLogger().error( "Error occured while converting date.", ex );
+        StatusLogger.getLogger().error( "Error occurred while converting date.", ex );
       }
 
       sbuf.append( LINE_SEP + "<tr>" + LINE_SEP );

--- a/plugins/pur/core/src/main/java/com/pentaho/di/purge/PurgeUtilityTextLayout.java
+++ b/plugins/pur/core/src/main/java/com/pentaho/di/purge/PurgeUtilityTextLayout.java
@@ -109,7 +109,7 @@ public class PurgeUtilityTextLayout implements StringLayout, IPurgeUtilityLayout
       try {
         time = df.format( date );
       } catch ( Exception ex ) {
-        StatusLogger.getLogger().error( "Error occured while converting date.", ex );
+        StatusLogger.getLogger().error( "Error occurred while converting date.", ex );
       }
 
       sbuf.append( time );


### PR DESCRIPTION
Fix common misspellings in comments, Javadoc and log/error messages:
- `occured` -> `occurred`
- `paramter` -> `parameter`

No functional changes.