### PR TITLE
[DEVO-14362] Repoint Maven repository URLs to repo.pentaho.com

### DIFF
--- a/plugins/file-stream/pom.xml
+++ b/plugins/file-stream/pom.xml
@@ -48,7 +48,7 @@
     <repository>
       <id>pentaho-nexus</id>
       <name>PentahoNexus</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
     </repository>
   </repositories>
 
@@ -56,7 +56,7 @@
     <pluginRepository>
       <id>pentaho-public-plugins</id>
       <name>Pentaho Public Plugins</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/plugins/streaming/impls/mqtt/pom.xml
+++ b/plugins/streaming/impls/mqtt/pom.xml
@@ -48,7 +48,7 @@
     <repository>
       <id>pentaho-nexus</id>
       <name>PentahoNexus</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
     </repository>
   </repositories>
 
@@ -56,7 +56,7 @@
     <pluginRepository>
       <id>pentaho-public-plugins</id>
       <name>Pentaho Public Plugins</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,7 @@
     <repository>
       <id>pentaho-public</id>
       <name>Pentaho Public</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <releases>
         <enabled>true</enabled>
         <updatePolicy>daily</updatePolicy>
@@ -463,7 +463,7 @@
     <pluginRepository>
       <id>pentaho-public-plugins</id>
       <name>Pentaho Public Plugins</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
### DEVO-14362 — repoint Maven repository URLs to `repo.pentaho.com`

Replaces the retiring host `repo.orl.eng.hitachivantara.com` with
`repo.pentaho.com`.

**Change:** 3 POM file(s), 6 occurrence(s). Private (`pntprv-*`) paths present: no.

**Host-only substitution.** Scheme, the `/artifactory/<path>/` segment and any
trailing slash are byte-identical; repository `<id>` and `<name>` are
untouched. Verified with `git diff --check` and a hostname-normalised
before/after diff that comes back empty, so nothing but the hostname moved.

**Files changed:**
  - `plugins/file-stream/pom.xml`
  - `plugins/streaming/impls/mqtt/pom.xml`
  - `pom.xml`

**Verification:** `mvn -q validate` passes.

---

This is part of a **coordinated change across 87 repositories in two orgs**
(`pentaho` and `webdetails`), tracked under DEVO-14362.

The full PR index — one row per repository, including those deliberately
skipped — is maintained at:
https://github.com/cardosov/devops-tasks/blob/task/devo-14362/.agent/memory/pull-requests.md

Please do not merge until the batch is reviewed as a whole.
