### PR TITLE
DEVO-14362: point Maven repository URLs at repo.pentaho.com (10.2)

### DIFF
--- a/plugins/file-stream/pom.xml
+++ b/plugins/file-stream/pom.xml
@@ -48,7 +48,7 @@
     <repository>
       <id>pentaho-nexus</id>
       <name>PentahoNexus</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
     </repository>
   </repositories>
 
@@ -56,7 +56,7 @@
     <pluginRepository>
       <id>pentaho-public-plugins</id>
       <name>Pentaho Public Plugins</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/plugins/streaming/impls/mqtt/pom.xml
+++ b/plugins/streaming/impls/mqtt/pom.xml
@@ -48,7 +48,7 @@
     <repository>
       <id>pentaho-nexus</id>
       <name>PentahoNexus</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
     </repository>
   </repositories>
 
@@ -56,7 +56,7 @@
     <pluginRepository>
       <id>pentaho-public-plugins</id>
       <name>Pentaho Public Plugins</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
     <repository>
       <id>pentaho-public</id>
       <name>Pentaho Public</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <releases>
         <enabled>true</enabled>
         <updatePolicy>daily</updatePolicy>
@@ -439,7 +439,7 @@
     <pluginRepository>
       <id>pentaho-public-plugins</id>
       <name>Pentaho Public Plugins</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
Backports the DEVO-14362 hostname change to the `10.2` service pack line.

`repo.orl.eng.hitachivantara.com` -> `repo.pentaho.com`, hostname only. Every `/artifactory/<path>/` segment,
scheme and trailing slash is preserved verbatim; no ids, names, versions or
formatting were touched.

- Files changed: 3
- Occurrences replaced: 6
- `mvn validate` passes
- `grep` for the old hostname over all `pom.xml` returns no hits

Base is `10.2`, not the default branch. Ticket: DEVO-14362