### PR TITLE
fix: correct edit db from step [PDI-20986]

### DIFF
--- a/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
+++ b/plugins/pur/core/src/main/java/org/pentaho/di/repository/pur/PurRepository.java
@@ -15,6 +15,7 @@
 
 package org.pentaho.di.repository.pur;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.di.cluster.ClusterSchema;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.Condition;
@@ -2328,70 +2329,116 @@ public class PurRepository extends AbstractRepository implements Repository, Rec
 
     readWriteLock.writeLock().lock();
     try {
-      // Even if the object id is null, we still have to check if the element is not present in the PUR
-      // For example, if we import data from an XML file and there is a element with the same name in it.
-      //
-      if ( element.getObjectId() == null ) {
-        element.setObjectId( getDatabaseID( element.getName() ) );
-      }
+      ensureDatabaseObjectId( element );
 
-      boolean isUpdate = element.getObjectId() != null;
-      RepositoryFile file = null;
-      if ( isUpdate ) {
-        file = pur.getFileById( element.getObjectId().getId() );
-
-        // update title
-        final String title = ( (DatabaseMeta) element ).getDisplayName();
-        Date modifiedDate = null;
-        if ( versionDate != null && versionDate.getTime() != null ) {
-          modifiedDate = versionDate.getTime();
-        } else {
-          modifiedDate = new Date();
-        }
-        file = new RepositoryFile.Builder( file ).title( RepositoryFile.DEFAULT_LOCALE, title )
-          .lastModificationDate( modifiedDate ).build();
-        renameIfNecessary( element, file );
-
-        file =
-          pur.updateFile( file, new NodeRepositoryFileData( databaseMetaTransformer.elementToDataNode( element ) ),
-            versionComment );
-
+      RepositoryFile file;
+      if ( element.getObjectId() != null ) {
+        file = updateDatabaseMetaFile( element, versionComment, versionDate );
       } else {
-        Date createdDate = null;
-        if ( versionDate != null && versionDate.getTime() != null ) {
-          createdDate = versionDate.getTime();
-        } else {
-          createdDate = new Date();
-        }
-
-        file =
-          new RepositoryFile.Builder(
-            checkAndSanitize( RepositoryFilenameUtils.escape( element.getName(), pur.getReservedChars() )
-              + RepositoryObjectType.DATABASE.getExtension() ) ).title( RepositoryFile.DEFAULT_LOCALE,
-            element.getName() ).createdDate( createdDate ).versioned( VERSION_SHARED_OBJECTS ).build();
-
-        file =
-          pur.createFile( getDatabaseMetaParentFolderId(), file,
-            new NodeRepositoryFileData( databaseMetaTransformer.elementToDataNode( element ) ), versionComment );
+        file = createDatabaseMetaFile( element, versionComment, versionDate );
       }
-      // side effects
-      ObjectId objectId = new StringObjectId( file.getId().toString() );
-      element.setObjectId( objectId );
-      element.setObjectRevision( getObjectRevision( objectId, null ) );
-      if ( element instanceof ChangedFlagInterface ) {
-        ( (ChangedFlagInterface) element ).clearChanged();
-      }
-      updateSharedObjectCache( element );
+
+      applyDatabaseMetaSaveSideEffects( element, file );
     } catch ( Exception e ) {
-      // determine if there is an "access denied" issue and throw a nicer error message.
-      if ( e.getMessage().indexOf( "access denied" ) >= 0 ) {
-        throw new KettleException(
-          BaseMessages.getString( PKG, "PurRepository.ERROR_0004_DATABASE_UPDATE_ACCESS_DENIED", element.getName() ),
-          e );
-      }
+      throw toDatabaseSaveException( element, e );
     } finally {
       readWriteLock.writeLock().unlock();
     }
+  }
+
+  private void ensureDatabaseObjectId( RepositoryElementInterface element ) throws KettleException {
+    // Even if the object id is null, we still have to check if the element is not present in the PUR.
+    // For example, if we import data from an XML file and there is an element with the same name in it.
+    if ( element.getObjectId() == null ) {
+      element.setObjectId( getDatabaseID( element.getName() ) );
+    }
+  }
+
+  @VisibleForTesting
+  RepositoryFile updateDatabaseMetaFile( RepositoryElementInterface element, String versionComment,
+                                         Calendar versionDate ) throws KettleException {
+    try {
+      RepositoryFile existingFile = pur.getFileById( element.getObjectId().getId() );
+      String title = ( (DatabaseMeta) element ).getDisplayName();
+      Date modifiedDate = resolveVersionDate( versionDate );
+
+      RepositoryFile fileToUpdate = new RepositoryFile.Builder( existingFile )
+        .title( RepositoryFile.DEFAULT_LOCALE, title )
+        .lastModificationDate( modifiedDate )
+        .build();
+
+      renameIfNecessary( element, fileToUpdate );
+
+      return pur.updateFile( fileToUpdate,
+        new NodeRepositoryFileData( databaseMetaTransformer.elementToDataNode( element ) ), versionComment );
+    } catch ( Exception e ) {
+      throw toDatabaseSaveException( element, e );
+    }
+  }
+
+  @VisibleForTesting
+  RepositoryFile createDatabaseMetaFile( RepositoryElementInterface element, String versionComment,
+                                         Calendar versionDate ) throws KettleException {
+    try {
+      Date createdDate = resolveVersionDate( versionDate );
+
+      RepositoryFile file = new RepositoryFile.Builder(
+        checkAndSanitize( RepositoryFilenameUtils.escape( element.getName(), pur.getReservedChars() )
+          + RepositoryObjectType.DATABASE.getExtension() ) )
+        .title( RepositoryFile.DEFAULT_LOCALE, element.getName() )
+        .createdDate( createdDate )
+        .versioned( VERSION_SHARED_OBJECTS )
+        .build();
+
+      return pur.createFile( getDatabaseMetaParentFolderId(), file,
+        new NodeRepositoryFileData( databaseMetaTransformer.elementToDataNode( element ) ), versionComment );
+    } catch ( Exception e ) {
+      throw toDatabaseSaveException( element, e );
+    }
+  }
+
+  @VisibleForTesting
+  Date resolveVersionDate( Calendar versionDate ) {
+    if ( versionDate != null && versionDate.getTime() != null ) {
+      return versionDate.getTime();
+    }
+    return new Date();
+  }
+
+  private void applyDatabaseMetaSaveSideEffects( RepositoryElementInterface element, RepositoryFile file )
+    throws KettleException {
+    ObjectId objectId = new StringObjectId( file.getId().toString() );
+    element.setObjectId( objectId );
+    element.setObjectRevision( getObjectRevision( objectId, null ) );
+    if ( element instanceof ChangedFlagInterface ) {
+      ( (ChangedFlagInterface) element ).clearChanged();
+    }
+    updateSharedObjectCache( element );
+  }
+
+  @VisibleForTesting
+  KettleException toDatabaseSaveException( RepositoryElementInterface element, Exception e ) {
+    // Determine if there is an "access denied" issue and throw a nicer error message.
+    if ( e.getMessage() != null && e.getMessage().indexOf( "access denied" ) >= 0 ) {
+      return new KettleException(
+        BaseMessages.getString( PKG, "PurRepository.ERROR_0004_DATABASE_UPDATE_ACCESS_DENIED", element.getName() ),
+        e );
+    }
+    if ( e instanceof KettleException ) {
+      return (KettleException) e;
+    }
+    return new KettleException( e );
+  }
+
+  @VisibleForTesting
+  void setDatabaseMetaTransformerForTesting( DatabaseDelegate databaseDelegate ) {
+    this.databaseMetaTransformer = databaseDelegate;
+  }
+
+  @VisibleForTesting
+  void setSharedObjectsByTypeForTesting(
+    Map<RepositoryObjectType, List<? extends SharedObjectInterface<?>>> sharedObjectsByType ) {
+    this.sharedObjectsByType = sharedObjectsByType;
   }
 
   @Override

--- a/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/PurRepositoryTest.java
+++ b/plugins/pur/core/src/test/java/org/pentaho/di/repository/pur/PurRepositoryTest.java
@@ -20,7 +20,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Before;
@@ -28,6 +31,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPointInterface;
 import org.pentaho.di.core.extension.ExtensionPointPluginType;
@@ -42,6 +46,7 @@ import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.imp.Import;
 import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.ObjectRevision;
 import org.pentaho.di.repository.RepositoryDirectory;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.repository.RepositoryElementInterface;
@@ -58,6 +63,7 @@ import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileTree;
 import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+import org.pentaho.platform.api.repository2.unified.data.node.DataNode;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -69,6 +75,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -630,6 +637,250 @@ public class PurRepositoryTest extends RepositoryTestLazySupport {
     purRepo.init( repoMeta );
     assertTrue( purRepo.getUri().isPresent() );
     assertThat( purRepo.getUri().get(), equalTo( new URI( "http://localhost:8080/pentaho" ) ) );
+  }
+
+  @Test
+  public void testUpdateDatabaseMetaFileReturnsUpdatedFile() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( "db" );
+    databaseMeta.setObjectId( new StringObjectId( "db-id" ) );
+
+    RepositoryFile existingFile = new RepositoryFile.Builder(
+      "db" + RepositoryObjectType.DATABASE.getExtension() ).id( "db-id" ).path( "/db" ).build();
+    RepositoryFile updatedFile = new RepositoryFile.Builder( "db" + RepositoryObjectType.DATABASE.getExtension() )
+      .id( "updated-id" ).path( "/db" ).build();
+
+    when( unifiedRepository.getFileById( "db-id" ) ).thenReturn( existingFile );
+    when( databaseDelegate.elementToDataNode( any( RepositoryElementInterface.class ) ) ).thenReturn( mock( DataNode.class ) );
+    when( unifiedRepository.updateFile( any( RepositoryFile.class ), any(), anyString() ) ).thenReturn( updatedFile );
+
+    RepositoryFile result = repository.updateDatabaseMetaFile( databaseMeta, "version comment", Calendar.getInstance() );
+
+    assertEquals( updatedFile, result );
+  }
+
+  @Test
+  public void testUpdateDatabaseMetaFileWrapsFailureInKettleException() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( "db" );
+    databaseMeta.setObjectId( new StringObjectId( "db-id" ) );
+
+    RepositoryFile existingFile = new RepositoryFile.Builder(
+      "db" + RepositoryObjectType.DATABASE.getExtension() ).id( "db-id" ).path( "/db" ).build();
+
+    when( unifiedRepository.getFileById( "db-id" ) ).thenReturn( existingFile );
+    when( databaseDelegate.elementToDataNode( any( RepositoryElementInterface.class ) ) ).thenReturn( mock( DataNode.class ) );
+    when( unifiedRepository.updateFile( any( RepositoryFile.class ), any(), anyString() ) )
+      .thenThrow( new RuntimeException( "boom" ) );
+
+    try {
+      repository.updateDatabaseMetaFile( databaseMeta, "version comment", Calendar.getInstance() );
+      fail( "Expected KettleException" );
+    } catch ( KettleException e ) {
+      assertThat( e.getCause(), is( instanceOf( RuntimeException.class ) ) );
+      assertEquals( "boom", e.getCause().getMessage() );
+    }
+  }
+
+  @Test
+  public void testSaveDatabaseMetaUpdatePathAndSideEffects() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( "db" );
+    databaseMeta.setObjectId( new StringObjectId( "db-id" ) );
+
+    RepositoryFile existingFile = new RepositoryFile.Builder(
+      "db" + RepositoryObjectType.DATABASE.getExtension() ).id( "db-id" ).path( "/db" ).build();
+    RepositoryFile updatedFile = new RepositoryFile.Builder( "db" + RepositoryObjectType.DATABASE.getExtension() )
+      .id( "updated-id" ).path( "/db" ).build();
+
+    when( unifiedRepository.getFileById( "db-id" ) ).thenReturn( existingFile );
+    when( databaseDelegate.elementToDataNode( any( RepositoryElementInterface.class ) ) ).thenReturn( mock( DataNode.class ) );
+    when( unifiedRepository.updateFile( any( RepositoryFile.class ), any(), anyString() ) ).thenReturn( updatedFile );
+
+    repository.saveDatabaseMeta( databaseMeta, "version comment", Calendar.getInstance() );
+
+    verify( unifiedRepository, times( 1 ) ).updateFile( any( RepositoryFile.class ), any(), anyString() );
+    assertEquals( "updated-id", databaseMeta.getObjectId().getId() );
+  }
+
+  @Test
+  public void testSaveDatabaseMetaCreatePathWhenObjectIdMissing() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( "db" );
+
+    RepositoryFile createdFile = new RepositoryFile.Builder(
+      "db" + RepositoryObjectType.DATABASE.getExtension() ).id( "created-id" ).path( "/db" ).build();
+
+    doReturn( null ).when( repository ).getDatabaseID( "db" );
+    when( unifiedRepository.getReservedChars() ).thenReturn( Collections.emptyList() );
+    when( databaseDelegate.elementToDataNode( any( RepositoryElementInterface.class ) ) ).thenReturn( mock( DataNode.class ) );
+    when( unifiedRepository.createFile( any( Serializable.class ), any( RepositoryFile.class ), any(), anyString() ) )
+      .thenReturn( createdFile );
+
+    repository.saveDatabaseMeta( databaseMeta, "version comment", null );
+
+    verify( unifiedRepository, times( 1 ) )
+      .createFile( any( Serializable.class ), any( RepositoryFile.class ), any(), anyString() );
+    assertEquals( "created-id", databaseMeta.getObjectId().getId() );
+  }
+
+  @Test
+  public void testSaveDatabaseMetaWrapsAndRethrowsKettleException() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( "db" );
+    databaseMeta.setObjectId( new StringObjectId( "db-id" ) );
+
+    RepositoryFile existingFile = new RepositoryFile.Builder(
+      "db" + RepositoryObjectType.DATABASE.getExtension() ).id( "db-id" ).path( "/db" ).build();
+
+    when( unifiedRepository.getFileById( "db-id" ) ).thenReturn( existingFile );
+    when( databaseDelegate.elementToDataNode( any( RepositoryElementInterface.class ) ) ).thenReturn( mock( DataNode.class ) );
+    when( unifiedRepository.updateFile( any( RepositoryFile.class ), any(), anyString() ) )
+      .thenThrow( new RuntimeException( "boom" ) );
+
+    try {
+      repository.saveDatabaseMeta( databaseMeta, "version comment", Calendar.getInstance() );
+      fail( "Expected KettleException" );
+    } catch ( KettleException e ) {
+      assertThat( e.getCause(), is( instanceOf( RuntimeException.class ) ) );
+      assertEquals( "boom", e.getCause().getMessage() );
+    }
+  }
+
+  @Test
+  public void testCreateDatabaseMetaFileReturnsCreatedFile() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( "db" );
+
+    RepositoryFile createdFile = new RepositoryFile.Builder(
+      "db" + RepositoryObjectType.DATABASE.getExtension() ).id( "created-id" ).path( "/db" ).build();
+
+    when( databaseDelegate.elementToDataNode( any( RepositoryElementInterface.class ) ) ).thenReturn( mock( DataNode.class ) );
+    when( unifiedRepository.createFile( any( Serializable.class ), any( RepositoryFile.class ), any(), anyString() ) )
+      .thenReturn( createdFile );
+
+    RepositoryFile result = repository.createDatabaseMetaFile( databaseMeta, "version comment", Calendar.getInstance() );
+
+    assertEquals( createdFile, result );
+  }
+
+  @Test
+  public void testCreateDatabaseMetaFileWrapsFailureInKettleException() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( "db" );
+
+    when( databaseDelegate.elementToDataNode( any( RepositoryElementInterface.class ) ) ).thenReturn( mock( DataNode.class ) );
+    when( unifiedRepository.createFile( any( Serializable.class ), any( RepositoryFile.class ), any(), anyString() ) )
+      .thenThrow( new RuntimeException( "boom" ) );
+
+    try {
+      repository.createDatabaseMetaFile( databaseMeta, "version comment", Calendar.getInstance() );
+      fail( "Expected KettleException" );
+    } catch ( KettleException e ) {
+      assertThat( e.getCause(), is( instanceOf( RuntimeException.class ) ) );
+      assertEquals( "boom", e.getCause().getMessage() );
+    }
+  }
+
+  @Test
+  public void testResolveVersionDateReturnsCurrentDateWhenNull() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    Date before = new Date();
+    Date result = repository.resolveVersionDate( null );
+    Date after = new Date();
+
+    assertTrue( !result.before( before ) && !result.after( after ) );
+  }
+
+  @Test
+  public void testResolveVersionDateReturnsCurrentDateWhenCalendarTimeIsNull() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    Calendar mockedCalendar = mock( Calendar.class );
+    when( mockedCalendar.getTime() ).thenReturn( null );
+
+    Date before = new Date();
+    Date result = repository.resolveVersionDate( mockedCalendar );
+    Date after = new Date();
+
+    assertTrue( !result.before( before ) && !result.after( after ) );
+  }
+
+  @Test
+  public void testToDatabaseSaveExceptionReturnsAccessDeniedMessage() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( "restricted-db" );
+
+    KettleException result = repository.toDatabaseSaveException( databaseMeta,
+      new RuntimeException( "access denied for update" ) );
+
+    assertThat( result.getCause(), is( instanceOf( RuntimeException.class ) ) );
+  }
+
+  @Test
+  public void testToDatabaseSaveExceptionReturnsOriginalKettleException() throws Exception {
+    IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+    DatabaseDelegate databaseDelegate = mock( DatabaseDelegate.class );
+    PurRepository repository = createRepositoryForDatabaseSaveTests( unifiedRepository, databaseDelegate );
+
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( "db" );
+
+    KettleException input = new KettleException( "already kettle" );
+    KettleException result = repository.toDatabaseSaveException( databaseMeta, input );
+
+    assertEquals( input, result );
+  }
+
+  private PurRepository createRepositoryForDatabaseSaveTests( IUnifiedRepository unifiedRepository,
+                                                              DatabaseDelegate databaseDelegate ) {
+    PurRepository repository = Mockito.spy( new PurRepository() );
+    repository.init( mock( PurRepositoryMeta.class ) );
+    repository.setTest( unifiedRepository );
+    repository.setDatabaseMetaTransformerForTesting( databaseDelegate );
+    Map sharedObjectCache = new EnumMap( RepositoryObjectType.class );
+    sharedObjectCache.put( RepositoryObjectType.DATABASE, new ArrayList<>() );
+    repository.setSharedObjectsByTypeForTesting( sharedObjectCache );
+    doReturn( mock( ObjectRevision.class ) ).when( repository ).createObjectRevision( any() );
+    doReturn( "db-parent-id" ).when( repository ).getDatabaseMetaParentFolderId();
+    return repository;
   }
 
 }

--- a/ui/src/main/java/org/pentaho/di/ui/job/entry/JobEntryDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/job/entry/JobEntryDialog.java
@@ -405,38 +405,20 @@ public class JobEntryDialog extends Dialog {
 
     @Override public void widgetSelected( SelectionEvent e ) {
       DatabaseMeta databaseMeta = jobMeta.findDatabase( wConnection.getText() );
-      String originalName = databaseMeta.getName();
-      DatabaseManagementInterface applicableDbMgr = null;
       if ( databaseMeta != null ) {
         try {
-          // Check each database manager in precedence order (bowl, global, local) to find which one holds the
-          // connection being edited.
-          DatabaseManagementInterface dbMgr =
-            spoonSupplier.get().getManagementBowl().getManager( DatabaseManagementInterface.class );
-          DatabaseManagementInterface globalDbMgr =
-            spoonSupplier.get().getGlobalManagementBowl().getManager( DatabaseManagementInterface.class );
-          DatabaseManagementInterface jobDbMgr = jobMeta.getDatabaseManagementInterface();
-
-          if ( applicableDbMgr == null && dbMgr.get( originalName ) != null ) {
-            applicableDbMgr = dbMgr;
-          } else if ( applicableDbMgr == null && globalDbMgr.get( originalName ) != null ) {
-            applicableDbMgr = globalDbMgr;
-          } else if ( applicableDbMgr == null && jobDbMgr.get( originalName ) != null ) {
-            applicableDbMgr = jobDbMgr;
-          }
+          String originalName = databaseMeta.getName();
+          DatabaseManagementInterface applicableDbMgr = DialogUtils.resolveContainingDatabaseManager(
+            spoonSupplier.get(), jobMeta.getDatabaseManagementInterface(), originalName );
 
           // cloning to avoid spoiling data on cancel or incorrect input
           DatabaseMeta clone = (DatabaseMeta) databaseMeta.clone();
-          // setting old Id, so a repository (if it used) could find and replace the existing connection
-          clone.setObjectId( databaseMeta.getObjectId() );
           String editedConnectionName = showDbDialogUnlessCancelledOrValid( clone, databaseMeta, applicableDbMgr );
           // name collision check has already happened. from here on, the new name is assumed to be ok.
           if ( editedConnectionName != null ) {
-            // To prevent the connection from moving between levels, the connection being edited is removed from and
-            // then added back to its original database manager.
-            applicableDbMgr.remove( databaseMeta );
-            applicableDbMgr.add( clone );
+            DialogUtils.persistEditedConnection( applicableDbMgr, databaseMeta, clone, editedConnectionName );
             reinitConnectionDropDown( wConnection, editedConnectionName );
+            spoonSupplier.get().refreshDbConnection( editedConnectionName );
             spoonSupplier.get().refreshTree( DBConnectionFolderProvider.STRING_CONNECTIONS );
           }
         } catch ( KettleException ex ) {

--- a/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
+++ b/ui/src/main/java/org/pentaho/di/ui/trans/step/BaseStepDialog.java
@@ -1544,40 +1544,23 @@ public class BaseStepDialog extends Dialog {
       this.wConnection = wConnection;
     }
 
+    @Override
     public void widgetSelected( SelectionEvent e ) {
       DatabaseMeta databaseMeta = transMeta.findDatabase( wConnection.getText() );
-      String originalName = databaseMeta.getName();
-      DatabaseManagementInterface applicableDbMgr = null;
       if ( databaseMeta != null ) {
         try {
-          // Check each database manager in precedence order (bowl, global, local) to find which one holds the
-          // connection being edited.
-          DatabaseManagementInterface dbMgr =
-            spoonSupplier.get().getManagementBowl().getManager( DatabaseManagementInterface.class );
-          DatabaseManagementInterface globalDbMgr =
-            spoonSupplier.get().getGlobalManagementBowl().getManager( DatabaseManagementInterface.class );
-          DatabaseManagementInterface transDbMgr = transMeta.getDatabaseManagementInterface();
-
-          if ( applicableDbMgr == null && dbMgr.get( originalName ) != null ) {
-            applicableDbMgr = dbMgr;
-          } else if ( applicableDbMgr == null && globalDbMgr.get( originalName ) != null ) {
-            applicableDbMgr = globalDbMgr;
-          } else if ( applicableDbMgr == null && transDbMgr.get( originalName ) != null ) {
-            applicableDbMgr = transDbMgr;
-          }
+          String originalName = databaseMeta.getName();
+          DatabaseManagementInterface applicableDbMgr = DialogUtils.resolveContainingDatabaseManager(
+            spoonSupplier.get(), transMeta.getDatabaseManagementInterface(), originalName );
 
           // cloning to avoid spoiling data on cancel or incorrect input
           DatabaseMeta clone = (DatabaseMeta) databaseMeta.clone();
-          // setting old Id, so a repository (if it used) could find and replace the existing connection
-          clone.setObjectId( databaseMeta.getObjectId() );
           String editedConnectionName = showDbDialogUnlessCancelledOrValid( clone, databaseMeta, applicableDbMgr );
           // name collision check has already happened. from here on, the new name is assumed to be ok.
-          if ( editedConnectionName != null ) {
-            // To prevent the connection from moving between levels, the connection being edited is removed from and
-            // then added back to its original database manager.
-            applicableDbMgr.remove( databaseMeta );
-            applicableDbMgr.add( clone );
+          if ( editedConnectionName != null) {
+            DialogUtils.persistEditedConnection( applicableDbMgr, databaseMeta, clone, editedConnectionName );
             reinitConnectionDropDown( wConnection, editedConnectionName );
+            spoonSupplier.get().refreshDbConnection( editedConnectionName );
             spoonSupplier.get().refreshTree( DBConnectionFolderProvider.STRING_CONNECTIONS );
           }
         } catch ( KettleException ex ) {

--- a/ui/src/main/java/org/pentaho/di/ui/util/DialogUtils.java
+++ b/ui/src/main/java/org/pentaho/di/ui/util/DialogUtils.java
@@ -16,12 +16,17 @@
 package org.pentaho.di.ui.util;
 
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.repository.RepositoryElementMetaInterface;
+import org.pentaho.di.shared.DatabaseManagementInterface;
 import org.pentaho.di.shared.SharedObjectInterface;
+import org.pentaho.di.ui.spoon.Spoon;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Objects;
 
 /**
  * @author Andrey Khayrutdinov
@@ -74,6 +79,67 @@ public class DialogUtils {
       path = path.replace( parentPath, "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_DIRECTORY + "}" );
     }
     return path;
+  }
+
+  /**
+   * Resolves the manager containing a connection by name.
+   * <p>
+   * Lookup order:
+   * 1. Spoon's management bowl database manager
+   * 2. Spoon's global management bowl database manager
+   * 3. The provided local manager (for job/trans local connections)
+   *
+   * @param spoon the active Spoon instance
+   * @param localDbMgr the local job/trans database manager
+   * @param originalName the connection name to resolve
+   * @return the manager that contains {@code originalName}
+   * @throws IllegalArgumentException when the connection does not exist in any candidate manager
+   * @throws KettleException if Spoon manager access fails
+   */
+  public static DatabaseManagementInterface resolveContainingDatabaseManager( Spoon spoon,
+                                                                              DatabaseManagementInterface localDbMgr,
+                                                                              String originalName )
+    throws KettleException {
+    Objects.requireNonNull( originalName, "originalName must not be null" );
+    DatabaseManagementInterface dbMgr = spoon.getManagementBowl().getManager( DatabaseManagementInterface.class );
+    DatabaseManagementInterface globalDbMgr = spoon.getGlobalManagementBowl().getManager( DatabaseManagementInterface.class );
+
+    if ( dbMgr.get( originalName ) != null ) {
+      return dbMgr;
+    }
+    if ( globalDbMgr.get( originalName ) != null ) {
+      return globalDbMgr;
+    }
+    if ( localDbMgr.get( originalName ) != null ) {
+      return localDbMgr;
+    }
+    throw new IllegalArgumentException( "Connection name not found in any database manager: " + originalName );
+  }
+
+  /**
+   * Persists an edited connection in its original manager.
+   * <p>
+   * If the name changed beyond case-only differences, the old entry is removed and the edited
+   * connection is re-added with a null object id so it is treated as a new object at save time.
+   *
+   * @param applicableDbMgr manager that owns the original connection
+   * @param originalConnection original connection before edit
+   * @param editedConnection edited connection to persist
+   * @param editedConnectionName final user-approved connection name
+   * @throws KettleException if the manager cannot remove/add the connection
+   */
+  public static void persistEditedConnection( DatabaseManagementInterface applicableDbMgr,
+                                              DatabaseMeta originalConnection,
+                                              DatabaseMeta editedConnection,
+                                              String editedConnectionName ) throws KettleException {
+    Objects.requireNonNull( originalConnection.getName(), "originalConnection name must not be null" );
+    if ( !editedConnectionName.equalsIgnoreCase( originalConnection.getName() ) ) {
+      // To prevent the connection from moving between levels, remove then re-add to original manager.
+      applicableDbMgr.remove( originalConnection );
+      // Clear objectId because this is persisted as a newly added object.
+      editedConnection.setObjectId( null );
+    }
+    applicableDbMgr.add( editedConnection );
   }
 
 }

--- a/ui/src/test/java/org/pentaho/di/ui/job/entry/JobEntryDialog_ConnectionLine_Test.java
+++ b/ui/src/test/java/org/pentaho/di/ui/job/entry/JobEntryDialog_ConnectionLine_Test.java
@@ -20,6 +20,7 @@ import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.shared.DatabaseManagementInterface;
 import org.pentaho.di.shared.MemorySharedObjectsIO;
 import org.pentaho.di.ui.core.database.dialog.DatabaseDialog;
@@ -37,6 +38,8 @@ import org.mockito.stubbing.Answer;
 import org.powermock.reflect.Whitebox;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.clearInvocations;
@@ -177,6 +180,39 @@ public class JobEntryDialog_ConnectionLine_Test {
     assertTotalDbs( jobMeta, 1 );
     assertNumberOfGlobalDBs( 1 );
     assertNumberOfLocalDBs( jobMeta, 0 );
+  }
+
+  @Test
+  public void edits_globalConnectionWhenRenamed_clearsObjectIdAndRefreshesEditedConnection() throws Exception {
+    JobMeta jobMeta = new JobMeta();
+    DatabaseMeta db = createDefaultDatabase();
+    ObjectId objectId = mock( ObjectId.class );
+    db.setObjectId( objectId );
+    dbMgr.add( db );
+
+    invokeEditConnectionListener( jobMeta, INPUT_NAME );
+
+    DatabaseMeta editedDb = dbMgr.get( INPUT_NAME );
+    assertNotNull( editedDb );
+    assertNull( editedDb.getObjectId() );
+    verify( mockSpoon, times( 1 ) ).refreshDbConnection( INPUT_NAME );
+  }
+
+  @Test
+  public void edits_globalConnectionWhenRenamedByCaseOnly_preservesObjectIdAndRefreshesEditedConnection() throws Exception {
+    JobMeta jobMeta = new JobMeta();
+    DatabaseMeta db = createDefaultDatabase();
+    ObjectId objectId = mock( ObjectId.class );
+    db.setObjectId( objectId );
+    dbMgr.add( db );
+
+    String editedConnectionName = INITIAL_NAME.toUpperCase();
+    invokeEditConnectionListener( jobMeta, editedConnectionName );
+
+    DatabaseMeta editedDb = dbMgr.get( editedConnectionName );
+    assertNotNull( editedDb );
+    assertNotNull( editedDb.getObjectId() );
+    verify( mockSpoon, times( 1 ) ).refreshDbConnection( editedConnectionName );
   }
 
   @Test

--- a/ui/src/test/java/org/pentaho/di/ui/trans/step/EditConnectionListenerTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/trans/step/EditConnectionListenerTest.java
@@ -14,25 +14,38 @@
 
 package org.pentaho.di.ui.trans.step;
 
+import org.pentaho.di.core.bowl.Bowl;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.junit.rules.RestorePDIEngineEnvironment;
+import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.shared.DatabaseManagementInterface;
 import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.trans.step.BaseStepDialog.EditConnectionListener;
+
+import java.util.function.Supplier;
 
 
 import org.eclipse.swt.custom.CCombo;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.reflect.Whitebox;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class EditConnectionListenerTest {
@@ -46,23 +59,91 @@ public class EditConnectionListenerTest {
 
   private EditConnectionListener editConnectionListener;
 
+  private DatabaseManagementInterface managementDbMgr;
+
+  private Spoon spoon;
+
   @BeforeClass
   public static void initKettle() throws Exception {
     KettleEnvironment.init();
   }
 
   @Before
-  public void init() {
+  public void init() throws Exception {
     dialog = mock( BaseStepDialog.class );
     when( dialog.showDbDialogUnlessCancelledOrValid( anyDbMeta(), anyDbMeta(), anyDbMgr() ) ).thenAnswer(
       new PropsSettingAnswer(
         TEST_NAME, TEST_HOST ) );
     dialog.transMeta = spy( new TransMeta() );
+
+    Supplier<Spoon> spoonSupplier = mock( Supplier.class );
+    spoon = mock( Spoon.class );
+    Bowl managementBowl = mock( Bowl.class );
+    Bowl globalBowl = mock( Bowl.class );
+    managementDbMgr = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface globalDbMgr = mock( DatabaseManagementInterface.class );
+
+    Whitebox.setInternalState( dialog, "spoonSupplier", spoonSupplier );
+    when( spoonSupplier.get() ).thenReturn( spoon );
+    when( spoon.getManagementBowl() ).thenReturn( managementBowl );
+    when( spoon.getGlobalManagementBowl() ).thenReturn( globalBowl );
+    when( managementBowl.getManager( DatabaseManagementInterface.class ) ).thenReturn( managementDbMgr );
+    when( globalBowl.getManager( DatabaseManagementInterface.class ) ).thenReturn( globalDbMgr );
+
     CCombo combo = mock( CCombo.class );
     when( combo.getText() ).thenReturn( TEST_NAME );
 
     editConnectionListener = spy( dialog.new EditConnectionListener( combo ) );
     doNothing().when( editConnectionListener ).showErrorDialog( any( Exception.class ) );
+  }
+
+  @Test
+  public void widgetSelected_refreshesEditedConnectionAndRemovesWhenRenamed() throws Exception {
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( TEST_NAME );
+    ObjectId objectId = mock( ObjectId.class );
+    databaseMeta.setObjectId( objectId );
+    dialog.transMeta.addDatabase( databaseMeta );
+
+    when( managementDbMgr.get( TEST_NAME ) ).thenReturn( databaseMeta );
+    when( dialog.showDbDialogUnlessCancelledOrValid( anyDbMeta(), anyDbMeta(), anyDbMgr() ) ).thenAnswer( invocation -> {
+      DatabaseMeta clonedMeta = (DatabaseMeta) invocation.getArguments()[ 0 ];
+      clonedMeta.setName( "RENAMED" );
+      return "RENAMED";
+    } );
+
+    editConnectionListener.widgetSelected( null );
+
+    verify( managementDbMgr, times( 1 ) ).remove( databaseMeta );
+    ArgumentCaptor<DatabaseMeta> addedDatabaseCaptor = ArgumentCaptor.forClass( DatabaseMeta.class );
+    verify( managementDbMgr, times( 1 ) ).add( addedDatabaseCaptor.capture() );
+    assertNull( addedDatabaseCaptor.getValue().getObjectId() );
+    verify( spoon, times( 1 ) ).refreshDbConnection( "RENAMED" );
+  }
+
+  @Test
+  public void widgetSelected_refreshesEditedConnectionAndSkipsRemoveWhenRenameIsCaseOnly() throws Exception {
+    DatabaseMeta databaseMeta = new DatabaseMeta();
+    databaseMeta.setName( TEST_NAME );
+    ObjectId objectId = mock( ObjectId.class );
+    databaseMeta.setObjectId( objectId );
+    dialog.transMeta.addDatabase( databaseMeta );
+
+    String editedConnectionName = TEST_NAME.toUpperCase();
+    when( managementDbMgr.get( TEST_NAME ) ).thenReturn( databaseMeta );
+    when( dialog.showDbDialogUnlessCancelledOrValid( anyDbMeta(), anyDbMeta(), anyDbMgr() ) ).thenAnswer( invocation -> {
+      DatabaseMeta clonedMeta = (DatabaseMeta) invocation.getArguments()[ 0 ];
+      clonedMeta.setName( editedConnectionName );
+      return editedConnectionName;
+    } );
+
+    editConnectionListener.widgetSelected( null );
+
+    verify( managementDbMgr, never() ).remove( databaseMeta );
+    ArgumentCaptor<DatabaseMeta> addedDatabaseCaptor = ArgumentCaptor.forClass( DatabaseMeta.class );
+    verify( managementDbMgr, times( 1 ) ).add( addedDatabaseCaptor.capture() );
+    assertNotNull( addedDatabaseCaptor.getValue().getObjectId() );
+    verify( spoon, times( 1 ) ).refreshDbConnection( editedConnectionName );
   }
 
   private static class PropsSettingAnswer implements Answer<String> {

--- a/ui/src/test/java/org/pentaho/di/ui/util/DialogUtilsTest.java
+++ b/ui/src/test/java/org/pentaho/di/ui/util/DialogUtilsTest.java
@@ -17,6 +17,7 @@ package org.pentaho.di.ui.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -26,10 +27,15 @@ import static org.pentaho.di.ui.util.DialogUtils.objectWithTheSameNameExists;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.pentaho.di.core.bowl.Bowl;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
 import org.junit.Test;
 import org.pentaho.di.repository.RepositoryDirectoryInterface;
 import org.pentaho.di.repository.RepositoryElementMetaInterface;
+import org.pentaho.di.shared.DatabaseManagementInterface;
 import org.pentaho.di.shared.SharedObjectInterface;
+import org.pentaho.di.ui.spoon.Spoon;
 
 /**
  * @author Andrey Khayrutdinov
@@ -124,6 +130,90 @@ public class DialogUtilsTest {
 
     String newPath = DialogUtils.getPath( parentPath, path );
     assertEquals( "${Internal.Entry.Current.Directory}/path/to/file", newPath );
+  }
+
+  @Test
+  public void resolveContainingDatabaseManager_prefersSpoonLocalManager() throws KettleException {
+    DatabaseManagementInterface spoonLocal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface spoonGlobal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface localDbMgr = mock( DatabaseManagementInterface.class );
+
+    when( spoonLocal.get( "conn" ) ).thenReturn( mock( DatabaseMeta.class ) );
+    when( spoonGlobal.get( "conn" ) ).thenReturn( mock( DatabaseMeta.class ) );
+    when( localDbMgr.get( "conn" ) ).thenReturn( mock( DatabaseMeta.class ) );
+
+    DatabaseManagementInterface result = DialogUtils.resolveContainingDatabaseManager(
+      mockSpoon( spoonLocal, spoonGlobal ), localDbMgr, "conn" );
+
+    assertSame( spoonLocal, result );
+  }
+
+  @Test
+  public void resolveContainingDatabaseManager_fallsBackToSpoonGlobalManager() throws KettleException {
+    DatabaseManagementInterface spoonLocal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface spoonGlobal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface localDbMgr = mock( DatabaseManagementInterface.class );
+
+    when( spoonLocal.get( "conn" ) ).thenReturn( null );
+    when( spoonGlobal.get( "conn" ) ).thenReturn( mock( DatabaseMeta.class ) );
+    when( localDbMgr.get( "conn" ) ).thenReturn( mock( DatabaseMeta.class ) );
+
+    DatabaseManagementInterface result = DialogUtils.resolveContainingDatabaseManager(
+      mockSpoon( spoonLocal, spoonGlobal ), localDbMgr, "conn" );
+
+    assertSame( spoonGlobal, result );
+  }
+
+  @Test
+  public void resolveContainingDatabaseManager_fallsBackToLocalManager() throws KettleException {
+    DatabaseManagementInterface spoonLocal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface spoonGlobal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface localDbMgr = mock( DatabaseManagementInterface.class );
+
+    when( spoonLocal.get( "conn" ) ).thenReturn( null );
+    when( spoonGlobal.get( "conn" ) ).thenReturn( null );
+    when( localDbMgr.get( "conn" ) ).thenReturn( mock( DatabaseMeta.class ) );
+
+    DatabaseManagementInterface result = DialogUtils.resolveContainingDatabaseManager(
+      mockSpoon( spoonLocal, spoonGlobal ), localDbMgr, "conn" );
+
+    assertSame( localDbMgr, result );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void resolveContainingDatabaseManager_throwsWhenConnectionMissingEverywhere() throws KettleException {
+    DatabaseManagementInterface spoonLocal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface spoonGlobal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface localDbMgr = mock( DatabaseManagementInterface.class );
+
+    when( spoonLocal.get( "missing" ) ).thenReturn( null );
+    when( spoonGlobal.get( "missing" ) ).thenReturn( null );
+    when( localDbMgr.get( "missing" ) ).thenReturn( null );
+
+    DialogUtils.resolveContainingDatabaseManager( mockSpoon( spoonLocal, spoonGlobal ), localDbMgr, "missing" );
+  }
+
+  @Test( expected = NullPointerException.class )
+  public void resolveContainingDatabaseManager_throwsWhenOriginalNameIsNull() throws KettleException {
+    DatabaseManagementInterface spoonLocal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface spoonGlobal = mock( DatabaseManagementInterface.class );
+    DatabaseManagementInterface localDbMgr = mock( DatabaseManagementInterface.class );
+
+    DialogUtils.resolveContainingDatabaseManager( mockSpoon( spoonLocal, spoonGlobal ), localDbMgr, null );
+  }
+
+  private Spoon mockSpoon( DatabaseManagementInterface spoonLocal,
+                           DatabaseManagementInterface spoonGlobal ) throws KettleException {
+    Spoon spoon = mock( Spoon.class );
+    Bowl managementBowl = mock( Bowl.class );
+    Bowl globalBowl = mock( Bowl.class );
+
+    when( spoon.getManagementBowl() ).thenReturn( managementBowl );
+    when( spoon.getGlobalManagementBowl() ).thenReturn( globalBowl );
+    when( managementBowl.getManager( DatabaseManagementInterface.class ) ).thenReturn( spoonLocal );
+    when( globalBowl.getManager( DatabaseManagementInterface.class ) ).thenReturn( spoonGlobal );
+
+    return spoon;
   }
 
 }


### PR DESCRIPTION
The cause was obscured because we were dropping an exception, resulting in
confusing UI behavior and incorrect cache state. Now propagating the exception
from PurRepository, and this area was refactored to make sonar happy with the
complexity.

The overall edit logic was incorrect and out of date with that from Spoon,
for both Steps and JobEntries. Now we only delete first if the name has
changed, and clear the object id if we will be adding a new database
(after deleting the old name).
